### PR TITLE
[internal] Use absolute library imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,8 @@ module.exports = {
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
   coveragePathIgnorePatterns: ['test'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^~/(.*)$': '<rootDir>/src/$1',
+  },
   setupFiles: ['./scripts/testSetup.js'],
 };

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "auto-changelog": "^1.13.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.8.0",
-    "babel-plugin-root-import": "^6.2.0",
     "coveralls": "^3.0.4",
     "cpy-cli": "^2.0.0",
     "cross-env": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:types": "tsc --emitDeclarationOnly -p ./src",
+    "build:types": "ttsc --emitDeclarationOnly -p ./src",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib",
     "build": "npm run build:lib && npm run build:types && cpy ./src/resource/normal.d.ts ./lib/resource",
@@ -87,6 +87,7 @@
     "@types/react": "^16.8.23",
     "@typescript-eslint/eslint-plugin": "^1.10.2",
     "@typescript-eslint/parser": "^1.10.2",
+    "@zerollup/ts-transform-paths": "^1.7.3",
     "auto-changelog": "^1.13.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.8.0",
@@ -114,6 +115,7 @@
     "rollup-plugin-terser": "^5.1.0",
     "scheduler": "^0.13.6",
     "ts-jest": "^24.0.2",
+    "ttypescript": "^1.5.7",
     "typescript": "^3.5.2"
   },
   "dependencies": {

--- a/src/react-integration/context.ts
+++ b/src/react-integration/context.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ActionTypes } from 'types';
-import { initialState } from '../state/reducer';
+import { initialState } from '~/state/reducer';
 
 export const StateContext = React.createContext(initialState);
 export const DispatchContext = React.createContext((value: ActionTypes) => {});

--- a/src/react-integration/hooks/useCache.ts
+++ b/src/react-integration/hooks/useCache.ts
@@ -1,5 +1,5 @@
-import { ReadShape, Schema } from '../../resource';
-import { makeSchemaSelector } from '../../state/selectors';
+import { ReadShape, Schema } from '~/resource';
+import { makeSchemaSelector } from '~/state/selectors';
 import useSelection from './useSelection';
 
 /** Access a resource if it is available. */

--- a/src/react-integration/hooks/useError.ts
+++ b/src/react-integration/hooks/useError.ts
@@ -1,4 +1,4 @@
-import { ReadShape, Schema, RequestResource } from '../../resource';
+import { ReadShape, Schema, RequestResource } from '~/resource';
 import useMeta from './useMeta';
 
 /** Access a resource or error if failed to get it */

--- a/src/react-integration/hooks/useFetcher.ts
+++ b/src/react-integration/hooks/useFetcher.ts
@@ -1,6 +1,6 @@
 import { useContext, useRef, useCallback } from 'react';
 
-import { RequestShape, Schema, isDeleteShape } from '../../resource';
+import { RequestShape, Schema, isDeleteShape } from '~/resource';
 import { DispatchContext } from '../context';
 
 const SHAPE_TYPE_TO_RESPONSE_TYPE: Record<

--- a/src/react-integration/hooks/useFetcher.ts
+++ b/src/react-integration/hooks/useFetcher.ts
@@ -1,7 +1,7 @@
 import { useContext, useRef, useCallback } from 'react';
 
 import { RequestShape, Schema, isDeleteShape } from '~/resource';
-import { DispatchContext } from '../context';
+import { DispatchContext } from '~/react-integration/context';
 
 const SHAPE_TYPE_TO_RESPONSE_TYPE: Record<
   RequestShape<any, any, any>['type'],

--- a/src/react-integration/hooks/useInvalidator.ts
+++ b/src/react-integration/hooks/useInvalidator.ts
@@ -1,6 +1,6 @@
 import { useContext, useCallback, useRef } from 'react';
 
-import { ReadShape, Schema } from '../../resource';
+import { ReadShape, Schema } from '~/resource';
 import { DispatchContext } from '../context';
 
 /** Invalidate a certain item within the cache */

