### PR TITLE
[enhance] Fully support Union and Values schemas in types and useDenormalized()

### DIFF
--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -162,6 +162,59 @@ export class PaginatedArticleResource extends OtherArticleResource {
   }
 }
 
+export class UnionResource extends Resource {
+  readonly id: string = '';
+  readonly body: string = '';
+  readonly type: string = '';
+
+  pk() {
+    return this.id;
+  }
+
+  static urlRoot = '/union/';
+
+  static detailShape<T extends typeof Resource>(
+    this: T,
+  ): ReadShape<SchemaDetail<AbstractInstanceType<T>>> {
+    const schema = new schemas.Union(
+      {
+        first: FirstUnionResource.getEntitySchema(),
+        second: SecondUnionResource.getEntitySchema(),
+      },
+      'type',
+    );
+    return {
+      ...super.detailShape(),
+      schema,
+    };
+  }
+  static listShape<T extends typeof Resource>(
+    this: T,
+  ): ReadShape<SchemaList<AbstractInstanceType<T>>> {
+    const schema = [
+      new schemas.Union(
+        {
+          first: FirstUnionResource.getEntitySchema(),
+          second: SecondUnionResource.getEntitySchema(),
+        },
+        (input: FirstUnionResource | SecondUnionResource) => input['type'],
+      ),
+    ];
+    return {
+      ...super.detailShape(),
+      schema,
+    };
+  }
+}
+export class FirstUnionResource extends UnionResource {
+  readonly type = 'first' as const;
+  readonly firstOnlyField: number = 5;
+}
+export class SecondUnionResource extends UnionResource {
+  readonly type = 'second' as const;
+  readonly secondeOnlyField: number = 10;
+}
+
 export class NestedArticleResource extends OtherArticleResource {
   readonly user: number | null = null;
 

--- a/src/state/selectors/__tests__/buildInferredResults.ts
+++ b/src/state/selectors/__tests__/buildInferredResults.ts
@@ -1,4 +1,7 @@
-import { CoolerArticleResource } from '../../../__tests__/common';
+import {
+  CoolerArticleResource,
+  UnionResource,
+} from '../../../__tests__/common';
 import { schemas } from '../../../resource';
 import buildInferredResults from '../buildInferredResults';
 
@@ -13,12 +16,42 @@ describe('buildInferredResults()', () => {
       data: { article: '5' },
     });
   });
-  it('should work with Array', () => {
+
+  it('should be null with Array', () => {
     const schema = {
       data: new schemas.Array(CoolerArticleResource.getEntitySchema()),
     };
     expect(buildInferredResults(schema, { id: 5 })).toBe(null);
+
+    const schema2 = {
+      data: [CoolerArticleResource.getEntitySchema()],
+    };
+    expect(buildInferredResults(schema2, { id: 5 })).toBe(null);
   });
+
+  it('should be null with Values', () => {
+    const schema = {
+      data: new schemas.Values(CoolerArticleResource.getEntitySchema()),
+    };
+    expect(buildInferredResults(schema, { id: 5 })).toBe(null);
+  });
+
+  it('should be null with Union and type', () => {
+    const schema = UnionResource.detailShape().schema;
+    expect(buildInferredResults(schema, { id: 5 })).toBe(null);
+  });
+
+  it('should work with Union', () => {
+    const schema = UnionResource.detailShape().schema;
+    expect(buildInferredResults(schema, { id: 5, type: 'first' }))
+      .toMatchInlineSnapshot(`
+      Object {
+        "id": "5",
+        "schema": "first",
+      }
+    `);
+  });
+
   it('should work with primitive defaults', () => {
     const schema = {
       pagination: { next: '', previous: '' },


### PR DESCRIPTION
### Motivation
Should support full range of schema types. Types before were sloppy and non-specific.

### Solution
- Adding tests for both Values and Unions in useDenormalized()
- Fleshing out all cases for typescript types - including resolving Denormalized<S> and ResultType<S>