### PR TITLE
[enhance] Handle null fetch response even in production

### DIFF
--- a/src/fsa.ts
+++ b/src/fsa.ts
@@ -1,0 +1,77 @@
+import { ErrorFSAAuto, FSA } from 'flux-standard-action';
+
+export type ErrorableFSAAuto<
+  Type extends string = string,
+  Payload = undefined,
+  Meta = undefined,
+  CustomError extends Error = Error
+> =
+  | ErrorFSAAuto<Type, CustomError, Meta>
+  | NoErrorFluxStandardActionAuto<Type, Payload, Meta>;
+
+export interface NoErrorFluxStandardAction<
+  Type extends string = string,
+  Payload = undefined,
+  Meta = undefined
+> extends FSA<Type, Payload, Meta> {
+  error?: false;
+}
+
+/**
+ * A Flux Standard action with a required payload property.
+ */
+export interface NoErrorFluxStandardActionWithPayload<
+  Type extends string = string,
+  Payload = undefined,
+  Meta = undefined
+> extends NoErrorFluxStandardAction<Type, Payload, Meta> {
+  /**
+   * The required `payload` property MAY be any type of value.
+   * It represents the payload of the action.
+   * Any information about the action that is not the type or status of the action should be part of the `payload` field.
+   * By convention, if `error` is `true`, the `payload` SHOULD be an error object.
+   * This is akin to rejecting a promise with an error object.
+   */
+  payload: Payload;
+}
+
+/**
+ * A Flux Standard action with a required metadata property.
+ */
+export interface NoErrorFluxStandardActionWithMeta<
+  Type extends string = string,
+  Payload = undefined,
+  Meta = undefined
+> extends NoErrorFluxStandardAction<Type, Payload, Meta> {
+  /**
+   * The required `meta` property MAY be any type of value.
+   * It is intended for any extra information that is not part of the payload.
+   */
+  meta: Meta;
+}
+/**
+ * A Flux Standard action with required payload and metadata properties.
+ */
+export type NoErrorFluxStandardActionWithPayloadAndMeta<
+  Type extends string = string,
+  Payload = undefined,
+  Meta = undefined
+> = NoErrorFluxStandardActionWithPayload<Type, Payload, Meta> &
+  NoErrorFluxStandardActionWithMeta<Type, Payload, Meta>;
+
+/**
+ * A Flux Standard action with inferred requirements for the payload and metadata properties.
+ * The `payload` and `meta` properties will be required if the corresponding type argument
+ * if not the `undefined` type.
+ */
+export type NoErrorFluxStandardActionAuto<
+  Type extends string = string,
+  Payload = undefined,
+  Meta = undefined
+> = Payload extends undefined
+  ? (Meta extends undefined
+      ? NoErrorFluxStandardAction<Type, Payload, Meta>
+      : NoErrorFluxStandardActionWithMeta<Type, Payload, Meta>)
+  : (Meta extends undefined
+      ? NoErrorFluxStandardActionWithPayload<Type, Payload, Meta>
+      : NoErrorFluxStandardActionWithPayloadAndMeta<Type, Payload, Meta>);

--- a/src/fsa.ts
+++ b/src/fsa.ts
@@ -1,13 +1,35 @@
-import { ErrorFSAAuto, FSA } from 'flux-standard-action';
+import {
+  ErrorFluxStandardActionWithPayloadAndMeta,
+  ErrorFluxStandardActionWithPayload,
+  FSA,
+} from 'flux-standard-action';
 
-export type ErrorableFSAAuto<
+export type ErrorableFSAWithPayloadAndMeta<
   Type extends string = string,
   Payload = undefined,
   Meta = undefined,
   CustomError extends Error = Error
 > =