--- a/src/react-integration/hooks/useInvalidator.ts
+++ b/src/react-integration/hooks/useInvalidator.ts
@@ -1,7 +1,7 @@
 import { useContext, useCallback, useRef } from 'react';
 
 import { ReadShape, Schema } from '~/resource';
-import { DispatchContext } from '../context';
+import { DispatchContext } from '~/react-integration/context';
 
 /** Invalidate a certain item within the cache */
 export default function useInvalidator<

--- a/src/react-integration/hooks/useMeta.ts
+++ b/src/react-integration/hooks/useMeta.ts
@@ -1,7 +1,7 @@
 import { useContext, useMemo } from 'react';
 
 import { RequestShape } from '~/resource';
-import { StateContext } from '../context';
+import { StateContext } from '~/react-integration/context';
 import { selectMeta } from '~/state/selectors';
 
 /** Gets meta for a url. */

--- a/src/react-integration/hooks/useMeta.ts
+++ b/src/react-integration/hooks/useMeta.ts
@@ -1,8 +1,8 @@
 import { useContext, useMemo } from 'react';
 
-import { RequestShape } from '../../resource';
+import { RequestShape } from '~/resource';
 import { StateContext } from '../context';
-import { selectMeta } from '../../state/selectors';
+import { selectMeta } from '~/state/selectors';
 
 /** Gets meta for a url. */
 export default function useMeta<Params extends Readonly<object>>(

--- a/src/react-integration/hooks/useResource.ts
+++ b/src/react-integration/hooks/useResource.ts
@@ -1,4 +1,4 @@
-import { ReadShape, Schema, RequestResource, SchemaOf } from '../../resource';
+import { ReadShape, Schema, RequestResource, SchemaOf } from '~/resource';
 import useCache from './useCache';
 import useRetrieve from './useRetrieve';
 import useError from './useError';

--- a/src/react-integration/hooks/useResultCache.ts
+++ b/src/react-integration/hooks/useResultCache.ts
@@ -1,8 +1,8 @@
 import { useContext, useMemo } from 'react';
 
-import { ReadShape } from '../../resource';
+import { ReadShape } from '~/resource';
 import { StateContext } from '../context';
-import { makeResults } from '../../state/selectors';
+import { makeResults } from '~/state/selectors';
 
 type Resolved<P extends Promise<any>> = P extends Promise<infer R> ? R : any;
 

--- a/src/react-integration/hooks/useResultCache.ts
+++ b/src/react-integration/hooks/useResultCache.ts
@@ -1,7 +1,7 @@
 import { useContext, useMemo } from 'react';
 
 import { ReadShape } from '~/resource';
-import { StateContext } from '../context';
+import { StateContext } from '~/react-integration/context';
 import { makeResults } from '~/state/selectors';
 
 type Resolved<P extends Promise<any>> = P extends Promise<infer R> ? R : any;

--- a/src/react-integration/hooks/useRetrieve.ts
+++ b/src/react-integration/hooks/useRetrieve.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { ReadShape, Schema } from '../../resource';
+import { ReadShape, Schema } from '~/resource';
 import useFetcher from './useFetcher';
 import useMeta from './useMeta';
 

--- a/src/react-integration/hooks/useSelection.ts
+++ b/src/react-integration/hooks/useSelection.ts
@@ -1,6 +1,6 @@
 import { useContext, useMemo } from 'react';
 
-import { StateContext } from '../context';
+import { StateContext } from '~/react-integration/context';
 import { State } from '~/types';
 
 /** Use selector to access part of state */

--- a/src/react-integration/hooks/useSelection.ts
+++ b/src/react-integration/hooks/useSelection.ts
@@ -1,7 +1,7 @@
 import { useContext, useMemo } from 'react';
 
 import { StateContext } from '../context';
-import { State } from '../../types';
+import { State } from '~/types';
 
 /** Use selector to access part of state */
 export default function useSelectionUnstable<

--- a/src/react-integration/hooks/useSubscription.ts
+++ b/src/react-integration/hooks/useSubscription.ts
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useRef } from 'react';
 
 import { DispatchContext } from '../context';
