### PR TITLE
[enhance] useMemo() instead of reselect (bundle size reduction)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
     '^.+\\.jsx?$': 'babel-jest',
   },
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
-  coveragePathIgnorePatterns: ['test'],
+  coveragePathIgnorePatterns: ['test', 'react-integration/hooks/useSelection'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   moduleNameMapper: {
     '^~/(.*)$': '<rootDir>/src/$1',

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "lodash": "^4.17.15",
     "normalizr": "^3.4.1",
     "redux": "^4.0.4",
-    "reselect": "^4.0.0",
     "superagent": "^5.1.0"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,13 +25,13 @@ import {
   useResultCache,
   useMeta,
   useError,
-  useSelectionUnstable,
   CacheProvider,
   useInvalidator,
   ExternalCacheProvider,
   NetworkErrorBoundary,
   NetworkError,
 } from './react-integration';
+import useSelectionUnstable from './react-integration/hooks/useSelection';
 import { Request as RequestType } from 'superagent';
 import {
   AbstractInstanceType,

--- a/src/react-integration/hooks/index.ts
+++ b/src/react-integration/hooks/index.ts
@@ -6,7 +6,6 @@ import useResource from './useResource';
 import useSubscription from './useSubscription';
 import useMeta from './useMeta';
 import useError from './useError';
-import useSelectionUnstable from './useSelection';
 import useInvalidator from './useInvalidator';
 
 export {
@@ -18,6 +17,5 @@ export {
   useResource,
   useSubscription,
   useMeta,
-  useSelectionUnstable,
   useInvalidator,
 };

--- a/src/react-integration/hooks/useCache.ts
+++ b/src/react-integration/hooks/useCache.ts
@@ -1,12 +1,17 @@
+import { useContext } from 'react';
+
+import { StateContext } from '~/react-integration/context';
 import { ReadShape, Schema } from '~/resource';
-import { makeSchemaSelector } from '~/state/selectors';
-import useSelection from './useSelection';
+import { useSchemaSelect } from '~/state/selectors';
 
 /** Access a resource if it is available. */
 export default function useCache<
   Params extends Readonly<object>,
   S extends Schema
->({ schema, getFetchKey }: ReadShape<S, Params, any>, params: Params | null) {
-  const select = makeSchemaSelector(schema, getFetchKey);
-  return useSelection(select, params, getFetchKey);
+>(
+  fetchShape: Pick<ReadShape<S, Params, any>, 'schema' | 'getFetchKey'>,
+  params: Params | null,
+) {
+  const state = useContext(StateContext);
+  return useSchemaSelect(fetchShape, state, params);
 }

--- a/src/react-integration/hooks/useError.ts
+++ b/src/react-integration/hooks/useError.ts
@@ -17,7 +17,9 @@ export default function useError<
     if (!meta.error) {
       // this means we probably deleted the entity found in this result
       const err: any = new Error(
-        `Resource not found in cache ${params ? fetchShape.getFetchKey(params) : ''}`,
+        `Resource not found in cache ${
+          params ? fetchShape.getFetchKey(params) : ''
+        }`,
       );
       err.status = 404;
       return err;

--- a/src/react-integration/index.ts
+++ b/src/react-integration/index.ts
@@ -8,7 +8,6 @@ import {
   useMeta,
   useError,
   useInvalidator,
-  useSelectionUnstable,
 } from './hooks';
 import { CacheProvider, ExternalCacheProvider } from './provider';
 import NetworkErrorBoundary, { NetworkError } from './NetworkErrorBoundary';
@@ -24,7 +23,6 @@ export {
   useInvalidator,
   useMeta,
   useError,
-  useSelectionUnstable,
   CacheProvider,
   ExternalCacheProvider,
   NetworkErrorBoundary,

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -1,7 +1,6 @@
-import { createSelector } from 'reselect';
-import { memoize } from 'lodash';
+import { useMemo, useRef, useEffect } from 'react';
 import { State } from '~/types';
-import { isEntity, SchemaOf } from '~/resource/types';
+import { isEntity, SchemaOf, ReadShape } from '~/resource/types';
 import { Schema, denormalize } from '~/resource/normal';
 import getEntityPath from './getEntityPath';
 
@@ -32,72 +31,89 @@ function resultFinderFromSchema<S extends Schema>(
   };
 }
 
-function makeSchemaSelectorSimple<
+
+export function useSchemaSelect<
   Params extends Readonly<object>,
   S extends Schema
 >(
-  schema: S,
-  getFetchKey: (params: Params) => string,
-): (state: State<any>, params: Params) => SchemaOf<typeof schema> | null {
-  const getResultList = resultFinderFromSchema(schema);
-  const dataSchema = getResultList
-    ? getResultList(schema)
-    : (schema as SchemaOf<typeof schema>);
-  const selectResults = makeResults<any>(getFetchKey);
-  const ret = createSelector(
-    (state: State<any>) => state.entities,
-    selectResults,
-    (state: State<any>, params: Params) => params,
-    (entities, results, params: Params) => {
-      // We can grab entities without actual results if the params compute a primary key
-      let getRequestListForThis = getResultList;
+  {
+    schema,
+    getFetchKey,
+  }: Pick<ReadShape<S, Params, any>, 'schema' | 'getFetchKey'>,
+  state: State<any>,
+  params: Params | null,
+): SchemaOf<typeof schema> | null {
+  // Precompute logic the only changes based on FetchShape
+  const [getResultList, dataSchema] = useMemo(() => {
+    const getResultList = resultFinderFromSchema(schema);
+    const dataSchema = getResultList
+      ? getResultList(schema)
+      : (schema as SchemaOf<typeof schema>);
+    return [getResultList, dataSchema];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const selectResults = useMemo(() => makeResults<any>(getFetchKey), []);
 
-      if (isEntity(dataSchema) && !results) {
-        const id = dataSchema.getId(params, undefined, '');
-        // in case we don't even have entities for a model yet, denormalize() will throw
-        if (
-          id !== undefined &&
-          id !== '' &&
-          entities[dataSchema.key] !== undefined
-        ) {
-          results = id;
-          // simplify schema since we already grabbed the id
-          schema = dataSchema;
-          // don't try to extract for this query
-          getRequestListForThis = null;
-        }
+  // Select from state
+  const entities = state.entities;
+  let results = params && selectResults(state, params);
+
+  return useMemo(() => {
+    if (!entities || !params) return null;
+    // We can grab entities without actual results if the params compute a primary key
+    // TODO: we should rebuild this to actually construct the results as expected.
+    // this will make each piece more composable, which will cleanup the exhaustive-deps workarounds
+    let getRequestListForThis = getResultList;
+    if (isEntity(dataSchema) && !results) {
+      const id = dataSchema.getId(params, undefined, '');
+      // in case we don't even have entities for a model yet, denormalize() will throw
+      if (
+        id !== undefined &&
+        id !== '' &&
+        entities[dataSchema.key] !== undefined
+      ) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        results = id;
+        // simplify schema since we already grabbed the id
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        schema = dataSchema;
+        // don't try to extract for this query
+        getRequestListForThis = null;
       }
-      if (!entities || !results) return null;
-      if (process.env.NODE_ENV !== 'production' && isEntity(schema)) {
-        if (Array.isArray(results)) {
-          throw new Error(
-            `url ${getFetchKey(
-              params,
-            )} has list results when single result is expected`,
-          );
-        }
-        if (typeof results === 'object') {
-          throw new Error(
-            `url ${getFetchKey(
-              params,
-            )} has object results when single result is expected`,
-          );
-        }
+    }
+
+    // Results are final so guard against null
+    if (!results) return null;
+
+    // Warn users with bad configurations
+    if (process.env.NODE_ENV !== 'production' && isEntity(schema)) {
+      if (Array.isArray(results)) {
+        throw new Error(
+          `url ${getFetchKey(
+            params,
+          )} has list results when single result is expected`,
+        );
       }
-      let output = denormalize(results, schema, entities);
-      if (getRequestListForThis) {
-        output = getRequestListForThis(output);
+      if (typeof results === 'object') {
+        throw new Error(
+          `url ${getFetchKey(
+            params,
+          )} has object results when single result is expected`,
+        );
       }
-      if (!output) return null;
-      if (Array.isArray(output)) {
-        output = output.filter(entity => entity);
-      }
-      return output;
-    },
-  );
-  return ret;
+    }
+
+    // Select the actual results now
+    let output = denormalize(results, schema, entities);
+    if (getRequestListForThis) {
+      output = getRequestListForThis(output);
+    }
+    if (!output) return null;
+    // entities are sometimes deleted but not removed from list results
+    if (Array.isArray(output)) {
+      output = output.filter(entity => entity);
+    }
+    return output;
+  }, [entities, results, params && getFetchKey(params)]);
 }
-
-export const makeSchemaSelector = memoize(
-  makeSchemaSelectorSimple,
-) as typeof makeSchemaSelectorSimple;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6832,11 +6832,6 @@ require-relative@^0.8.7:
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
   integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
 
-reselect@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
-
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #126.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Reselect's sole existence is to provide short-circuiting on a per-component basis with a memoization memory of one. This is identical to the capabilities of useMemo(), so there's no reason to add an additional dependency.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Turn our selector into a hook selector. This restricts its capability to be run inside hook contexts but that's already the assumption.
