### PR TITLE
[fix] useResource() with multiple args should throw errors when they …

### DIFF
--- a/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
+++ b/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
@@ -114,7 +114,7 @@ Object {
 }
 `;
 
-exports[`useResource should dispatch an action that fetches 1`] = `
+exports[`useResource() should dispatch an action that fetches 1`] = `
 Object {
   "meta": Object {
     "options": undefined,
@@ -138,7 +138,7 @@ Object {
 }
 `;
 
-exports[`useResource should dispatch fetch when sent multiple arguments 1`] = `
+exports[`useResource() should dispatch fetch when sent multiple arguments 1`] = `
 Object {
   "meta": Object {
     "options": undefined,
@@ -162,7 +162,7 @@ Object {
 }
 `;
 
-exports[`useResource should dispatch fetch when sent multiple arguments 2`] = `
+exports[`useResource() should dispatch fetch when sent multiple arguments 2`] = `
 Object {
   "meta": Object {
     "options": undefined,

--- a/src/react-integration/__tests__/hooks.tsx
+++ b/src/react-integration/__tests__/hooks.tsx
@@ -383,7 +383,7 @@ describe('useRetrieve', () => {
   });
 });
 
-describe('useResource', () => {
+describe('useResource()', () => {
   let fbmock = jest.fn();
 
   function Fallback() {

--- a/src/react-integration/__tests__/integration.tsx
+++ b/src/react-integration/__tests__/integration.tsx
@@ -132,6 +132,18 @@ for (const makeProvider of [makeRestProvider, makeExternalCacheProvider]) {
       expect((result.error as any).status).toBe(403);
     });
 
+    it('useResource() should throw errors on bad network (multiarg)', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useResource([CoolerArticleResource.singleRequest(), {
+          title: '0',
+        }]);
+      });
+      expect(result.current).toBe(null);
+      await waitForNextUpdate();
+      expect(result.error).toBeDefined();
+      expect((result.error as any).status).toBe(403);
+    });
+
     it('should resolve parallel useResource() request', async () => {
       const { result, waitForNextUpdate } = renderRestHook(() => {
         return useResource(

--- a/src/react-integration/hooks/useResource.ts
+++ b/src/react-integration/hooks/useResource.ts
@@ -68,6 +68,13 @@ function useManyResources<A extends ResourceArgs<any, any, any>[]>(
   if (promises.length) {
     throw Promise.all(promises);
   }
+  // throw any errors that exist after all promises have resolved
+  for (let i = 0; i < resourceList.length; i++) {
+    const [selectShape, params] = resourceList[i];
+    const resource = resources[i];
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useError(selectShape, params, resource);
+  }
   return resources;
 }
 


### PR DESCRIPTION
…happen.

This could have potentially cause infinite loops when errors occur and the resource isn't populated.