### PR TITLE
[fix] Network error can have an undefined status

### DIFF
--- a/src/react-integration/NetworkErrorBoundary.tsx
+++ b/src/react-integration/NetworkErrorBoundary.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 export interface NetworkError extends Error {
-  status: number;
+  status: number | undefined;
   response?: { statusText?: string, body?: any };
 }
 
 function isNetworkError(error: NetworkError | any): error is NetworkError {
-  return !!(error as NetworkError).status;
+  return Object.prototype.hasOwnProperty.call(error, 'status');
 }
 
 interface Props<E extends NetworkError> {


### PR DESCRIPTION
```tsx
console.log(error, error.status, Object.prototype.hasOwnProperty.call(error, 'status'));
```

![Screenshot 2019-03-27 at 13 38 01](https://user-images.githubusercontent.com/302891/55076602-29e99080-5096-11e9-875e-51a0c6ac9a9e.png)
