### PR TITLE
[feature] Support for custom dataExpiryLength and errorExpiryLength on resources

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@
   - [Authentication](guides/auth.md)
   - [Cross-orgin requests with JSONP](guides/jsonp.md)
   - [Custom networking library](guides/custom-networking.md)
+  - [Custom cache lifetime](guides/resource-lifetime.md)
 - 💨 Performance Optimizations (optional)
   - [Nesting related resources (server-side join)](guides/nested-response.md)
   - [Cross-resource multi-update RPC (dealing with side-effects)](guides/rpc.md)

--- a/docs/api/RequestShape.md
+++ b/docs/api/RequestShape.md
@@ -17,6 +17,8 @@ Params extends Readonly<object>,
 Body extends Readonly<object> | void,
 > {
   readonly type: 'read' | 'mutate' | 'delete';
+  readonly dataExpiryLength?: number;
+  readonly errorExpiryLength?: number;
   fetch(url: string, body: Body): Promise<any>;
   getUrl(params: Params): string;
   readonly schema: S;
@@ -41,6 +43,14 @@ mutation update properly in the cache without having to do another request.
 
 It sends a request and represents a success response to mean that entity is deleted.
 Upon success it will purge that entity from the cache.
+
+### dataExpiryLength: number
+
+Custom data cache lifetime for the fetched resource. Will override the value set in NetworkManager.
+
+### errorExpiryLength: number
+
+Custom data error lifetime for the fetched resource. Will override the value set in NetworkManager.
 
 ### fetch(url: string, body: Payload): Promise\<any>
 

--- a/docs/api/RequestShape.md
+++ b/docs/api/RequestShape.md
@@ -17,11 +17,10 @@ Params extends Readonly<object>,
 Body extends Readonly<object> | void,
 > {
   readonly type: 'read' | 'mutate' | 'delete';
-  readonly dataExpiryLength?: number;
-  readonly errorExpiryLength?: number;
   fetch(url: string, body: Body): Promise<any>;
   getUrl(params: Params): string;
   readonly schema: S;
+  readonly options?: RequestOptions;
 }
 ```
 
@@ -44,14 +43,6 @@ mutation update properly in the cache without having to do another request.
 It sends a request and represents a success response to mean that entity is deleted.
 Upon success it will purge that entity from the cache.
 
-### dataExpiryLength: number
-
-Custom data cache lifetime for the fetched resource. Will override the value set in NetworkManager.
-
-### errorExpiryLength: number
-
-Custom data error lifetime for the fetched resource. Will override the value set in NetworkManager.
-
 ### fetch(url: string, body: Payload): Promise\<any>
 
 Handles performing an actual network request. This usually just proxies to the `Resource`
@@ -65,3 +56,25 @@ Turns the provided object params into a url to fetch.
 
 Schemas define the shape of the response data and are used to parse and update
 the normalized cache. Read more about [schemas at the normalizr documentation](https://github.com/paularmstrong/normalizr/blob/master/docs/api.md#schema).
+
+### options?: RequestOptions
+
+
+# RequestOptions
+
+Additional optional request options passed on to network manager and reducer.
+
+```typescript
+export interface RequestOptions {
+  readonly dataExpiryLength?: number;
+  readonly errorExpiryLength?: number;
+}
+```
+
+### dataExpiryLength?: number
+
+Custom data cache lifetime for the fetched resource. Will override the value set in NetworkManager.
+
+### errorExpiryLength?: number
+
+Custom data error lifetime for the fetched resource. Will override the value set in NetworkManager.

--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -118,7 +118,7 @@ Returns an `Object` with only the defined (non-default) members of `instance`.
 
 Returns an `Array` of all defined (non-default) keys of `instance`.
 
-## Static network methods
+## Static network methods and properties
 
 These are the basic building blocks used to compile the [Request shapes](../api/RequestShape.md) below.
 
@@ -141,6 +141,15 @@ on network error. This can be useful to override to really customize your transp
 Returns the [shape of the data](https://github.com/paularmstrong/normalizr/blob/master/docs/api.md#schema)
 when requesting one resource at a time. Defaults to a plain object
 containing the keys. This can be useful to override if your response is in a different form.
+
+### static dataExpiryLength?: number
+
+Cache lifetime of the resource. Will override the value set in NetworkManager if defined.
+
+### static errorExpiryLength?: number
+
+Cache lifetime of network errors. Will override the value set in NetworkManager if defined.
+
 
 ## [Request shapes](../api/RequestShape.md)
 

--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -142,14 +142,9 @@ Returns the [shape of the data](https://github.com/paularmstrong/normalizr/blob/
 when requesting one resource at a time. Defaults to a plain object
 containing the keys. This can be useful to override if your response is in a different form.
 
-### static dataExpiryLength?: number
+### static getRequestOptions() => [RequestOptions](../api/RequestShape.md#RequestOptions) | undefined
 
-Cache lifetime of the resource. Will override the value set in NetworkManager if defined.
-
-### static errorExpiryLength?: number
-
-Cache lifetime of network errors. Will override the value set in NetworkManager if defined.
-
+Returns the default request options for this resource. By default this returns undefined
 
 ## [Request shapes](../api/RequestShape.md)
 

--- a/docs/guides/resource-lifetime.md
+++ b/docs/guides/resource-lifetime.md
@@ -1,0 +1,30 @@
+# Custom Resource cache lifetime
+
+By default the NetworkManager specifies the liftime of data and errors in the cache.
+If some resources are longer living, or shorter living than other, the can specify their own expiry length values,
+which will be passed on to all request shape creator functions on Resource.
+
+## Examples
+
+### Long cache lifetime
+
+`LongLivingResource.ts`
+```typescript
+
+// We can now extend LongLivingResource to get a resource that will be cached for one hour
+abstract class LongLivingResource extends Resource {
+  static readonly dataExpiryLength = 60 * 60 * 1000; // one hour
+}
+```
+
+
+### Never retry on error
+
+`NoRetryResource.ts`
+```typescript
+
+// We can now extend NoRetryResource to get a resource that will never retry on network error
+abstract class NoRetryResource extends Resource {
+  static readonly errorExpiryLength = Infinity;
+}
+```

--- a/docs/guides/resource-lifetime.md
+++ b/docs/guides/resource-lifetime.md
@@ -1,6 +1,6 @@
 # Custom Resource cache lifetime
 
-By default the NetworkManager specifies the liftime of data and errors in the cache.
+By default the NetworkManager specifies the lifetime of data and errors in the cache.
 If some resources are longer living, or shorter living than other, the can specify their own expiry length values,
 which will be passed on to all request shape creator functions on Resource.
 
@@ -9,22 +9,31 @@ which will be passed on to all request shape creator functions on Resource.
 ### Long cache lifetime
 
 `LongLivingResource.ts`
-```typescript
 
+```typescript
 // We can now extend LongLivingResource to get a resource that will be cached for one hour
 abstract class LongLivingResource extends Resource {
-  static readonly dataExpiryLength = 60 * 60 * 1000; // one hour
+  static getRequestOptions() {
+    return {
+      ...super.getRequestOptions(),
+      dataExpiryLength: 60 * 60 * 1000, // one hour
+    };
+  }
 }
 ```
-
 
 ### Never retry on error
 
 `NoRetryResource.ts`
-```typescript
 
+```typescript
 // We can now extend NoRetryResource to get a resource that will never retry on network error
 abstract class NoRetryResource extends Resource {
-  static readonly errorExpiryLength = Infinity;
+  static getRequestOptions() {
+    return {
+      ...super.getRequestOptions(),
+      errorExpiryLength: Infinity,
+    };
+  }
 }
 ```

--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -20,6 +20,20 @@ export class ArticleResource extends Resource {
     }
     return super.url(urlParams);
   }
+
+  static longLivingRequest<T extends typeof Resource>(this: T) {
+    return {
+      ...this.singleRequest(),
+      dataExpiryLength: 1000 * 60 * 60
+    }
+  }
+
+  static neverRetryOnErrorRequest<T extends typeof Resource>(this: T) {
+    return {
+      ...this.singleRequest(),
+      errorExpiryLength: Infinity
+    }
+  }
 }
 
 export class CoolerArticleResource extends ArticleResource {
@@ -27,6 +41,11 @@ export class CoolerArticleResource extends ArticleResource {
   get things() {
     return `${this.title} five`;
   }
+}
+
+export class StaticArticleResource extends ArticleResource {
+  static urlRoot = 'http://test.com/article-static/';
+  static dataExpiryLength = Infinity;
 }
 
 export class UserResource extends Resource {

--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -22,16 +22,24 @@ export class ArticleResource extends Resource {
   }
 
   static longLivingRequest<T extends typeof Resource>(this: T) {
+    const single = this.singleRequest();
     return {
-      ...this.singleRequest(),
-      dataExpiryLength: 1000 * 60 * 60
+      ...single,
+      options: {
+        ...single.options,
+        dataExpiryLength: 1000 * 60 * 60,
+      },
     }
   }
 
   static neverRetryOnErrorRequest<T extends typeof Resource>(this: T) {
+    const single = this.singleRequest();
     return {
-      ...this.singleRequest(),
-      errorExpiryLength: Infinity
+      ...single,
+      options: {
+        ...single.options,
+        errorExpiryLength: Infinity,
+      },
     }
   }
 }
@@ -45,7 +53,13 @@ export class CoolerArticleResource extends ArticleResource {
 
 export class StaticArticleResource extends ArticleResource {
   static urlRoot = 'http://test.com/article-static/';
-  static dataExpiryLength = Infinity;
+
+  static getRequestOptions() {
+    return {
+      ...super.getRequestOptions(),
+      dataExpiryLength: Infinity
+    }
+  }
 }
 
 export class UserResource extends Resource {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import {
   NetworkError,
 } from './react-integration';
 import { Request as RequestType } from 'superagent';
-import { AbstractInstanceType } from './types';
+import { AbstractInstanceType, RequestOptions } from './types';
 
 export type DeleteShape<
 S extends schemas.Entity,
@@ -50,6 +50,7 @@ export type SchemaArray<T> = SchemaArray<T>;
 export type SchemaBase<T> = SchemaBase<T>;
 export type SchemaOf<T> = SchemaOf<T>;
 export type AbstractInstanceType<T> = AbstractInstanceType<T>;
+export type RequestOptions = RequestOptions;
 
 export type NetworkError = NetworkError;
 export type Request = RequestType;

--- a/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
+++ b/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
@@ -45,8 +45,7 @@ Array [
 exports[`useFetcher should dispatch an action that fetches a create 1`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": undefined,
-    "errorExpiryLength": undefined,
+    "options": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rpc",
@@ -70,8 +69,7 @@ Object {
 exports[`useFetcher should dispatch an action that fetches a full update 1`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": undefined,
-    "errorExpiryLength": undefined,
+    "options": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rpc",
@@ -95,8 +93,7 @@ Object {
 exports[`useFetcher should dispatch an action that fetches a partial update 1`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": undefined,
-    "errorExpiryLength": undefined,
+    "options": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rpc",
@@ -120,8 +117,7 @@ Object {
 exports[`useResource should dispatch an action that fetches 1`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": undefined,
-    "errorExpiryLength": undefined,
+    "options": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -145,8 +141,7 @@ Object {
 exports[`useResource should dispatch fetch when sent multiple arguments 1`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": undefined,
-    "errorExpiryLength": undefined,
+    "options": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -170,8 +165,7 @@ Object {
 exports[`useResource should dispatch fetch when sent multiple arguments 2`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": undefined,
-    "errorExpiryLength": undefined,
+    "options": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -197,8 +191,7 @@ Object {
 exports[`useRetrieve should dispatch singles 1`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": undefined,
-    "errorExpiryLength": undefined,
+    "options": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -222,8 +215,9 @@ Object {
 exports[`useRetrieve should dispatch with request shape defined dataExpiryLength 1`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": 3600000,
-    "errorExpiryLength": undefined,
+    "options": Object {
+      "dataExpiryLength": 3600000,
+    },
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -247,8 +241,10 @@ Object {
 exports[`useRetrieve should dispatch with request shape defined errorExpiryLength 1`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": Infinity,
-    "errorExpiryLength": Infinity,
+    "options": Object {
+      "dataExpiryLength": Infinity,
+      "errorExpiryLength": Infinity,
+    },
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -272,8 +268,9 @@ Object {
 exports[`useRetrieve should dispatch with resource defined dataExpiryLength 1`] = `
 Object {
   "meta": Object {
-    "dataExpiryLength": Infinity,
-    "errorExpiryLength": undefined,
+    "options": Object {
+      "dataExpiryLength": Infinity,
+    },
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",

--- a/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
+++ b/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
@@ -45,6 +45,8 @@ Array [
 exports[`useFetcher should dispatch an action that fetches a create 1`] = `
 Object {
   "meta": Object {
+    "dataExpiryLength": undefined,
+    "errorExpiryLength": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rpc",
@@ -68,6 +70,8 @@ Object {
 exports[`useFetcher should dispatch an action that fetches a full update 1`] = `
 Object {
   "meta": Object {
+    "dataExpiryLength": undefined,
+    "errorExpiryLength": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rpc",
@@ -91,6 +95,8 @@ Object {
 exports[`useFetcher should dispatch an action that fetches a partial update 1`] = `
 Object {
   "meta": Object {
+    "dataExpiryLength": undefined,
+    "errorExpiryLength": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rpc",
@@ -114,6 +120,8 @@ Object {
 exports[`useResource should dispatch an action that fetches 1`] = `
 Object {
   "meta": Object {
+    "dataExpiryLength": undefined,
+    "errorExpiryLength": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -137,6 +145,8 @@ Object {
 exports[`useResource should dispatch fetch when sent multiple arguments 1`] = `
 Object {
   "meta": Object {
+    "dataExpiryLength": undefined,
+    "errorExpiryLength": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -160,6 +170,8 @@ Object {
 exports[`useResource should dispatch fetch when sent multiple arguments 2`] = `
 Object {
   "meta": Object {
+    "dataExpiryLength": undefined,
+    "errorExpiryLength": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -185,6 +197,8 @@ Object {
 exports[`useRetrieve should dispatch singles 1`] = `
 Object {
   "meta": Object {
+    "dataExpiryLength": undefined,
+    "errorExpiryLength": undefined,
     "reject": [Function],
     "resolve": [Function],
     "responseType": "receive",
@@ -199,6 +213,81 @@ Object {
     },
     "throttle": true,
     "url": "http://test.com/article-cooler/5",
+  },
+  "payload": [Function],
+  "type": "fetch",
+}
+`;
+
+exports[`useRetrieve should dispatch with request shape defined dataExpiryLength 1`] = `
+Object {
+  "meta": Object {
+    "dataExpiryLength": 3600000,
+    "errorExpiryLength": undefined,
+    "reject": [Function],
+    "resolve": [Function],
+    "responseType": "receive",
+    "schema": EntitySchema {
+      "_getId": [Function],
+      "_idAttribute": [Function],
+      "_key": "http://test.com/article-static/",
+      "_mergeStrategy": [Function],
+      "_processStrategy": [Function],
+      "denormalize": [Function],
+      "schema": Object {},
+    },
+    "throttle": true,
+    "url": "http://test.com/article-static/5",
+  },
+  "payload": [Function],
+  "type": "fetch",
+}
+`;
+
+exports[`useRetrieve should dispatch with request shape defined errorExpiryLength 1`] = `
+Object {
+  "meta": Object {
+    "dataExpiryLength": Infinity,
+    "errorExpiryLength": Infinity,
+    "reject": [Function],
+    "resolve": [Function],
+    "responseType": "receive",
+    "schema": EntitySchema {
+      "_getId": [Function],
+      "_idAttribute": [Function],
+      "_key": "http://test.com/article-static/",
+      "_mergeStrategy": [Function],
+      "_processStrategy": [Function],
+      "denormalize": [Function],
+      "schema": Object {},
+    },
+    "throttle": true,
+    "url": "http://test.com/article-static/5",
+  },
+  "payload": [Function],
+  "type": "fetch",
+}
+`;
+
+exports[`useRetrieve should dispatch with resource defined dataExpiryLength 1`] = `
+Object {
+  "meta": Object {
+    "dataExpiryLength": Infinity,
+    "errorExpiryLength": undefined,
+    "reject": [Function],
+    "resolve": [Function],
+    "responseType": "receive",
+    "schema": EntitySchema {
+      "_getId": [Function],
+      "_idAttribute": [Function],
+      "_key": "http://test.com/article-static/",
+      "_mergeStrategy": [Function],
+      "_processStrategy": [Function],
+      "denormalize": [Function],
+      "schema": Object {},
+    },
+    "throttle": true,
+    "url": "http://test.com/article-static/5",
   },
   "payload": [Function],
   "type": "fetch",

--- a/src/react-integration/__tests__/hooks.tsx
+++ b/src/react-integration/__tests__/hooks.tsx
@@ -8,6 +8,7 @@ import {
   CoolerArticleResource,
   UserResource,
   PaginatedArticleResource,
+  StaticArticleResource,
 } from '../../__tests__/common';
 import {
   useFetcher,
@@ -265,6 +266,9 @@ describe('useRetrieve', () => {
       .get(`/article-cooler/${payload.id}`)
       .reply(200, payload);
     nock('http://test.com')
+      .get(`/article-static/${payload.id}`)
+      .reply(200, payload);
+    nock('http://test.com')
       .get(`/user/`)
       .reply(200, users);
   });
@@ -289,6 +293,27 @@ describe('useRetrieve', () => {
     params = payload;
     rerender();
     expect(dispatch).toBeCalled();
+  });
+  it('should dispatch with resource defined dataExpiryLength', async () => {
+    function FetchTester() {
+      useRetrieve(StaticArticleResource.singleRequest(), payload);
+      return null;
+    }
+    await testDispatchFetch(FetchTester, [payload]);
+  });
+  it('should dispatch with request shape defined dataExpiryLength', async () => {
+    function FetchTester() {
+      useRetrieve(StaticArticleResource.longLivingRequest(), payload);
+      return null;
+    }
+    await testDispatchFetch(FetchTester, [payload]);
+  });
+  it('should dispatch with request shape defined errorExpiryLength', async () => {
+    function FetchTester() {
+      useRetrieve(StaticArticleResource.neverRetryOnErrorRequest(), payload);
+      return null;
+    }
+    await testDispatchFetch(FetchTester, [payload]);
   });
 });
 

--- a/src/react-integration/hooks/useFetcher.ts
+++ b/src/react-integration/hooks/useFetcher.ts
@@ -18,7 +18,7 @@ Params extends Readonly<object>,
 Body extends Readonly<object> | void,
 S extends Schema
 >(requestShape: RequestShape<S, Params, Body>, throttle = false) {
-  const { fetch, schema, type, getUrl } = requestShape;
+  const { fetch, schema, type, getUrl, dataExpiryLength, errorExpiryLength } = requestShape;
   const responseType = SHAPE_TYPE_TO_RESPONSE_TYPE[type];
 
   const dispatch = useContext(DispatchContext);
@@ -43,6 +43,8 @@ S extends Schema
           responseType,
           url: identifier,
           throttle,
+          dataExpiryLength,
+          errorExpiryLength,
           resolve,
           reject,
         },

--- a/src/react-integration/hooks/useFetcher.ts
+++ b/src/react-integration/hooks/useFetcher.ts
@@ -4,8 +4,8 @@ import { RequestShape, Schema, isDeleteShape } from '../../resource';
 import { DispatchContext } from '../context';
 
 const SHAPE_TYPE_TO_RESPONSE_TYPE: Record<
-RequestShape<any, any, any>['type'],
-'receive' | 'rpc' | 'purge'
+  RequestShape<any, any, any>['type'],
+  'receive' | 'rpc' | 'purge'
 > = {
   read: 'receive',
   mutate: 'rpc',
@@ -14,11 +14,11 @@ RequestShape<any, any, any>['type'],
 
 /** Build an imperative dispatcher to issue network requests. */
 export default function useFetcher<
-Params extends Readonly<object>,
-Body extends Readonly<object> | void,
-S extends Schema
+  Params extends Readonly<object>,
+  Body extends Readonly<object> | void,
+  S extends Schema
 >(requestShape: RequestShape<S, Params, Body>, throttle = false) {
-  const { fetch, schema, type, getUrl, dataExpiryLength, errorExpiryLength } = requestShape;
+  const { fetch, schema, type, getUrl, options } = requestShape;
   const responseType = SHAPE_TYPE_TO_RESPONSE_TYPE[type];
 
   const dispatch = useContext(DispatchContext);
@@ -43,8 +43,7 @@ S extends Schema
           responseType,
           url: identifier,
           throttle,
-          dataExpiryLength,
-          errorExpiryLength,
+          options,
           resolve,
           reject,
         },

--- a/src/resource/Resource.ts
+++ b/src/resource/Resource.ts
@@ -43,6 +43,10 @@ export default abstract class Resource {
   static readonly urlRoot: string;
   /** A function to mutate all requests for fetch */
   static fetchPlugin?: request.Plugin;
+  /** Default data expiry length in all request shapes, will fall back to NetworkManager default if not defined */
+  static readonly dataExpiryLength?: number;
+  /** Default error expiry length in all request shapes, will fall back to NetworkManager default if not defined */
+  static readonly errorExpiryLength?: number;
   /** A unique identifier for this Resource */
   abstract pk(): string | number | null;
 
@@ -213,6 +217,8 @@ export default abstract class Resource {
     return {
       type: 'read',
       schema,
+      dataExpiryLength: this.dataExpiryLength,
+      errorExpiryLength: this.errorExpiryLength,
       getUrl,
       fetch(url: string, body?: Readonly<object>) {
         return self.fetch('get', url, body);
@@ -234,6 +240,8 @@ export default abstract class Resource {
     return {
       type: 'read',
       schema,
+      dataExpiryLength: this.dataExpiryLength,
+      errorExpiryLength: this.errorExpiryLength,
       getUrl,
       fetch(url: string, body?: Readonly<object>) {
         return self.fetch('get', url, body);
@@ -252,6 +260,8 @@ export default abstract class Resource {
     return {
       type: 'mutate',
       schema: self.getEntitySchema(),
+      dataExpiryLength: this.dataExpiryLength,
+      errorExpiryLength: this.errorExpiryLength,
       getUrl(params: Readonly<Record<string, string>>) {
         return self.listUrl(params);
       },
@@ -272,6 +282,8 @@ export default abstract class Resource {
     return {
       type: 'mutate',
       schema: self.getEntitySchema(),
+      dataExpiryLength: this.dataExpiryLength,
+      errorExpiryLength: this.errorExpiryLength,
       getUrl(params: object) {
         return self.url(params);
       },
@@ -292,6 +304,8 @@ export default abstract class Resource {
     return {
       type: 'mutate',
       schema: self.getEntitySchema(), //TODO: change merge strategy in case we want to handle partial returns
+      dataExpiryLength: this.dataExpiryLength,
+      errorExpiryLength: this.errorExpiryLength,
       getUrl(params: Readonly<object>) {
         return self.url(params);
       },
@@ -308,6 +322,8 @@ export default abstract class Resource {
     return {
       type: 'delete',
       schema: self.getEntitySchema(),
+      dataExpiryLength: this.dataExpiryLength,
+      errorExpiryLength: this.errorExpiryLength,
       getUrl(params: object) {
         return self.url(params);
       },

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -10,6 +10,8 @@ export interface RequestShape<
   fetch(url: string, body: Body): Promise<any>;
   getUrl(params: Params): string;
   readonly schema: S;
+  readonly dataExpiryLength?: number;
+  readonly errorExpiryLength?: number;
 }
 
 /** Purges a value from the server */

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -1,4 +1,5 @@
 import { schemas, Schema, SchemaArray, SchemaBase } from './normal';
+import { RequestOptions } from 'types';
 
 /** Defines the shape of a network request */
 export interface RequestShape<
@@ -10,8 +11,7 @@ export interface RequestShape<
   fetch(url: string, body: Body): Promise<any>;
   getUrl(params: Params): string;
   readonly schema: S;
-  readonly dataExpiryLength?: number;
-  readonly errorExpiryLength?: number;
+  readonly options?: RequestOptions;
 }
 
 /** Purges a value from the server */

--- a/src/state/NetworkManager.ts
+++ b/src/state/NetworkManager.ts
@@ -58,9 +58,12 @@ export default class NetworkManager {
       throttle,
       resolve,
       reject,
-      dataExpiryLength = this.dataExpiryLength,
-      errorExpiryLength = this.errorExpiryLength
+      options = {},
     } = action.meta;
+    const {
+      dataExpiryLength = this.dataExpiryLength,
+      errorExpiryLength = this.errorExpiryLength,
+    } = options;
 
     const deferedFetch = () =>
       fetch()
@@ -138,7 +141,7 @@ export default class NetworkManager {
     return <R extends React.Reducer<any, any>>({
       dispatch,
     }: {
-    dispatch: React.Dispatch<React.ReducerAction<R>>;
+      dispatch: React.Dispatch<React.ReducerAction<R>>;
     }) => {
       return (next: React.Dispatch<React.ReducerAction<R>>) => (
         action: React.ReducerAction<R>,
@@ -153,7 +156,7 @@ export default class NetworkManager {
           if (action.meta.url in this.fetched) {
             this.handleReceive(action);
           }
-          // fallthrough is on purpose
+        // fallthrough is on purpose
         default:
           return next(action);
         }

--- a/src/state/NetworkManager.ts
+++ b/src/state/NetworkManager.ts
@@ -58,7 +58,10 @@ export default class NetworkManager {
       throttle,
       resolve,
       reject,
+      dataExpiryLength = this.dataExpiryLength,
+      errorExpiryLength = this.errorExpiryLength
     } = action.meta;
+
     const deferedFetch = () =>
       fetch()
         .then(data => {
@@ -70,7 +73,7 @@ export default class NetworkManager {
               schema,
               url,
               date: now,
-              expiresAt: now + this.dataExpiryLength,
+              expiresAt: now + dataExpiryLength,
             },
           });
           return data;
@@ -84,7 +87,7 @@ export default class NetworkManager {
               schema,
               url,
               date: now,
-              expiresAt: now + this.errorExpiryLength,
+              expiresAt: now + errorExpiryLength,
             },
             error: true,
           });

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,13 @@ export type State<T> = Readonly<{
   }>;
 }>;
 
+export interface RequestOptions {
+  /** Default data expiry length, will fall back to NetworkManager default if not defined */
+  readonly dataExpiryLength?: number;
+  /** Default error expiry length, will fall back to NetworkManager default if not defined */
+  readonly errorExpiryLength?: number;
+}
+
 export interface ReceiveAction extends FSA<any, any> {
   type: 'receive';
   meta: {
@@ -49,8 +56,7 @@ export interface FetchAction extends FSA<any, any> {
     url: string;
     responseType: 'rpc' | 'receive' | 'purge';
     throttle: boolean;
-    errorExpiryLength?: number;
-    dataExpiryLength?: number;
+    options?: RequestOptions;
     resolve: (value?: any | PromiseLike<any>) => void;
     reject: (reason?: any) => void;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export interface FetchAction extends FSA<any, any> {
     url: string;
     responseType: 'rpc' | 'receive' | 'purge';
     throttle: boolean;
+    errorExpiryLength?: number;
+    dataExpiryLength?: number;
     resolve: (value?: any | PromiseLike<any>) => void;
     reject: (reason?: any) => void;
   };


### PR DESCRIPTION
This feature allows defining custom data and error lifetimes for resources and request shapes.

NetworkManager will pass on dataExpiryLength and errorExpiryLength from FetchAction. Defaults to NetworkManager values if undefined.

Static dataExpiryLength and errorExpiryLength fields on Resource, undefined by default. Passed to all request shapes.