### PR TITLE
[enhance] Use React's scheduler to queue resolution of promises

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@
   - [useSubscription](api/useSubscription.md)
   - [useRetrieve](api/useRetrieve.md)
 - Components:
-  - [RestProvider](api/RestProvider.md)
+  - [CacheProvider](api/CacheProvider.md)
   - [ExternalCacheProvider](api/ExternalCacheProvider.md)
   - [NetworkErrorBoundary](api/NetworkErrorBoundary.md)
 - [Manager](api/Manager.md)s

--- a/docs/api/CacheProvider.md
+++ b/docs/api/CacheProvider.md
@@ -1,5 +1,5 @@
 ---
-title: <RestProvider />
+title: <CacheProvider />
 ---
 Manages state, providing all context needed to use the hooks. Should be placed as high as possible
 in application tree as any usage of the hooks is only possible for components below the provider
@@ -8,13 +8,13 @@ in the React tree.
 `index.tsx`
 
 ```tsx
-import { RestProvider } from 'rest-hooks';
+import { CacheProvider } from 'rest-hooks';
 import ReactDOM from 'react-dom';
 
 ReactDOM.render(
-  <RestProvider>
+  <CacheProvider>
     <App />
-  </RestProvider>,
+  </CacheProvider>,
   document.body
 );
 ```

--- a/docs/api/ExternalCacheProvider.md
+++ b/docs/api/ExternalCacheProvider.md
@@ -5,7 +5,7 @@ Integrates external stores with `rest-hooks`. Should be placed as high as possib
 in application tree as any usage of the hooks is only possible for components below the provider
 in the React tree.
 
-**Is a replacement for \<RestProvider /> - do _NOT_ use both at once**
+**Is a replacement for \<CacheProvider /> - do _NOT_ use both at once**
 
 `index.tsx`
 

