### PR TITLE
[fix] Suspend properly when loading nested array schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.0",
-    "@rest-hooks/normalizr": "^4.0.0-beta.0",
+    "@rest-hooks/normalizr": "^4.0.0-beta.2",
     "@types/superagent": "^4.1.3",
     "flux-standard-action": "^2.1.1",
     "lodash": "^4.17.15",

--- a/src/state/selectors/__tests__/useDenormalized.ts
+++ b/src/state/selectors/__tests__/useDenormalized.ts
@@ -1,44 +1,483 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { CoolerArticleResource } from '../../../__tests__/common';
+import {
+  CoolerArticleResource,
+  PaginatedArticleResource,
+  NestedArticleResource,
+  UserResource,
+} from '../../../__tests__/common';
+import { normalize } from '../../../resource';
 import useDenormalized from '../useDenormalized';
 
 describe('useDenormalized()', () => {
-  it('should throw when results are Array', () => {
-    const params = { title: 'bob' };
-    const state = {
-      entities: {},
-      results: {
-        [CoolerArticleResource.detailShape().getFetchKey(params)]: [5, 6, 7],
-      },
-      meta: {},
-    };
-    const { result } = renderHook(() =>
-      useDenormalized(CoolerArticleResource.detailShape(), params, state),
-    );
-    expect(result.error).toBeDefined();
-  });
-  it('should throw when results are Object', () => {
-    const params = { title: 'bob' };
-    const state = {
-      entities: {},
-      results: {
-        [CoolerArticleResource.detailShape().getFetchKey(params)]: {
-          results: [5, 6, 7],
-        },
-      },
-      meta: {},
-    };
-    const { result } = renderHook(() =>
-      useDenormalized(CoolerArticleResource.detailShape(), params, state),
-    );
-    expect(result.error).toBeDefined();
-  });
-  it('should be undefined when state is empty', () => {
-    const state: any = { entities: {}, results: {}, meta: {} };
-    const { result } = renderHook(() =>
-      useDenormalized(CoolerArticleResource.detailShape(), { id: 5 }, state),
-    );
+  describe('Single', () => {
+    const params = { id: 5, title: 'bob', content: 'head' };
+    const article = CoolerArticleResource.fromJS(params);
+    describe('state is empty', () => {
+      const state = { entities: {}, results: {}, meta: {} };
+      const { result } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.detailShape(), { id: 5 }, state),
+      );
 
-    expect(result.current).toStrictEqual([undefined, false]);
+      it('found should be false', () => {
+        expect(result.current[1]).toBe(false);
+      });
+
+      it('should provide inferred results with undefined', () => {
+        expect(result.current[0]).toMatchInlineSnapshot(`undefined`);
+      });
+    });
+    describe('state is populated just not with our query', () => {
+      const state = {
+        entities: {
+          [CoolerArticleResource.getKey()]: {
+            [params.id]: article,
+          },
+        },
+        results: {
+          [CoolerArticleResource.detailShape().getFetchKey(params)]: params.id,
+        },
+        meta: {},
+      };
+      const { result } = renderHook(() =>
+        useDenormalized(
+          CoolerArticleResource.detailShape(),
+          {
+            id: 543345345345453,
+          },
+          state,
+        ),
+      );
+
+      it('found should be false', () => {
+        expect(result.current[1]).toBe(false);
+      });
+
+      it('should provide inferred results with undefined', () => {
+        expect(result.current[0]).toMatchInlineSnapshot(`undefined`);
+      });
+    });
+    describe('when state exists', () => {
+      const state = {
+        entities: {
+          [CoolerArticleResource.getKey()]: {
+            [params.id]: article,
+          },
+        },
+        results: {
+          [CoolerArticleResource.detailShape().getFetchKey(params)]: params.id,
+        },
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.detailShape(), params, state),
+      );
+
+      it('found should be true', () => {
+        expect(found).toBe(true);
+      });
+
+      it('should provide inferred results', () => {
+        expect(value).toBe(article);
+      });
+    });
+    describe('without entity with defined results', () => {
+      const state = {
+        entities: { [CoolerArticleResource.getKey()]: {} },
+        results: {
+          [CoolerArticleResource.detailShape().getFetchKey(params)]: params.id,
+        },
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.detailShape(), params, state),
+      );
+
+      it('found should be false', () => {
+        expect(found).toBe(false);
+      });
+
+      it('should provide inferred results with undefined', () => {
+        expect(value).toMatchInlineSnapshot(`undefined`);
+      });
+    });
+    describe('no result exists but primary key is used', () => {
+      const state = {
+        entities: {
+          [CoolerArticleResource.getKey()]: {
+            [params.id]: article,
+          },
+        },
+        results: {},
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.detailShape(), params, state),
+      );
+
+      it('found should be true', () => {
+        expect(found).toBe(true);
+      });
+
+      it('should provide inferred results', () => {
+        expect(value).toBe(article);
+      });
+    });
+    describe('no result exists but primary key is used when using nested schema', () => {
+      const pageArticle = PaginatedArticleResource.fromJS(article);
+      const state = {
+        entities: {
+          [PaginatedArticleResource.getKey()]: {
+            [params.id]: pageArticle,
+          },
+        },
+        results: {},
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(PaginatedArticleResource.detailShape(), params, state),
+      );
+
+      it('found should be true', () => {
+        expect(found).toBe(true);
+      });
+
+      it('should provide inferred results', () => {
+        expect(value.data).toBe(pageArticle);
+      });
+    });
+    describe('not using primary key as param', () => {
+      const urlParams = { title: 'bob' };
+      const state = {
+        entities: {
+          [CoolerArticleResource.getKey()]: {
+            [params.id]: article,
+          },
+        },
+        results: {
+          [CoolerArticleResource.detailShape().getFetchKey(
+            urlParams,
+          )]: params.id,
+        },
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.detailShape(), params, state),
+      );
+
+      it('found should be true', () => {
+        expect(found).toBe(true);
+      });
+
+      it('should provide inferred results', () => {
+        expect(value).toBe(article);
+      });
+    });
+    it('should throw when results are Array', () => {
+      const params = { title: 'bob' };
+      const state = {
+        entities: {},
+        results: {
+          [CoolerArticleResource.detailShape().getFetchKey(params)]: [5, 6, 7],
+        },
+        meta: {},
+      };
+      const { result } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.detailShape(), params, state),
+      );
+      expect(result.error).toBeDefined();
+    });
+    it('should throw when results are Object', () => {
+      const params = { title: 'bob' };
+      const state = {
+        entities: {},
+        results: {
+          [CoolerArticleResource.detailShape().getFetchKey(params)]: {
+            results: [5, 6, 7],
+          },
+        },
+        meta: {},
+      };
+      const { result } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.detailShape(), params, state),
+      );
+      expect(result.error).toBeDefined();
+    });
+    describe('nested resources', () => {
+      const nestedArticle = NestedArticleResource.fromJS({
+        ...params,
+        user: 23,
+      });
+      const user = UserResource.fromJS({ id: 23, username: 'anne' });
+
+      const state = {
+        entities: {
+          [NestedArticleResource.getKey()]: {
+            [`${nestedArticle.pk()}`]: nestedArticle,
+          },
+          [UserResource.getKey()]: { [`${user.pk()}`]: user },
+        },
+        results: {},
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(NestedArticleResource.detailShape(), params, state),
+      );
+      it('found should be true', () => {
+        expect(found).toBe(true);
+      });
+
+      it('should provide inferred results', () => {
+        expect(value).toMatchInlineSnapshot(`
+          NestedArticleResource {
+            "author": null,
+            "content": "head",
+            "id": 5,
+            "tags": Array [],
+            "title": "bob",
+            "user": 23,
+          }
+        `);
+      });
+    });
+  });
+
+  describe('List', () => {
+    const params = { things: 5 };
+    const articles = [
+      CoolerArticleResource.fromJS({ id: 5 }),
+      CoolerArticleResource.fromJS({ id: 6 }),
+      CoolerArticleResource.fromJS({ id: 34, title: 'five' }),
+    ];
+    describe('state is empty', () => {
+      const state = { entities: {}, results: {}, meta: {} };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(PaginatedArticleResource.listShape(), {}, state),
+      );
+
+      it('found should be false', () => {
+        expect(found).toBe(false);
+      });
+
+      it('should provide inferred results with undefined for entity', () => {
+        expect(value).toMatchInlineSnapshot(`
+          Object {
+            "nextPage": "",
+            "prevPage": "",
+            "results": undefined,
+          }
+        `);
+      });
+    });
+    describe('state is partial', () => {
+      const { entities } = normalize(
+        articles,
+        CoolerArticleResource.listShape().schema,
+      );
+      const state = { entities, results: {}, meta: {} };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.listShape(), {}, state),
+      );
+
+      it('found should be false', () => {
+        expect(found).toBe(false);
+      });
+
+      it('should provide inferred results with undefined for entity', () => {
+        expect(value).toMatchInlineSnapshot(`undefined`);
+      });
+    });
+    describe('state exists', () => {
+      const { entities, result: resultState } = normalize(
+        articles,
+        CoolerArticleResource.listShape().schema,
+      );
+      const state = {
+        entities,
+        results: {
+          [CoolerArticleResource.listShape().getFetchKey(params)]: resultState,
+        },
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.listShape(), params, state),
+      );
+
+      it('found should be true', () => {
+        expect(found).toBe(true);
+      });
+
+      it('should provide inferred results', () => {
+        expect(value).toEqual(articles);
+      });
+    });
+    describe('missing some ids in entities table', () => {
+      const { entities, result: resultState } = normalize(
+        articles,
+        CoolerArticleResource.listShape().schema,
+      );
+      delete entities[CoolerArticleResource.getKey()]['5'];
+      const state = {
+        entities,
+        results: {
+          [CoolerArticleResource.listShape().getFetchKey(params)]: resultState,
+        },
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(CoolerArticleResource.listShape(), params, state),
+      );
+
+      const expectedArticles = articles.slice(1);
+
+      it('found should be true', () => {
+        expect(found).toBe(true);
+      });
+
+      it('should simply ignore missing entities', () => {
+        expect(value).toEqual(expectedArticles);
+      });
+    });
+    describe('paginated results + missing some ids in entities table', () => {
+      const { entities, result: resultState } = normalize(
+        { results: articles },
+        PaginatedArticleResource.listShape().schema,
+      );
+      delete entities[PaginatedArticleResource.getKey()]['5'];
+      const state = {
+        entities,
+        results: {
+          [PaginatedArticleResource.listShape().getFetchKey(
+            params,
+          )]: resultState,
+        },
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(PaginatedArticleResource.listShape(), params, state),
+      );
+
+      it('found should be true', () => {
+        expect(found).toBe(true);
+      });
+
+      it('should match normalized articles', () => {
+        const expectedArticles = articles.slice(1);
+        expect(value.results).toEqual(expectedArticles);
+      });
+    });
+    describe('paginated results', () => {
+      const { entities, result: resultState } = normalize(
+        { results: articles },
+        PaginatedArticleResource.listShape().schema,
+      );
+      const state = {
+        entities,
+        results: {
+          [PaginatedArticleResource.listShape().getFetchKey(
+            params,
+          )]: resultState,
+        },
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(PaginatedArticleResource.listShape(), params, state),
+      );
+
+      it('found should be true', () => {
+        expect(found).toBe(true);
+      });
+
+      it('should match normalized articles', () => {
+        expect(value.results).toEqual(articles);
+      });
+    });
+    describe('paginated results still loading', () => {
+      const { entities, result: resultState } = normalize(
+        { results: articles },
+        PaginatedArticleResource.listShape().schema,
+      );
+      const state = {
+        entities,
+        results: {},
+        meta: {},
+      };
+      const {
+        result: {
+          current: [value, found],
+        },
+      } = renderHook(() =>
+        useDenormalized(PaginatedArticleResource.listShape(), params, state),
+      );
+
+      it('found should be false', () => {
+        expect(found).toBe(false);
+      });
+
+      it('value should be inferred for pagination primitives', () => {
+        expect(value).toMatchInlineSnapshot(`
+          Object {
+            "nextPage": "",
+            "prevPage": "",
+            "results": undefined,
+          }
+        `);
+      });
+    });
+    it('should throw with invalid schemas', () => {
+      const shape = PaginatedArticleResource.listShape();
+      shape.schema = { happy: { go: { lucky: 5 } } } as any;
+      const { result } = renderHook(() =>
+        useDenormalized(shape, params, {} as any),
+      );
+      expect(result.error).toBeDefined();
+    });
   });
 });

