### PR TITLE
[enhance] Improve normalizr type expressiveness

### DIFF
--- a/src/resource/normal.d.ts
+++ b/src/resource/normal.d.ts
@@ -13,25 +13,29 @@ declare namespace schemas {
   ) => S;
   type EntityMap<T = any> = { [key: string]: Entity<T> };
 
-  export class Array<T = any> {
-    constructor(
-      definition: Schema<T>,
-      schemaAttribute?: string | SchemaFunction,
-    );
+  export class Array<S extends Schema = Schema<any>> {
+    private _identifier: 'Array';
+    constructor(definition: S, schemaAttribute?: string | SchemaFunction);
     define(definition: Schema): void;
+    readonly schema: S;
   }
 
-  export interface EntityOptions<T = any> {
-    idAttribute?: string | SchemaFunction;
+  export interface EntityOptions<T = any, ID = string> {
+    idAttribute?: string | SchemaFunction<ID>;
     mergeStrategy?: MergeFunction;
     processStrategy?: StrategyFunction<T>;
   }
 
-  export class Entity<T = any> {
-    constructor(key: string, definition?: Schema, options?: EntityOptions<T>);
+  export class Entity<T = any, K extends string = string> {
+    private _identifier: 'Entity';
+    constructor(
+      key: K,
+      definition?: Schema,
+      options?: EntityOptions<T, string>,
+    );
     define(definition: Schema): void;
-    key: string;
-    getId: SchemaFunction;
+    readonly key: K;
+    getId: SchemaFunction<string>;
     _processStrategy: StrategyFunction<T>;
   }
 
@@ -41,9 +45,11 @@ declare namespace schemas {
   > {
     constructor(definition: O);
     define(definition: Schema): void;
+    readonly schema: O;
   }
 
   export class Union<Choices extends EntityMap = any> {
+    private _identifier: 'Union';
     constructor(
       definition: Choices,
       schemaAttribute:
@@ -53,9 +59,11 @@ declare namespace schemas {
     define(definition: Schema): void;
     inferSchema: SchemaAttributeFunction<Choices[keyof Choices]>;
     getSchemaAttribute: SchemaFunction<keyof Choices>;
+    readonly schema: Choices;
   }
 
   export class Values<Choices extends EntityMap | Schema = any> {
+    private _identifier: 'Values';
     constructor(
       definition: Choices,
       schemaAttribute?: Choices extends EntityMap<infer T>
@@ -63,13 +71,14 @@ declare namespace schemas {
         : undefined,
     );
     define(definition: Schema): void;
-    isSingleSchema: Choices extends EntityMap ? false : true;
+    readonly isSingleSchema: Choices extends EntityMap ? false : true;
     inferSchema: SchemaAttributeFunction<
       Choices extends EntityMap ? Choices[keyof Choices] : Choices
     >;
     getSchemaAttribute: Choices extends EntityMap
       ? SchemaFunction<keyof Choices>
       : false;
+    readonly schema: Choices;
   }
 }
 
@@ -103,11 +112,14 @@ interface SchemaArray<T> extends Array<SchemaDetail<T>> {}
 export type SchemaDetail<T> =
   | schemas.Entity<T>
   | schemas.Object<T>
-  | schemas.Union<{ [key: string]: schemas.Entity<T> }>
-  | schemas.Values<{ [key: string]: schemas.Entity<T> } | schemas.Entity<T>>
+  | schemas.Union<schemas.EntityMap<T>>
+  | schemas.Values<schemas.Entity<T> | SchemaObjectOne<T>>
   | SchemaObjectOne<T>;
 
-export type SchemaList<T> = SchemaArray<T> | SchemaObjectMany<T>;
+export type SchemaList<T> =
+  | SchemaArray<T>
+  | SchemaObjectMany<T>
+  | schemas.Array<SchemaDetail<T>>;
 
 export type Schema<T = any> = SchemaDetail<T> | SchemaList<T>;
 
@@ -128,7 +140,7 @@ export function denormalize<S extends Schema>(
   entities: any,
 ): Denormalized<S>;
 
-export type Denormalized<S> = S extends schemas.Entity<infer T>
+export type DenormalizedCore<S> = S extends schemas.Entity<infer T>
   ? T
   : S extends schemas.Values<infer Choices>
   ? Record<
@@ -142,9 +154,9 @@ export type Denormalized<S> = S extends schemas.Entity<infer T>
   : S extends schemas.Union<infer Choices>
   ? (Choices[keyof Choices] extends schemas.Entity<infer T> ? T : never) // TODO: typescript 3.7 make this recursive instead
   : S extends schemas.Object<any, infer O>
-  ? { [K in keyof O]: O[K] extends Schema ? Denormalized<O[K]> : O[K] }
+  ? { [K in keyof O]: O[K] extends Schema ? DenormalizedCore<O[K]> : O[K] }
   : S extends { [key: string]: any }
-  ? { [K in keyof S]: S[K] extends Schema ? Denormalized<S[K]> : S[K] }
+  ? { [K in keyof S]: S[K] extends Schema ? DenormalizedCore<S[K]> : S[K] }
   : S;
 
 type UnionResult<Choices extends schemas.EntityMap> = {
@@ -152,21 +164,33 @@ type UnionResult<Choices extends schemas.EntityMap> = {
   schema: keyof Choices;
 };
 
-export type ResultType<S> = S extends schemas.Entity
-  ? ReturnType<S['getId']>
+export type Denormalized<S> = Extract<S, schemas.Entity<any>> extends never
+  ? (S extends (infer I)[] | schemas.Array<infer I>
+      ? DenormalizedCore<Extract<I, schemas.Entity<any>>>[]
+      : DenormalizedCore<S>)
+  : DenormalizedCore<Extract<S, schemas.Entity<any>>>;
+
+export type ResultTypeCore<S> = S extends schemas.Entity<any>
+  ? ReturnType<S['getId']> // should always be string
   : S extends schemas.Values<infer Choices>
   ? Record<
       string,
       Choices extends schemas.EntityMap
         ? UnionResult<Choices>
-        : Choices extends schemas.Entity
+        : Choices extends schemas.Entity<any>
         ? ReturnType<Choices['getId']> // TODO: typescript 3.7 let's us make this recursive
         : never
     >
   : S extends schemas.Union<infer Choices>
   ? UnionResult<Choices>
   : S extends schemas.Object<any, infer O>
-  ? { [K in keyof O]: O[K] extends Schema ? ResultType<O[K]> : O[K] }
+  ? { [K in keyof O]: O[K] extends Schema ? ResultTypeCore<O[K]> : O[K] }
   : S extends { [key: string]: any }
-  ? { [K in keyof S]: S[K] extends Schema ? ResultType<S[K]> : S[K] }
+  ? { [K in keyof S]: S[K] extends Schema ? ResultTypeCore<S[K]> : S[K] }
   : S;
+
+export type ResultType<S> = Extract<S, schemas.Entity<any>> extends never
+  ? (S extends (infer I)[] | schemas.Array<infer I>
+      ? ResultTypeCore<Extract<I, schemas.Entity<any>>>[]
+      : ResultTypeCore<S>)
+  : ResultTypeCore<Extract<S, schemas.Entity<any>>>;


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->



### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Fake nominal typing for schema types (since they have pretty similar signatures).
  - future: should change to tracking return value of normalize as that can encode proper typings. We can use the schema provided and build on that to pretty convincingly manifest the algo. This can replace the giant ResultType and Denormalized block.
- Add missing readonly member schema
- Include Array in Schema and SchemaList def
- Add greedy resolution to Entity in ResultType and Denormalized generics.
  - This means if we only have SchemaDetail or SchemaList it will resolve to T and T[] respectively. While we don't actually know this - it enables a broad base class definition for our REST shapes. In the future a better solution is to simply make those shapes a mixin and encourage more often writing own shapes from scratch.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Should we just try to fix the normalize/denormalize algo now?