-import { ReadShape, Schema } from '../../resource';
+import { ReadShape, Schema } from '~/resource';
 
 /** Keeps a resource fresh by subscribing to updates. */
 export default function useSubscription<

--- a/src/react-integration/hooks/useSubscription.ts
+++ b/src/react-integration/hooks/useSubscription.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useRef } from 'react';
 
-import { DispatchContext } from '../context';
+import { DispatchContext } from '~/react-integration/context';
 import { ReadShape, Schema } from '~/resource';
 
 /** Keeps a resource fresh by subscribing to updates. */

--- a/src/react-integration/provider/ExternalCacheProvider.tsx
+++ b/src/react-integration/provider/ExternalCacheProvider.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useEffect, useState } from 'react';
-import { StateContext, DispatchContext } from '../context';
+import { StateContext, DispatchContext } from '~/react-integration/context';
 import { State, ActionTypes } from '~/types';
 
 interface Store<S> {

--- a/src/react-integration/provider/ExternalCacheProvider.tsx
+++ b/src/react-integration/provider/ExternalCacheProvider.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 import { StateContext, DispatchContext } from '../context';
-import { State, ActionTypes } from '../../types';
+import { State, ActionTypes } from '~/types';
 
 interface Store<S> {
   subscribe(listener: () => void): () => void;

--- a/src/react-integration/provider/RestProvider.tsx
+++ b/src/react-integration/provider/RestProvider.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useEffect } from 'react';
-import { StateContext, DispatchContext } from '../context';
+import { StateContext, DispatchContext } from '~/react-integration/context';
 import masterReducer, {
   initialState as defaultState,
 } from '~/state/reducer';

--- a/src/react-integration/provider/RestProvider.tsx
+++ b/src/react-integration/provider/RestProvider.tsx
@@ -2,12 +2,12 @@ import React, { ReactNode, useEffect } from 'react';
 import { StateContext, DispatchContext } from '../context';
 import masterReducer, {
   initialState as defaultState,
-} from '../../state/reducer';
-import NetworkManager from '../../state/NetworkManager';
-import SubscriptionManager from '../../state/SubscriptionManager';
-import PollingSubscription from '../../state/PollingSubscription';
+} from '~/state/reducer';
+import NetworkManager from '~/state/NetworkManager';
+import SubscriptionManager from '~/state/SubscriptionManager';
+import PollingSubscription from '~/state/PollingSubscription';
+import { State } from '~/types';
 import createEnhancedReducerHook from './middleware';
