### PR TITLE
[enhance] Allow string type for body (payload) parameters

### DIFF
--- a/docs/api/FetchShape.md
+++ b/docs/api/FetchShape.md
@@ -31,7 +31,7 @@ interface FetchShape {
 interface FetchShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object> | undefined
 > {
   readonly type: 'read' | 'mutate' | 'delete';
   fetch(params: Params, body: Body): Promise<any>;

--- a/docs/api/useFetcher.md
+++ b/docs/api/useFetcher.md
@@ -22,7 +22,7 @@ type FetchFunction = (
 ```typescript
 function useFetcher<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(
   fetchShape: FetchShape<S, Params, Body>,

--- a/docs/api/useResource.md
+++ b/docs/api/useResource.md
@@ -19,13 +19,13 @@ function useResource(...[fetchShape: ReadShape, params: Params | null]):
 ```typescript
 function useResource<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(fetchShape: ReadShape<S, Params, Body>, params: Params | null): SchemaOf<S>;
 
 function useResource<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(...[fetchShape: ReadShape<S, Params, Body>, params: Params | null]): SchemaOf<S>[];
 ```

--- a/docs/api/useRetrieve.md
+++ b/docs/api/useRetrieve.md
@@ -9,7 +9,7 @@ title: useRetrieve()
 function useRetrieve(
   fetchShape: ReadShape,
   params: Readonly<object> | null,
-  body?: Readonly<object> | void,
+  body?: Readonly<object | string> | void,
 ): Promise<any> | undefined;
 ```
 
@@ -18,7 +18,7 @@ function useRetrieve(
 ```typescript
 function useRetrieve<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(
   fetchShape: ReadShape<S, Params, Body>,

--- a/docs/api/useSubscription.md
+++ b/docs/api/useSubscription.md
@@ -9,7 +9,7 @@ title: useSubscription()
 function useSubscription(
   fetchShape: ReadShape,
   params: Readonly<object> | null,
-  body?: Readonly<object> | void,
+  body?: Readonly<object | string> | void,
   active?: boolean = true,
 ): void;
 ```
@@ -19,7 +19,7 @@ function useSubscription(
 ```typescript
 function useSubscription<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(
   fetchShape: ReadShape<S, Params, Body>,

--- a/docs/guides/custom-networking.md
+++ b/docs/guides/custom-networking.md
@@ -26,7 +26,7 @@ export default abstract class Resource extends SimpleResource {
     this: T,
     method: Method,
     url: string,
-    body?: Readonly<object>,
+    body?: Readonly<object | string>,
   ) {
     let req = request[method](url).on('error', () => {});
     if (this.fetchPlugin) req = req.use(this.fetchPlugin);
@@ -61,7 +61,7 @@ export default abstract class FetchResource extends SimpleResource {
     this: T,
     method: Method,
     url: string,
-    body?: Readonly<object>
+    body?: Readonly<object | string>
   ) {
     let options: RequestInit = {
       method: method.toUpperCase(),
@@ -94,7 +94,7 @@ export default abstract class AxiosResource extends SimpleResource {
     this: T,
     method: Method,
     url: string,
-    body?: Readonly<object>
+    body?: Readonly<object | string>
   ) {
     return await axios[method](url, body);
   }

--- a/docs/guides/endpoints.md
+++ b/docs/guides/endpoints.md
@@ -193,7 +193,7 @@ export default class UserResource extends Resource {
       getFetchKey({ id }: { id: number }) {
         return `/users/${id}/make_manager`;
       },
-      fetch({ id }: { id: number }, body?: Readonly<object>) {
+      fetch({ id }: { id: number }, body?: Readonly<object | string>) {
         return self.fetch('post', `/users/${id}/make_manager`, body);
       },
     };
@@ -233,7 +233,7 @@ export default class UserResource extends Resource {
       getFetchKey() {
         return '/current_user/';
       },
-      fetch(params: {}, body?: Readonly<object>) {
+      fetch(params: {}, body?: Readonly<object | string>) {
         return self.fetch('post', `/current_user/`, body);
       },
     };

--- a/docs/guides/mocking-unfinished.md
+++ b/docs/guides/mocking-unfinished.md
@@ -40,7 +40,7 @@ export default class RatingResource extends Resource {
   ): ReadShape<SchemaList<AbstractInstanceType<T>>> {
     return {
       ...super.listShape(),
-      fetch(params: Readonly<object>, body?: Readonly<object>) {
+      fetch(params: Readonly<object>, body?: Readonly<object | string>) {
         return Promise.resolve(
           ['Morningstar', 'Seekingalpha', 'Morningstar', 'CNBC'].map(
             author => ({

--- a/docs/guides/network-transform.md
+++ b/docs/guides/network-transform.md
@@ -35,7 +35,7 @@ abstract class CamelResource extends Resource {
     this: T,
     method: Method = 'get',
     url: string,
-    body?: Readonly<object>,
+    body?: Readonly<object | string>,
   ) {
     // we'll need to do the inverse operation when sending data back to the server
     if (body) {
@@ -68,7 +68,7 @@ class ArticleResource extends CamelResource {
     this: T,
     method: Method = 'get',
     url: string,
-    body?: Readonly<object>,
+    body?: Readonly<object | string>,
   ) {
     // we'll need to do the inverse operation when sending data back to the server
     if (body && 'carrotsUsed' in body) {
@@ -134,7 +134,7 @@ abstract class StreamResource extends CamelResource {
     const superShape = super.detailShape();
     return {
       ...superShape,
-      fetch: async (params: { username: string }, body?: Readonly<object>) => {
+      fetch: async (params: { username: string }, body?: Readonly<object | string>) => {
         const response = await superShape.fetch(params, body);
         response.username = params.username;
         return response;

--- a/docs/guides/no-suspense.md
+++ b/docs/guides/no-suspense.md
@@ -19,7 +19,7 @@ import { useRetrieve, useCache, useError, Schema, ReadShape } from 'rest-hooks';
 function hasUsableData<
   S extends Schema,
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void
+  Body extends Readonly<object | string> | void
 >(
   resource: RequestResource<ReadShape<S, Params, Body>> | null,
   fetchShape: ReadShape<S, Params, Body>,
@@ -33,7 +33,7 @@ function hasUsableData<
 /** Ensure a resource is available; loading and error returned explicitly. */
 function useStatefulResource<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(fetchShape: ReadShape<S, Params, Body>, params: Params | null) {
   let maybePromise = useRetrieve(fetchShape, params);

--- a/docs/guides/pagination.md
+++ b/docs/guides/pagination.md
@@ -110,7 +110,7 @@ export default class ArticleResource extends Resource {
 
   /** Shape to get a list of entities */
   static listShape<T extends typeof Resource>(this: T): ReadShape<SchemaList<AbstractInstanceType<T>>> {
-    const fetch = async (params: Readonly<object>, body?: Readonly<object>) => {
+    const fetch = async (params: Readonly<object>, body?: Readonly<object | string>) => {
       const url = this.listUrl(params);
       let req = request['get'](url).on('error', () => {});
       if (this.fetchPlugin) req = req.use(this.fetchPlugin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,17 +58,17 @@ export type DeleteShape<
 export type MutateShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object> | undefined
 > = MutateShape<S, Params, Body>;
 export type ReadShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object> | undefined
 > = ReadShape<S, Params, Body>;
 export type FetchShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object> | undefined
 > = FetchShape<S, Params, Body>;
 
 export type State<T> = State<T>;

--- a/src/react-integration/hooks/useError.ts
+++ b/src/react-integration/hooks/useError.ts
@@ -4,7 +4,7 @@ import useMeta from './useMeta';
 /** Access a resource or error if failed to get it */
 export default function useError<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(
   fetchShape: ReadShape<S, Params, Body>,

--- a/src/react-integration/hooks/useFetcher.ts
+++ b/src/react-integration/hooks/useFetcher.ts
@@ -15,7 +15,7 @@ const SHAPE_TYPE_TO_RESPONSE_TYPE: Record<
 /** Build an imperative dispatcher to issue network requests. */
 export default function useFetcher<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(fetchShape: FetchShape<S, Params, Body>, throttle = false) {
   const dispatch = useContext(DispatchContext);

--- a/src/react-integration/hooks/useResource.ts
+++ b/src/react-integration/hooks/useResource.ts
@@ -7,14 +7,14 @@ import { useMemo } from 'react';
 type ResourceArgs<
   S extends Schema,
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void
+  Body extends Readonly<object | string> | void
 > = [ReadShape<S, Params, Body>, Params | null];
 
 /** If the invalidIfStale option is set we suspend if resource has expired */
 function hasUsableData<
   S extends Schema,
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void
+  Body extends Readonly<object | string> | void
 >(
   resource: RequestResource<ReadShape<S, Params, Body>> | null,
   fetchShape: ReadShape<S, Params, Body>,
@@ -28,7 +28,7 @@ function hasUsableData<
 /** single form resource */
 function useOneResource<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(fetchShape: ReadShape<S, Params, Body>, params: Params | null) {
   let maybePromise = useRetrieve(fetchShape, params);
@@ -53,7 +53,7 @@ function useManyResources<A extends ResourceArgs<any, any, any>[]>(
   const resources = resourceList.map(
     <
       Params extends Readonly<object>,
-      Body extends Readonly<object> | void,
+      Body extends Readonly<object | string> | void,
       S extends Schema
     >([select, params]: ResourceArgs<S, Params, Body>) =>
       // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -94,7 +94,7 @@ type CondNull<P, R> = P extends null ? null : R;
 /** Ensure a resource is available; suspending to React until it is. */
 export default function useResource<
   P extends Readonly<object> | null,
-  B extends Readonly<object> | void,
+  B extends Readonly<object | string> | void,
   S extends Schema
 >(
   fetchShape: ReadShape<S, NonNullable<P>, B>,
@@ -102,15 +102,15 @@ export default function useResource<
 ): CondNull<P, SchemaOf<S>>;
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object> | void,
+  B1 extends Readonly<object | string> | void,
   S1 extends Schema
 >(v1: [ReadShape<S1, NonNullable<P1>, B1>, P1]): [CondNull<P1, SchemaOf<S1>>];
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object> | void,
+  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object> | void,
+  B2 extends Readonly<object | string> | void,
   S2 extends Schema
 >(
   v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
@@ -118,13 +118,13 @@ export default function useResource<
 ): [CondNull<P1, SchemaOf<S1>>, CondNull<P2, SchemaOf<S2>>];
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object> | void,
+  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object> | void,
+  B2 extends Readonly<object | string> | void,
   S2 extends Schema,
   P3 extends Readonly<object> | null,
-  B3 extends Readonly<object> | void,
+  B3 extends Readonly<object | string> | void,
   S3 extends Schema
 >(
   v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
@@ -137,16 +137,16 @@ export default function useResource<
 ];
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object> | void,
+  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object> | void,
+  B2 extends Readonly<object | string> | void,
   S2 extends Schema,
   P3 extends Readonly<object> | null,
-  B3 extends Readonly<object> | void,
+  B3 extends Readonly<object | string> | void,
   S3 extends Schema,
   P4 extends Readonly<object> | null,
-  B4 extends Readonly<object> | void,
+  B4 extends Readonly<object | string> | void,
   S4 extends Schema
 >(
   v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
@@ -161,19 +161,19 @@ export default function useResource<
 ];
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object> | void,
+  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object> | void,
+  B2 extends Readonly<object | string> | void,
   S2 extends Schema,
   P3 extends Readonly<object> | null,
-  B3 extends Readonly<object> | void,
+  B3 extends Readonly<object | string> | void,
   S3 extends Schema,
   P4 extends Readonly<object> | null,
-  B4 extends Readonly<object> | void,
+  B4 extends Readonly<object | string> | void,
   S4 extends Schema,
   P5 extends Readonly<object> | null,
-  B5 extends Readonly<object> | void,
+  B5 extends Readonly<object | string> | void,
   S5 extends Schema
 >(
   v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
@@ -190,7 +190,7 @@ export default function useResource<
 ];
 export default function useResource<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(...args: ResourceArgs<S, Params, Body> | ResourceArgs<S, Params, Body>[]) {
   // this conditional use of hooks is ok as long as the structure of the arguments don't change

--- a/src/react-integration/hooks/useRetrieve.ts
+++ b/src/react-integration/hooks/useRetrieve.ts
@@ -7,7 +7,7 @@ import useMeta from './useMeta';
 /** Returns whether the data at this url is fresh or stale */
 function useIsStale<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(fetchShape: ReadShape<S, Params, Body>, params: Params | null): boolean {
   const meta = useMeta(fetchShape, params);
@@ -20,7 +20,7 @@ function useIsStale<
 /** Request a resource if it is not in cache. */
 export default function useRetrieve<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(fetchShape: ReadShape<S, Params, Body>, params: Params | null, body?: Body) {
   const fetch = useFetcher(fetchShape, true);

--- a/src/react-integration/hooks/useSubscription.ts
+++ b/src/react-integration/hooks/useSubscription.ts
@@ -6,7 +6,7 @@ import { ReadShape, Schema } from '~/resource';
 /** Keeps a resource fresh by subscribing to updates. */
 export default function useSubscription<
   Params extends Readonly<object>,
-  Body extends Readonly<object> | void,
+  Body extends Readonly<object | string> | void,
   S extends Schema
 >(
   fetchShape: ReadShape<S, Params, Body>,

--- a/src/resource/Resource.ts
+++ b/src/resource/Resource.ts
@@ -13,7 +13,7 @@ export default abstract class Resource extends SimpleResource {
     this: T,
     method: Method,
     url: string,
-    body?: Readonly<object>,
+    body?: Readonly<object | string>,
   ) {
     let req = request[method](url).on('error', () => {});
     if (this.fetchPlugin) req = req.use(this.fetchPlugin);

--- a/src/resource/SimpleResource.ts
+++ b/src/resource/SimpleResource.ts
@@ -199,7 +199,7 @@ export default abstract class SimpleResource {
     this: T,
     method: Method,
     url: string,
-    body?: Readonly<object>,
+    body?: Readonly<object | string>,
   ): Promise<any> {
     // typescript currently doesn't allow abstract static methods
     throw new Error('not implemented');
@@ -237,7 +237,7 @@ export default abstract class SimpleResource {
       schema,
       options,
       getFetchKey,
-      fetch(params: Readonly<object>, body?: Readonly<object>) {
+      fetch(params: Readonly<object>, body?: Readonly<object | string>) {
         return self.fetch('get', self.url(params), body);
       },
     };
@@ -262,7 +262,7 @@ export default abstract class SimpleResource {
       getFetchKey,
       fetch(
         params: Readonly<Record<string, string | number>>,
-        body?: Readonly<object>,
+        body?: Readonly<object | string>,
       ) {
         return self.fetch('get', self.listUrl(params), body);
       },

--- a/src/resource/index.ts
+++ b/src/resource/index.ts
@@ -26,17 +26,17 @@ export type DeleteShape<
 export type MutateShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object | string> | undefined
 > = MutateShape<S, Params, Body>;
 export type ReadShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object | string> | undefined
 > = ReadShape<S, Params, Body>;
 export type FetchShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object | string> | undefined
 > = FetchShape<S, Params, Body>;
 export type Schema<T = any> = Schema<T>;
 export type SchemaOf<T> = SchemaOf<T>;

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -5,7 +5,7 @@ import { RequestOptions } from '~/types';
 export interface FetchShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object | string> | undefined
 > {
   readonly type: 'read' | 'mutate' | 'delete';
   fetch(params: Params, body: Body): Promise<any>;
@@ -27,7 +27,7 @@ export interface DeleteShape<
 export interface MutateShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object | string> | undefined
 > extends FetchShape<S, Params, Body> {
   readonly type: 'mutate';
 }
@@ -36,7 +36,7 @@ export interface MutateShape<
 export interface ReadShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object | string> | undefined
 > extends FetchShape<S, Params, Body> {
   readonly type: 'read';
 }

--- a/src/test/mockState.ts
+++ b/src/test/mockState.ts
@@ -10,7 +10,7 @@ export interface Fixture {
 export default function mockInitialState<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object> | void = Readonly<object> | undefined
+  Body extends Readonly<object | string> | void = Readonly<object> | undefined
 >(results: Fixture[]) {
   const now = Date.now();
   const mockState = results.reduce((acc, { request, params, result }) => {


### PR DESCRIPTION
### Motivation
Strings are completely legal arguments for body so they should be allowed.