-  | ErrorFSAAuto<Type, CustomError, Meta>
-  | NoErrorFluxStandardActionAuto<Type, Payload, Meta>;
+  | ErrorFluxStandardActionWithPayloadAndMeta<Type, CustomError, Meta>
+  | NoErrorFluxStandardActionWithPayloadAndMeta<Type, Payload, Meta>;
+
+export type ErrorableFSAWithMeta<
+  Type extends string = string,
+  Payload = undefined,
+  Meta = undefined,
+  CustomError extends Error = Error
+> =
+  | ErrorFluxStandardActionWithPayloadAndMeta<Type, CustomError, Meta>
+  | NoErrorFluxStandardActionWithMeta<Type, Payload, Meta>;
+
+export type ErrorableFSAWithPayload<
+  Type extends string = string,
+  Payload = undefined,
+  Meta = undefined,
+  CustomError extends Error = Error
+> =
+  | ErrorFluxStandardActionWithPayload<Type, CustomError, Meta>
+  | NoErrorFluxStandardActionWithPayload<Type, Payload, Meta>;
 
 export interface NoErrorFluxStandardAction<
   Type extends string = string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ import {
   State,
   FetchAction,
   ReceiveAction,
+  RPCAction,
+  PurgeAction,
   Middleware,
   Manager,
 } from './types';
@@ -82,8 +84,16 @@ export type Method = Method;
 
 export type NetworkError = NetworkError;
 export type Request = RequestType;
-export type FetchAction = FetchAction;
-export type ReceiveAction = ReceiveAction;
+export type FetchAction<
+  Payload extends object | string | number = object | string | number
+> = FetchAction<Payload>;
+export type ReceiveAction<
+  Payload extends object | string | number = object | string | number
+> = ReceiveAction<Payload>;
+export type RPCAction<
+  Payload extends object | string | number = object | string | number
+> = RPCAction<Payload>;
+export type PurgeAction = PurgeAction;
 
 export type Middleware = Middleware;
 export type Manager = Manager;

