### PR TITLE
[fix] exhaustive-deps lint; make useFetch() recompute less

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
   "rules": {
     "react/prop-types": "off",
     "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-member-accessibility": "off",

--- a/src/react-integration/hooks/useMeta.ts
+++ b/src/react-integration/hooks/useMeta.ts
@@ -13,7 +13,7 @@ export default function useMeta<Params extends Readonly<object>>(
   const url = params ? getUrl(params) : '';
 
   return useMemo(() => {
-    if (!params) return null;
+    if (!url) return null;
     return selectMeta(state, url);
-  }, [state, url]);
+  }, [url, state]);
 }

--- a/src/react-integration/hooks/useResultCache.ts
+++ b/src/react-integration/hooks/useResultCache.ts
@@ -25,10 +25,12 @@ export default function useResultCache<
   const resultSelector = useMemo(() => makeResults((p: Params) => getUrl(p)), [
     getUrl,
   ]);
-  const results = useMemo(() => params && resultSelector(state, params), [
-    state,
-    params && getUrl(params),
-  ]);
+  const results = useMemo(
+    () => params && resultSelector(state, params),
+    // params must be serialized in check
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [params && getUrl(params), resultSelector, state],
+  );
   if (defaults && !results) {
     return defaults as any;
   }

--- a/src/react-integration/hooks/useRetrieve.ts
+++ b/src/react-integration/hooks/useRetrieve.ts
@@ -32,5 +32,8 @@ export default function useRetrieve<
     // null params mean don't do anything
     if (!params) return;
     return fetch(body as Body, params);
-  }, [dataStale, params && selectShape.getUrl(params)]);
+    // we don't care to re-request on body (should we?)
+    // we need to check against serialized params, since params can change frequently
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataStale, fetch, params && selectShape.getUrl(params)]);
 }

--- a/src/react-integration/hooks/useSelection.ts
+++ b/src/react-integration/hooks/useSelection.ts
@@ -15,10 +15,12 @@ export default function useSelectionUnstable<
   const state = useContext(StateContext);
   // TODO: if this is identical to before and render was triggered by state update,
   // we should short-circuit entire rest of render
+  // params must be serialized in check
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const resource = useMemo(() => params && select(state, params), [
+    params && paramSerializer(params),
     select,
     state,
-    params && paramSerializer(params), // serialize?
   ]);
   return resource;
 }

--- a/src/react-integration/provider/ExternalCacheProvider.tsx
+++ b/src/react-integration/provider/ExternalCacheProvider.tsx
@@ -18,13 +18,14 @@ export default function ExternalCacheProvider<S>({
   store,
   selector,
 }: Props<S>) {
-  // TODO: Does this short-circuit if state === prevState? if not we should useReducer()
   const [state, setState] = useState(() => selector(store.getState()));
   useEffect(() => {
     const unsubscribe = store.subscribe(() => {
       setState(selector(store.getState()));
     });
     return unsubscribe;
+    // we don't care to recompute if they change selector - only when store updates
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store]);
   return (
     <DispatchContext.Provider value={store.dispatch}>


### PR DESCRIPTION
- Had to disable some lines due to params needing to be serialized to have any meaning.
- Improved useFetcher() by boxing the requestShape() since it's values are only needed at call-time in dispatch().