### PR TITLE
[fix] Avoid recreating default managers by using defaultProps

### DIFF
--- a/src/react-integration/provider/RestProvider.tsx
+++ b/src/react-integration/provider/RestProvider.tsx
@@ -11,15 +11,15 @@ import { State } from '../../types';
 
 interface ProviderProps {
   children: ReactNode;
-  manager?: NetworkManager;
-  subscriptionManager?: SubscriptionManager<any>;
+  manager: NetworkManager;
+  subscriptionManager: SubscriptionManager<any>;
   initialState?: State<unknown>;
 }
 /** Controller managing state of the REST cache and coordinating network requests. */
 export default function RestProvider({
   children,
-  manager = new NetworkManager(),
-  subscriptionManager = new SubscriptionManager(PollingSubscription),
+  manager,
+  subscriptionManager,
   initialState = defaultState,
 }: ProviderProps) {
   // TODO: option to use redux
@@ -46,4 +46,8 @@ export default function RestProvider({
       <StateContext.Provider value={state}>{children}</StateContext.Provider>
     </DispatchContext.Provider>
   );
+}
+RestProvider.defaultProps = {
+  manager: new NetworkManager(),
+  subscriptionManager: new SubscriptionManager(PollingSubscription),
 }


### PR DESCRIPTION
Default function parameters are evaluated every call (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters), so a new manager was created. By using defaultProps we enable React to only create them as the component is created.

Likely avoids issues like https://github.com/coinbase/rest-hooks/issues/78 and https://github.com/coinbase/rest-hooks/issues/50