### PR TITLE
[enhance] Merge results from partial nested resources

### DIFF
--- a/src/react-integration/__tests__/integration.tsx
+++ b/src/react-integration/__tests__/integration.tsx
@@ -47,6 +47,30 @@ describe('<RestProvider />', () => {
       isAdmin: true,
     },
   ];
+  const nested = [
+    {
+      id: 5,
+      title: 'hi ho',
+      content: 'whatever',
+      tags: ['a', 'best', 'react'],
+      author: {
+        id: 23,
+        username: 'bob',
+      },
+    },
+    {
+      id: 3,
+      title: 'the next time',
+      content: 'whatever',
+      author: {
+        id: 23,
+        username: 'charles',
+        email: 'bob@bob.com',
+      },
+    },
+  ];
+
+  // TODO: add nested resource test case that has multiple partials to test merge functionality
   let manager: NetworkManager;
   function testProvider(callback: () => void, fbmock: jest.Mock<any, any>) {
     function Fallback() {
@@ -82,6 +106,9 @@ describe('<RestProvider />', () => {
     nock('http://test.com')
       .get(`/article-cooler/0`)
       .reply(403, {});
+    nock('http://test.com')
+      .get(`/article-cooler/`)
+      .reply(200, nested);
     nock('http://test.com')
       .get(`/user/`)
       .reply(200, users);
@@ -190,7 +217,7 @@ describe('<RestProvider />', () => {
             id: payload.id,
           },
         ],
-        [UserResource.listRequest(), {}],
+        [UserResource.listRequest(), {}]
       );
     }, fbmock);
     expect(fbmock).toBeCalled();

--- a/src/resource/Resource.ts
+++ b/src/resource/Resource.ts
@@ -6,7 +6,7 @@ import { ReadShape, MutateShape, DeleteShape } from './types';
 import { schemas, SchemaBase, SchemaArray } from './normal';
 
 const getEntitySchema: <T extends typeof Resource>(
-  M: T,
+  M: T
 ) => schemas.Entity<AbstractInstanceType<T>> = memoize(
   <T extends typeof Resource>(M: T) => {
     const e = new schemas.Entity(
@@ -19,15 +19,18 @@ const getEntitySchema: <T extends typeof Resource>(
         processStrategy: value => {
           return M.fromJS(value);
         },
-        mergeStrategy: (a, b) => b,
-      },
+        mergeStrategy: (
+          a: AbstractInstanceType<T>,
+          b: AbstractInstanceType<T>
+        ) => (a.constructor as T).merge(a, b),
+      }
     );
     // TODO: long term figure out a plan to actually denormalize
     (e as any).denormalize = function denormalize(entity: any) {
       return entity;
     };
     return e;
-  },
+  }
 ) as any;
 
 const DefinedMembersKey = Symbol('Defined Members');
