### PR TITLE
[fix] Allow Resource to have 'url' member

### DIFF
--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -87,6 +87,9 @@ export class ArticleResource extends Resource {
   }
 }
 
+export class UrlArticleResource extends ArticleResource {
+  readonly url: string = 'happy.com';
+}
 
 export class CoolerArticleResource extends ArticleResource {
   static urlRoot = 'http://test.com/article-cooler/';

--- a/src/resource/Resource.ts
+++ b/src/resource/Resource.ts
@@ -150,10 +150,12 @@ export default abstract class Resource {
 
   /** URL to find this Resource */
   get url(): string {
+    if (this.__url !== undefined) return this.__url;
     // typescript thinks constructor is just a function
     const Static = this.constructor as typeof Resource;
     return Static.url(this);
   }
+  private __url?: string;
 
   /** Get the url for a Resource
    *
@@ -237,7 +239,9 @@ export default abstract class Resource {
     const getFetchKey = (params: Readonly<object>) => {
       return 'GET ' + this.url(params);
     };
-    const schema: SchemaDetail<AbstractInstanceType<T>> = this.getEntitySchema();
+    const schema: SchemaDetail<
+      AbstractInstanceType<T>
+    > = this.getEntitySchema();
     const options = this.getRequestOptions();
     return {
       type: 'read',
@@ -363,3 +367,11 @@ export default abstract class Resource {
     };
   }
 }
+
+// We're only allowing this to get set for descendants but
+// by default we want Typescript to treat it as readonly.
+Object.defineProperty(Resource.prototype, 'url', {
+  set(url: string) {
+    this.__url = url;
+  },
+});

--- a/src/resource/__tests__/resource.ts
+++ b/src/resource/__tests__/resource.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 
-import { CoolerArticleResource, UserResource } from '../../__tests__/common';
+import { CoolerArticleResource, UserResource, UrlArticleResource } from '../../__tests__/common';
 import { Resource, normalize } from '..';
 
 describe('Resource', () => {
@@ -19,6 +19,10 @@ describe('Resource', () => {
   });
   it('should not init Resource itself', () => {
     expect(() => Resource.fromJS({})).toThrow();
+  });
+  it('should work with `url` member', () => {
+    expect(() => UrlArticleResource.fromJS({})).not.toThrow();
+    expect(() => UrlArticleResource.fromJS({url: 'five'})).not.toThrow();
   });
   it('should convert class to string', () => {
     expect(CoolerArticleResource.toString()).toBeDefined();


### PR DESCRIPTION
Fixes https://github.com/coinbase/rest-hooks/issues/106

This maintains url's type as readonly string unless overridden. However, technically in JS people can set (this is fine as we don't enforce JS-side anyway). Setting JS side is necessary to make setting default property work. Technically this still limits descendants to only using string type for url. However, this seems unlikely to be a problem as I can't imagine something named 'url' being a number. Most likely any issues with this will be if someone uses an object type. Will revisit if that becomes an issue.