### PR TITLE
[docs] Replace SchemaBase with SchemaDetail

### DIFF
--- a/docs/guides/endpoints.md
+++ b/docs/guides/endpoints.md
@@ -180,14 +180,14 @@ we'll be extended that schema definition.
 import {
   Resource,
   MutateShape,
-  SchemaBase,
+  SchemaDetail,
   AbstractInstanceType,
 } from 'rest-hooks';
 
 export default class UserResource extends Resource {
   static makeManagerRequest<T extends typeof Resource>(
     this: T,
-  ): MutateShape<SchemaBase<AbstractInstanceType<T>>, { id: number }, {}> {
+  ): MutateShape<SchemaDetail<AbstractInstanceType<T>>, { id: number }, {}> {
     return {
       ...this.createShape(),
       getFetchKey({ id }: { id: number }) {
@@ -219,7 +219,7 @@ is only one - we won't need to send any params.
 import {
   Resource,
   ReadShape,
-  SchemaBase,
+  SchemaDetail,
   AbstractInstanceType,
 } from 'rest-hooks';
 
@@ -227,7 +227,7 @@ export default class UserResource extends Resource {
   /** Retrieves current logged in user */
   static currentRequest<T extends typeof Resource>(
     this: T,
-  ): ReadShape<SchemaBase<AbstractInstanceType<T>>, {}> {
+  ): ReadShape<SchemaDetail<AbstractInstanceType<T>>, {}> {
     return {
       ...this.detailShape(),
       getFetchKey() {

--- a/docs/guides/network-transform.md
+++ b/docs/guides/network-transform.md
@@ -130,7 +130,7 @@ abstract class StreamResource extends CamelResource {
 
   static detailShape<T extends typeof Resource>(
     this: T,
-  ): ReadShape<SchemaBase<AbstractInstanceType<T>>, { username: string }> {
+  ): ReadShape<SchemaDetail<AbstractInstanceType<T>>, { username: string }> {
     const superShape = super.detailShape();
     return {
       ...superShape,

--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -49,7 +49,7 @@ shape.
 import {
   Resource,
   MutateShape,
-  SchemaBase,
+  SchemaDetail,
   AbstractInstanceType,
 } from 'rest-hooks';
 
@@ -58,7 +58,7 @@ class TradeResource extends Resource {
   static createShape<T extends typeof Resource>(
     this: T,
   ): MutateShape<
-    SchemaBase<AbstractInstanceType<T>>,
+    SchemaDetail<AbstractInstanceType<T>>,
     any,
     Partial<AbstractInstanceType<T>>
   > {


### PR DESCRIPTION
I found that the docs were out of date, using the latest release (2.0.3) when it came to using `SchemaBase`. The migration page says that the interface was renamed and so the docs were not correct.

This PR replaces references of the outdated interface `SchemaBase` to `SchemaDetail` in the docs.