### PR TITLE
[fix] Send most updated state to manager middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "rollup-plugin-node-resolve": "^5.0.0",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-terser": "^5.0.0",
+    "scheduler": "^0.13.6",
     "ts-jest": "^24.0.2",
     "typescript": "^3.4.5"
   },

--- a/src/react-integration/provider/middleware.ts
+++ b/src/react-integration/provider/middleware.ts
@@ -12,8 +12,8 @@ export default function createEnhancedReducerHook(
     startingState: React.ReducerState<R>,
   ): [React.ReducerState<R>, React.Dispatch<React.ReducerAction<R>>] => {
     const [state, realDispatch] = useReducer(reducer, startingState);
-    const store = useRef({ state });
-    store.current.state = state;
+    const store = useRef(state);
+    store.current = state;
 
     let outerDispatch = useMemo(() => {
       let dispatch: React.Dispatch<React.ReducerAction<R>> = () => {
@@ -24,7 +24,7 @@ export default function createEnhancedReducerHook(
       };
       // closure here around dispatch allows us to change it after middleware is constructed
       const middlewareAPI = {
-        getState: () => store.current.state,
+        getState: () => store.current,
         dispatch: (action: React.ReducerAction<R>) => dispatch(action),
       };
       const chain = middlewares.map(middleware => middleware(middlewareAPI));

--- a/src/react-integration/provider/middleware.ts
+++ b/src/react-integration/provider/middleware.ts
@@ -1,4 +1,4 @@
-import { useReducer, useMemo } from 'react';
+import { useReducer, useMemo, useRef } from 'react';
 import compose from 'lodash/fp/compose';
 import { Middleware } from '../../types';
 
@@ -12,6 +12,8 @@ export default function createEnhancedReducerHook(
     startingState: React.ReducerState<R>,
   ): [React.ReducerState<R>, React.Dispatch<React.ReducerAction<R>>] => {
     const [state, realDispatch] = useReducer(reducer, startingState);
+    const store = useRef({ state });
+    store.current.state = state;
 
     let outerDispatch = useMemo(() => {
       let dispatch: React.Dispatch<React.ReducerAction<R>> = () => {
@@ -22,14 +24,13 @@ export default function createEnhancedReducerHook(
       };
       // closure here around dispatch allows us to change it after middleware is constructed
       const middlewareAPI = {
-        // state is not needed in useMemo() param list since it's retrieved as function
-        getState: () => state,
+        getState: () => store.current.state,
         dispatch: (action: React.ReducerAction<R>) => dispatch(action),
       };
       const chain = middlewares.map(middleware => middleware(middlewareAPI));
       dispatch = compose(chain)(realDispatch);
       return dispatch;
-    }, [realDispatch]);
+    }, [realDispatch, store]);
     return [state, outerDispatch];
   };
   return useEnhancedReducer;

--- a/src/state/NetworkManager.ts
+++ b/src/state/NetworkManager.ts
@@ -151,12 +151,15 @@ export default class NetworkManager {
         case 'rest-hooks/purge':
         case 'rest-hooks/rpc':
         case 'rest-hooks/receive':
+          // only receive after new state is computed
+          next(action);
           if (action.meta.url in this.fetched) {
             this.handleReceive(action);
           }
-          // fallthrough is on purpose
+          return;
         default:
-          return next(action);
+          next(action);
+          return;
         }
       };
     };

--- a/src/types/scheduler.d.ts
+++ b/src/types/scheduler.d.ts
@@ -1,0 +1,17 @@
+/* eslint @typescript-eslint/camelcase: 0 */
+export const unstable_IdlePriority: number;
+export const unstable_ImmediatePriority: number;
+export const unstable_LowPriority: number;
+export const unstable_NormalPriority: number;
+export const unstable_UserBlockingPriority: number;
+export function unstable_cancelCallback(callbackNode: any): void;
+export function unstable_continueExecution(): void;
+export function unstable_getCurrentPriorityLevel(): any;
+export function unstable_getFirstCallbackNode(): any;
+export function unstable_next(eventHandler: any): any;
+export function unstable_now(): any;
+export function unstable_pauseExecution(): void;
+export function unstable_runWithPriority(priorityLevel: any, eventHandler: any): any;
+export function unstable_scheduleCallback( callback: any, deprecated_options: any): any;
+export function unstable_shouldYield(): any;
+export function unstable_wrapCallback(callback: any): any;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "paths": { "scheduler": ["types/scheduler.d.ts"] },
     /* Basic Options */
     "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */


### PR DESCRIPTION
Before getState() would only ever return the initial value. This was not caught as it is never actually used by the existing managers.

We use a ref here so we can retrieve inside a mutable object.