### PR TITLE
[breaking] FetchShape.fetch return type is strict

### DIFF
--- a/docs/api/FetchShape.md
+++ b/docs/api/FetchShape.md
@@ -18,7 +18,7 @@ specific results needed.
 ```typescript
 interface FetchShape {
   readonly type: 'read' | 'mutate' | 'delete';
-  fetch(params: Readonly<object>, body: Readonly<object> | void): Promise<any>;
+  fetch(params: Readonly<object>, body: Readonly<object> | void): Promise<Denormalized<typeof schema>>;
   getFetchKey(params: Readonly<object>): string;
   readonly schema: Schema;
   readonly options?: RequestOptions;
@@ -34,7 +34,7 @@ interface FetchShape<
   Body extends Readonly<object | string> | void = Readonly<object> | undefined
 > {
   readonly type: 'read' | 'mutate' | 'delete';
-  fetch(params: Params, body: Body): Promise<any>;
+  fetch(params: Params, body: Body): Promise<Denormalized<S>>;
   getFetchKey(params: Params): string;
   readonly schema: S;
   readonly options?: RequestOptions;

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -1,4 +1,4 @@
-import { schemas, Schema, SchemaList, SchemaDetail } from './normal';
+import { schemas, Schema, SchemaList, SchemaDetail, Denormalized } from './normal';
 import { RequestOptions } from '~/types';
 
 /** Defines the shape of a network request */
@@ -10,7 +10,7 @@ export interface FetchShape<
     | undefined
 > {
   readonly type: 'read' | 'mutate' | 'delete';
-  fetch(params: Params, body: Body): Promise<any>;
+  fetch(params: Params, body: Body): Promise<Denormalized<S>>;
   getFetchKey(params: Params): string;
   readonly schema: S;
   readonly options?: RequestOptions;


### PR DESCRIPTION
### Motivation
Making the return value of fetch more strict ensures proper enforcement as well as enables type introspection for various use cases.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

