### PR TITLE
[breaking] Make middleware async - enabling execution after commit

### DIFF
--- a/docs/guides/redux.md
+++ b/docs/guides/redux.md
@@ -14,13 +14,17 @@ First make sure you have redux installed:
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--yarn-->
+
 ```bash
 yarn add redux
 ```
+
 <!--npm-->
+
 ```bash
 npm install redux
 ```
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 Note: react-redux is _not_ needed for this integration (though you can use it if you want).
@@ -31,6 +35,10 @@ the rest-hooks specific part of the state.
 
 > Note: You should only use ONE provider; nested another provider will override the previous.
 
+> Note: Rest Hooks manager middlewares return promises, which is different from how redux middlewares work.
+> Because of this, if you want to integrate both, you'll need to place all redux middlewares
+> after the `PromiseifyMiddleware` adapter, and place all Rest Hooks manager middlewares before.
+
 #### `index.tsx`
 
 ```tsx
@@ -40,6 +48,7 @@ import {
   SubscriptionManager,
   PollingSubscription,
   ExternalCacheProvider,
+  PromiseifyMiddleware,
 } from 'rest-hooks';
 import { createStore, applyMiddleware } from 'redux';
 import ReactDOM from 'react-dom';
@@ -49,7 +58,13 @@ const subscriptionManager = new SubscriptionManager(PollingSubscription);
 
 const store = createStore(
   reducer,
-  applyMiddleware(manager.getMiddleware(), subscriptionManager.getMiddleware()),
+  applyMiddleware(
+    manager.getMiddleware(),
+    subscriptionManager.getMiddleware(),
+    // place Rest Hooks built middlewares before PromiseifyMiddleware
+    PromiseifyMiddleware,
+    // place redux middlewares after PromiseifyMiddleware
+  ),
 );
 const selector = state => state;
 
@@ -74,7 +89,11 @@ const store = createStore(
     restHooks: restReducer,
     myOtherState: otherReducer,
   }),
-  applyMiddleware(manager.getMiddleware(), subscriptionManager.getMiddleware()),
+  applyMiddleware(
+    manager.getMiddleware(),
+    subscriptionManager.getMiddleware(),
+    PromiseifyMiddleware,
+  ),
 );
 const selector = state => state.restHooks;
 // ...

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   schemas,
 } from './resource';
 import NetworkManager from './state/NetworkManager';
+import RIC from './state/RIC';
 import PollingSubscription from './state/PollingSubscription';
 import SubscriptionManager from './state/SubscriptionManager';
 import reducer, { initialState } from './state/reducer';
@@ -46,6 +47,8 @@ import {
   ReceiveAction,
   RPCAction,
   PurgeAction,
+  Dispatch,
+  MiddlewareAPI,
   Middleware,
   Manager,
 } from './types';
@@ -55,6 +58,7 @@ const __INTERNAL__ = {
   initialState,
   StateContext,
   DispatchContext,
+  RIC,
 };
 
 export type DeleteShape<
@@ -99,6 +103,10 @@ export type RPCAction<
 > = RPCAction<Payload>;
 export type PurgeAction = PurgeAction;
 
+export type Dispatch<R extends React.Reducer<any, any>> = Dispatch<R>;
+export type MiddlewareAPI<
+  R extends React.Reducer<any, any> = React.Reducer<any, any>
+> = MiddlewareAPI<R>;
 export type Middleware = Middleware;
 export type Manager = Manager;
 

--- a/src/react-integration/__tests__/hooks.tsx
+++ b/src/react-integration/__tests__/hooks.tsx
@@ -56,7 +56,7 @@ async function testDispatchFetch(
 function testRestHook(
   callback: () => void,
   state: State<unknown>,
-  dispatch = (v: ActionTypes) => {},
+  dispatch = (v: ActionTypes) => Promise.resolve(),
 ) {
   return renderHook(callback, {
     wrapper: function Wrapper({ children }) {
@@ -680,7 +680,7 @@ describe('useResource()', () => {
 
     const tree = (
       <StateContext.Provider value={state}>
-        <DispatchContext.Provider value={() => {}}>
+        <DispatchContext.Provider value={() => Promise.resolve()}>
           <Suspense fallback={<Fallback />}>
             <ArticleComponentTester />
           </Suspense>{' '}
@@ -750,7 +750,7 @@ describe('useResource()', () => {
 
     const tree = (
       <StateContext.Provider value={state}>
-        <DispatchContext.Provider value={() => {}}>
+        <DispatchContext.Provider value={() => Promise.resolve()}>
           <Suspense fallback={<Fallback />}>
             <ArticleComponentTester invalidIfStale />
           </Suspense>

--- a/src/react-integration/__tests__/useResourceNew.tsx
+++ b/src/react-integration/__tests__/useResourceNew.tsx
@@ -227,7 +227,7 @@ describe('useResourceNew()', () => {
 
     const tree = (
       <StateContext.Provider value={state}>
-        <DispatchContext.Provider value={() => {}}>
+        <DispatchContext.Provider value={() => Promise.resolve()}>
           <Suspense fallback={<Fallback />}>
             <ArticleComponentTester />
           </Suspense>{' '}
@@ -297,7 +297,7 @@ describe('useResourceNew()', () => {
 
     const tree = (
       <StateContext.Provider value={state}>
-        <DispatchContext.Provider value={() => {}}>
+        <DispatchContext.Provider value={() => Promise.resolve()}>
           <Suspense fallback={<Fallback />}>
             <ArticleComponentTester invalidIfStale />
           </Suspense>

--- a/src/react-integration/context.ts
+++ b/src/react-integration/context.ts
@@ -15,4 +15,5 @@ export const DispatchContext = React.createContext((value: ActionTypes) => {
       );
     }
   }
+  return Promise.resolve();
 });

--- a/src/react-integration/provider/ExternalCacheProvider.tsx
+++ b/src/react-integration/provider/ExternalCacheProvider.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useEffect, useState } from 'react';
 import { StateContext, DispatchContext } from '~/react-integration/context';
 import { State, ActionTypes } from '~/types';
+import usePromisifiedDispatch from './usePromisifiedDispatch';
 
 interface Store<S> {
   subscribe(listener: () => void): () => void;
@@ -19,6 +20,7 @@ export default function ExternalCacheProvider<S>({
   selector,
 }: Props<S>) {
   const [state, setState] = useState(() => selector(store.getState()));
+
   useEffect(() => {
     const unsubscribe = store.subscribe(() => {
       setState(selector(store.getState()));
@@ -27,8 +29,11 @@ export default function ExternalCacheProvider<S>({
     // we don't care to recompute if they change selector - only when store updates
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store]);
+
+  const dispatch = usePromisifiedDispatch(store.dispatch, state);
+
   return (
-    <DispatchContext.Provider value={store.dispatch}>
+    <DispatchContext.Provider value={dispatch}>
       <StateContext.Provider value={state}>{children}</StateContext.Provider>
     </DispatchContext.Provider>
   );

--- a/src/react-integration/provider/__tests__/provider.tsx
+++ b/src/react-integration/provider/__tests__/provider.tsx
@@ -36,7 +36,7 @@ describe('<CacheProvider />', () => {
     expect(curDisp).toBe(dispatch);
     expect(count).toBe(1);
     rerender(
-      <DispatchContext.Provider value={() => null}>
+      <DispatchContext.Provider value={() => Promise.resolve()}>
         {chil}
       </DispatchContext.Provider>,
     );

--- a/src/react-integration/provider/usePromisifiedDispatch.ts
+++ b/src/react-integration/provider/usePromisifiedDispatch.ts
@@ -1,0 +1,42 @@
+import { useRef, useCallback, useEffect } from 'react';
+
+type PromiseHolder = { promise: Promise<void>; resolve: () => void };
+
+export default function usePromisifiedDispatch<
+  R extends React.Reducer<any, any>
+>(
+  dispatch: React.Dispatch<React.ReducerAction<R>>,
+  state: React.ReducerState<R>,
+) {
+  const dispatchPromiseRef = useRef<null | PromiseHolder>(null);
+  useEffect(() => {
+    if (dispatchPromiseRef.current) {
+      dispatchPromiseRef.current.resolve();
+      dispatchPromiseRef.current = null;
+    }
+  }, [state]);
+
+  return useCallback(
+    (action: React.ReducerAction<R>) => {
+      if (!dispatchPromiseRef.current) {
+        dispatchPromiseRef.current = NewPromiseHolder();
+      }
+      // we use the promise before dispatch so we know it will be resolved
+      // however that can also make the ref clear, so we need to make sure we have to promise before
+      // dispatching so we can return it even if the ref changes.
+      const promise = dispatchPromiseRef.current.promise;
+      dispatch(action);
+      return promise;
+    },
+    [dispatch],
+  );
+}
+
+function NewPromiseHolder(): PromiseHolder {
+  // any so we can build it
+  const promiseHolder: any = {};
+  promiseHolder.promise = new Promise(resolve => {
+    promiseHolder.resolve = resolve;
+  });
+  return promiseHolder;
+}

--- a/src/state/PollingSubscription.ts
+++ b/src/state/PollingSubscription.ts
@@ -1,4 +1,5 @@
 import { Schema } from '~/resource';
+import { Dispatch } from '~/types';
 import { Subscription, SubscriptionInit } from './SubscriptionManager';
 
 /**
@@ -12,13 +13,13 @@ export default class PollingSubscription implements Subscription {
   protected readonly url: string;
   protected frequency: number;
   protected frequencyHistogram: Map<number, number> = new Map();
-  protected dispatch: React.Dispatch<any>;
+  protected dispatch: Dispatch<any>;
   protected intervalId?: NodeJS.Timeout;
   protected lastIntervalId?: NodeJS.Timeout;
 
   constructor(
     { url, schema, fetch, frequency }: SubscriptionInit,
-    dispatch: React.Dispatch<any>,
+    dispatch: Dispatch<any>,
   ) {
     if (frequency === undefined)
       throw new Error('frequency needed for polling subscription');

--- a/src/state/RIC.ts
+++ b/src/state/RIC.ts
@@ -1,0 +1,5 @@
+const RIC: (cb: (...args: any[]) => void, options: any) => void =
+  typeof (global as any).requestIdleCallback === 'function'
+    ? (global as any).requestIdleCallback
+    : cb => global.setTimeout(cb, 0);
+export default RIC;

--- a/src/state/__tests__/networkManager.ts
+++ b/src/state/__tests__/networkManager.ts
@@ -159,7 +159,7 @@ describe('NetworkManager', () => {
 
       const dispatch = jest.fn();
 
-      middleware({ dispatch, getState })(() => {})({
+      middleware({ dispatch, getState })(() => Promise.resolve())({
         ...fetchResolveAction,
         meta: {
           ...fetchResolveAction.meta,
@@ -178,7 +178,7 @@ describe('NetworkManager', () => {
 
       const dispatch = jest.fn();
 
-      middleware({ dispatch, getState })(() => {})({
+      middleware({ dispatch, getState })(() => Promise.resolve())({
         ...fetchResolveAction,
         meta: {
           ...fetchResolveAction.meta,
@@ -221,7 +221,7 @@ describe('NetworkManager', () => {
 
       const dispatch = jest.fn();
 
-      middleware({ dispatch, getState })(() => {})({
+      middleware({ dispatch, getState })(() => Promise.resolve())({
         ...fetchRejectAction,
         meta: {
           ...fetchRejectAction.meta,
@@ -242,7 +242,7 @@ describe('NetworkManager', () => {
 
       const dispatch = jest.fn();
 
-      middleware({ dispatch, getState })(() => {})({
+      middleware({ dispatch, getState })(() => Promise.resolve())({
         ...fetchRejectAction,
         meta: {
           ...fetchRejectAction.meta,
@@ -311,7 +311,7 @@ describe('RequestIdleCallback', () => {
     (global as any).requestIdleCallback = undefined;
     jest.resetModules();
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { RIC } = require('../NetworkManager');
+    const RIC = require('../RIC').default;
     const fn = jest.fn();
     jest.useFakeTimers();
     RIC(fn, {});

--- a/src/state/__tests__/subscriptionManager.ts
+++ b/src/state/__tests__/subscriptionManager.ts
@@ -71,7 +71,7 @@ describe('SubscriptionManager', () => {
     const manager = new SubscriptionManager(TestSubscription);
     const middleware = manager.getMiddleware();
     const next = jest.fn();
-    const dispatch = () => {};
+    const dispatch = () => Promise.resolve();
 
     it('subscribe should add a subscription', () => {
       const action = createSubscribeAction({ id: 5 });

--- a/src/test/managers.ts
+++ b/src/test/managers.ts
@@ -1,13 +1,13 @@
 import { act } from '@testing-library/react-hooks';
-
-import { NetworkManager, FetchAction, ReceiveAction } from '..';
+import { NetworkManager, FetchAction, ReceiveAction, Dispatch } from '..';
 
 export class MockNetworkManager extends NetworkManager {
-  handleFetch(action: FetchAction, dispatch: React.Dispatch<any>) {
+  handleFetch(action: FetchAction, dispatch: Dispatch<any>) {
     const mockDispatch: typeof dispatch = (v: any) => {
       act(() => {
         dispatch(v);
       });
+      return Promise.resolve();
     };
     return super.handleFetch(action, mockDispatch);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,17 +152,19 @@ export type ActionTypes =
   | InvalidateAction
   | ResetAction;
 
+export type Dispatch<R extends React.Reducer<any, any>> = (
+  action: React.ReducerAction<R>,
+) => Promise<void>;
+
 export type Middleware = <R extends React.Reducer<any, any>>({
   dispatch,
-}: MiddlewareAPI<R>) => (
-  next: React.Dispatch<React.ReducerAction<R>>,
-) => (action: React.ReducerAction<R>) => void;
+}: MiddlewareAPI<R>) => (next: Dispatch<R>) => Dispatch<R>;
 
 export interface MiddlewareAPI<
   R extends React.Reducer<any, any> = React.Reducer<any, any>
 > {
   getState: () => React.ReducerState<R>;
-  dispatch: React.Dispatch<React.ReducerAction<R>>;
+  dispatch: Dispatch<R>;
 }
 
 export interface Manager {


### PR DESCRIPTION
### Motivation
React useReducer() operates differently than redux; thus needing a different middleware API. The primary difference being the async nature. State is committed async, and thus using as synchronous API doesn't allow for doing things after the state is committed or even knowing what the final state is.

### Solution
Promises make this all very nice. The dispatch function now returns a promise that resolves to void. This is reflected in next(action) in the middleware API, as this eventually calls through to the promise. This also means all middleware functions must pass through that promise to work. Thankfully typescript will enforce this and help ensure this is properly followed.

This also means the NetworkManager's middleware has been cleaned up as it can now easily resolve its promises only after the commit stage.


```typescript
({ getState }: MiddlewareAPI) => {
    return (next: any) => async (action: any) => {
      const beforeState = getState();
      await next(action);
      const afterState = getState();
    };
  };
```
