### PR TITLE
[fix] useRetrieve(): Only refetch on param changes

### DIFF
--- a/src/react-integration/__tests__/fixtures.ts
+++ b/src/react-integration/__tests__/fixtures.ts
@@ -74,5 +74,5 @@ export const nested = [
 ];
 
 describe('fixtures', () => {
-  it('should pass', () => {})
+  it('should pass', () => {});
 });

--- a/src/react-integration/hooks/useRetrieve.ts
+++ b/src/react-integration/hooks/useRetrieve.ts
@@ -5,16 +5,16 @@ import useFetcher from './useFetcher';
 import useMeta from './useMeta';
 
 /** Returns whether the data at this url is fresh or stale */
-function useIsStale<
+function useExpiresAt<
   Params extends Readonly<object>,
   Body extends Readonly<object | string> | void,
   S extends Schema
->(fetchShape: ReadShape<S, Params, Body>, params: Params | null): boolean {
+>(fetchShape: ReadShape<S, Params, Body>, params: Params | null): number {
   const meta = useMeta(fetchShape, params);
   if (!meta) {
-    return true;
+    return 0;
   }
-  return Date.now() > meta.expiresAt;
+  return meta.expiresAt;
 }
 
 /** Request a resource if it is not in cache. */
@@ -24,16 +24,16 @@ export default function useRetrieve<
   S extends Schema
 >(fetchShape: ReadShape<S, Params, Body>, params: Params | null, body?: Body) {
   const fetch = useFetcher(fetchShape, true);
-  const dataStale = useIsStale(fetchShape, params);
+  const expiresAt = useExpiresAt(fetchShape, params);
 
   // TODO: figure out how to express that body is optional in FetchShape as we don't need to cast here
   return useMemo(() => {
-    if (!dataStale) return;
+    if (Date.now() <= expiresAt) return;
     // null params mean don't do anything
     if (!params) return;
     return fetch(body as Body, params);
     // we don't care to re-request on body (should we?)
     // we need to check against serialized params, since params can change frequently
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataStale, fetch, params && fetchShape.getFetchKey(params)]);
+  }, [expiresAt, fetch, params && fetchShape.getFetchKey(params)]);
 }


### PR DESCRIPTION
### Motivation
Previously, useRetrive() (and thus also useResource()) would trigger fetches anytime the component it was used in re-rendered for any reason - so long as the data was considered stale. This is not the designated behavior.

* Breaks idempotence of render()
* Which resulted in unpredictable fetches

We were previously syncing to `dataStale` for our fetch trigger. This is bad because it is derivative data of Date.now() - which is not idempotent. By the transitive property, any component using this hook not idempotent. **General rule: only sync with values that are derived from React-controlled state (context, props, useState) and/or things that are constant.**

Issue discovered by @saivann

### Solution
We need to move the check for Date.now() inside our hook callback so we don't need to sync on it. We can still sync on expiresAt - which enables us to still refetch on any `useInvalidator()` calls.
