### PR TITLE
[breaking] Don't import polyfills but assume they are already loaded

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -19,6 +19,31 @@ npm install rest-hooks
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 
+## Include polyfill (optional IE support)
+
+Rest-hooks is built to be compatible with old browsers, but assumes polyfills will
+already be loaded. If you want to support old browsers like Internet Explorer, you'll
+need to install core-js and import it at the entry point of your bundle.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--yarn-->
+```bash
+yarn add core-js
+```
+<!--npm-->
+```bash
+npm install core-js
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+#### `index.tsx`
+
+```tsx
+import 'core-js/stable';
+// place the above line at top
+```
+
+
 ## Add provider at top-level component
 
 #### `index.tsx`

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "@types/superagent": "^4.1.2",
-    "core-js": "^3.0.0",
     "flux-standard-action": "^2.1.0",
     "lodash": "^4.17.11",
     "normalizr": "^3.4.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,7 +31,6 @@ const presets = [
     '@anansi/babel-preset',
     {
       typing: 'typescript',
-      useBuiltIns: false,
     },
   ],
 ];

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -3,8 +3,7 @@
     [
       "@anansi/babel-preset",
       {
-        "typing": "typescript",
-        "useBuiltIns": "usage"
+        "typing": "typescript"
       }
     ]
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,7 +2715,7 @@ core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
-core-js@^3.0.0, core-js@^3.1.4:
+core-js@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.4.tgz#3a2837fc48e582e1ae25907afcd6cf03b0cc7a07"
   integrity sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==


### PR DESCRIPTION
This makes the library more flexible to different usages.

- Different polyfill libraries can be used (helps with https://github.com/coinbase/rest-hooks/issues/25)
- Old browsers can be unsupported without adding to bundle size
- Different bundles targeting different browsers can be built.
- Potential feature-detection of polyfills