--- a/docs/api/Manager.md
+++ b/docs/api/Manager.md
@@ -30,7 +30,7 @@ interface Manager {
 ## getMiddleware()
 
 getMiddleware() returns a function that is 100% redux compatible. This enables it to be integrated into redux,
-or used by the internal useReducer() enhancer in <RestProvider />.
+or used by the internal useReducer() enhancer in <CacheProvider />.
 
 Middlewares will intercept actions that are dispatched and then potentially dispatch their own actions as well.
 To read more about middlewares, see the [redux documentation](https://redux.js.org/advanced/middleware).

--- a/docs/api/NetworkErrorBoundary.md
+++ b/docs/api/NetworkErrorBoundary.md
@@ -22,7 +22,7 @@ Custom fallback usage example:
 
 ```tsx
 import React from 'react';
-import { RestProvider, NetworkErrorBoundary, NetworkError } from 'rest-hooks';
+import { CacheProvider, NetworkErrorBoundary, NetworkError } from 'rest-hooks';
 
 function ErrorPage({ error }: { error: NetworkError }) {
   return (
@@ -34,11 +34,11 @@ function ErrorPage({ error }: { error: NetworkError }) {
 
 export default function App(): React.ReactElement {
   return (
-    <RestProvider>
+    <CacheProvider>
       <NetworkErrorBoundary fallbackComponent={ErrorPage}>
         <Router />
       </NetworkErrorBoundary>
-    </RestProvider>
+    </CacheProvider>
   );
 }
 ```

--- a/docs/api/PollingSubscription.md
+++ b/docs/api/PollingSubscription.md
@@ -10,15 +10,15 @@ Will dispatch a `fetch` action at the minimum interval of all subscriptions to t
 resource.
 
 ```tsx
-import { SubscriptionManager, PollingSubscription, RestProvider } from 'rest-hooks';
+import { SubscriptionManager, PollingSubscription, CacheProvider } from 'rest-hooks';
 import ReactDOM from 'react-dom';
 
 const subscriptionManager = new SubscriptionManager(PollingSubscription);
 
 ReactDOM.render(
-  <RestProvider subscriptionManager={subscriptionManager}>
+  <CacheProvider subscriptionManager={subscriptionManager}>
     <App />
-  </RestProvider>,
+  </CacheProvider>,
   document.body
 );
 ```
@@ -29,4 +29,4 @@ ReactDOM.render(
 
 > #### Note:
 >
-> This is already used by `RestProvider` by default.
+> This is already used by `CacheProvider` by default.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -16,7 +16,7 @@ title: API Reference
 - [useInvalidator](useInvalidator.md)
 
 ## Components
-- [RestProvider](RestProvider.md)
+- [CacheProvider](CacheProvider.md)
 - [ExternalCacheProvider](ExternalCacheProvider.md)
 - [NetworkErrorBoundary](NetworkErrorBoundary.md)
 
@@ -36,6 +36,6 @@ to production themselves.
 
 - [\<MockProvider />](MockProvider)
 - [makeRenderRestHook()](makeRenderRestHook)
-- [makeRestProvider()](makeRestProvider)
+- [makeCacheProvider()](makeCacheProvider)
 - [makeExternalCacheProvider()](makeExternalCacheProvider)
 

--- a/docs/api/RequestShape.md
+++ b/docs/api/RequestShape.md
@@ -5,7 +5,7 @@ title: RequestShape
 
 `RequestShape` is the most basic interface sent to hooks telling rest-hooks how to
 handle the request. Several methods of `Resource` return `RequestShapes`, which offers a bridge between
-both APIs. In fact, using `Resource` is not even needed to work with `RestProvider` and
+both APIs. In fact, using `Resource` is not even needed to work with `CacheProvider` and
 simply operates as a convenience to organize schemas.
 
 Because of the different capabilities of each shape, some shapes won't be usable with

--- a/docs/api/makeCacheProvider.md
+++ b/docs/api/makeCacheProvider.md
@@ -1,16 +1,16 @@
 ---
-title: makeRestProvider()
+title: makeCacheProvider()
 ---
 
 ```typescript
-declare const makeRestProvider: (
+declare const makeCacheProvider: (
   manager: NetworkManager,
   subscriptionManager: SubscriptionManager<any>,
   initialState?: State<unknown>,
 ) => ({ children }: { children: React.ReactNode }) => JSX.Element;
 ```
 
-Used to build a [\<RestProvider />](./RestProvider.md) for [makeRenderRestHook()](./makeRenderRestHook.md)
+Used to build a [\<CacheProvider />](./CacheProvider.md) for [makeRenderRestHook()](./makeRenderRestHook.md)
 
 ## Arguments
 
@@ -33,7 +33,7 @@ Simple wrapper component that only has child as prop.
 ```tsx
 const manager = new MockNetworkManager();
 const subscriptionManager = new SubscriptionManager(PollingSubscription);
-const Provider = makeRestProvider(manager, subscriptionManager);
+const Provider = makeCacheProvider(manager, subscriptionManager);
 
 function renderRestHook<T>(callback: () => T) {
   return renderHook(callback, {

--- a/docs/api/makeRenderRestHook.md
+++ b/docs/api/makeRenderRestHook.md
@@ -26,7 +26,7 @@ type ProviderType = (
 Function to generate the provider used in `renderRestHook()`. The purpose of this is to unify construction of
 providers as they both are initialized in a very different fashion.
 
-- [makeRestProvider()](./makeRestProvider.md)
+- [makeCacheProvider()](./makeCacheProvider.md)
 - [makeExternalCacheProvider()](./makeExternalCacheProvider.md)
 
 ## Returns
@@ -90,7 +90,7 @@ Cleans up all managers used in tests. Should be run in `afterEach()` to ensure e
 ## Example
 
 ```typescript
-import { makeRenderRestHook, makeRestProvider } from 'rest-hooks/test';
+import { makeRenderRestHook, makeCacheProvider } from 'rest-hooks/test';
 
 const payload = {
   id: 5,
@@ -103,7 +103,7 @@ beforeEach(() => {
   nock('http://test.com')
     .get(`/article-cooler/${payload.id}`)
     .reply(200, payload);
-  renderRestHook = makeRenderRestHook(makeRestProvider);
+  renderRestHook = makeRenderRestHook(makeCacheProvider);
 });
 
 afterEach(() => {

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,6 +19,31 @@ npm install rest-hooks
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 
+## Include polyfill (optional IE support)
+
+Rest-hooks is built to be compatible with old browsers, but assumes polyfills will
+already be loaded. If you want to support old browsers like Internet Explorer, you'll
+need to install core-js and import it at the entry point of your bundle.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--yarn-->
+```bash
+yarn add core-js
+```
+<!--npm-->
+```bash
+npm install core-js
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+#### `index.tsx`
+
+```tsx
+import 'core-js/stable';
+// place the above line at top
+```
+
+
 ## Add provider at top-level component
 
 #### `index.tsx`

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -49,13 +49,13 @@ import 'core-js/stable';
 #### `index.tsx`
 
 ```tsx
-import { RestProvider } from 'rest-hooks';
+import { CacheProvider } from 'rest-hooks';
 import ReactDOM from 'react-dom';
 
 ReactDOM.render(
-  <RestProvider>
+  <CacheProvider>
     <App />
-  </RestProvider>,
+  </CacheProvider>,
   document.body
 );
 ```

--- a/docs/guides/redux.md
+++ b/docs/guides/redux.md
@@ -26,7 +26,7 @@ npm install redux
 Note: react-redux is _not_ needed for this integration (though you can use it if you want).
 
 Then you'll want to use the [\<ExternalCacheProvider />](../api/ExternalCacheProvider.md) instead of
-[\<RestProvider />](../api/RestProvider.md) and pass in the store and a selector function to grab
+[\<CacheProvider />](../api/CacheProvider.md) and pass in the store and a selector function to grab
 the rest-hooks specific part of the state.
 
 > Note: You should only use ONE provider; nested another provider will override the previous.

--- a/docs/guides/unit-testing-hooks.md
+++ b/docs/guides/unit-testing-hooks.md
@@ -22,7 +22,7 @@ upon test completion.
 
 ```typescript
 import nock from 'nock';
-import { makeRenderRestHook, makeRestProvider } from 'rest-hooks/test';
+import { makeRenderRestHook, makeCacheProvider } from 'rest-hooks/test';
 
 describe('useResource()', () => {
   let renderRestHook: ReturnType<typeof makeRenderRestHook>;
@@ -31,7 +31,7 @@ describe('useResource()', () => {
     nock('http://test.com')
       .get(`/article/0`)
       .reply(403, {});
-    renderRestHook = makeRenderRestHook(makeRestProvider);
+    renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
 
   afterEach(() => {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,9 @@
   "peerDependenciesMeta": {
     "@types/react": {
       "optional": true
+    },
+    "scheduler": {
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
   },
   "peerDependencies": {
     "@types/react": "^16.8.2",
-    "react": "^16.8.2"
+    "react": "^16.8.2",
+    "scheduler": "^0.13.6"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@types/superagent": "^4.1.2",
-    "core-js": "^3.0.0",
     "flux-standard-action": "^2.1.0",
     "lodash": "^4.17.11",
     "normalizr": "^3.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,7 +31,6 @@ const presets = [
     '@anansi/babel-preset',
     {
       typing: 'typescript',
-      useBuiltIns: false,
     },
   ],
 ];

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -3,8 +3,7 @@
     [
       "@anansi/babel-preset",
       {
-        "typing": "typescript",
-        "useBuiltIns": "usage"
+        "typing": "typescript"
       }
     ]
   ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,8 @@ import {
   State,
   FetchAction,
   ReceiveAction,
+  Middleware,
+  Manager,
 } from './types';
 import { StateContext, DispatchContext } from './react-integration/context';
 
@@ -80,6 +82,9 @@ export type NetworkError = NetworkError;
 export type Request = RequestType;
 export type FetchAction = FetchAction;
 export type ReceiveAction = ReceiveAction;
+
+export type Middleware = Middleware;
+export type Manager = Manager;
 
 export {
   Resource,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import {
   useMeta,
   useError,
   useSelectionUnstable,
-  RestProvider,
+  CacheProvider,
   useInvalidator,
   ExternalCacheProvider,
   NetworkErrorBoundary,
@@ -83,7 +83,7 @@ export type ReceiveAction = ReceiveAction;
 
 export {
   Resource,
-  RestProvider,
+  CacheProvider,
   ExternalCacheProvider,
   useCache,
   useFetcher,

--- a/src/react-integration/__tests__/hooks.tsx
+++ b/src/react-integration/__tests__/hooks.tsx
@@ -26,8 +26,7 @@ import { Resource, Schema } from '../../resource';
 import { ReadShape } from '../../resource';
 import makeRenderRestHook from '../../test/makeRenderRestHook';
 import {
-  makeRestProvider,
-  makeExternalCacheProvider,
+  makeCacheProvider,
 } from '../../test/providers';
 
 async function testDispatchFetch(
@@ -477,7 +476,7 @@ describe('useResource()', () => {
     await testDispatchFetch(MultiResourceTester, [payload, users]);
   });
   it('should throw same promise until both resolve', async () => {
-    const renderRestHook = makeRenderRestHook(makeRestProvider);
+    const renderRestHook = makeRenderRestHook(makeCacheProvider);
     jest.useFakeTimers();
     nock('http://test.com')
       .get(`/article-cooler/${payload.id}`)

--- a/src/react-integration/__tests__/integration.tsx
+++ b/src/react-integration/__tests__/integration.tsx
@@ -6,7 +6,7 @@ import { CoolerArticleResource, UserResource } from '../../__tests__/common';
 import { useResource, useFetcher } from '../hooks';
 import makeRenderRestHook from '../../test/makeRenderRestHook';
 import {
-  makeRestProvider,
+  makeCacheProvider,
   makeExternalCacheProvider,
 } from '../../test/providers';
 
@@ -14,7 +14,7 @@ afterEach(() => {
   cleanup();
 });
 
-for (const makeProvider of [makeRestProvider, makeExternalCacheProvider]) {
+for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
   describe(`${makeProvider.name} => <Provider />`, () => {
     const payload = {
       id: 5,

--- a/src/react-integration/__tests__/subscriptions.tsx
+++ b/src/react-integration/__tests__/subscriptions.tsx
@@ -8,14 +8,14 @@ import { PollingArticleResource } from '../../__tests__/common';
 import { useSubscription, useCache } from '../hooks';
 import makeRenderRestHook from '../../test/makeRenderRestHook';
 import {
-  makeRestProvider,
+  makeCacheProvider,
   makeExternalCacheProvider,
 } from '../../test/providers';
 import { DispatchContext } from '../context';
 
 afterEach(cleanup);
 
-for (const makeProvider of [makeRestProvider, makeExternalCacheProvider]) {
+for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
   describe(`${makeProvider.name} with subscriptions`, () => {
     const articlePayload = {
       id: 5,

--- a/src/react-integration/index.ts
+++ b/src/react-integration/index.ts
@@ -10,7 +10,7 @@ import {
   useInvalidator,
   useSelectionUnstable,
 } from './hooks';
-import { RestProvider, ExternalCacheProvider } from './provider';
+import { CacheProvider, ExternalCacheProvider } from './provider';
 import NetworkErrorBoundary, { NetworkError } from './NetworkErrorBoundary';
 
 export type NetworkError = NetworkError;
@@ -25,7 +25,7 @@ export {
   useMeta,
   useError,
   useSelectionUnstable,
-  RestProvider,
+  CacheProvider,
   ExternalCacheProvider,
   NetworkErrorBoundary,
 };

--- a/src/react-integration/provider/CacheProvider.tsx
+++ b/src/react-integration/provider/CacheProvider.tsx
@@ -16,7 +16,7 @@ interface ProviderProps {
   initialState?: State<unknown>;
 }
 /** Controller managing state of the REST cache and coordinating network requests. */
-export default function RestProvider({
+export default function CacheProvider({
   children,
   manager,
   subscriptionManager,
@@ -47,7 +47,7 @@ export default function RestProvider({
     </DispatchContext.Provider>
   );
 }
-RestProvider.defaultProps = {
+CacheProvider.defaultProps = {
   manager: new NetworkManager(),
   subscriptionManager: new SubscriptionManager(PollingSubscription),
 };

--- a/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
+++ b/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<RestProvider /> should change state 1`] = `
+exports[`<CacheProvider /> should change state 1`] = `
 Object {
   "entities": Object {
     "http://test.com/article-cooler/": Object {

--- a/src/react-integration/provider/__tests__/provider.tsx
+++ b/src/react-integration/provider/__tests__/provider.tsx
@@ -29,7 +29,7 @@ describe('<CacheProvider />', () => {
     expect(curDisp).toBe(dispatch);
     expect(count).toBe(1);
     const manager = new NetworkManager();
-    rerender(<CacheProvider manager={manager}>{chil}</CacheProvider>);
+    rerender(<CacheProvider managers={[manager]}>{chil}</CacheProvider>);
     expect(curDisp).toBe(dispatch);
     expect(count).toBe(1);
     rerender(

--- a/src/react-integration/provider/__tests__/provider.tsx
+++ b/src/react-integration/provider/__tests__/provider.tsx
@@ -3,12 +3,12 @@ import { cleanup, act, render } from 'react-testing-library';
 
 import { DispatchContext, StateContext } from '../../context';
 import { CoolerArticleResource } from '../../../__tests__/common';
-import RestProvider from '../RestProvider';
+import CacheProvider from '../CacheProvider';
 import NetworkManager from '../../../state/NetworkManager';
 
 afterEach(cleanup);
 
-describe('<RestProvider />', () => {
+describe('<CacheProvider />', () => {
   it('should not change dispatch function on re-render', () => {
     let dispatch;
     let count = 0;
@@ -18,18 +18,18 @@ describe('<RestProvider />', () => {
       return null;
     }
     const chil = <DispatchTester />;
-    const tree = <RestProvider>{chil}</RestProvider>;
+    const tree = <CacheProvider>{chil}</CacheProvider>;
     const { rerender } = render(tree);
     expect(dispatch).toBeDefined();
     const curDisp = dispatch;
     rerender(tree);
     expect(curDisp).toBe(dispatch);
     expect(count).toBe(1);
-    rerender(<RestProvider>{chil}</RestProvider>);
+    rerender(<CacheProvider>{chil}</CacheProvider>);
     expect(curDisp).toBe(dispatch);
     expect(count).toBe(1);
     const manager = new NetworkManager();
-    rerender(<RestProvider manager={manager}>{chil}</RestProvider>);
+    rerender(<CacheProvider manager={manager}>{chil}</CacheProvider>);
     expect(curDisp).toBe(dispatch);
     expect(count).toBe(1);
     rerender(
@@ -50,7 +50,7 @@ describe('<RestProvider />', () => {
       return null;
     }
     const chil = <ContextTester />;
-    const tree = <RestProvider>{chil}</RestProvider>;
+    const tree = <CacheProvider>{chil}</CacheProvider>;
     render(tree);
     expect(dispatch).toBeDefined();
     expect(state).toBeDefined();

--- a/src/react-integration/provider/index.ts
+++ b/src/react-integration/provider/index.ts
@@ -1,4 +1,4 @@
-import RestProvider from './RestProvider';
+import CacheProvider from './CacheProvider';
 import ExternalCacheProvider from './ExternalCacheProvider';
 
-export { RestProvider, ExternalCacheProvider };
+export { CacheProvider, ExternalCacheProvider };

--- a/src/state/NetworkManager.ts
+++ b/src/state/NetworkManager.ts
@@ -1,6 +1,5 @@
 import { memoize } from 'lodash';
-import { FetchAction, ReceiveAction, MiddlewareAPI } from '~/types';
-
+import { FetchAction, ReceiveAction, MiddlewareAPI, Manager } from '~/types';
 export const RIC: (cb: (...args: any[]) => void, options: any) => void =
   typeof (global as any).requestIdleCallback === 'function'
     ? (global as any).requestIdleCallback
@@ -13,7 +12,7 @@ export const RIC: (cb: (...args: any[]) => void, options: any) => void =
  *
  * Interfaces with store via a redux-compatible middleware.
  */
-export default class NetworkManager {
+export default class NetworkManager implements Manager {
   protected fetched: { [k: string]: Promise<any> } = {};
   protected resolvers: { [k: string]: (value?: any) => void } = {};
   protected rejectors: { [k: string]: (value?: any) => void } = {};

--- a/src/state/NetworkManager.ts
+++ b/src/state/NetworkManager.ts
@@ -1,5 +1,7 @@
 import { memoize } from 'lodash';
+import { unstable_scheduleCallback } from 'scheduler';
 import { FetchAction, ReceiveAction, MiddlewareAPI, Manager } from '~/types';
+
 export const RIC: (cb: (...args: any[]) => void, options: any) => void =
   typeof (global as any).requestIdleCallback === 'function'
     ? (global as any).requestIdleCallback
@@ -124,9 +126,8 @@ export default class NetworkManager implements Manager {
         this.clear(action.meta.url);
       }
     };
-    // TODO: this should call after the reducer has been updated
-    // in all concurrent fibers
-    RIC(completePromise, { timeout: 1000 });
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    unstable_scheduleCallback(completePromise, null);
   }
 
   /** Attaches NetworkManager to store

--- a/src/state/SubscriptionManager.ts
+++ b/src/state/SubscriptionManager.ts
@@ -1,5 +1,10 @@
 import { memoize } from 'lodash';
-import { MiddlewareAPI, SubscribeAction, UnsubscribeAction } from '~/types';
+import {
+  MiddlewareAPI,
+  SubscribeAction,
+  UnsubscribeAction,
+  Manager,
+} from '~/types';
 import { Schema } from '~/resource';
 
 type Actions = UnsubscribeAction | SubscribeAction;
@@ -29,7 +34,8 @@ export interface SubscriptionConstructable {
  * Constructor takes a SubscriptionConstructable class to control how
  * subscriptions are handled. (e.g., polling, websockets)
  */
-export default class SubscriptionManager<S extends SubscriptionConstructable> {
+export default class SubscriptionManager<S extends SubscriptionConstructable>
+  implements Manager {
   protected subscriptions: {
     [url: string]: InstanceType<S>;
   } = {};

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,12 +1,12 @@
 import { MockNetworkManager } from './managers';
 import makeRenderRestHook from './makeRenderRestHook';
-import { makeExternalCacheProvider, makeRestProvider } from './providers';
+import { makeExternalCacheProvider, makeCacheProvider } from './providers';
 import MockProvider from './MockProvider';
 
 export {
   MockNetworkManager,
   makeRenderRestHook,
   makeExternalCacheProvider,
-  makeRestProvider,
+  makeCacheProvider,
   MockProvider,
 };

--- a/src/test/makeRenderRestHook.tsx
+++ b/src/test/makeRenderRestHook.tsx
@@ -4,17 +4,11 @@ import { renderHook } from 'react-hooks-testing-library';
 
 import { MockNetworkManager } from './managers';
 import mockInitialState, { Fixture } from './mockState';
-import {
-  State,
-  NetworkManager,
-  SubscriptionManager,
-  PollingSubscription,
-} from '..';
+import { State, SubscriptionManager, PollingSubscription, Manager } from '..';
 
 export default function makeRenderRestHook(
   makeProvider: (
-    manager: NetworkManager,
-    subManager: SubscriptionManager<any>,
+    managers: Manager[],
     initialState?: State<unknown>,
   ) => React.ComponentType<{ children: React.ReactChild }>,
 ) {
@@ -30,8 +24,7 @@ export default function makeRenderRestHook(
     const initialState =
       options && options.results && mockInitialState(options.results);
     const Provider: React.ComponentType<any> = makeProvider(
-      manager,
-      subManager,
+      [manager, subManager],
       initialState,
     );
     const Wrapper = options && options.wrapper;

--- a/src/test/providers.tsx
+++ b/src/test/providers.tsx
@@ -7,7 +7,7 @@ import {
   NetworkManager,
   SubscriptionManager,
   ExternalCacheProvider,
-  RestProvider,
+  CacheProvider,
 } from '..';
 
 // Extension of the DeepPartial type defined by Redux which handles unknown
@@ -44,26 +44,26 @@ const makeExternalCacheProvider = (
   };
 };
 
-const makeRestProvider = (
+const makeCacheProvider = (
   manager: NetworkManager,
   subscriptionManager: SubscriptionManager<any>,
   initialState?: State<unknown>,
 ) => {
-  return function ConfiguredRestProvider({
+  return function ConfiguredCacheProvider({
     children,
   }: {
     children: ReactNode;
   }) {
     return (
-      <RestProvider
+      <CacheProvider
         manager={manager}
         subscriptionManager={subscriptionManager}
         initialState={initialState}
       >
         {children}
-      </RestProvider>
+      </CacheProvider>
     );
   };
 };
 
-export { makeExternalCacheProvider, makeRestProvider };
+export { makeExternalCacheProvider, makeCacheProvider };

--- a/src/test/providers.tsx
+++ b/src/test/providers.tsx
@@ -4,10 +4,9 @@ import { ReactNode } from 'react';
 import {
   State,
   reducer,
-  NetworkManager,
-  SubscriptionManager,
   ExternalCacheProvider,
   CacheProvider,
+  Manager,
 } from '..';
 
 // Extension of the DeepPartial type defined by Redux which handles unknown
@@ -18,17 +17,13 @@ type DeepPartialWithUnknown<T> = {
 };
 
 const makeExternalCacheProvider = (
-  manager: NetworkManager,
-  subscriptionManager: SubscriptionManager<any>,
+  managers: Manager[],
   initialState?: DeepPartialWithUnknown<State<any>>,
 ) => {
   const store = createStore(
     reducer,
     initialState,
-    applyMiddleware(
-      manager.getMiddleware(),
-      subscriptionManager.getMiddleware(),
-    ),
+    applyMiddleware(...managers.map(manager => manager.getMiddleware())),
   );
 
   return function ConfiguredExternalCacheProvider({
@@ -45,8 +40,7 @@ const makeExternalCacheProvider = (
 };
 
 const makeCacheProvider = (
-  manager: NetworkManager,
-  subscriptionManager: SubscriptionManager<any>,
+  managers: Manager[],
   initialState?: State<unknown>,
 ) => {
   return function ConfiguredCacheProvider({
@@ -55,11 +49,7 @@ const makeCacheProvider = (
     children: ReactNode;
   }) {
     return (
-      <CacheProvider
-        manager={manager}
-        subscriptionManager={subscriptionManager}
-        initialState={initialState}
-      >
+      <CacheProvider managers={managers} initialState={initialState}>
         {children}
       </CacheProvider>
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,3 +113,8 @@ export interface MiddlewareAPI<
   getState: () => React.ReducerState<R>;
   dispatch: React.Dispatch<React.ReducerAction<R>>;
 }
+
+export interface Manager {
+  getMiddleware(): Middleware;
+  cleanup(): void;
+}

--- a/test.d.ts
+++ b/test.d.ts
@@ -1,2 +1,2 @@
-import { MockNetworkManager, makeRenderRestHook, makeExternalCacheProvider, makeRestProvider, MockProvider } from './lib/test';
-export { MockNetworkManager, makeRenderRestHook, makeExternalCacheProvider, makeRestProvider, MockProvider, };
+import { MockNetworkManager, makeRenderRestHook, makeExternalCacheProvider, makeCacheProvider, MockProvider } from './lib/test';
+export { MockNetworkManager, makeRenderRestHook, makeExternalCacheProvider, makeCacheProvider, MockProvider, };

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -5,17 +5,20 @@
     "previous": "Previous",
     "tagline": "Delightful data fetching",
     "docs": {
+      "api/CacheProvider": {
+        "title": "<CacheProvider />"
+      },
       "api/ExternalCacheProvider": {
         "title": "<ExternalCacheProvider />"
+      },
+      "api/makeCacheProvider": {
+        "title": "makeCacheProvider()"
       },
       "api/makeExternalCacheProvider": {
         "title": "makeExternalCacheProvider()"
       },
       "api/makeRenderRestHook": {
         "title": "makeRenderRestHook()"
-      },
-      "api/makeRestProvider": {
-        "title": "makeRestProvider()"
       },
       "api/Manager": {
         "title": "Manager"
@@ -42,9 +45,6 @@
       },
       "api/resource": {
         "title": "Resource"
-      },
-      "api/RestProvider": {
-        "title": "<RestProvider />"
       },
       "api/SubscriptionManager": {
         "title": "SubscriptionManager<S extends SubscriptionConstructable> implements Manager",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -86,7 +86,7 @@
         "type": "subcategory",
         "label": "Components",
         "ids": [
-          "api/RestProvider",
+          "api/CacheProvider",
           "api/ExternalCacheProvider",
           "api/NetworkErrorBoundary"
         ]
@@ -107,7 +107,7 @@
         "ids": [
           "api/MockProvider",
           "api/makeRenderRestHook",
-          "api/makeRestProvider",
+          "api/makeCacheProvider",
           "api/makeExternalCacheProvider"
         ]
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,7 +2715,7 @@ core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
-core-js@^3.0.0, core-js@^3.1.4:
+core-js@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.4.tgz#3a2837fc48e582e1ae25907afcd6cf03b0cc7a07"
   integrity sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==


### PR DESCRIPTION
RequestIdleCallback was always a hack to try to let React update context before the promises were considered resolved so it won't try to re-render until the state is available.

Since React is using scheduler to queue the context update itself, this will place the promise resolution in queue after so things will more consistently happen in the correct order.