--- a/src/state/selectors/useDenormalized.ts
+++ b/src/state/selectors/useDenormalized.ts
@@ -70,9 +70,7 @@ export default function useDenormalized<
       schema,
       entities,
     );
-    // only consider missing entities a failure if results was inferred
-    // delete will sometimes remove entities
-    return [denormalized, !!cacheResults || entitiesFound] as any;
+    return [denormalized, entitiesFound] as any;
     // TODO: would be nice to make this only recompute on the entity types that are in schema
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entities, params && getFetchKey(params), results]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1211,10 +1211,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@rest-hooks/normalizr@^4.0.0-beta.0":
-  version "4.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@rest-hooks/normalizr/-/normalizr-4.0.0-beta.0.tgz#1b7b5addf256437e584193dd69ad56647fb0b2ad"
-  integrity sha512-G9Q1GB1WOmYTpCajGTYQwsR/a0uYe6URjVGnfcEPK7CFG+qbvf2JRoZXLRnLiUp6UW0CPXRsJPAdSAeDhK4yTA==
+"@rest-hooks/normalizr@^4.0.0-beta.2":
+  version "4.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@rest-hooks/normalizr/-/normalizr-4.0.0-beta.2.tgz#5f8900c71f4425047a4df251cc1e0f2bd583a397"
+  integrity sha512-PGSnJhTUqM+aQ6GgBklAfbE+C6m8QFyoWHJiYtv7kJEFFuLyOhVLpWe1QO5uSQpiu4jveMea831B+IYYG45+7Q==
   dependencies:
     "@babel/runtime" "^7.6.0"
 


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The inferred state of an array nested would be something like `{ results undefined }` and this was being detected as 'found' and thus not suspending.


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Added a gauntlet of tests for usedDenormalized(). Many are adapted from useSchemaSelect(), but additional use cases were added as well.
