### PR TITLE
[enhance] Weaken requirements for RestProvider 'manager' prop

### DIFF
--- a/src/react-integration/provider/index.tsx
+++ b/src/react-integration/provider/index.tsx
@@ -2,11 +2,13 @@ import React, { ReactNode, useEffect } from 'react';
 import { StateContext, DispatchContext } from '../context';
 import masterReducer, { initialState } from '../../state/reducer';
 import NetworkManager from '../../state/NetworkManager';
+import { INetworkManager } from '../../types';
 import createEnhancedReducerHook from './middleware';
+
 
 interface ProviderProps {
   children: ReactNode;
-  manager?: NetworkManager;
+  manager?: INetworkManager;
 }
 /** Controller managing state of the REST cache and coordinating network requests. */
 export default function RestProvider({

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,3 +71,8 @@ dispatch: React.Dispatch<React.ReducerAction<R>>;
 }) => (
   next: React.Dispatch<React.ReducerAction<R>>,
 ) => (action: React.ReducerAction<R>) => void;
+
+export interface INetworkManager {
+  cleanup(): void;
+  getMiddleware(): Middleware;
+}


### PR DESCRIPTION
The NetworkManager interface currently exposes its constructor signature, which is not a requirement for consumption in RestProvider. Therefore, providing an interface with much weaker definition could help in allowing fully custom NetworkManager plugins.