### PR TITLE
[internal] use checksum yarn.lock and add args to yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,16 +15,16 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package.json" }}
+            - v2-dependencies-{{ checksum "yarn.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
 
-      - run: yarn install
+      - run: yarn install --prefer-offline --frozen-lockfile
 
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v2-dependencies-{{ checksum "yarn.lock" }}
 
       # run tests!
       - run: yarn run lint


### PR DESCRIPTION
- `--prefer-offline`: faster install
- `--frozen-lockfile`: fails if package.json doesn't match yarn.lock (yarn.lock should be updated)