### PR TITLE
[enhance] Merge changes to resource instances

### DIFF
--- a/src/state/__tests__/reducer.ts
+++ b/src/state/__tests__/reducer.ts
@@ -9,7 +9,7 @@ describe('resourceCustomizer', () => {
     const a = ArticleResource.fromJS({ id, title: 'hi', content: 'this is the content' });
     const b = ArticleResource.fromJS({ id, title: 'hello' });
 
-    const merged = resourceCustomizer(a, b, "", undefined, undefined);
+    const merged = resourceCustomizer(a, b);
     expect(merged).toBeInstanceOf(ArticleResource);
     expect(merged).toEqual(
       ArticleResource.fromJS({

--- a/src/state/__tests__/reducer.ts
+++ b/src/state/__tests__/reducer.ts
@@ -1,6 +1,65 @@
 import { ArticleResource, PaginatedArticleResource } from '../../__tests__/common';
-import reducer from '../reducer';
+import reducer, { resourceCustomizer } from '../reducer';
 import { FetchAction, RPCAction, ReceiveAction, PurgeAction, State } from '../../types';
+import { mergeWith } from 'lodash';
+
+describe('resourceCustomizer', () => {
+  it('should merge two Resource instances', () => {
+    const id = 20;
+    const a = ArticleResource.fromJS({ id, title: 'hi', content: 'this is the content' });
+    const b = ArticleResource.fromJS({ id, title: 'hello' });
+
+    const merged = resourceCustomizer(a, b, "", undefined, undefined);
+    expect(merged).toBeInstanceOf(ArticleResource);
+    expect(merged).toEqual(
+      ArticleResource.fromJS({
+        id,
+        title: 'hello',
+        content: 'this is the content'
+      })
+    )
+  });
+  it('should handle merging of Resource instances when used with lodash.mergeWith()', () => {
+    const id = 20;
+    const entitiesA = {
+      [ArticleResource.getKey()]: {
+        [id]: ArticleResource.fromJS({ id, title: 'hi', content: 'this is the content' }),
+      },
+    }
+    const entitiesB = {
+      [ArticleResource.getKey()]: {
+        [id]: ArticleResource.fromJS({ id, title: 'hello' }),
+      },
+    }
+
+    const merged = mergeWith({ ...entitiesA }, entitiesB, resourceCustomizer);
+    expect(merged[ArticleResource.getKey()][id]).toBeInstanceOf(ArticleResource);
+    expect(merged[ArticleResource.getKey()][id]).toEqual(
+      ArticleResource.fromJS({
+        id,
+        title: 'hello',
+        content: 'this is the content'
+      })
+    )
+  });
+  it('should not affect merging of plain objects when used with lodash.mergeWith()', () => {
+    const id = 20;
+    const entitiesA = {
+      [ArticleResource.getKey()]: {
+        [id]: ArticleResource.fromJS({ id, title: 'hi', content: 'this is the content' }),
+        [42]: ArticleResource.fromJS({ id: 42, title: 'dont touch me', content: 'this is mine' }),
+      },
+    }
+    const entitiesB = {
+      [ArticleResource.getKey()]: {
+        [id]: ArticleResource.fromJS({ id, title: 'hi', content: 'this is the content' }),
+      },
+    }
+
+    const merged = mergeWith({ ...entitiesA }, entitiesB, resourceCustomizer);
+    expect(merged[ArticleResource.getKey()][42]).toBe(entitiesA[ArticleResource.getKey()][42]);
+  });
+});
 
 describe('reducer', () => {
   describe('singles', () => {

--- a/src/state/__tests__/reducer.ts
+++ b/src/state/__tests__/reducer.ts
@@ -15,6 +15,10 @@ describe('reducer', () => {
         expiresAt: 5000500000,
       },
     };
+    const partialResultAction: ReceiveAction = {
+      ...action,
+      payload: { id, title: 'hello' },
+    };
     const iniState = {
       entities: {},
       results: {},
@@ -32,6 +36,21 @@ describe('reducer', () => {
       const nextEntity = getEntity(nextState);
       expect(nextEntity).not.toBe(prevEntity);
       expect(nextEntity).toBeDefined();
+    })
+    it('should merge partial entity with existing entity', () => {
+      const getEntity = (state: any): ArticleResource => state.entities[ArticleResource.getKey()][`${ArticleResource.pk(action.payload)}`]
+      const prevEntity = getEntity(newState);
+      expect(prevEntity).toBeDefined();
+      const nextState = reducer(newState, partialResultAction);
+      const nextEntity = getEntity(nextState);
+      expect(nextEntity).not.toBe(prevEntity);
+      expect(nextEntity).toBeDefined();
+
+      expect(nextEntity.title).not.toBe(prevEntity.title);
+      expect(nextEntity.title).toBe(partialResultAction.payload.title);
+
+      expect(nextEntity.content).toBe(prevEntity.content);
+      expect(nextEntity.content).not.toBe(partialResultAction.payload.content);
     })
   });
   it('mutate should never change results', () => {

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -1,5 +1,5 @@
 import { normalize } from '../resource';
-import { mergeWith, MergeWithCustomizer } from 'lodash';
+import { mergeWith } from 'lodash';
 import { Resource } from '../resource';
 import { ActionTypes, State } from '../types';
 
@@ -13,15 +13,28 @@ type Writable<T> = {
   [P in keyof T]: NonNullable<T[P]>;
 }
 
-export const resourceCustomizer: MergeWithCustomizer = (a, b) => {
-  if (a instanceof Resource && b instanceof Resource) {
-    const Static = b.constructor as typeof Resource;
+interface MergeableStatic<T> {
+  new(): T;
+  merge(a: T, b: T): T;
+}
+
+function isMergeable<T>(
+  constructor: any
+): constructor is MergeableStatic<T> {
+  return (
+    constructor &&
+    typeof constructor.merge === 'function'
+  );
+}
+
+export const resourceCustomizer = (a: any, b: any): any => {
+  const Static = b && b.constructor;
+  if (a && Static && isMergeable(Static)) {
     return Static.merge(a, b);
   }
 
   // use default merging in lodash.merge()
-  return undefined;
-}
+};
 
 export default function reducer(state: State<Resource>, action: ActionTypes) {
   switch (action.type) {

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -14,9 +14,9 @@ type Writable<T> = {
 }
 
 function resourceCustomizer(a: any, b: any): any {
-  if (b instanceof Resource) {
-    const merged = mergeWith({ ...a }, b, resourceCustomizer);
-    return Object.assign(b, merged);
+  if (a instanceof Resource && b instanceof Resource) {
+    const Static = b.constructor as typeof Resource;
+    return Static.merge(a, b);
   }
 }
 

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -1,5 +1,5 @@
 import { normalize } from '../resource';
-import { mergeWith } from 'lodash';
+import { mergeWith, MergeWithCustomizer } from 'lodash';
 import { Resource } from '../resource';
 import { ActionTypes, State } from '../types';
 
@@ -13,11 +13,14 @@ type Writable<T> = {
   [P in keyof T]: NonNullable<T[P]>;
 }
 
-function resourceCustomizer(a: any, b: any): any {
+export const resourceCustomizer: MergeWithCustomizer = (a, b) => {
   if (a instanceof Resource && b instanceof Resource) {
     const Static = b.constructor as typeof Resource;
     return Static.merge(a, b);
   }
+
+  // use default merging in lodash.merge()
+  return undefined;
 }
 
 export default function reducer(state: State<Resource>, action: ActionTypes) {

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -13,12 +13,11 @@ type Writable<T> = {
   [P in keyof T]: NonNullable<T[P]>;
 }
 
-function resourceCustomizer(a, b) {
-	if (b instanceof Resource) {
-			const merged = mergeWith({ ...a }, b, resourceCustomizer);
-
-			return Object.assign(b, merged);
-	}
+function resourceCustomizer(a: any, b: any): any {
+  if (b instanceof Resource) {
+    const merged = mergeWith({ ...a }, b, resourceCustomizer);
+    return Object.assign(b, merged);
+  }
 }
 
 export default function reducer(state: State<Resource>, action: ActionTypes) {


### PR DESCRIPTION
Adresses #9 

lodash merge only recursively merges arrays and plain objects, not class instances.

Use lodash mergeWith and a customizer that can handle instances of Resource.

The `resourceCustomizer` function will merge Resources recursively.