-import { State } from '../../types';
 
 interface ProviderProps {
   children: ReactNode;

--- a/src/react-integration/provider/middleware.ts
+++ b/src/react-integration/provider/middleware.ts
@@ -1,6 +1,6 @@
 import { useReducer, useMemo, useRef } from 'react';
 import compose from 'lodash/fp/compose';
-import { Middleware } from '../../types';
+import { Middleware } from '~/types';
 
 // TODO: release as own library?
 /** Redux-middleware compatible integration for useReducer() */

--- a/src/resource/Resource.ts
+++ b/src/resource/Resource.ts
@@ -1,6 +1,6 @@
 import request from 'superagent';
 import { memoize } from 'lodash';
-import { AbstractInstanceType, Method, RequestOptions } from '../types';
+import { AbstractInstanceType, Method, RequestOptions } from '~/types';
 
 import { ReadShape, MutateShape, DeleteShape } from './types';
 import { schemas, SchemaBase, SchemaArray } from './normal';

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -1,5 +1,5 @@
 import { schemas, Schema, SchemaArray, SchemaBase } from './normal';
-import { RequestOptions } from '../types';
+import { RequestOptions } from '~/types';
 
 /** Defines the shape of a network request */
 export interface RequestShape<

--- a/src/state/NetworkManager.ts
+++ b/src/state/NetworkManager.ts
@@ -1,5 +1,5 @@
 import { memoize } from 'lodash';
-import { FetchAction, ReceiveAction, MiddlewareAPI } from '../types';
+import { FetchAction, ReceiveAction, MiddlewareAPI } from '~/types';
 
 export const RIC: (cb: (...args: any[]) => void, options: any) => void =
   typeof (global as any).requestIdleCallback === 'function'

--- a/src/state/PollingSubscription.ts
+++ b/src/state/PollingSubscription.ts
@@ -1,4 +1,4 @@
-import { Schema } from '../resource';
+import { Schema } from '~/resource';
 import { Subscription, SubscriptionInit } from './SubscriptionManager';
 
 function min(iter: IterableIterator<number>) {

--- a/src/state/SubscriptionManager.ts
+++ b/src/state/SubscriptionManager.ts
@@ -1,6 +1,6 @@
 import { memoize } from 'lodash';
-import { MiddlewareAPI, SubscribeAction, UnsubscribeAction } from '../types';
-import { Schema } from '../resource';
+import { MiddlewareAPI, SubscribeAction, UnsubscribeAction } from '~/types';
+import { Schema } from '~/resource';
 
 type Actions = UnsubscribeAction | SubscribeAction;
 

--- a/src/state/getEntityPath.ts
+++ b/src/state/getEntityPath.ts
@@ -1,5 +1,5 @@
-import { isEntity } from '../resource/types';
-import { Schema, schemas } from '../resource/normal';
+import { isEntity } from '~/resource/types';
+import { Schema, schemas } from '~/resource/normal';
 
 export default function getEntityPath(schema: Schema): string[] | false {
   if (

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -1,6 +1,6 @@
-import { normalize } from '../resource';
 import { mergeWith } from 'lodash';
-import { ActionTypes, State } from '../types';
+import { normalize } from '~/resource';
+import { ActionTypes, State } from '~/types';
 
 export const initialState: State<unknown> = {
   entities: {},

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -1,8 +1,8 @@
 import { createSelector } from 'reselect';
 import { memoize } from 'lodash';
-import { State } from '../types';
-import { isEntity, SchemaOf } from '../resource/types';
-import { Schema, denormalize } from '../resource/normal';
+import { State } from '~/types';
+import { isEntity, SchemaOf } from '~/resource/types';
+import { Schema, denormalize } from '~/resource/normal';
 import getEntityPath from './getEntityPath';
 
 export function selectMeta<R = any>(state: State<R>, url: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "paths": { "scheduler": ["types/scheduler.d.ts"] },
+    "plugins": [{ "transform": "@zerollup/ts-transform-paths" }],
     /* Basic Options */
     "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
@@ -40,7 +40,10 @@
     /* Module Resolution Options */
     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
-    "paths": {"~/*": ["*"]},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "paths": {
+      "scheduler": ["types/scheduler.d.ts"],
+      "~/*": ["*"]
+    },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": ["./src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,7 @@
     /* Module Resolution Options */
     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "paths": {"~/*": ["*"]},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": ["./src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2287,15 +2287,6 @@ browserslist@^4.6.0:
     electron-to-chromium "^1.3.133"
     node-releases "^1.1.19"
 
-browserslist@^4.6.2:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.3.tgz#0530cbc6ab0c1f3fc8c819c72377ba55cf647f05"
-  integrity sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==
-  dependencies:
-    caniuse-lite "^1.0.30000975"
-    electron-to-chromium "^1.3.164"
-    node-releases "^1.1.23"
-
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -2438,11 +2429,6 @@ caniuse-lite@^1.0.30000967, caniuse-lite@^1.0.30000971:
   version "1.0.30000971"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz#d1000e4546486a6977756547352bc96a4cfd2b13"
   integrity sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==
-
-caniuse-lite@^1.0.30000975:
-  version "1.0.30000975"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000975.tgz#d4e7131391dddcf2838999d3ce75065f65f1cdfc"
-  integrity sha512-ZsXA9YWQX6ATu5MNg+Vx/cMQ+hM6vBBSqDeJs8ruk9z0ky4yIHML15MoxcFt088ST2uyjgqyUGRJButkptWf0w==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -2697,18 +2683,18 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-compat@^3.0.0, core-js-compat@^3.1.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.1.4.tgz#e4d0c40fbd01e65b1d457980fe4112d4358a7408"
-  integrity sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.1.2.tgz#c29ab9722517094b98622175e2218c3b7398176d"
+  integrity sha512-X0Ch5f6itrHxhg5HSJucX6nNLNAGr+jq+biBh6nPGc3YAWz2a8p/ZIZY8cUkDzSRNG54omAuu3hoEF8qZbu/6Q==
   dependencies:
-    browserslist "^4.6.2"
-    core-js-pure "3.1.4"
-    semver "^6.1.1"
+    browserslist "^4.6.0"
+    core-js-pure "3.1.2"
+    semver "^6.0.0"
 
-core-js-pure@3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
-  integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
+core-js-pure@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.2.tgz#62fc435f35b7374b9b782013cdcb2f97e9f6dffa"
+  integrity sha512-5ckIdBF26B3ldK9PM177y2ZcATP2oweam9RskHSoqfZCrJ2As6wVg8zJ1zTriFsZf6clj/N1ThDFRGaomMsh9w==
 
 core-js@^2.6.5:
   version "2.6.9"
@@ -3122,11 +3108,6 @@ electron-to-chromium@^1.3.133:
   version "1.3.136"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz#758a156109077536780cfa8207b1aeaa99843e33"
   integrity sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ==
-
-electron-to-chromium@^1.3.164:
-  version "1.3.165"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.165.tgz#51864c9e3c9bd9e1c020b9493fddcc0f49888e3a"
-  integrity sha512-iIS8axR524EAnvUtWUNnREnYjQrS0zUvutIKYgTVuN3MzcjrV31EuJYKw7DGOtFO9DQw+JiXeaVDPQWMskG1wQ==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -5624,13 +5605,6 @@ node-releases@^1.1.19:
   version "1.1.21"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.21.tgz#46c86f9adaceae4d63c75d3c2f2e6eee618e55f3"
   integrity sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==
-  dependencies:
-    semver "^5.3.0"
-
-node-releases@^1.1.23:
-  version "1.1.23"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
-  integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
   dependencies:
     semver "^5.3.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,6 +1489,20 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+"@zerollup/ts-helpers@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@zerollup/ts-helpers/-/ts-helpers-1.7.0.tgz#491269c65fbe4207ad7d88b483488f652f83ade8"
+  integrity sha512-Nr5taViAcvl4uo41/vlXcyDoLrEKiJUJkk4jN/WUzCyHZC5In6pGFK7WpYabwi67wxWn2Na6OV8oBtbFpqKUXw==
+  dependencies:
+    resolve "^1.8.1"
+
+"@zerollup/ts-transform-paths@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@zerollup/ts-transform-paths/-/ts-transform-paths-1.7.3.tgz#cc93a0be4f6f8e33598b5a6da46fa0e4ccf85168"
+  integrity sha512-HxwlDpxB7awHypfO7vr+E9WXYXw0ymZJckXLMdtp51Hm8bP4M4VX0c1vOrfmcji85h7BkcxNKt1aONc98r3ANw==
+  dependencies:
+    "@zerollup/ts-helpers" "^1.7.0"
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -6688,7 +6702,7 @@ resolve@^1.10.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.11.0, resolve@^1.11.1:
+resolve@^1.11.0, resolve@^1.11.1, resolve@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
   integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
@@ -7554,6 +7568,13 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
+
+ttypescript@^1.5.7:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.7.tgz#76bb96765b331194b58a4e7d79fae82b886fc29a"
+  integrity sha512-qloW8S60+xWVC2bQWldYQfESNFkIgDL5/M+vAOOsuLJ1pQu0SG2vQx5DNJO2nlwSrHxD8cDuF2sVDXg6v3GG3Q==
+  dependencies:
+    resolve "^1.9.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
In my issue https://github.com/grrowl/ts-transformer-imports/issues/15#issuecomment-506940292 someone pointed out that [@zerollup/ts-transform-paths](https://www.npmjs.com/package/@zerollup/ts-transform-paths) seemed to work for this. Seems to be working so far.

This time I opened the .d.ts files in /lib after a build to ensure the relative paths were there (the transform should be changing the ~/). Also after re-opening vscode, it was able to resolve all type imports in the src files as well.