### PR TITLE
[feature] Add optimistic update on create

### DIFF
--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -95,6 +95,24 @@ export class UrlArticleResource extends ArticleResource {
   readonly url: string = 'happy.com';
 }
 
+export class ArticleResourceWithOtherListUrl extends ArticleResource {
+  static otherListShape<T extends typeof ArticleResourceWithOtherListUrl>(
+    this: T,
+  ): ReadShape<SchemaList<AbstractInstanceType<T>>> {
+    const getFetchKey = () => this.otherListUrl();
+    return {
+      ...this.listShape(),
+      getFetchKey,
+      fetch: (_params: object, body: object) =>
+        this.fetch('get', getFetchKey(), body),
+    };
+  }
+
+  static otherListUrl<T extends typeof ArticleResource>(this: T): string {
+    return this.urlRoot + 'some-list-url';
+  }
+}
+
 export class CoolerArticleResource extends ArticleResource {
   static urlRoot = 'http://test.com/article-cooler/';
   get things() {
@@ -145,6 +163,7 @@ export class UserResource extends Resource {
   static urlRoot = 'http://test.com/user/';
 }
 class OtherArticleResource extends CoolerArticleResource {}
+
 export class PaginatedArticleResource extends OtherArticleResource {
   static urlRoot = 'http://test.com/article-paginated/';
   static listShape<T extends typeof Resource>(this: T) {

--- a/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
+++ b/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
@@ -114,6 +114,61 @@ Object {
 }
 `;
 
+exports[`useFetcher should dispatch an action with multiple updaters in the meta if update shapes params are passed in 1`] = `
+Object {
+  "meta": Object {
+    "options": undefined,
+    "reject": [Function],
+    "resolve": [Function],
+    "responseType": "rest-hooks/rpc",
+    "schema": EntitySchema {
+      "_getId": [Function],
+      "_idAttribute": [Function],
+      "_key": "http://test.com/article/",
+      "_mergeStrategy": [Function],
+      "_processStrategy": [Function],
+      "denormalize": [Function],
+      "schema": Object {},
+    },
+    "throttle": false,
+    "updaters": Object {
+      "GET http://test.com/article/": [Function],
+      "http://test.com/article/some-list-url": [Function],
+    },
+    "url": "POST http://test.com/article/",
+  },
+  "payload": [Function],
+  "type": "rest-hooks/fetch",
+}
+`;
+
+exports[`useFetcher should dispatch an action with updater in the meta if update shapes params are passed in 1`] = `
+Object {
+  "meta": Object {
+    "options": undefined,
+    "reject": [Function],
+    "resolve": [Function],
+    "responseType": "rest-hooks/rpc",
+    "schema": EntitySchema {
+      "_getId": [Function],
+      "_idAttribute": [Function],
+      "_key": "http://test.com/article-cooler/",
+      "_mergeStrategy": [Function],
+      "_processStrategy": [Function],
+      "denormalize": [Function],
+      "schema": Object {},
+    },
+    "throttle": false,
+    "updaters": Object {
+      "GET http://test.com/article-cooler/": [Function],
+    },
+    "url": "POST http://test.com/article-cooler/",
+  },
+  "payload": [Function],
+  "type": "rest-hooks/fetch",
+}
+`;
+
 exports[`useResource() should dispatch an action that fetches 1`] = `
 Object {
   "meta": Object {

--- a/src/react-integration/__tests__/fixtures.ts
+++ b/src/react-integration/__tests__/fixtures.ts
@@ -5,6 +5,13 @@ export const payload = {
   tags: ['a', 'best', 'react'],
 };
 
+export const createPayload = {
+  id: 1,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
 export const articlesPages = {
   prevPage: '23asdl',
   nextPage: 's3f3',
@@ -72,6 +79,37 @@ export const nested = [
     },
   },
 ];
+
+const moreNested = [
+  {
+    id: 7,
+    title: 'article 7',
+    content: 'whatever',
+    tags: ['blah'],
+    author: {
+      id: 23,
+      username: 'bob',
+    },
+  },
+  {
+    id: 8,
+    title: 'article 8',
+    content: 'whatever',
+    author: {
+      id: 27,
+      username: 'zac',
+      email: 'zac@bob.com',
+    },
+  },
+];
+
+export const paginatedFirstPage = {
+  results: nested,
+};
+
+export const paginatedSecondPage = {
+  results: moreNested,
+};
 
 describe('fixtures', () => {
   it('should pass', () => {});

--- a/src/react-integration/__tests__/hooks.tsx
+++ b/src/react-integration/__tests__/hooks.tsx
@@ -9,6 +9,7 @@ import {
   CoolerArticleResource,
   UserResource,
   PaginatedArticleResource,
+  ArticleResourceWithOtherListUrl,
   StaticArticleResource,
   InvalidIfStaleArticleResource,
 } from '../../__tests__/common';
@@ -100,6 +101,52 @@ describe('useFetcher', () => {
     }
     await testDispatchFetch(DispatchTester, [payload]);
   });
+
+  it('should dispatch an action with updater in the meta if update shapes params are passed in', async () => {
+    nock('http://test.com')
+      .post(`/article-cooler/`)
+      .reply(201, payload);
+
+    function DispatchTester() {
+      const create = useFetcher(CoolerArticleResource.createShape());
+      const params = { content: 'hi' };
+      create(params, {}, [
+        [
+          CoolerArticleResource.listShape(),
+          {},
+          (article: any, articles: any) => [...articles, article],
+        ],
+      ]);
+      return null;
+    }
+    await testDispatchFetch(DispatchTester, [payload]);
+  });
+
+  it('should dispatch an action with multiple updaters in the meta if update shapes params are passed in', async () => {
+    nock('http://test.com')
+      .post(`/article/`)
+      .reply(201, payload);
+
+    function DispatchTester() {
+      const create = useFetcher(ArticleResourceWithOtherListUrl.createShape());
+      const params = { content: 'hi' };
+      create(params, {}, [
+        [
+          ArticleResourceWithOtherListUrl.listShape(),
+          {},
+          (article: any, articles: any) => [...articles, article],
+        ],
+        [
+          ArticleResourceWithOtherListUrl.otherListShape(),
+          {},
+          (article: any, articles: any) => [...articles, article],
+        ],
+      ]);
+      return null;
+    }
+    await testDispatchFetch(DispatchTester, [payload]);
+  });
+
   it('should console.error() a warning when fetching without a Provider', () => {
     const oldError = console.error;
     const spy = (console.error = jest.fn());
@@ -116,6 +163,7 @@ describe('useFetcher', () => {
     `);
     console.error = oldError;
   });
+
   it('should dispatch an action that fetches a partial update', async () => {
     nock('http://test.com')
       .patch(`/article-cooler/1`)
@@ -128,6 +176,7 @@ describe('useFetcher', () => {
     }
     await testDispatchFetch(DispatchTester, [payload]);
   });
+
   it('should dispatch an action that fetches a full update', async () => {
     nock('http://test.com')
       .put(`/article-cooler/1`)

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -16,13 +16,22 @@ export interface FetchShape<
   readonly options?: RequestOptions;
 }
 
+export type SchemaFromShape<
+  F extends FetchShape<any, any, any>
+> = F extends FetchShape<infer S, any, any> ? S : never;
+export type ParamsFromShape<
+  F extends FetchShape<any, any, any>
+> = F extends FetchShape<any, infer P, any> ? P : never;
+export type BodyFromShape<
+  F extends FetchShape<any, any, any>
+> = F extends FetchShape<any, any, infer B> ? B : never;
+
 /** Purges a value from the server */
 export interface DeleteShape<
   S extends schemas.Entity,
   Params extends Readonly<object> = Readonly<object>
 > extends FetchShape<S, Params, any> {
   readonly type: 'delete';
-  readonly schema: S;
 }
 
 /** To change values on the server */
@@ -72,12 +81,18 @@ export type BodyArg<RS> = RS extends {
   : never;
 export type RequestResource<RS> = SchemaOf<ResultShape<RS>>;
 
-export function isEntity<T>(schema: Schema): schema is schemas.Entity<T> {
-  return (schema as schemas.Entity<T>).key !== undefined;
+export function isEntity<T>(schema: Schema<T>): schema is schemas.Entity<T> {
+  return (schema as schemas.Entity).key !== undefined;
 }
 
-export type SchemaOf<T> = T extends SchemaList<infer R>
+export type SchemaOf2<T> = T extends SchemaList<infer R>
   ? R[]
   : T extends SchemaDetail<infer R>
   ? R
   : never;
+
+export type SchemaOf<S> = Extract<S, schemas.Entity<any>> extends never
+  ? (S extends (infer I)[] | schemas.Array<infer I>
+      ? SchemaOf2<Extract<I, schemas.Entity<any>>>[]
+      : SchemaOf2<S>)
+  : SchemaOf2<Extract<S, schemas.Entity<any>>>;

--- a/src/state/__tests__/applyUpdatersToResults.ts
+++ b/src/state/__tests__/applyUpdatersToResults.ts
@@ -1,0 +1,53 @@
+import { ArticleResourceWithOtherListUrl } from '../../__tests__/common';
+import applyUpdatersToResults from '../applyUpdatersToResults';
+
+describe('applyUpdatersToResults', () => {
+  const results = {
+    [ArticleResourceWithOtherListUrl.listShape().getFetchKey({})]: ['1', '2'],
+  };
+
+  it('returns results if updaters is not defined', () => {
+    expect(applyUpdatersToResults(results, '3', undefined)).toStrictEqual(
+      results,
+    );
+  });
+
+  it('handles a single updater', () => {
+    const newResults = applyUpdatersToResults(results, '3', {
+      [ArticleResourceWithOtherListUrl.listShape().getFetchKey({})]: (
+        article: string,
+        articles: string[] | undefined,
+      ) => [article, ...(articles || [])],
+    });
+    expect(newResults).toStrictEqual({
+      ...results,
+      [ArticleResourceWithOtherListUrl.listShape().getFetchKey({})]: [
+        '3',
+        '1',
+        '2',
+      ],
+    });
+  });
+
+  it('handles multiple updaters sequentially', () => {
+    const newResults = applyUpdatersToResults(results, '3', {
+      [ArticleResourceWithOtherListUrl.listShape().getFetchKey({})]: (
+        article: string,
+        articles: string[] | undefined,
+      ) => [article, ...(articles || [])],
+      [ArticleResourceWithOtherListUrl.otherListShape().getFetchKey({})]: (
+        article: string,
+        articles: string[] | undefined,
+      ) => [...(articles || []), article],
+    });
+    expect(newResults).toStrictEqual({
+      ...results,
+      [ArticleResourceWithOtherListUrl.listShape().getFetchKey({})]: [
+        '3',
+        '1',
+        '2',
+      ],
+      [ArticleResourceWithOtherListUrl.otherListShape().getFetchKey({})]: ['3'],
+    });
+  });
+});

--- a/src/state/applyUpdatersToResults.ts
+++ b/src/state/applyUpdatersToResults.ts
@@ -1,0 +1,31 @@
+import { UpdateFunction } from '~/types';
+import { ResultType, Schema } from '~/resource/normal';
+
+type ResultStateFromUpdateFunctions<
+  SourceSchema extends Schema,
+  UpdateFunctions extends {
+    [key: string]: UpdateFunction<SourceSchema, any>;
+  }
+> = { [K in keyof UpdateFunctions]: any };
+
+export default function applyUpdatersToResults<
+  SourceSchema extends Schema,
+  UpdateFunctions extends {
+    [key: string]: UpdateFunction<SourceSchema, any>;
+  }
+>(
+  results: ResultStateFromUpdateFunctions<SourceSchema, UpdateFunctions>,
+  result: ResultType<SourceSchema>,
+  updaters: UpdateFunctions | undefined,
+) {
+  if (!updaters) return results;
+  return {
+    ...results,
+    ...Object.fromEntries(
+      Object.entries(updaters).map(([fetchKey, updater]) => [
+        fetchKey,
+        updater(result, results[fetchKey]),
+      ]),
+    ),
+  };
+}


### PR DESCRIPTION
Fixes https://github.com/coinbase/rest-hooks/issues/96

### Motivation
Provide both the mechanism for common case optimistic updates, as well as well designed extension points for unusual cases like https://github.com/coinbase/rest-hooks/issues/124

### Solution
Update the API of the function returned from `useFetcher` to take in an array of updaters:

```ts
const createArticle = useFetcher(ArticleResource.createShape());

createArticle({ id: 1 }, {}, [
  [ArticleResource.listShape(), {}, (newArticle, articles) => [...articles, newArticle]]
])
```

Additionally, this supports the same case for GETs, in the case of pagination:

```ts
class PaginatedArticleResource extends Resource {
  readonly id: number | null = null;
  readonly title: string = '';
  readonly content: string = '';
  readonly author: number | null = null;
  readonly tags: string[] = [];

  pk() {
    return this.id;
  }

  static urlRoot = 'http://test.com/article/';

  static listShape<T extends typeof Resource>(this: T) {
    return {
      ...super.listShape(),
      schema: { results: [this.getEntitySchema()] },
    };
  }
}

function mergeArticles(
  newPage: { results: string[] },
  articles: { results?: string[] },
): { results: string[] } {
  return [...(articles.results || []), ...newPage.results];
}

function useNextPageFetcher() {
  const getNextPage = useFetcher(ArticleResource.listShape());
  return useCallback(() => {
    return getNextPage({}, { cursor: 2 }, [
      [ArticleResource.listShape(), {}, mergeArticles],
    ]);
  }, [getNextPage]);
}
```

### Credit

@zacharyfmarion wrote much of this code, but was rebased together so this attribution was lost in this PR
