### PR TITLE
[enhance] Use own deepmerge instead of lodash.mergeWith

### DIFF
--- a/src/react-integration/NetworkErrorBoundary.tsx
+++ b/src/react-integration/NetworkErrorBoundary.tsx
@@ -5,7 +5,7 @@ export interface NetworkError extends Error {
   response?: { statusText?: string; body?: any };
 }
 
-function isNetworkError(error: NetworkError | any): error is NetworkError {
+function isNetworkError(error: NetworkError | unknown): error is NetworkError {
   return Object.prototype.hasOwnProperty.call(error, 'status');
 }
 

--- a/src/state/__tests__/merge.tsx
+++ b/src/state/__tests__/merge.tsx
@@ -1,0 +1,213 @@
+import React from 'react';
+import { ArticleResource } from '../../__tests__/common';
+import mergeDeepCopy from '../merge/mergeDeepCopy';
+import isMergeable from '../merge/isMergeable';
+
+describe('mergeDeepCopy()', () => {
+  describe('with instance.constructor.merge()', () => {
+    it('should merge two Resource instances', () => {
+      const id = 20;
+      const a = ArticleResource.fromJS({
+        id,
+        title: 'hi',
+        content: 'this is the content',
+      });
+      const b = ArticleResource.fromJS({ id, title: 'hello' });
+
+      const merged = mergeDeepCopy(a, b);
+      expect(merged).toBeInstanceOf(ArticleResource);
+      expect(merged).toEqual(
+        ArticleResource.fromJS({
+          id,
+          title: 'hello',
+          content: 'this is the content',
+        }),
+      );
+    });
+    it('should handle merging of Resource instances when used with lodash.mergeWith()', () => {
+      const id = 20;
+      const entitiesA = {
+        [ArticleResource.getKey()]: {
+          [id]: ArticleResource.fromJS({
+            id,
+            title: 'hi',
+            content: 'this is the content',
+          }),
+        },
+      };
+      const entitiesB = {
+        [ArticleResource.getKey()]: {
+          [id]: ArticleResource.fromJS({ id, title: 'hello' }),
+        },
+      };
+
+      const merged = mergeDeepCopy(entitiesA, entitiesB);
+      expect(merged[ArticleResource.getKey()][id]).toBeInstanceOf(
+        ArticleResource,
+      );
+      expect(merged[ArticleResource.getKey()][id]).toEqual(
+        ArticleResource.fromJS({
+          id,
+          title: 'hello',
+          content: 'this is the content',
+        }),
+      );
+    });
+    it('should not affect merging of plain objects when used with lodash.mergeWith()', () => {
+      const id = 20;
+      const entitiesA = {
+        [ArticleResource.getKey()]: {
+          [id]: ArticleResource.fromJS({
+            id,
+            title: 'hi',
+            content: 'this is the content',
+          }),
+          [42]: ArticleResource.fromJS({
+            id: 42,
+            title: 'dont touch me',
+            content: 'this is mine',
+          }),
+        },
+      };
+      const entitiesB = {
+        [ArticleResource.getKey()]: {
+          [id]: ArticleResource.fromJS({
+            id,
+            title: 'hi',
+            content: 'this is the content',
+          }),
+        },
+      };
+
+      const merged = mergeDeepCopy(entitiesA, entitiesB);
+      expect(merged[ArticleResource.getKey()][42]).toBe(
+        entitiesA[ArticleResource.getKey()][42],
+      );
+    });
+  });
+
+  describe('basics', function() {
+    it('should merge `source` into `object`', function() {
+      const names = {
+        characters: [{ name: 'barney' }, { name: 'fred' }],
+      };
+
+      const ages = {
+        characters: [{ age: 36 }, { age: 40 }],
+      };
+
+      const expected = {
+        characters: [{ name: 'barney', age: 36 }, { name: 'fred', age: 40 }],
+      };
+
+      expect(mergeDeepCopy(names, ages)).toStrictEqual(expected);
+    });
+
+    it('should treat sparse array sources as dense', function() {
+      const array = [1];
+      array[3] = 3;
+
+      const array2 = [];
+      array2[1] = 5;
+
+      const actual = mergeDeepCopy(array, array2),
+        expected: any = array.slice();
+
+      expected[1] = 5;
+      expected[2] = undefined;
+
+      expect(actual).toStrictEqual(expected);
+    });
+
+    it('should assign `null` values', function() {
+      const actual = mergeDeepCopy({ a: 1 }, { a: null });
+      expect(actual.a).toBe(null);
+    });
+
+    it('should assign non array/buffer/typed-array/plain-object source values directly', function() {
+      class Foo {}
+
+      const values = [true, new Date(), Foo, 5, '', new RegExp('')],
+        expected = values.map(() => true);
+
+      const actual = values.map(function(value) {
+        const object = mergeDeepCopy({}, { a: value, b: { c: value } });
+        return object.a === value && object.b.c === value;
+      });
+
+      expect(actual).toStrictEqual(expected);
+    });
+
+    it('should not augment source objects', function() {
+      const source1 = { a: [{ a: 1 }] },
+        source2 = { a: [{ b: 2 }] },
+        actual = mergeDeepCopy(source1, source2);
+
+      expect(source1.a).toStrictEqual([{ a: 1 }]);
+      expect(source2.a).toStrictEqual([{ b: 2 }]);
+      expect(actual.a).toStrictEqual([{ a: 1, b: 2 }]);
+
+      const source1b = { a: [[1, 2, 3]] },
+        source2b = { a: [[3, 4]] },
+        actualb = mergeDeepCopy(source1b, source2b);
+
+      expect(source1b.a).toStrictEqual([[1, 2, 3]]);
+      expect(source2b.a).toStrictEqual([[3, 4]]);
+      expect(actualb.a).toStrictEqual([[3, 4, 3]]);
+    });
+
+    it('should not overwrite existing values with `undefined` values of object sources', function() {
+      const actual = mergeDeepCopy({ a: 1 }, { a: undefined, b: undefined });
+      expect(actual).toStrictEqual({ a: 1, b: undefined });
+    });
+
+    it('should not overwrite existing values with `undefined` values of array sources', function() {
+      let array: any[] = [1];
+      array[2] = 3;
+
+      let actual = mergeDeepCopy([4, 5, 6], array);
+      const expected = [1, 5, 3];
+
+      expect(actual).toStrictEqual(expected);
+
+      // eslint-disable-next-line no-sparse-arrays
+      array = [1, , 3];
+      array[1] = undefined;
+
+      actual = mergeDeepCopy([4, 5, 6], array);
+      expect(actual).toStrictEqual(expected);
+    });
+
+    it('should still clone even when overwriting', () => {
+      const nested = { fiver: 'fine' };
+      const merged = mergeDeepCopy({ a: [1, 2, 3] }, { a: nested });
+      expect(merged).toMatchInlineSnapshot(`
+        Object {
+          "a": Object {
+            "fiver": "fine",
+          },
+        }
+      `);
+      expect(merged.a).not.toBe(nested);
+
+      const nested2 = [1, 2, 3];
+      const merged2 = mergeDeepCopy({ a: { fiver: 'fine' } }, { a: [1, 2, 3] });
+      expect(merged2).toMatchInlineSnapshot(`
+        Object {
+          "a": Array [
+            1,
+            2,
+            3,
+          ],
+        }
+      `);
+      expect(merged2.a).not.toBe(nested2);
+    });
+  });
+});
+
+describe('isMergeable()', () => {
+  it('should not consider react elements to be mergeable', () => {
+    expect(isMergeable(<div />)).toBe(false);
+  });
+});

--- a/src/state/__tests__/networkManager.ts
+++ b/src/state/__tests__/networkManager.ts
@@ -14,7 +14,7 @@ describe('NetworkManager', () => {
     it('should return the different value for a different instance', () => {
       const a = manager.getMiddleware();
       const manager2 = new NetworkManager();
-      const a2 = manager2.getMiddleware()
+      const a2 = manager2.getMiddleware();
       expect(a).not.toBe(a2);
       expect(a2).toBe(manager2.getMiddleware());
     });

--- a/src/state/__tests__/reducer.ts
+++ b/src/state/__tests__/reducer.ts
@@ -2,7 +2,7 @@ import {
   ArticleResource,
   PaginatedArticleResource,
 } from '../../__tests__/common';
-import reducer, { resourceCustomizer } from '../reducer';
+import reducer from '../reducer';
 import {
   FetchAction,
   RPCAction,
@@ -10,89 +10,6 @@ import {
   PurgeAction,
   InvalidateAction,
 } from '../../types';
-import { mergeWith } from 'lodash';
-
-describe('resourceCustomizer', () => {
-  it('should merge two Resource instances', () => {
-    const id = 20;
-    const a = ArticleResource.fromJS({
-      id,
-      title: 'hi',
-      content: 'this is the content',
-    });
-    const b = ArticleResource.fromJS({ id, title: 'hello' });
-
-    const merged = resourceCustomizer(a, b);
-    expect(merged).toBeInstanceOf(ArticleResource);
-    expect(merged).toEqual(
-      ArticleResource.fromJS({
-        id,
-        title: 'hello',
-        content: 'this is the content',
-      }),
-    );
-  });
-  it('should handle merging of Resource instances when used with lodash.mergeWith()', () => {
-    const id = 20;
-    const entitiesA = {
-      [ArticleResource.getKey()]: {
-        [id]: ArticleResource.fromJS({
-          id,
-          title: 'hi',
-          content: 'this is the content',
-        }),
-      },
-    };
-    const entitiesB = {
-      [ArticleResource.getKey()]: {
-        [id]: ArticleResource.fromJS({ id, title: 'hello' }),
-      },
-    };
-
-    const merged = mergeWith({ ...entitiesA }, entitiesB, resourceCustomizer);
-    expect(merged[ArticleResource.getKey()][id]).toBeInstanceOf(
-      ArticleResource,
-    );
-    expect(merged[ArticleResource.getKey()][id]).toEqual(
-      ArticleResource.fromJS({
-        id,
-        title: 'hello',
-        content: 'this is the content',
-      }),
-    );
-  });
-  it('should not affect merging of plain objects when used with lodash.mergeWith()', () => {
-    const id = 20;
-    const entitiesA = {
-      [ArticleResource.getKey()]: {
-        [id]: ArticleResource.fromJS({
-          id,
-          title: 'hi',
-          content: 'this is the content',
-        }),
-        [42]: ArticleResource.fromJS({
-          id: 42,
-          title: 'dont touch me',
-          content: 'this is mine',
-        }),
-      },
-    };
-    const entitiesB = {
-      [ArticleResource.getKey()]: {
-        [id]: ArticleResource.fromJS({
-          id,
-          title: 'hi',
-          content: 'this is the content',
-        }),
-      },
-    };
-
-    const merged = mergeWith({ ...entitiesA }, entitiesB, resourceCustomizer);
-    expect(merged[ArticleResource.getKey()][42]).toBe(
-      entitiesA[ArticleResource.getKey()][42],
-    );
-  });
-});
 
 describe('reducer', () => {
   describe('singles', () => {

--- a/src/state/merge/isMergeable.ts
+++ b/src/state/merge/isMergeable.ts
@@ -1,0 +1,28 @@
+// copied from https://github.com/TehShrike/is-mergeable-object
+
+export default function isMergeableObject(value: any) {
+  return isNonNullObject(value) && !isSpecial(value);
+}
+
+function isNonNullObject(value: any) {
+  return !!value && typeof value === 'object';
+}
+
+function isSpecial(value: any) {
+  const stringValue = Object.prototype.toString.call(value);
+
+  return (
+    stringValue === '[object RegExp]' ||
+    stringValue === '[object Date]' ||
+    isReactElement(value)
+  );
+}
+
+// see https://github.com/facebook/react/blob/b5ac963fb791d1298e7f396236383bc955f916c1/src/isomorphic/classic/element/ReactElement.js#L21-L25
+const canUseSymbol = typeof Symbol === 'function' && Symbol.for;
+/* istanbul ignore next */
+const REACT_ELEMENT_TYPE = canUseSymbol ? Symbol.for('react.element') : 0xeac7;
+
+function isReactElement(value: any) {
+  return value.$$typeof === REACT_ELEMENT_TYPE;
+}

--- a/src/state/merge/mergeDeepCopy.ts
+++ b/src/state/merge/mergeDeepCopy.ts
@@ -1,0 +1,52 @@
+import isMergeableObject from './isMergeable';
+
+// Note: the return types are technically not as strict as they could be; but this is sufficient for our local usage.
+
+/**
+ * Deep merge two objects or arrays. Uses static merge function if exists.
+ */
+export default function mergeDeepCopy<T1, T2>(target: T1, source: T2): T1 & T2 {
+  const sourceIsArray = Array.isArray(source);
+  const targetIsArray = Array.isArray(target);
+  const sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;
+  const Static: StaticType<T2> = source && (source as any).constructor;
+
+  if (target && Static && isMergeable(Static)) {
+    if (isMergeable((target as any).constructor)) {
+      return Static.merge(target, source) as any;
+    } else {
+      return source as any;
+    }
+  } else if (isMergeableObject(source)) {
+    // target and source are mergeable
+    if (isMergeableObject(target) && sourceAndTargetTypesMatch) {
+      const destination: any = targetIsArray
+        ? [...(target as any)]
+        : { ...target };
+      Object.keys(source).forEach(key => {
+        destination[key] = mergeDeepCopy(
+          destination[key],
+          (source as any)[key],
+        );
+      });
+      return destination;
+      // not mergeable, but still need to clone source
+    } else {
+      return mergeDeepCopy(sourceIsArray ? [] : ({} as any), source as any);
+    }
+  } else if (source === undefined) {
+    return target as any;
+  }
+  return source as any;
+}
+
+type StaticType<T> = T extends { constructor: infer U } ? U : undefined;
+
+interface MergeableStatic<T> {
+  new (): T;
+  merge(a: T, b: T): T;
+}
+
+function isMergeable<T>(constructor: any): constructor is MergeableStatic<T> {
+  return constructor && typeof constructor.merge === 'function';
+}


### PR DESCRIPTION
### Motivation
Lodash.mergeWith is pretty bloated. Custom solution will be much more efficient.

### Solution
Integrated deepmerge that detects .merge members
