### PR TITLE
[feature] Add optional redux integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For the small price of 7kb gziped. &nbsp;&nbsp; [🏁Get started now](docs/getti
 - [x] 🌳 Tree-shakable (only use what you need)
 - [x] 🔁 Subscriptions
 - [ ] 🚯 Pluggable garbage collection policy
-- [ ] ♻️ Optional [redux](https://redux.js.org/) integration
+- [x] ♻️ Optional [redux](https://redux.js.org/) integration
 - [ ] 📙 [Storybook](https://storybook.js.org/) mocking
 
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ For the small price of 7kb gziped. &nbsp;&nbsp; [🏁Get started now](docs/getti
 - [x] 💥 Tiny bundle footprint
 - [x] 🛑 Automatic overfetching elimination
 - [x] ✨ Optimistic updates
-- [x] 🧘 Flexible to fit any API design (one size fits all)
+- [x] 🧘 [Flexible](docs/api/RequestShape.md) to fit any API design (one size fits all)
 - [x] 🌳 Tree-shakable (only use what you need)
-- [x] 🔁 Subscriptions
+- [x] 🔁 [Subscriptions](docs/api/useSubscription.md)
+- [x] ♻️ Optional [redux](https://redux.js.org/) [integration](docs/guides/redux.md)
 - [ ] 🚯 Pluggable garbage collection policy
-- [x] ♻️ Optional [redux](https://redux.js.org/) integration
 - [ ] 📙 [Storybook](https://storybook.js.org/) mocking
 
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@
 ## Soon
 
 - [ ] Optimistic query update on create
-- [ ] Optional redux-integration
+- [x] Optional redux-integration
 - [x] Polling based subscriptions
 - [ ] Automatic batching
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
   - [useRetrieve](api/useRetrieve.md)
 - Components:
   - [RestProvider](api/RestProvider.md)
+  - [ExternalCacheProvider](api/ExternalCacheProvider.md)
   - [NetworkErrorBoundary](api/NetworkErrorBoundary.md)
 
 ## 🎎 Patterns & Examples
@@ -27,6 +28,7 @@
   - [Pagination](guides/pagination.md)
   - [Understanding Immutability](guides/immutability.md)
   - [Mocking unfinished endpoints](guides/mocking-unfinished.md)
+  - [Redux integration](guides/redux.md)
 - 🖧 Defining your network interface
   - [Defining your Resource types](guides/resource-types.md)
   - [Computed properties](guides/computed-properties.md)

--- a/docs/api/ExternalCacheProvider.md
+++ b/docs/api/ExternalCacheProvider.md
@@ -1,0 +1,44 @@
+# \<ExternalCacheProvider />
+
+Integrates external stores with `rest-hooks`. Should be placed as high as possible
+in application tree as any usage of the hooks is only possible for components below the provider
+in the React tree.
+
+**Is a replacement for \<RestProvider /> - do _NOT_ use both at once**
+
+`index.tsx`
+
+```tsx
+import { ExternalCacheProvider } from 'rest-hooks';
+import ReactDOM from 'react-dom';
+
+import store from './store';
+
+ReactDOM.render(
+  <ExternalCacheProvider store={store} selector={s => s}>
+    <App />
+  </ExternalCacheProvider>,
+  document.body,
+);
+```
+
+See [redux example](../guides/redux.md) for a more complete example.
+
+## store
+
+```typescript
+interface Store<S> {
+  subscribe(listener: () => void): () => void;
+  dispatch: React.Dispatch<ActionTypes>;
+  getState(): S;
+}
+```
+
+Store simply needs to conform to this interface. A common implementation is a [redux store](https://redux.js.org/api/store),
+but theoretically any external store could be used.
+
+[Read more about integrating redux.](../guides/redux.md)
+
+## selector: (state: Object) => State<unknown>
+
+This function is used to retrieve the `rest-hooks` specific part of the store's state tree.

--- a/docs/guides/redux.md
+++ b/docs/guides/redux.md
@@ -1,0 +1,87 @@
+# Redux integration
+
+Using redux is completely optional. However, for many it means easy integration or migration
+with existing projects, or just a nice centralized state management abstraction.
+
+Integration is fairly straightforward as rest-hooks already uses the same paradigms as redux under
+the hood. However, care should be taken to integrate the reducer and middlewares properly
+or it won't work as expected.
+
+First make sure you have redux installed:
+
+`yarn add redux`
+
+Note: react-redux is _not_ needed for this integration (though you can use it if you want).
+
+Then you'll want to use the [\<ExternalCacheProvider />](../ExternalCacheProvider.md) instead of [\<RestProvider />](../RestProvider.md) and pass in
+the store and a selector function to grab the rest-hooks specific part of the state.
+
+Note: You should only use ONE provider; using
+
+`index.tsx`
+
+```tsx
+import {
+  reducer,
+  NeworkManager,
+  SubscriptionManager,
+  PollingSubscription,
+  ExternalCacheProvider,
+} from 'rest-hooks';
+import { createStore } from 'redux';
+import ReactDOM from 'react-dom';
+
+const manager = new NetworkManager();
+const subscriptionManager = new SubscriptionManager(PollingSubscription);
+
+const store = createStore(
+  reducer,
+  applyMiddleware(manager.getMiddleware(), subscriptionManager.getMiddleware()),
+);
+
+ReactDOM.render(
+  <ExternalCacheProvider store={store} selector={s => s}>
+    <App />
+  </ExternalCacheProvider>,
+  document.body,
+);
+```
+
+Above we have the simplest case where the entire redux store is used for rest-hooks.
+However, more commonly you will be integrating with other state. In this case, you
+will need to use the `selector` prop of `<ExternalCacheProvider />` to specify
+where in the state tree the rest-hooks information is.
+
+```tsx
+import {
+  reducer as restReducer,
+  NeworkManager,
+  SubscriptionManager,
+  PollingSubscription,
+  ExternalCacheProvider,
+} from 'rest-hooks';
+import { createStore, combineReducers } from 'redux';
+import ReactDOM from 'react-dom';
+
+const manager = new NetworkManager();
+const subscriptionManager = new SubscriptionManager(PollingSubscription);
+
+const store = createStore(
+  // Now we have other reducers
+  combineReducers({
+    restHooks: restReducer,
+    myOtherState: otherReducer,
+  }),
+  applyMiddleware(manager.getMiddleware(), subscriptionManager.getMiddleware()),
+);
+
+ReactDOM.render(
+  // Our selector gets the part of the tree rest-hooks cares about.
+  <ExternalCacheProvider store={store} selector={s => s.restHooks}>
+    <App />
+  </ExternalCacheProvider>,
+  document.body,
+);
+```
+
+Here we store rest-hooks state information in the 'restHooks' part of the tree.

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
     '^.+\\.jsx?$': 'babel-jest',
   },
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+  coveragePathIgnorePatterns: ['test'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
-  setupFiles: ['./testSetup.js']
+  setupFiles: ['./testSetup.js'],
 };

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "react-dom": "16.8.6",
     "react-hooks-testing-library": "^0.4.1",
     "react-testing-library": "^6.1.2",
+    "redux": "^4.0.1",
     "rollup": "^1.10.0",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "fetch",
     "data fetching",
     "api",
-    "typescript"
+    "typescript",
+    "redux"
   ],
   "author": "Nathaniel Tucker <me@ntucker.me> (https://github.com/ntucker)",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   schemas,
 } from './resource';
 import NetworkManager from './state/NetworkManager';
+import reducer from './state/reducer';
 import {
   useCache,
   useFetcher,
@@ -22,6 +23,7 @@ import {
   useError,
   useSelectionUnstable,
   RestProvider,
+  ExternalCacheProvider,
   NetworkErrorBoundary,
   NetworkError,
 } from './react-integration';
@@ -62,6 +64,7 @@ export type Request = RequestType;
 export {
   Resource,
   RestProvider,
+  ExternalCacheProvider,
   useCache,
   useFetcher,
   useRetrieve,
@@ -72,6 +75,7 @@ export {
   useError,
   useSelectionUnstable,
   NetworkManager,
+  reducer,
   NetworkErrorBoundary,
   schemas,
 };

--- a/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
+++ b/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
@@ -48,7 +48,7 @@ Object {
     "options": undefined,
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "rpc",
+    "responseType": "rest-hooks/rpc",
     "schema": EntitySchema {
       "_getId": [Function],
       "_idAttribute": [Function],
@@ -62,7 +62,7 @@ Object {
     "url": "http://test.com/article-cooler/",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;
 
@@ -72,7 +72,7 @@ Object {
     "options": undefined,
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "rpc",
+    "responseType": "rest-hooks/rpc",
     "schema": EntitySchema {
       "_getId": [Function],
       "_idAttribute": [Function],
@@ -86,7 +86,7 @@ Object {
     "url": "http://test.com/article-cooler/1",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;
 
@@ -96,7 +96,7 @@ Object {
     "options": undefined,
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "rpc",
+    "responseType": "rest-hooks/rpc",
     "schema": EntitySchema {
       "_getId": [Function],
       "_idAttribute": [Function],
@@ -110,7 +110,7 @@ Object {
     "url": "http://test.com/article-cooler/1",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;
 
@@ -120,7 +120,7 @@ Object {
     "options": undefined,
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "receive",
+    "responseType": "rest-hooks/receive",
     "schema": EntitySchema {
       "_getId": [Function],
       "_idAttribute": [Function],
@@ -134,7 +134,7 @@ Object {
     "url": "http://test.com/article-cooler/5",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;
 
@@ -144,7 +144,7 @@ Object {
     "options": undefined,
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "receive",
+    "responseType": "rest-hooks/receive",
     "schema": EntitySchema {
       "_getId": [Function],
       "_idAttribute": [Function],
@@ -158,7 +158,7 @@ Object {
     "url": "http://test.com/article-cooler/5",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;
 
@@ -168,7 +168,7 @@ Object {
     "options": undefined,
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "receive",
+    "responseType": "rest-hooks/receive",
     "schema": Array [
       EntitySchema {
         "_getId": [Function],
@@ -184,7 +184,7 @@ Object {
     "url": "http://test.com/user/",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;
 
@@ -194,7 +194,7 @@ Object {
     "options": undefined,
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "receive",
+    "responseType": "rest-hooks/receive",
     "schema": EntitySchema {
       "_getId": [Function],
       "_idAttribute": [Function],
@@ -208,7 +208,7 @@ Object {
     "url": "http://test.com/article-cooler/5",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;
 
@@ -220,7 +220,7 @@ Object {
     },
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "receive",
+    "responseType": "rest-hooks/receive",
     "schema": EntitySchema {
       "_getId": [Function],
       "_idAttribute": [Function],
@@ -234,7 +234,7 @@ Object {
     "url": "http://test.com/article-static/5",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;
 
@@ -247,7 +247,7 @@ Object {
     },
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "receive",
+    "responseType": "rest-hooks/receive",
     "schema": EntitySchema {
       "_getId": [Function],
       "_idAttribute": [Function],
@@ -261,7 +261,7 @@ Object {
     "url": "http://test.com/article-static/5",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;
 
@@ -273,7 +273,7 @@ Object {
     },
     "reject": [Function],
     "resolve": [Function],
-    "responseType": "receive",
+    "responseType": "rest-hooks/receive",
     "schema": EntitySchema {
       "_getId": [Function],
       "_idAttribute": [Function],
@@ -287,6 +287,6 @@ Object {
     "url": "http://test.com/article-static/5",
   },
   "payload": [Function],
-  "type": "fetch",
+  "type": "rest-hooks/fetch",
 }
 `;

--- a/src/react-integration/__tests__/integration.tsx
+++ b/src/react-integration/__tests__/integration.tsx
@@ -1,202 +1,164 @@
-import React, { Suspense } from 'react';
-import { render } from 'react-testing-library';
-import { cleanup, renderHook, act } from 'react-hooks-testing-library';
+import React from 'react';
+import { cleanup } from 'react-hooks-testing-library';
 import nock from 'nock';
 
 import { CoolerArticleResource, UserResource } from '../../__tests__/common';
 import { useResource, useFetcher } from '../hooks';
-import RestProvider from '../provider';
-import NetworkManager from '../../state/NetworkManager';
-import { FetchAction, ReceiveAction } from '../../types';
-
-class MockNetworkManager extends NetworkManager {
-  handleFetch(action: FetchAction, dispatch: React.Dispatch<any>) {
-    const mockDispatch: typeof dispatch = (v: any) => {
-      act(() => {
-        dispatch(v);
-      });
-    };
-    return super.handleFetch(action, mockDispatch);
-  }
-  handleReceive(action: ReceiveAction) {
-    act(() => {
-      super.handleReceive(action);
-    });
-  }
-}
+import createRenderRestHook from '../../test/helper';
+import {
+  makeRestProvider,
+  makeExternalCacheProvider,
+} from '../../test/providers';
 
 afterEach(() => {
   cleanup();
 });
 
-describe('<RestProvider />', () => {
-  const payload = {
-    id: 5,
-    title: 'hi ho',
-    content: 'whatever',
-    tags: ['a', 'best', 'react'],
-  };
-  const users = [
-    {
-      id: 23,
-      username: 'bob',
-      email: 'bob@bob.com',
-      isAdmin: false,
-    },
-    {
-      id: 7342,
-      username: 'lindsey',
-      email: 'lindsey@bob.com',
-      isAdmin: true,
-    },
-  ];
-  const nested = [
-    {
+for (const makeProvider of [makeRestProvider, makeExternalCacheProvider]) {
+  describe(`${makeProvider.name} => <Provider />`, () => {
+    const payload = {
       id: 5,
       title: 'hi ho',
       content: 'whatever',
       tags: ['a', 'best', 'react'],
-      author: {
+    };
+    const users = [
+      {
         id: 23,
         username: 'bob',
-      },
-    },
-    {
-      id: 3,
-      title: 'the next time',
-      content: 'whatever',
-      author: {
-        id: 23,
-        username: 'charles',
         email: 'bob@bob.com',
+        isAdmin: false,
       },
-    },
-  ];
+      {
+        id: 7342,
+        username: 'lindsey',
+        email: 'lindsey@bob.com',
+        isAdmin: true,
+      },
+    ];
+    const nested = [
+      {
+        id: 5,
+        title: 'hi ho',
+        content: 'whatever',
+        tags: ['a', 'best', 'react'],
+        author: {
+          id: 23,
+          username: 'bob',
+        },
+      },
+      {
+        id: 3,
+        title: 'the next time',
+        content: 'whatever',
+        author: {
+          id: 23,
+          username: 'charles',
+          email: 'bob@bob.com',
+        },
+      },
+    ];
+    // TODO: add nested resource test case that has multiple partials to test merge functionality
 
-  // TODO: add nested resource test case that has multiple partials to test merge functionality
-  let manager: NetworkManager;
-  function testProvider<T>(callback: () => T) {
-    return renderHook(callback, {
-      wrapper: ({ children }) => (
-        <RestProvider manager={manager}>
-          <Suspense fallback={() => null}>{children}</Suspense>
-        </RestProvider>
-      ),
-    });
-  }
+    let renderRestHook: ReturnType<typeof createRenderRestHook>;
 
-  function onError(e: any) {
-    e.preventDefault();
-  }
-  beforeEach(() => {
-    window.addEventListener('error', onError);
-  });
-  afterEach(() => {
-    window.removeEventListener('error', onError);
-  });
-
-  beforeEach(() => {
-    nock('http://test.com')
-      .get(`/article-cooler/${payload.id}`)
-      .reply(200, payload);
-    nock('http://test.com')
-      .delete(`/article-cooler/${payload.id}`)
-      .reply(200, {});
-    nock('http://test.com')
-      .get(`/article-cooler/0`)
-      .reply(403, {});
-    nock('http://test.com')
-      .get(`/article-cooler/`)
-      .reply(200, nested);
-    nock('http://test.com')
-      .get(`/user/`)
-      .reply(200, users);
-    manager = new MockNetworkManager();
-  });
-  afterEach(() => {
-    manager.cleanup();
-  });
-  it('should mount/umount happily', async () => {
-    function Component() {
-      return <>hi</>;
+    function onError(e: any) {
+      e.preventDefault();
     }
-    const tree = (
-      <RestProvider manager={manager}>
-        <Suspense fallback={null}>
-          <Component />
-        </Suspense>
-      </RestProvider>
-    );
-    const { getByText, unmount } = render(tree);
-    const hi = getByText('hi');
-    expect(hi).toBeDefined();
-    unmount();
-  });
-
-  it('should resolve useResource()', async () => {
-    const { result, waitForNextUpdate } = testProvider(() => {
-      return useResource(CoolerArticleResource.singleRequest(), payload);
+    beforeEach(() => {
+      window.addEventListener('error', onError);
     });
-    expect(result.current).toBe(null);
-    await waitForNextUpdate();
-    expect(result.current instanceof CoolerArticleResource).toBe(true);
-    expect(result.current.title).toBe(payload.title);
-  });
-
-  it('should throw 404 once deleted', async () => {
-    let del: any;
-    const { result, waitForNextUpdate } = testProvider(() => {
-      del = useFetcher(CoolerArticleResource.deleteRequest());
-      return useResource(CoolerArticleResource.singleRequest(), payload);
+    afterEach(() => {
+      window.removeEventListener('error', onError);
     });
-    expect(result.current).toBe(null);
-    await waitForNextUpdate();
-    expect(result.current instanceof CoolerArticleResource).toBe(true);
-    expect(result.current.title).toBe(payload.title);
 
-    await del({}, payload);
-    expect(result.error).toBeDefined();
-    expect((result.error as any).status).toBe(404);
-  });
-  it('useResource() should throw errors on bad network', async () => {
-    const { result, waitForNextUpdate } = testProvider(() => {
-      return useResource(CoolerArticleResource.singleRequest(), {
-        title: '0',
+    beforeEach(() => {
+      nock('http://test.com')
+        .get(`/article-cooler/${payload.id}`)
+        .reply(200, payload);
+      nock('http://test.com')
+        .delete(`/article-cooler/${payload.id}`)
+        .reply(200, {});
+      nock('http://test.com')
+        .get(`/article-cooler/0`)
+        .reply(403, {});
+      nock('http://test.com')
+        .get(`/article-cooler/`)
+        .reply(200, nested);
+      nock('http://test.com')
+        .get(`/user/`)
+        .reply(200, users);
+      renderRestHook = createRenderRestHook(makeProvider);
+    });
+    afterEach(() => {
+      renderRestHook.cleanup();
+    });
+
+    it('should resolve useResource()', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useResource(CoolerArticleResource.singleRequest(), payload);
       });
+      expect(result.current).toBe(null);
+      await waitForNextUpdate();
+      expect(result.current instanceof CoolerArticleResource).toBe(true);
+      expect(result.current.title).toBe(payload.title);
     });
-    expect(result.current).toBe(null);
-    await waitForNextUpdate();
-    expect(result.error).toBeDefined();
-    expect((result.error as any).status).toBe(403);
-  });
-  it('should resolve parallel useResource() request', async () => {
-    const { result, waitForNextUpdate } = testProvider(() => {
-      return useResource(
-        [
-          CoolerArticleResource.singleRequest(),
-          {
-            id: payload.id,
-          },
-        ],
-        [UserResource.listRequest(), {}],
-      );
+
+    it('should throw 404 once deleted', async () => {
+      let del: any;
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        del = useFetcher(CoolerArticleResource.deleteRequest());
+        return useResource(CoolerArticleResource.singleRequest(), payload);
+      });
+      expect(result.current).toBe(null);
+      await waitForNextUpdate();
+      expect(result.current instanceof CoolerArticleResource).toBe(true);
+      expect(result.current.title).toBe(payload.title);
+
+      await del({}, payload);
+      expect(result.error).toBeDefined();
+      expect((result.error as any).status).toBe(404);
     });
-    expect(result.current).toBe(null);
-    await waitForNextUpdate();
-    const [article, users] = result.current;
-    expect(article instanceof CoolerArticleResource).toBe(true);
-    expect(article.title).toBe(payload.title);
-    expect(users).toBeDefined();
-    expect(users.length).toBeTruthy();
-    expect(users[0] instanceof UserResource).toBe(true);
-  });
-  it('should not suspend with no params to useResource()', async () => {
-    let article: any;
-    const { result, waitForNextUpdate } = testProvider(() => {
-      article = useResource(CoolerArticleResource.singleRequest(), null);
-      return 'done';
+    it('useResource() should throw errors on bad network', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useResource(CoolerArticleResource.singleRequest(), {
+          title: '0',
+        });
+      });
+      expect(result.current).toBe(null);
+      await waitForNextUpdate();
+      expect(result.error).toBeDefined();
+      expect((result.error as any).status).toBe(403);
     });
-    expect(result.current).toBe('done');
-    expect(article).toBeNull();
+    it('should resolve parallel useResource() request', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useResource(
+          [
+            CoolerArticleResource.singleRequest(),
+            {
+              id: payload.id,
+            },
+          ],
+          [UserResource.listRequest(), {}],
+        );
+      });
+      expect(result.current).toBe(null);
+      await waitForNextUpdate();
+      const [article, users] = result.current;
+      expect(article instanceof CoolerArticleResource).toBe(true);
+      expect(article.title).toBe(payload.title);
+      expect(users).toBeDefined();
+      expect(users.length).toBeTruthy();
+      expect(users[0] instanceof UserResource).toBe(true);
+    });
+    it('should not suspend with no params to useResource()', async () => {
+      let article: any;
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        article = useResource(CoolerArticleResource.singleRequest(), null);
+        return 'done';
+      });
+      expect(result.current).toBe('done');
+      expect(article).toBeNull();
+    });
   });
-});
+}

--- a/src/react-integration/__tests__/subscriptions.tsx
+++ b/src/react-integration/__tests__/subscriptions.tsx
@@ -3,110 +3,72 @@ import { cleanup, renderHook, act } from 'react-hooks-testing-library';
 
 import nock from 'nock';
 
-import {
-  PollingArticleResource,
-} from '../../__tests__/common';
+import { PollingArticleResource } from '../../__tests__/common';
 import { useSubscription, useCache } from '../hooks';
-import RestProvider from '../provider';
-import NetworkManager from '../../state/NetworkManager';
-import SubscriptionManager from '../../state/SubscriptionManager';
-import PollingSubscription from '../../state/PollingSubscription';
-import { FetchAction, ReceiveAction } from '../../types';
-
-class MockNetworkManager extends NetworkManager {
-  handleFetch(action: FetchAction, dispatch: React.Dispatch<any>) {
-    const mockDispatch: typeof dispatch = (v: any) => {
-      act(() => {
-        dispatch(v);
-      });
-    };
-    return super.handleFetch(action, mockDispatch);
-  }
-  handleReceive(action: ReceiveAction) {
-    act(() => {
-      super.handleReceive(action);
-    });
-  }
-}
-class MockPollingSubscription extends PollingSubscription {
-  update() {
-    act(() => {
-      super.update();
-    });
-  }
-}
+import createRenderRestHook from '../../test/helper';
+import {
+  makeRestProvider,
+  makeExternalCacheProvider,
+} from '../../test/providers';
 
 afterEach(cleanup);
 
-describe('<RestProvider /> with subscriptions', () => {
-  const articlePayload = {
-    id: 5,
-    title: 'hi ho',
-    content: 'whatever',
-    tags: ['a', 'best', 'react'],
-  };
+for (const makeProvider of [makeRestProvider, makeExternalCacheProvider]) {
+  describe(`${makeProvider.name} with subscriptions`, () => {
+    const articlePayload = {
+      id: 5,
+      title: 'hi ho',
+      content: 'whatever',
+      tags: ['a', 'best', 'react'],
+    };
+    let renderRestHook: ReturnType<typeof createRenderRestHook>;
 
-  // TODO: add nested resource test case that has multiple partials to test merge functionality
-  let manager: NetworkManager;
-  let subManager: SubscriptionManager<typeof MockPollingSubscription>;
-  function testProvider<T>(callback: () => T) {
-    return renderHook(callback, {
-      wrapper: ({ children }) => (
-        <RestProvider manager={manager} subscriptionManager={subManager}>
-          <Suspense fallback={() => null}>{children}</Suspense>
-        </RestProvider>
-      ),
+    function onError(e: any) {
+      e.preventDefault();
+    }
+    beforeEach(() => {
+      window.addEventListener('error', onError);
     });
-  }
+    afterEach(() => {
+      window.removeEventListener('error', onError);
+    });
 
-  function onError(e: any) {
-    e.preventDefault();
-  }
-  beforeEach(() => {
-    window.addEventListener('error', onError);
-  });
-  afterEach(() => {
-    window.removeEventListener('error', onError);
-  });
+    beforeEach(() => {
+      nock('http://test.com')
+        .get(`/article/${articlePayload.id}`)
+        .reply(200, articlePayload);
+      renderRestHook = createRenderRestHook(makeProvider);
+    });
+    afterEach(() => {
+      renderRestHook.cleanup();
+    });
 
-  beforeEach(() => {
-    nock('http://test.com')
-      .get(`/article/${articlePayload.id}`)
-      .reply(200, articlePayload);
-    manager = new MockNetworkManager();
-    subManager = new SubscriptionManager(MockPollingSubscription);
-  });
-  afterEach(() => {
-    manager.cleanup();
-    subManager.cleanup();
-  });
+    it('useSubscription() + useCache()', async () => {
+      jest.useFakeTimers();
+      const frequency: number = (PollingArticleResource.singleRequest()
+        .options as any).pollFrequency;
 
-  it('useSubscription() + useCache()', async () => {
-    jest.useFakeTimers();
-    const frequency: number = (PollingArticleResource.singleRequest()
-      .options as any).pollFrequency;
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        useSubscription(PollingArticleResource.singleRequest(), articlePayload);
+        return useCache(PollingArticleResource.singleRequest(), articlePayload);
+      });
 
-    const { result, waitForNextUpdate } = testProvider(() => {
-      useSubscription(PollingArticleResource.singleRequest(), articlePayload);
-      return useCache(
-        PollingArticleResource.singleRequest(),
-        articlePayload,
+      // should be null to start
+      expect(result.current).toBeNull();
+      // should be defined after frequency milliseconds
+      jest.advanceTimersByTime(frequency);
+      await waitForNextUpdate();
+      expect(result.current).toBeInstanceOf(PollingArticleResource);
+      expect(result.current).toEqual(
+        PollingArticleResource.fromJS(articlePayload),
       );
+      // should update again after frequency
+      nock('http://test.com')
+        .get(`/article/${articlePayload.id}`)
+        .reply(200, { ...articlePayload, title: 'fiver' });
+      jest.advanceTimersByTime(frequency);
+      await waitForNextUpdate();
+      expect((result.current as any).title).toBe('fiver');
     });
-
-    // should be null to start
-    expect(result.current).toBeNull();
-    // should be defined after frequency milliseconds
-    jest.advanceTimersByTime(frequency);
-    await waitForNextUpdate();
-    expect(result.current).toBeInstanceOf(PollingArticleResource);
-    expect(result.current).toEqual(PollingArticleResource.fromJS(articlePayload));
-    // should update again after frequency
-    nock('http://test.com')
-      .get(`/article/${articlePayload.id}`)
-      .reply(200, { ...articlePayload, title: 'fiver' });
-    jest.advanceTimersByTime(frequency);
-    await waitForNextUpdate();
-    expect((result.current as any).title).toBe('fiver');
   });
-});
+}

--- a/src/react-integration/hooks/useFetcher.ts
+++ b/src/react-integration/hooks/useFetcher.ts
@@ -5,11 +5,11 @@ import { DispatchContext } from '../context';
 
 const SHAPE_TYPE_TO_RESPONSE_TYPE: Record<
   RequestShape<any, any, any>['type'],
-  'receive' | 'rpc' | 'purge'
+  'rest-hooks/receive' | 'rest-hooks/rpc' | 'rest-hooks/purge'
 > = {
-  read: 'receive',
-  mutate: 'rpc',
-  delete: 'purge',
+  read: 'rest-hooks/receive',
+  mutate: 'rest-hooks/rpc',
+  delete: 'rest-hooks/purge',
 };
 
 /** Build an imperative dispatcher to issue network requests. */
@@ -36,7 +36,7 @@ export default function useFetcher<
       });
 
       dispatch({
-        type: 'fetch',
+        type: 'rest-hooks/fetch',
         payload: () => fetch(url, body),
         meta: {
           schema,

--- a/src/react-integration/hooks/useSubscription.ts
+++ b/src/react-integration/hooks/useSubscription.ts
@@ -15,7 +15,7 @@ export default function useSubscription<
 
   useEffect(() => {
     dispatch({
-      type: 'subscribe',
+      type: 'rest-hooks/subscribe',
       meta: {
         schema,
         fetch: () => fetch(url, body as Body),
@@ -25,7 +25,7 @@ export default function useSubscription<
     });
     return () => {
       dispatch({
-        type: 'unsubscribe',
+        type: 'rest-hooks/unsubscribe',
         meta: {
           url,
           frequency: options && options.pollFrequency,

--- a/src/react-integration/index.ts
+++ b/src/react-integration/index.ts
@@ -9,7 +9,7 @@ import {
   useError,
   useSelectionUnstable,
 } from './hooks';
-import RestProvider from './provider';
+import { RestProvider, ExternalCacheProvider } from './provider';
 import NetworkErrorBoundary, { NetworkError } from './NetworkErrorBoundary';
 
 export type NetworkError = NetworkError;
@@ -24,5 +24,6 @@ export {
   useError,
   useSelectionUnstable,
   RestProvider,
+  ExternalCacheProvider,
   NetworkErrorBoundary,
 };

--- a/src/react-integration/provider/ExternalCacheProvider.tsx
+++ b/src/react-integration/provider/ExternalCacheProvider.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode, useEffect, useState } from 'react';
+import { StateContext, DispatchContext } from '../context';
+import { State } from '../../types';
+import { ActionTypes } from 'types';
+
+
+interface Store<S> {
+  subscribe(listener: () => void): () => void;
+  dispatch: React.Dispatch<ActionTypes>;
+  getState(): S;
+}
+interface Props<S> {
+  children: ReactNode;
+  store: Store<S>;
+  selector: (state: S) => State<unknown>;
+}
+
+export default function ExternalCacheProvider<S>({
+  children,
+  store,
+  selector,
+}: Props<S>) {
+  // TODO: Does this short-circuit if state === prevState? if not we should useReducer()
+  const [state, setState] = useState(() => selector(store.getState()));
+  useEffect(() => {
+    const unsubscribe = store.subscribe(() => {
+      setState(selector(store.getState()));
+    });
+    return unsubscribe;
+  }, [store]);
+  return (
+    <DispatchContext.Provider value={store.dispatch}>
+      <StateContext.Provider value={state}>{children}</StateContext.Provider>
+    </DispatchContext.Provider>
+  );
+}

--- a/src/react-integration/provider/RestProvider.tsx
+++ b/src/react-integration/provider/RestProvider.tsx
@@ -14,9 +14,6 @@ interface ProviderProps {
   manager?: NetworkManager;
   subscriptionManager?: SubscriptionManager<any>;
   initialState?: State<unknown>;
-  store?: {
-    state: State<unknown>;
-  };
 }
 /** Controller managing state of the REST cache and coordinating network requests. */
 export default function RestProvider({
@@ -24,7 +21,6 @@ export default function RestProvider({
   manager = new NetworkManager(),
   subscriptionManager = new SubscriptionManager(PollingSubscription),
   initialState = defaultState,
-  store,
 }: ProviderProps) {
   // TODO: option to use redux
   const useEnhancedReducer = createEnhancedReducerHook(
@@ -32,9 +28,6 @@ export default function RestProvider({
     subscriptionManager.getMiddleware(),
   );
   const [state, dispatch] = useEnhancedReducer(masterReducer, initialState);
-  if (store) {
-    store.state = state;
-  }
 
   // if we change out the manager we need to make sure it has no hanging async
   useEffect(() => {

--- a/src/react-integration/provider/__tests__/provider.tsx
+++ b/src/react-integration/provider/__tests__/provider.tsx
@@ -55,7 +55,7 @@ describe('<RestProvider />', () => {
     expect(dispatch).toBeDefined();
     expect(state).toBeDefined();
     const action = {
-      type: 'receive',
+      type: 'rest-hooks/receive',
       payload: { id: 5, title: 'hi', content: 'more things here' },
       meta: {
         schema: CoolerArticleResource.getEntitySchema(),

--- a/src/react-integration/provider/__tests__/provider.tsx
+++ b/src/react-integration/provider/__tests__/provider.tsx
@@ -3,7 +3,7 @@ import { cleanup, act, render } from 'react-testing-library';
 
 import { DispatchContext, StateContext } from '../../context';
 import { CoolerArticleResource } from '../../../__tests__/common';
-import RestProvider from '..';
+import RestProvider from '../RestProvider';
 import NetworkManager from '../../../state/NetworkManager';
 
 afterEach(cleanup);

--- a/src/react-integration/provider/index.ts
+++ b/src/react-integration/provider/index.ts
@@ -1,0 +1,4 @@
+import RestProvider from './RestProvider';
+import ExternalCacheProvider from './ExternalCacheProvider';
+
+export { RestProvider, ExternalCacheProvider };

--- a/src/state/NetworkManager.ts
+++ b/src/state/NetworkManager.ts
@@ -41,7 +41,7 @@ export default class NetworkManager {
     delete this.fetched[url];
   }
 
-  /** Called when middleware intercepts 'fetch' action.
+  /** Called when middleware intercepts 'rest-hooks/fetch' action.
    *
    * Will then start a promise for a url and potentially start the network
    * fetch.
@@ -132,9 +132,9 @@ export default class NetworkManager {
 
   /** Attaches NetworkManager to store
    *
-   * Intercepts 'fetch' actions to start requests.
+   * Intercepts 'rest-hooks/fetch' actions to start requests.
    *
-   * Resolve/rejects a request when matching 'receive' event
+   * Resolve/rejects a request when matching 'rest-hooks/receive' event
    * is seen.
    */
   getMiddleware = memoize(function<T extends NetworkManager>(this: T) {
@@ -145,12 +145,12 @@ export default class NetworkManager {
         action: React.ReducerAction<R>,
       ) => {
         switch (action.type) {
-        case 'fetch':
+        case 'rest-hooks/fetch':
           this.handleFetch(action, dispatch);
           return;
-        case 'purge':
-        case 'rpc':
-        case 'receive':
+        case 'rest-hooks/purge':
+        case 'rest-hooks/rpc':
+        case 'rest-hooks/receive':
           if (action.meta.url in this.fetched) {
             this.handleReceive(action);
           }

--- a/src/state/PollingSubscription.ts
+++ b/src/state/PollingSubscription.ts
@@ -104,12 +104,12 @@ export default class PollingSubscription implements Subscription {
   /** Trigger request for latest resource */
   protected update() {
     this.dispatch({
-      type: 'fetch',
+      type: 'rest-hooks/fetch',
       payload: this.fetch,
       meta: {
         schema: this.schema,
         url: this.url,
-        responseType: 'receive',
+        responseType: 'rest-hooks/receive',
         throttle: true,
         options: {
           dataExpiryLength: this.frequency / 2,

--- a/src/state/SubscriptionManager.ts
+++ b/src/state/SubscriptionManager.ts
@@ -47,7 +47,7 @@ export default class SubscriptionManager<S extends SubscriptionConstructable> {
     }
   }
 
-  /** Called when middleware intercepts 'subscribe' action.
+  /** Called when middleware intercepts 'rest-hooks/subscribe' action.
    *
    */
   protected handleSubscribe(
@@ -70,7 +70,7 @@ export default class SubscriptionManager<S extends SubscriptionConstructable> {
     }
   }
 
-  /** Called when middleware intercepts 'unsubscribe' action.
+  /** Called when middleware intercepts 'rest-hooks/unsubscribe' action.
    *
    */
   protected handleUnsubscribe(
@@ -90,10 +90,10 @@ export default class SubscriptionManager<S extends SubscriptionConstructable> {
 
   /** Attaches Manager to store
    *
-   * Intercepts 'subscribe'/'unsubscribe' to register resources that
+   * Intercepts 'rest-hooks/subscribe'/'rest-hooks/unsubscribe' to register resources that
    * need to be kept up to date.
    *
-   * Will possibly dispatch 'fetch' or 'receive' to keep resources fresh
+   * Will possibly dispatch 'rest-hooks/fetch' or 'rest-hooks/receive' to keep resources fresh
    *
    */
   getMiddleware<T extends SubscriptionManager<S>>(this: T) {
@@ -104,10 +104,10 @@ export default class SubscriptionManager<S extends SubscriptionConstructable> {
         action: Actions,
       ) => {
         switch (action.type) {
-        case 'subscribe':
+        case 'rest-hooks/subscribe':
           this.handleSubscribe(action, dispatch);
           return;
-        case 'unsubscribe':
+        case 'rest-hooks/unsubscribe':
           this.handleUnsubscribe(action, dispatch);
           return;
         default:

--- a/src/state/__tests__/__snapshots__/pollingSubscription.ts.snap
+++ b/src/state/__tests__/__snapshots__/pollingSubscription.ts.snap
@@ -10,7 +10,7 @@ Array [
       },
       "reject": [Function],
       "resolve": [Function],
-      "responseType": "receive",
+      "responseType": "rest-hooks/receive",
       "schema": EntitySchema {
         "_getId": [Function],
         "_idAttribute": [Function],
@@ -24,7 +24,7 @@ Array [
       "url": "test.com",
     },
     "payload": [MockFunction],
-    "type": "fetch",
+    "type": "rest-hooks/fetch",
   },
 ]
 `;
@@ -39,7 +39,7 @@ Array [
       },
       "reject": [Function],
       "resolve": [Function],
-      "responseType": "receive",
+      "responseType": "rest-hooks/receive",
       "schema": EntitySchema {
         "_getId": [Function],
         "_idAttribute": [Function],
@@ -53,7 +53,7 @@ Array [
       "url": "test.com",
     },
     "payload": [MockFunction],
-    "type": "fetch",
+    "type": "rest-hooks/fetch",
   },
 ]
 `;

--- a/src/state/__tests__/networkManager.ts
+++ b/src/state/__tests__/networkManager.ts
@@ -33,24 +33,24 @@ describe('NetworkManager', () => {
   });
   describe('middleware', () => {
     const fetchResolveAction: FetchAction = {
-      type: 'fetch',
+      type: 'rest-hooks/fetch',
       payload: () => Promise.resolve({ id: 5, title: 'hi' }),
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.url({ id: 5 }),
-        responseType: 'receive',
+        responseType: 'rest-hooks/receive',
         throttle: false,
         reject: (v: any) => null,
         resolve: (v: any) => null,
       },
     };
     const fetchRejectAction: FetchAction = {
-      type: 'fetch',
+      type: 'rest-hooks/fetch',
       payload: () => Promise.reject(new Error('Failed')),
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.url({ id: 5 }),
-        responseType: 'receive',
+        responseType: 'rest-hooks/receive',
         throttle: false,
         reject: (v: any) => null,
         resolve: (v: any) => null,

--- a/src/state/__tests__/reducer.ts
+++ b/src/state/__tests__/reducer.ts
@@ -97,7 +97,7 @@ describe('reducer', () => {
   describe('singles', () => {
     const id = 20;
     const action: ReceiveAction = {
-      type: 'receive',
+      type: 'rest-hooks/receive',
       payload: { id, title: 'hi', content: 'this is the content' },
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -154,7 +154,7 @@ describe('reducer', () => {
     const id = 20;
     const payload = { id, title: 'hi', content: 'this is the content' };
     const action: RPCAction = {
-      type: 'rpc',
+      type: 'rest-hooks/rpc',
       payload,
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -172,7 +172,7 @@ describe('reducer', () => {
   it('purge should delete entities', () => {
     const id = 20;
     const action: PurgeAction = {
-      type: 'purge',
+      type: 'rest-hooks/purge',
       payload: {},
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -207,7 +207,7 @@ describe('reducer', () => {
     const id = 20;
     const error = new Error('hi');
     const action: ReceiveAction = {
-      type: 'receive',
+      type: 'rest-hooks/receive',
       payload: error,
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -229,7 +229,7 @@ describe('reducer', () => {
     const id = 20;
     const error = new Error('hi');
     const action: RPCAction = {
-      type: 'rpc',
+      type: 'rest-hooks/rpc',
       payload: error,
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -249,7 +249,7 @@ describe('reducer', () => {
     const id = 20;
     const error = new Error('hi');
     const action: PurgeAction = {
-      type: 'purge',
+      type: 'rest-hooks/purge',
       payload: error,
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -273,12 +273,12 @@ describe('reducer', () => {
   });
   it('other types should do nothing', () => {
     const action: FetchAction = {
-      type: 'fetch',
+      type: 'rest-hooks/fetch',
       payload: () => new Promise<any>(() => null),
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.url({ id: 5 }),
-        responseType: 'rpc',
+        responseType: 'rest-hooks/rpc',
         throttle: true,
         reject: (v: any) => null,
         resolve: (v: any) => null,

--- a/src/state/__tests__/subscriptionManager.ts
+++ b/src/state/__tests__/subscriptionManager.ts
@@ -49,7 +49,7 @@ describe('SubscriptionManager', () => {
         ? () => Promise.reject(new Error('Failed'))
         : () => Promise.resolve(payload);
       return {
-        type: 'subscribe',
+        type: 'rest-hooks/subscribe',
         meta: {
           schema: PollingArticleResource.getEntitySchema(),
           url: PollingArticleResource.url(payload),
@@ -60,7 +60,7 @@ describe('SubscriptionManager', () => {
     }
     function createUnsubscribeAction(payload: {}): UnsubscribeAction {
       return {
-        type: 'unsubscribe',
+        type: 'rest-hooks/unsubscribe',
         meta: {
           url: PollingArticleResource.url(payload),
           frequency: 1000,
@@ -143,7 +143,7 @@ describe('SubscriptionManager', () => {
     });
 
     it('should let other actions pass through', () => {
-      const action = { type: 'receive' };
+      const action = { type: 'rest-hooks/receive' };
       next.mockReset();
 
       middleware({ dispatch, getState })(next)(action as any);

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -31,7 +31,7 @@ export const resourceCustomizer = (a: any, b: any): any => {
 export default function reducer(state: State<unknown> | undefined, action: ActionTypes) {
   if (!state) state = initialState;
   switch (action.type) {
-  case 'receive':
+  case 'rest-hooks/receive':
     if (action.error) {
       return {
         ...state,
@@ -64,7 +64,7 @@ export default function reducer(state: State<unknown> | undefined, action: Actio
         },
       },
     };
-  case 'rpc':
+  case 'rest-hooks/rpc':
     if (action.error) return state;
     let { entities } = normalize(action.payload, action.meta.schema);
     return {
@@ -75,7 +75,7 @@ export default function reducer(state: State<unknown> | undefined, action: Actio
         resourceCustomizer,
       ),
     };
-  case 'purge':
+  case 'rest-hooks/purge':
     if (action.error) return state;
     const key = action.meta.schema.key;
     const pk = action.meta.url;

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -28,7 +28,8 @@ export const resourceCustomizer = (a: any, b: any): any => {
   // use default merging in lodash.merge()
 };
 
-export default function reducer(state: State<unknown>, action: ActionTypes) {
+export default function reducer(state: State<unknown> | undefined, action: ActionTypes) {
+  if (!state) state = initialState;
   switch (action.type) {
   case 'receive':
     if (action.error) {

--- a/src/test/helper.tsx
+++ b/src/test/helper.tsx
@@ -1,9 +1,10 @@
 import React, { Suspense } from 'react';
 import { renderHook } from 'react-hooks-testing-library';
 
-import { MockNetworkManager, MockPollingSubscription } from './managers';
+import { MockNetworkManager } from './managers';
 import NetworkManager from '../state/NetworkManager';
 import SubscriptionManager from '../state/SubscriptionManager';
+import PollingSubscription from '../state/PollingSubscription';
 
 export default function createRenderRestHook(
   makeProvider: (
@@ -12,7 +13,7 @@ export default function createRenderRestHook(
   ) => React.ComponentType<{ children: React.ReactChild }>,
 ) {
   const manager = new MockNetworkManager();
-  const subManager = new SubscriptionManager(MockPollingSubscription);
+  const subManager = new SubscriptionManager(PollingSubscription);
   const Provider = makeProvider(manager, subManager);
 
   function renderRestHook<T>(callback: () => T) {

--- a/src/test/helper.tsx
+++ b/src/test/helper.tsx
@@ -1,0 +1,32 @@
+import React, { Suspense } from 'react';
+import { renderHook } from 'react-hooks-testing-library';
+
+import { MockNetworkManager, MockPollingSubscription } from './managers';
+import NetworkManager from '../state/NetworkManager';
+import SubscriptionManager from '../state/SubscriptionManager';
+
+export default function createRenderRestHook(
+  makeProvider: (
+    manager: NetworkManager,
+    subManager: SubscriptionManager<any>,
+  ) => React.ComponentType<{ children: React.ReactChild }>,
+) {
+  const manager = new MockNetworkManager();
+  const subManager = new SubscriptionManager(MockPollingSubscription);
+  const Provider = makeProvider(manager, subManager);
+
+  function renderRestHook<T>(callback: () => T) {
+    return renderHook(callback, {
+      wrapper: ({ children }) => (
+        <Provider>
+          <Suspense fallback={() => null}>{children}</Suspense>
+        </Provider>
+      ),
+    });
+  }
+  renderRestHook.cleanup = () => {
+    manager.cleanup();
+    subManager.cleanup();
+  };
+  return renderRestHook;
+}

--- a/src/test/managers.ts
+++ b/src/test/managers.ts
@@ -1,8 +1,6 @@
 import { act } from 'react-hooks-testing-library';
 
 import NetworkManager from '../state/NetworkManager';
-import SubscriptionManager from '../state/SubscriptionManager';
-import PollingSubscription from '../state/PollingSubscription';
 import { FetchAction, ReceiveAction } from '../types';
 
 export class MockNetworkManager extends NetworkManager {
@@ -17,14 +15,6 @@ export class MockNetworkManager extends NetworkManager {
   handleReceive(action: ReceiveAction) {
     act(() => {
       super.handleReceive(action);
-    });
-  }
-}
-
-export class MockPollingSubscription extends PollingSubscription {
-  update() {
-    act(() => {
-      super.update();
     });
   }
 }

--- a/src/test/managers.ts
+++ b/src/test/managers.ts
@@ -1,0 +1,30 @@
+import { act } from 'react-hooks-testing-library';
+
+import NetworkManager from '../state/NetworkManager';
+import SubscriptionManager from '../state/SubscriptionManager';
+import PollingSubscription from '../state/PollingSubscription';
+import { FetchAction, ReceiveAction } from '../types';
+
+export class MockNetworkManager extends NetworkManager {
+  handleFetch(action: FetchAction, dispatch: React.Dispatch<any>) {
+    const mockDispatch: typeof dispatch = (v: any) => {
+      act(() => {
+        dispatch(v);
+      });
+    };
+    return super.handleFetch(action, mockDispatch);
+  }
+  handleReceive(action: ReceiveAction) {
+    act(() => {
+      super.handleReceive(action);
+    });
+  }
+}
+
+export class MockPollingSubscription extends PollingSubscription {
+  update() {
+    act(() => {
+      super.update();
+    });
+  }
+}

--- a/src/test/providers.tsx
+++ b/src/test/providers.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { createStore, applyMiddleware } from 'redux';
+import reducer from '../state/reducer';
+import NetworkManager from '../state/NetworkManager';
+import SubscriptionManager from '../state/SubscriptionManager';
+import ExternalCacheProvider from '../react-integration/provider/ExternalCacheProvider';
+import RestProvider from '../react-integration/provider/RestProvider';
+import { ReactNode } from 'react';
+
+const makeExternalCacheProvider = (
+  manager: NetworkManager,
+  subscriptionManager: SubscriptionManager<any>,
+) => {
+  const store = createStore(
+    reducer,
+    applyMiddleware(
+      manager.getMiddleware(),
+      subscriptionManager.getMiddleware(),
+    ),
+  );
+
+  return ({ children }: { children: ReactNode }) => (
+    <ExternalCacheProvider store={store} selector={s => s}>
+      {children}
+    </ExternalCacheProvider>
+  );
+};
+
+const makeRestProvider = (
+  manager: NetworkManager,
+  subscriptionManager: SubscriptionManager<any>,
+) => {
+  return ({ children }: { children: ReactNode }) => (
+    <RestProvider manager={manager} subscriptionManager={subscriptionManager}>
+      {children}
+    </RestProvider>
+  );
+};
+
+export { makeExternalCacheProvider, makeRestProvider };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  FSAAuto,
   FSAWithPayloadAndMeta,
   FSAWithMeta,
 } from 'flux-standard-action';
@@ -31,8 +30,9 @@ export interface RequestOptions {
   readonly pollFrequency?: number;
 }
 
+
 export interface ReceiveAction
-  extends FSAWithPayloadAndMeta<'receive', any, any> {
+  extends FSAWithPayloadAndMeta<'rest-hooks/receive', any, any> {
   meta: {
     schema: Schema;
     url: string;
@@ -40,13 +40,13 @@ export interface ReceiveAction
     expiresAt: number;
   };
 }
-export interface RPCAction extends FSAWithPayloadAndMeta<'rpc', any, any> {
+export interface RPCAction extends FSAWithPayloadAndMeta<'rest-hooks/rpc', any, any> {
   meta: {
     schema: Schema;
     url: string;
   };
 }
-export interface PurgeAction extends FSAWithPayloadAndMeta<'purge', any, any> {
+export interface PurgeAction extends FSAWithPayloadAndMeta<'rest-hooks/purge', any, any> {
   meta: {
     schema: schemas.Entity;
     url: string;
@@ -54,11 +54,11 @@ export interface PurgeAction extends FSAWithPayloadAndMeta<'purge', any, any> {
 }
 
 export interface FetchAction
-  extends FSAWithPayloadAndMeta<'fetch', () => Promise<any>, any> {
+  extends FSAWithPayloadAndMeta<'rest-hooks/fetch', () => Promise<any>, any> {
   meta: {
     schema?: Schema;
     url: string;
-    responseType: 'rpc' | 'receive' | 'purge';
+    responseType: 'rest-hooks/rpc' | 'rest-hooks/receive' | 'rest-hooks/purge';
     throttle: boolean;
     options?: RequestOptions;
     resolve: (value?: any | PromiseLike<any>) => void;
@@ -67,7 +67,7 @@ export interface FetchAction
 }
 
 export interface SubscribeAction
-  extends FSAWithMeta<'subscribe', undefined, any> {
+  extends FSAWithMeta<'rest-hooks/subscribe', undefined, any> {
   meta: {
     schema: Schema;
     fetch: () => Promise<any>;
@@ -77,7 +77,7 @@ export interface SubscribeAction
 }
 
 export interface UnsubscribeAction
-  extends FSAWithMeta<'unsubscribe', undefined, any> {
+  extends FSAWithMeta<'rest-hooks/unsubscribe', undefined, any> {
   meta: {
     url: string;
     frequency?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6576,6 +6576,14 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
+redux@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
+  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
+
 regenerate-unicode-properties@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.1.tgz#58a4a74e736380a7ab3c5f7e03f303a941b31289"
@@ -7441,6 +7449,11 @@ symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
   integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
This is tree-shakable so it won't increase bundle size at all if not uses. Could even be used only server-side to do SSR.

Added: `<ExternalCacheProvider />` as alternative to `<RestProvider />`. This enables external store as prop instead of store based on `useReducer()`.