### PR TITLE
[enhance] Improve useResource() error handling conditions

### DIFF
--- a/src/react-integration/__tests__/hooks.tsx
+++ b/src/react-integration/__tests__/hooks.tsx
@@ -461,23 +461,19 @@ describe('useResource()', () => {
         );
         return article;
       } catch (e) {
+        // TODO: we're not handling suspense properly so react complains
+        // When upgrading test util we should be able to fix this as we'll suspense ourselves.
         if (typeof e.then === 'function') {
           return e;
         } else {
-          // TODO: we're not handling suspense properly so react complains
-          // When upgrading test until we should be able to fix this as we'll suspense ourselves.
-          if (e.name === 'Invariant Violation') {
-            return null;
-          } else {
-            throw e;
-          }
+          throw e;
         }
       }
     }
-    const { rerender, result, waitForNextUpdate } = renderRestHook(
-      MultiResourceTester,
-    );
+    const { rerender, result } = renderRestHook(MultiResourceTester);
     const firstPromise = result.current;
+    expect(firstPromise).toBeDefined();
+    expect(typeof firstPromise.then).toBe('function');
     jest.advanceTimersByTime(50);
     rerender();
     expect(result.current).toBe(firstPromise);
@@ -495,7 +491,19 @@ describe('useResource()', () => {
     jest.runAllTimers();
     await result.current;
     rerender();
-    expect(result.current).toBe(null);
+    expect(result.current).toMatchInlineSnapshot(`
+      CoolerArticleResource {
+        "author": null,
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      }
+    `);
     // eslint-disable-next-line require-atomic-updates
     console.error = oldError;
   });

--- a/src/react-integration/__tests__/useResourceNew.tsx
+++ b/src/react-integration/__tests__/useResourceNew.tsx
@@ -137,23 +137,20 @@ describe('useResourceNewNew()', () => {
         );
         return article;
       } catch (e) {
+        // TODO: we're not handling suspense properly so react complains
+        // When upgrading test util we should be able to fix this as we'll suspense ourselves.
         if (typeof e.then === 'function') {
           return e;
         } else {
-          // TODO: we're not handling suspense properly so react complains
-          // When upgrading test util we should be able to fix this as we'll suspense ourselves.
-          if (e.name === 'Invariant Violation') {
-            return null;
-          } else {
-            throw e;
-          }
+          throw e;
         }
       }
     }
-    const { rerender, result, waitForNextUpdate } = renderRestHook(
-      MultiResourceTester,
-    );
+    const { rerender, result } = renderRestHook(MultiResourceTester);
     const firstPromise = result.current;
+    expect(firstPromise).toBeDefined();
+    expect(typeof firstPromise.then).toBe('function');
+
     jest.advanceTimersByTime(50);
     rerender();
     expect(result.current).toBe(firstPromise);
@@ -171,7 +168,19 @@ describe('useResourceNewNew()', () => {
     jest.runAllTimers();
     await result.current;
     rerender();
-    expect(result.current).toBe(null);
+    expect(result.current).toMatchInlineSnapshot(`
+      CoolerArticleResource {
+        "author": null,
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      }
+    `);
     // eslint-disable-next-line require-atomic-updates
     console.error = oldError;
   });

--- a/src/react-integration/hooks/hasUsableData.ts
+++ b/src/react-integration/hooks/hasUsableData.ts
@@ -1,0 +1,16 @@
+import { FetchShape, Schema, RequestResource } from '~/resource';
+
+/** If the invalidIfStale option is set we suspend if resource has expired */
+export default function hasUsableData<
+  S extends Schema,
+  Params extends Readonly<object>,
+  Body extends Readonly<object | string> | void
+>(
+  resource: RequestResource<FetchShape<S, Params, Body>> | null,
+  fetchShape: Pick<FetchShape<S, Params, Body>, 'options'>,
+) {
+  return !(
+    (fetchShape.options && fetchShape.options.invalidIfStale) ||
+    !resource
+  );
+}