--- a/src/resource/Resource.ts
+++ b/src/resource/Resource.ts
@@ -19,7 +19,10 @@ export default abstract class Resource extends SimpleResource {
     if (this.fetchPlugin) req = req.use(this.fetchPlugin);
     if (body) req = req.send(body);
     return req.then(res => {
-      if (!res.type.includes('json') && Object.keys(res.body).length === 0 || res.body === null) {
+      if (
+        (!res.type.includes('json') && Object.keys(res.body).length === 0) ||
+        res.body === null
+      ) {
         throw new Error('JSON expected but not returned from API');
       }
       return res.body;

--- a/src/resource/Resource.ts
+++ b/src/resource/Resource.ts
@@ -19,10 +19,8 @@ export default abstract class Resource extends SimpleResource {
     if (this.fetchPlugin) req = req.use(this.fetchPlugin);
     if (body) req = req.send(body);
     return req.then(res => {
-      if (process.env.NODE_ENV !== 'production') {
-        if (!res.type.includes('json') && Object.keys(res.body).length === 0) {
-          throw new Error('JSON expected but not returned from API');
-        }
+      if (!res.type.includes('json') && Object.keys(res.body).length === 0 || res.body === null) {
+        throw new Error('JSON expected but not returned from API');
       }
       return res.body;
     });

--- a/src/state/__tests__/reducer.ts
+++ b/src/state/__tests__/reducer.ts
@@ -97,9 +97,10 @@ describe('resourceCustomizer', () => {
 describe('reducer', () => {
   describe('singles', () => {
     const id = 20;
-    const action: ReceiveAction = {
+    const payload = { id, title: 'hi', content: 'this is the content' };
+    const action: ReceiveAction<typeof payload> = {
       type: 'rest-hooks/receive',
-      payload: { id, title: 'hi', content: 'this is the content' },
+      payload,
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.url({ id }),
@@ -107,7 +108,7 @@ describe('reducer', () => {
         expiresAt: 5000500000,
       },
     };
-    const partialResultAction: ReceiveAction = {
+    const partialResultAction = {
       ...action,
       payload: { id, title: 'hello' },
     };
@@ -148,7 +149,7 @@ describe('reducer', () => {
       expect(nextEntity.title).toBe(partialResultAction.payload.title);
 
       expect(nextEntity.content).toBe(prevEntity.content);
-      expect(nextEntity.content).not.toBe(partialResultAction.payload.content);
+      expect(nextEntity.content).not.toBe(undefined);
     });
   });
   it('mutate should never change results', () => {
@@ -174,7 +175,6 @@ describe('reducer', () => {
     const id = 20;
     const action: PurgeAction = {
       type: 'rest-hooks/purge',
-      payload: {},
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: id.toString(),

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -53,7 +53,7 @@ export const resourceCustomizer = (a: any, b: any): any => {
 export default function reducer(
   state: State<unknown> | undefined,
   action: ActionTypes,
-) {
+): State<unknown> {
   if (!state) state = initialState;
   switch (action.type) {
     case 'rest-hooks/receive':

--- a/src/test/mockState.ts
+++ b/src/test/mockState.ts
@@ -1,4 +1,4 @@
-import { ReadShape, Schema, reducer, __INTERNAL__ } from '..';
+import { ReadShape, ReceiveAction, Schema, reducer, __INTERNAL__ } from '..';
 const { initialState } = __INTERNAL__;
 
 export interface Fixture {

--- a/src/test/mockState.ts
+++ b/src/test/mockState.ts
@@ -4,7 +4,7 @@ const { initialState } = __INTERNAL__;
 export interface Fixture {
   request: ReadShape<Schema, object, any>;
   params: object;
-  result: any;
+  result: object | string | number;
 }
 
 export default function mockInitialState<

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FSAWithPayloadAndMeta, FSAWithMeta } from 'flux-standard-action';
-import { ErrorableFSAAuto } from './fsa';
+import { ErrorableFSAWithPayloadAndMeta, ErrorableFSAWithMeta } from './fsa';
 import { Schema, schemas } from './resource';
 
 export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';
@@ -39,7 +39,7 @@ interface ReceiveMeta {
 
 export type ReceiveAction<
   Payload extends object | string | number = object | string | number
-> = ErrorableFSAAuto<'rest-hooks/receive', Payload, ReceiveMeta>;
+> = ErrorableFSAWithPayloadAndMeta<'rest-hooks/receive', Payload, ReceiveMeta>;
 
 interface RPCMeta {
   schema: Schema;
@@ -48,14 +48,14 @@ interface RPCMeta {
 
 export type RPCAction<
   Payload extends object | string | number = object | string | number
-> = ErrorableFSAAuto<'rest-hooks/rpc', Payload, RPCMeta>;
+> = ErrorableFSAWithPayloadAndMeta<'rest-hooks/rpc', Payload, RPCMeta>;
 
 interface PurgeMeta {
   schema: schemas.Entity;
   url: string;
 }
 
-export type PurgeAction = ErrorableFSAAuto<
+export type PurgeAction = ErrorableFSAWithMeta<
   'rest-hooks/purge',
   undefined,
   PurgeMeta

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import { FSAWithPayloadAndMeta, FSAWithMeta, ErrorFSAWithMeta } from 'flux-standard-action';
+import { FSAWithPayloadAndMeta, FSAWithMeta } from 'flux-standard-action';
+import { ErrorableFSAAuto } from './fsa';
 import { Schema, schemas } from './resource';
 
 export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';
@@ -34,33 +35,40 @@ interface ReceiveMeta {
   url: string;
   date: number;
   expiresAt: number;
-};
-
-export interface ReceiveAction
-  extends FSAWithPayloadAndMeta<'rest-hooks/receive', object | string | number, ReceiveMeta> {
-  error?: undefined;
 }
 
-export type ReceiveErrorAction = ErrorFSAWithMeta<'rest-hooks/receive', Error, ReceiveMeta>;
+export type ReceiveAction<
+  Payload extends object | string | number = object | string | number
+> = ErrorableFSAAuto<'rest-hooks/receive', Payload, ReceiveMeta>;
 
-export interface RPCAction
-  extends FSAWithPayloadAndMeta<'rest-hooks/rpc', object | string | number, any> {
-  meta: {
-    schema: Schema;
-    url: string;
-  };
+interface RPCMeta {
+  schema: Schema;
+  url: string;
 }
 
-export interface PurgeAction
-  extends FSAWithPayloadAndMeta<'rest-hooks/purge', undefined, any> {
-  meta: {
-    schema: schemas.Entity;
-    url: string;
-  };
+export type RPCAction<
+  Payload extends object | string | number = object | string | number
+> = ErrorableFSAAuto<'rest-hooks/rpc', Payload, RPCMeta>;
+
+interface PurgeMeta {
+  schema: schemas.Entity;
+  url: string;
 }
 
-export interface FetchAction
-  extends FSAWithPayloadAndMeta<'rest-hooks/fetch', () => Promise<object | string | number>, any> {
+export type PurgeAction = ErrorableFSAAuto<
+  'rest-hooks/purge',
+  undefined,
+  PurgeMeta
+>;
+
+export interface FetchAction<
+  Payload extends object | string | number = object | string | number
+>
+  extends FSAWithPayloadAndMeta<
+    'rest-hooks/fetch',
+    () => Promise<Payload>,
+    any
+  > {
   meta: {
     schema?: Schema;
     url: string;
@@ -101,7 +109,6 @@ export interface InvalidateAction
 export type ActionTypes =
   | FetchAction
   | ReceiveAction
-  | ReceiveErrorAction
   | RPCAction
   | PurgeAction
   | SubscribeAction

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FSAWithPayloadAndMeta, FSAWithMeta } from 'flux-standard-action';
+import { FSAWithPayloadAndMeta, FSAWithMeta, ErrorFSAWithMeta } from 'flux-standard-action';
 import { Schema, schemas } from './resource';
 
 export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';
@@ -29,24 +29,30 @@ export interface RequestOptions {
   readonly invalidIfStale?: boolean;
 }
 
+interface ReceiveMeta {
+  schema: Schema;
+  url: string;
+  date: number;
+  expiresAt: number;
+};
+
 export interface ReceiveAction
-  extends FSAWithPayloadAndMeta<'rest-hooks/receive', any, any> {
-  meta: {
-    schema: Schema;
-    url: string;
-    date: number;
-    expiresAt: number;
-  };
+  extends FSAWithPayloadAndMeta<'rest-hooks/receive', object | string | number, ReceiveMeta> {
+  error?: undefined;
 }
+
+export type ReceiveErrorAction = ErrorFSAWithMeta<'rest-hooks/receive', Error, ReceiveMeta>;
+
 export interface RPCAction
-  extends FSAWithPayloadAndMeta<'rest-hooks/rpc', any, any> {
+  extends FSAWithPayloadAndMeta<'rest-hooks/rpc', object | string | number, any> {
   meta: {
     schema: Schema;
     url: string;
   };
 }
+
 export interface PurgeAction
-  extends FSAWithPayloadAndMeta<'rest-hooks/purge', any, any> {
+  extends FSAWithPayloadAndMeta<'rest-hooks/purge', undefined, any> {
   meta: {
     schema: schemas.Entity;
     url: string;
@@ -54,7 +60,7 @@ export interface PurgeAction
 }
 
 export interface FetchAction
-  extends FSAWithPayloadAndMeta<'rest-hooks/fetch', () => Promise<any>, any> {
+  extends FSAWithPayloadAndMeta<'rest-hooks/fetch', () => Promise<object | string | number>, any> {
   meta: {
     schema?: Schema;
     url: string;
@@ -95,6 +101,7 @@ export interface InvalidateAction
 export type ActionTypes =
   | FetchAction
   | ReceiveAction
+  | ReceiveErrorAction
   | RPCAction
   | PurgeAction
   | SubscribeAction


### PR DESCRIPTION
### Motivation
Bad network responses can happen even in production - catching all client side code won't help that.

### Solution
Do early checks to ensure error messages are graceful and the code still runs. Remove production checks for such things. Production checks should only happen if it's conceivable that hitting those points during development of the JS will prevent the issue from happening in production. Since server code is independent of JS this cannot be reasonably expected.

- Resource.fetch() will always (including prod) guard against invalid responses
- (for actions) Payload type is more discriminatory: object | string | number. Does not allow void.
- Export new types RPCAction, PurgeAction
- Future work: make fetch return promise resolve to object | string | number instead of any.
