### PR TITLE
[breaking][test] renderRestHook() takes results fixtures in options instead of initialState

### DIFF
--- a/docs/api/makeRenderRestHook.md
+++ b/docs/api/makeRenderRestHook.md
@@ -37,7 +37,7 @@ type RenderRestHookFunction = {
     callback: (props: P) => R,
     options?: {
       initialProps?: P;
-      initialState?: State<unknown>;
+      results?: Fixture[];
       wrapper?: React.ComponentType;
     },
   ): {
@@ -59,9 +59,10 @@ type RenderRestHookFunction = {
 
 Hooks to run inside React. Return value will become available in `result`
 
-#### options.initialState
+#### options.results
 
-Can be used to prime the cache if test expects cache values to already be filled.
+Can be used to prime the cache if test expects cache values to already be filled. Takes same
+[array of fixtures as MockProvider](https://resthooks.io/docs/api/MockProvider#results)
 
 #### options.initialProps
 

--- a/src/react-integration/__tests__/integration.tsx
+++ b/src/react-integration/__tests__/integration.tsx
@@ -4,7 +4,7 @@ import nock from 'nock';
 
 import { CoolerArticleResource, UserResource } from '../../__tests__/common';
 import { useResource, useFetcher } from '../hooks';
-import makeRenderRestHook from '../../test/helper';
+import makeRenderRestHook from '../../test/makeRenderRestHook';
 import {
   makeRestProvider,
   makeExternalCacheProvider,

--- a/src/react-integration/__tests__/subscriptions.tsx
+++ b/src/react-integration/__tests__/subscriptions.tsx
@@ -5,7 +5,7 @@ import nock from 'nock';
 
 import { PollingArticleResource } from '../../__tests__/common';
 import { useSubscription, useCache } from '../hooks';
-import makeRenderRestHook from '../../test/helper';
+import makeRenderRestHook from '../../test/makeRenderRestHook';
 import {
   makeRestProvider,
   makeExternalCacheProvider,

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,5 +1,5 @@
 import { MockNetworkManager } from './managers';
-import makeRenderRestHook from './helper';
+import makeRenderRestHook from './makeRenderRestHook';
 import { makeExternalCacheProvider, makeRestProvider } from './providers';
 import MockProvider from './MockProvider';
 

--- a/src/test/makeRenderRestHook.tsx
+++ b/src/test/makeRenderRestHook.tsx
@@ -1,8 +1,9 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { RenderOptions } from 'react-testing-library';
 import { renderHook } from 'react-hooks-testing-library';
 
 import { MockNetworkManager } from './managers';
+import mockInitialState, { Fixture } from './mockState';
 import {
   State,
   NetworkManager,
@@ -14,7 +15,7 @@ export default function makeRenderRestHook(
   makeProvider: (
     manager: NetworkManager,
     subManager: SubscriptionManager<any>,
-    initialState?: State<unknown>,
+    results?: State<unknown>,
   ) => React.ComponentType<{ children: React.ReactChild }>,
 ) {
   const manager = new MockNetworkManager();
@@ -23,13 +24,15 @@ export default function makeRenderRestHook(
     callback: (props: P) => R,
     options?: {
       initialProps?: P;
-      initialState?: State<unknown>;
+      results?: Fixture[];
     } & RenderOptions,
   ) {
+    const initialState =
+      options && options.results && mockInitialState(options.results);
     const Provider: React.ComponentType<any> = makeProvider(
       manager,
       subManager,
-      options && options.initialState,
+      initialState,
     );
     const Wrapper = options && options.wrapper;
     const wrapper: React.ComponentType<any> = Wrapper

--- a/src/test/makeRenderRestHook.tsx
+++ b/src/test/makeRenderRestHook.tsx
@@ -15,7 +15,7 @@ export default function makeRenderRestHook(
   makeProvider: (
     manager: NetworkManager,
     subManager: SubscriptionManager<any>,
-    results?: State<unknown>,
+    initialState?: State<unknown>,
   ) => React.ComponentType<{ children: React.ReactChild }>,
 ) {
   const manager = new MockNetworkManager();

--- a/src/test/providers.tsx
+++ b/src/test/providers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { createStore, applyMiddleware, DeepPartial } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import { ReactNode } from 'react';
 import {
   State,


### PR DESCRIPTION
- Change name of `makeRenderRestHook` file from helper to match the name of the default export.
- Change `makeRenderRestHook` to take in an array of fixtures instead of initialState so that hooks using useCache can be properly tested.

NOTE: running `yarn eslint --fix --ext .ts,.tsx src` and `yarn format` change `makeRenderRestHook` back and forth, indenting and un-indenting part of the code.

Closes https://github.com/coinbase/rest-hooks/issues/63