### PR TITLE
[fix] Gracefully handle network errors for 'rpc' and 'purge' types

### DIFF
--- a/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reducer should set error in meta 1`] = `
+exports[`reducer should set error in meta for "receive" 1`] = `
 Object {
   "entities": Object {},
   "meta": Object {

--- a/src/state/__tests__/reducer.ts
+++ b/src/state/__tests__/reducer.ts
@@ -86,7 +86,7 @@ describe('reducer', () => {
     expect(newState.entities[ArticleResource.getKey()]).toEqual(expectedEntities);
 
   });
-  it('should set error in meta', () => {
+  it('should set error in meta for "receive"', () => {
     const id = 20;
     const error = new Error('hi');
     const action: ReceiveAction = {
@@ -107,6 +107,52 @@ describe('reducer', () => {
     };
     const newState = reducer(iniState, action);
     expect(newState).toMatchSnapshot();
+  });
+  it('should not modify state on error for "rpc"', () => {
+    const id = 20;
+    const error = new Error('hi');
+    const action: RPCAction = {
+      type: 'rpc',
+      payload: error,
+      meta: {
+        schema: ArticleResource.getEntitySchema(),
+        url: ArticleResource.url({ id }),
+      },
+      error: true,
+    };
+    const iniState = {
+      entities: {},
+      results: {},
+      meta: {},
+    };
+    const newState = reducer(iniState, action);
+    expect(newState).toEqual(iniState);
+  });
+  it('should not delete on error for "purge"', () => {
+    const id = 20;
+    const error = new Error('hi');
+    const action: PurgeAction = {
+      type: 'purge',
+      payload: error,
+      meta: {
+        schema: ArticleResource.getEntitySchema(),
+        url: ArticleResource.url({ id }),
+      },
+      error: true,
+    };
+    const iniState = {
+      entities: {
+        [ArticleResource.getKey()]: {
+          [id]: ArticleResource.fromJS({})
+        }
+      },
+      results: {
+        [ArticleResource.url({ id })]: id,
+      },
+      meta: {},
+    };
+    const newState = reducer(iniState, action);
+    expect(newState).toEqual(iniState);
   });
   it('other types should do nothing', () => {
     const action: FetchAction = {

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -45,12 +45,14 @@ export default function reducer(state: State<Resource>, action: ActionTypes) {
         },
       };
     case 'rpc':
+      if (action.error) return state;
       let { entities } = normalize(action.payload, action.meta.schema);
       return {
         ...state,
         entities: merge({ ...state.entities }, entities),
       };
     case 'purge':
+      if (action.error) return state;
       const key = action.meta.schema.key;
       const pk = action.meta.url;
       const e: Writable<typeof state.entities> = {};


### PR DESCRIPTION
Fixes https://github.com/coinbase/rest-hooks/issues/21

For both rpc and purge we should simply not update state.