### PR TITLE
Changed pk() types, replace 'null' with 'undefined'

### DIFF
--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -96,7 +96,7 @@ the instance in construction.
 
 ## Be sure to always provide:
 
-### pk: () => string | number | null
+### pk: () => string | number | undefined
 
 PK stands for *primary key* and is intended to provide a standard means of retrieving
 a key identifier for any `Resource`. In many cases there will simply be an 'id' field
@@ -110,11 +110,11 @@ pk() {
 }
 ```
 
-#### Null value
+#### Undefined value
 
-A `null` can be used as a default to indicate the resource has not been created yet.
+A `undefined` can be used as a default to indicate the resource has not been created yet.
 This is useful when initializing a creation form using [Resource.fromJS()](./api/resource#static-fromjs-t-extends-typeof-resource-this-t-props-partial-abstractinstancetype-t-abstractinstancetype-t)
-directly. If `pk()` resolves to null it is considered not persisted to the server,
+directly. If `pk()` resolves to undefined it is considered not persisted to the server,
 and thus will not be kept in the cache.
 
 #### Other uses

--- a/src/resource/SimpleResource.ts
+++ b/src/resource/SimpleResource.ts
@@ -16,7 +16,7 @@ export default abstract class SimpleResource {
   /** Used as base of url construction */
   static readonly urlRoot: string;
   /** A unique identifier for this SimpleResource */
-  abstract pk(): string | number | null;
+  abstract pk(): string | number | undefined;
 
   /** SimpleResource factory. Takes an object of properties to assign to SimpleResource. */
   static fromJS<T extends typeof SimpleResource>(


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #118  .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
I believe this is exactly what was asked for. I updated the docs as well and think everything is in order.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
"One of the main purposes of SimpleResource.pk() is to pass as a key in React. However, React types keys as possibly being undefined - not null so the type should reflect that here."

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
