### PR TITLE
[fix][test] MockProvider should use the same context as root imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "react-dom": "16.8.6",
     "react-hooks-testing-library": "^0.4.1",
     "react-testing-library": "^6.1.2",
-    "redux": "^4.0.1",
     "rollup": "^1.15.5",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^10.0.0",
@@ -126,6 +125,7 @@
     "flux-standard-action": "^2.1.0",
     "lodash": "^4.17.11",
     "normalizr": "^3.4.0",
+    "redux": "^4.0.1",
     "reselect": "^4.0.0",
     "superagent": "^5.0.2"
   },

--- a/src/test/MockProvider.tsx
+++ b/src/test/MockProvider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import mockState, { Fixture } from './mockState';
-import { __INTERNAL__ } from '../index';
+import { __INTERNAL__ } from '..';
 const { StateContext } = __INTERNAL__;
 
 export default function MockProvider({

--- a/src/test/makeRenderRestHook.tsx
+++ b/src/test/makeRenderRestHook.tsx
@@ -9,7 +9,7 @@ import {
   NetworkManager,
   SubscriptionManager,
   PollingSubscription,
-} from '../index';
+} from '..';
 
 export default function makeRenderRestHook(
   makeProvider: (

--- a/src/test/managers.ts
+++ b/src/test/managers.ts
@@ -1,6 +1,6 @@
 import { act } from 'react-hooks-testing-library';
 
-import { NetworkManager, FetchAction, ReceiveAction } from '../index';
+import { NetworkManager, FetchAction, ReceiveAction } from '..';
 
 export class MockNetworkManager extends NetworkManager {
   handleFetch(action: FetchAction, dispatch: React.Dispatch<any>) {

--- a/src/test/mockState.ts
+++ b/src/test/mockState.ts
@@ -1,4 +1,4 @@
-import { ReadShape, Schema, reducer, __INTERNAL__ } from '../index';
+import { ReadShape, Schema, reducer, __INTERNAL__ } from '..';
 const { initialState } = __INTERNAL__;
 
 export interface Fixture {

--- a/src/test/providers.tsx
+++ b/src/test/providers.tsx
@@ -8,7 +8,7 @@ import {
   SubscriptionManager,
   ExternalCacheProvider,
   RestProvider,
-} from '../index';
+} from '..';
 
 // Extension of the DeepPartial type defined by Redux which handles unknown
 type DeepPartialWithUnknown<T> = {


### PR DESCRIPTION
Fixes https://github.com/coinbase/rest-hooks/issues/85