### PR TITLE
[docs] Remove a tiny "s" typo in network errors doc

### DIFF
--- a/docs/guides/network-errors.md
+++ b/docs/guides/network-errors.md
@@ -32,7 +32,7 @@ boundary, but it is placed above the route selected.
 
 Alternatively you could create your own error boundary where you might
 try dispatching the errors to another provider to use in a transient
-popups.
+popup.
 
 Additionally you could also use one error boundary for any error
 type and handle network errors there.


### PR DESCRIPTION
![bitmoji](https://render.bitstrips.com/v2/cpanel/80022036-f455-4594-8375-99e8f1fb4fdf-91ea9fba-3979-4111-b473-0a4125b29f47-v1.png?transparent=1&palette=1&width=246)