### PR TITLE
[fix] Keep promise sync list the same size so React doesn't complain

### DIFF
--- a/src/react-integration/hooks/useResource.ts
+++ b/src/react-integration/hooks/useResource.ts
@@ -65,16 +65,15 @@ function useManyResources<A extends ResourceArgs<any, any, any>[]>(
       useRetrieve(select, params),
     )
     // only wait on promises without results
-    .filter((p, i) => p && !hasUsableData(resources[i], resourceList[i][0]));
-
-  const promiseDeps = (promises as unknown[]).concat([promises.length]);
+    .map((p, i) => !hasUsableData(resources[i], resourceList[i][0]) && p);
 
   const promise = useMemo(() => {
-    if (promises.length) {
-      return Promise.all(promises);
+    const activePromises = promises.filter(p => p);
+    if (activePromises.length) {
+      return Promise.all(activePromises);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, promiseDeps);
+  }, promises);
 
   if (promise) throw promise;
 

--- a/src/react-integration/hooks/useResourceNew.ts
+++ b/src/react-integration/hooks/useResourceNew.ts
@@ -65,16 +65,15 @@ function useManyResources<A extends ResourceArgs<any, any, any>[]>(
       useRetrieve(select, params),
     )
     // only wait on promises without results
-    .filter((p, i) => p && !hasUsableData(resources[i], resourceList[i][0]));
-
-  const promiseDeps = (promises as unknown[]).concat([promises.length]);
+    .map((p, i) => !hasUsableData(resources[i], resourceList[i][0]) && p);
 
   const promise = useMemo(() => {
-    if (promises.length) {
-      return Promise.all(promises);
+    const activePromises = promises.filter(p => p);
+    if (activePromises.length) {
+      return Promise.all(activePromises);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, promiseDeps);
+  }, promises);
 
   if (promise) throw promise;
 


### PR DESCRIPTION
### Motivation
While it technically worked before, React would complain about the dependency list changing size. 

### Solution
Let's keep it the same size by simply changing the resolution to false if a promise is not active

