### PR TITLE
[fix][test] Fix build so test.cjs imports properly

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,7 +78,7 @@ export default [
   // test utils commonjs build
   {
     input: 'src/test/index.ts',
-    external: id => id === '../index' || isExternal(id),
+    external: id => id === '..' || isExternal(id),
     output: [{ file: 'dist/test.cjs.js', format: 'cjs' }],
     plugins: [
       babel({


### PR DESCRIPTION
https://github.com/coinbase/rest-hooks/pull/86 supposedly fixed this issue, but I somehow missed updating the 'external' specification. Tested this with a repo extensively using the testing framework here.