@@ -49,7 +52,7 @@ export default abstract class Resource {
   /** Resource factory. Takes an object of properties to assign to Resource. */
   static fromJS<T extends typeof Resource>(
     this: T,
-    props: Partial<AbstractInstanceType<T>>,
+    props: Partial<AbstractInstanceType<T>>
   ) {
     if (this === Resource)
       throw new Error('cannot construct on abstract types');
@@ -75,12 +78,12 @@ export default abstract class Resource {
   static merge<T extends typeof Resource>(
     this: T,
     first: AbstractInstanceType<T>,
-    second: AbstractInstanceType<T>,
+    second: AbstractInstanceType<T>
   ) {
     const props = Object.assign(
       {},
       this.toObjectDefined(first),
-      this.toObjectDefined(second),
+      this.toObjectDefined(second)
     );
     return this.fromJS(props);
   }
@@ -89,7 +92,7 @@ export default abstract class Resource {
   static hasDefined<T extends typeof Resource>(
     this: T,
     instance: AbstractInstanceType<T>,
-    key: Filter<keyof AbstractInstanceType<T>, string>,
+    key: Filter<keyof AbstractInstanceType<T>, string>
   ) {
     return ((instance as any) as ResourceMembers<T>)[
       DefinedMembersKey
@@ -99,7 +102,7 @@ export default abstract class Resource {
   /** Returns simple object with all the non-default members */
   static toObjectDefined<T extends typeof Resource>(
     this: T,
-    instance: AbstractInstanceType<T>,
+    instance: AbstractInstanceType<T>
   ) {
     const defined: Partial<AbstractInstanceType<T>> = {};
     for (const member of ((instance as any) as ResourceMembers<T>)[
@@ -113,7 +116,7 @@ export default abstract class Resource {
   /** Returns array of all keys that have values defined in instance */
   static keysDefined<T extends typeof Resource>(
     this: T,
-    instance: AbstractInstanceType<T>,
+    instance: AbstractInstanceType<T>
   ) {
     return ((instance as any) as ResourceMembers<T>)[DefinedMembersKey];
   }
@@ -130,7 +133,7 @@ export default abstract class Resource {
   /** A unique identifier for this Resource */
   static pk<T extends typeof Resource>(
     this: T,
-    params: Partial<AbstractInstanceType<T>>,
+    params: Partial<AbstractInstanceType<T>>
   ): string | number | null {
     return this.prototype.pk.call(params);
   }
@@ -148,7 +151,7 @@ export default abstract class Resource {
    */
   static url<T extends typeof Resource>(
     this: T,
-    urlParams?: Partial<AbstractInstanceType<T>>,
+    urlParams?: Partial<AbstractInstanceType<T>>
   ): string {
     if (urlParams) {
       if (
@@ -171,7 +174,7 @@ export default abstract class Resource {
    */
   static listUrl<T extends typeof Resource>(
     this: T,
-    searchParams?: Readonly<Record<string, string | number>>,
+    searchParams?: Readonly<Record<string, string | number>>
   ): string {
     if (searchParams && Object.keys(searchParams).length) {
       const params = new URLSearchParams(searchParams as any);
@@ -186,7 +189,7 @@ export default abstract class Resource {
     this: T,
     method: Method = 'get',
     url: string,
-    body?: Readonly<object>,
+    body?: Readonly<object>
   ) {
     let req = request[method](url).on('error', () => {});
     if (this.fetchPlugin) req = req.use(this.fetchPlugin);
@@ -208,7 +211,7 @@ export default abstract class Resource {
   // TODO: memoize these so they can be referentially compared
   /** Shape to get a single entity */
   static singleRequest<T extends typeof Resource>(
-    this: T,
+    this: T
   ): ReadShape<SchemaBase<AbstractInstanceType<T>>> {
     const self = this;
     const getUrl = (params: Readonly<object>) => {
@@ -229,7 +232,7 @@ export default abstract class Resource {
 
   /** Shape to get a list of entities */
   static listRequest<T extends typeof Resource>(
-    this: T,
+    this: T
   ): ReadShape<SchemaArray<AbstractInstanceType<T>>> {
     const self = this;
     const getUrl = (params: Readonly<Record<string, string>>) => {
@@ -251,7 +254,7 @@ export default abstract class Resource {
   }
   /** Shape to create a new entity (post) */
   static createRequest<T extends typeof Resource>(
-    this: T,
+    this: T
   ): MutateShape<
     SchemaBase<AbstractInstanceType<T>>,
     Readonly<object>,
@@ -273,7 +276,7 @@ export default abstract class Resource {
   }
   /** Shape to update an existing entity (put) */
   static updateRequest<T extends typeof Resource>(
-    this: T,
+    this: T
   ): MutateShape<
     SchemaBase<AbstractInstanceType<T>>,
     Readonly<object>,
@@ -295,7 +298,7 @@ export default abstract class Resource {
   }
   /** Shape to update a subset of fields of an existing entity (patch) */
   static partialUpdateRequest<T extends typeof Resource>(
-    this: T,
+    this: T
   ): MutateShape<
     SchemaBase<AbstractInstanceType<T>>,
     Readonly<object>,
@@ -317,7 +320,7 @@ export default abstract class Resource {
   }
   /** Shape to delete an entity (delete) */
   static deleteRequest<T extends typeof Resource>(
-    this: T,
+    this: T
   ): DeleteShape<schemas.Entity<AbstractInstanceType<T>>, Readonly<object>> {
     const self = this;
     const options = this.getRequestOptions();

--- a/src/resource/__tests__/__snapshots__/resource.ts.snap
+++ b/src/resource/__tests__/__snapshots__/resource.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Resource getEntitySchema() merging should match snapshot 1`] = `
+Object {
+  "entities": Object {
+    "http://test.com/article-cooler/": Object {
+      "3": CoolerArticleResource {
+        "author": "23",
+        "content": "whatever",
+        "id": 3,
+        "tags": Array [],
+        "title": "the next time",
+      },
+      "5": CoolerArticleResource {
+        "author": "23",
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+    },
+    "http://test.com/user/": Object {
+      "23": UserResource {
+        "email": "bob@bob.com",
+        "id": 23,
+        "isAdmin": false,
+        "username": "charles",
+      },
+    },
+  },
+  "result": Array [
+    "5",
+    "3",
+  ],
+}
+`;


### PR DESCRIPTION
Sometimes when nested resources (server-side join) the server will only include partial results in some of the cases. This will merge them so they get the most complete picture possible.

This is especially important to support graphql which regularly includes partial results.