--- a/src/react-integration/hooks/useError.ts
+++ b/src/react-integration/hooks/useError.ts
@@ -1,6 +1,8 @@
 import { ReadShape, Schema, RequestResource } from '~/resource';
 import useMeta from './useMeta';
 
+type UseErrorReturn<P> = P extends null ? undefined : Error;
+
 /** Access a resource or error if failed to get it */
 export default function useError<
   Params extends Readonly<object>,
@@ -10,8 +12,9 @@ export default function useError<
   fetchShape: ReadShape<S, Params, Body>,
   params: Params | null,
   resource: RequestResource<typeof fetchShape> | null,
-) {
+): UseErrorReturn<typeof params> {
   const meta = useMeta(fetchShape, params);
+  if (!params) return;
   if (!resource) {
     if (!meta) return;
     if (!meta.error) {
@@ -24,7 +27,7 @@ export default function useError<
       err.status = 404;
       return err;
     } else {
-      return meta.error;
+      return meta.error as any;
     }
   }
 }

--- a/src/react-integration/hooks/useResource.ts
+++ b/src/react-integration/hooks/useResource.ts
@@ -20,7 +20,7 @@ function useOneResource<
 >(
   fetchShape: ReadShape<S, Params, Body>,
   params: Params | null,
-): typeof params extends null ? null : NonNullable<typeof resource> {
+): CondNull<typeof params, NonNullable<SchemaOf<S>>> {
   // maybePromise is undefined when data is stale or params is null
   const maybePromise = useRetrieve(fetchShape, params);
   // resource is null when it is not in cache or params is null

--- a/src/react-integration/hooks/useResource.ts
+++ b/src/react-integration/hooks/useResource.ts
@@ -1,8 +1,10 @@
-import { ReadShape, Schema, RequestResource, SchemaOf } from '~/resource';
+import { ReadShape, Schema, SchemaOf } from '~/resource';
 import useCache from './useCache';
 import useRetrieve from './useRetrieve';
 import useError from './useError';
 import { useMemo } from 'react';
+
+import hasUsableData from './hasUsableData';
 
 type ResourceArgs<
   S extends Schema,
@@ -10,40 +12,25 @@ type ResourceArgs<
   Body extends Readonly<object | string> | void
 > = [ReadShape<S, Params, Body>, Params | null];
 
-/** If the invalidIfStale option is set we suspend if resource has expired */
-function hasUsableData<
-  S extends Schema,
-  Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void
->(
-  resource: RequestResource<ReadShape<S, Params, Body>> | null,
-  fetchShape: ReadShape<S, Params, Body>,
-) {
-  return !(
-    (fetchShape.options && fetchShape.options.invalidIfStale) ||
-    !resource
-  );
-}
-
 /** single form resource */
 function useOneResource<
   Params extends Readonly<object>,
   Body extends Readonly<object | string> | void,
   S extends Schema
->(fetchShape: ReadShape<S, Params, Body>, params: Params | null) {
+>(
+  fetchShape: ReadShape<S, Params, Body>,
+  params: Params | null,
+): typeof params extends null ? null : NonNullable<typeof resource> {
+  // maybePromise is undefined when data is stale or params is null
   const maybePromise = useRetrieve(fetchShape, params);
+  // resource is null when it is not in cache or params is null
   const resource = useCache(fetchShape, params);
-
-  if (
-    !hasUsableData(resource, fetchShape) &&
-    maybePromise &&
-    typeof maybePromise.then === 'function'
-  )
-    throw maybePromise;
   const error = useError(fetchShape, params, resource);
+
+  if (!hasUsableData(resource, fetchShape) && maybePromise) throw maybePromise;
   if (error) throw error;
 
-  return resource as NonNullable<typeof resource>;
+  return resource as any;
 }
 
 /** many form resource */
@@ -55,17 +42,26 @@ function useManyResources<A extends ResourceArgs<any, any, any>[]>(
       Params extends Readonly<object>,
       Body extends Readonly<object | string> | void,
       S extends Schema
-    >([select, params]: ResourceArgs<S, Params, Body>) =>
+    >([fetchShape, params]: ResourceArgs<S, Params, Body>) =>
       // eslint-disable-next-line react-hooks/rules-of-hooks
-      useCache(select, params),
+      useCache(fetchShape, params),
   );
   const promises = resourceList
-    .map(([select, params]) =>
+    .map(([fetchShape, params]) =>
       // eslint-disable-next-line react-hooks/rules-of-hooks
-      useRetrieve(select, params),
+      useRetrieve(fetchShape, params),
     )
     // only wait on promises without results
     .map((p, i) => !hasUsableData(resources[i], resourceList[i][0]) && p);
+
+  // throw first valid error
+  for (let i = 0; i < resourceList.length; i++) {
+    const [fetchShape, params] = resourceList[i];
+    const resource = resources[i];
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const error = useError(fetchShape, params, resource);
+    if (error && !promises[i]) throw error;
+  }
 
   const promise = useMemo(() => {
     const activePromises = promises.filter(p => p);
@@ -77,14 +73,6 @@ function useManyResources<A extends ResourceArgs<any, any, any>[]>(
 
   if (promise) throw promise;
 
-  // throw any errors that exist after all promises have resolved
-  for (let i = 0; i < resourceList.length; i++) {
-    const [fetchShape, params] = resourceList[i];
-    const resource = resources[i];
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const error = useError(fetchShape, params, resource);
-    if (error) throw error;
-  }
   return resources;
 }
 

--- a/src/react-integration/hooks/useResourceNew.ts
+++ b/src/react-integration/hooks/useResourceNew.ts
@@ -1,4 +1,5 @@
 import { ReadShape, Schema, SchemaOf } from '~/resource';
+import { Denormalized } from '~/resource/normal';
 import useCacheNew from './useCacheNew';
 import useRetrieve from './useRetrieve';
 import useError from './useError';
@@ -20,7 +21,7 @@ function useOneResource<
 >(
   fetchShape: ReadShape<S, Params, Body>,
   params: Params | null,
-): typeof params extends null ? null : NonNullable<typeof resource> {
+): CondNull<typeof params, Denormalized<S>> {
   // maybePromise is undefined when data is stale or params is null
   const maybePromise = useRetrieve(fetchShape, params);
   // resource is null when it is not in cache or params is null

--- a/src/state/selectors/useSchemaSelect.ts
+++ b/src/state/selectors/useSchemaSelect.ts
@@ -15,7 +15,7 @@ export default function useSchemaSelect<
   }: Pick<ReadShape<S, Params, any>, 'schema' | 'getFetchKey'>,
   params: Params | null,
   state: State<any>,
-): SchemaOf<typeof schema> | null {
+): typeof params extends null ? null : (SchemaOf<typeof schema> | null) {
   const denormalized = useDenormalized({ schema, getFetchKey }, params, state);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const getItemsFromResults = useMemo(() => resultFinderFromSchema(schema), []);
@@ -26,7 +26,7 @@ export default function useSchemaSelect<
         : denormalized,
     [denormalized, getItemsFromResults],
   );
-  return output;
+  return output as any;
 }
 
 // TODO: there should honestly be a way to use the pre-existing normalizr object


### PR DESCRIPTION
### Motivation
https://github.com/coinbase/rest-hooks/pull/109 incorporated some useful improvements to error mechanisms. However, after careful consideration it seems like not the best approach, so this should incorporate those improvements and some others.

### Solution
* Never generate errors when params are null (previously could create fake 404 when resource wasn't found)
* Improve some typings to factor in conditional of param being null
* multi-resource requests now immediately throw error on first error and stop suspending.
