### PR TITLE
[breaking] useFetcher() now takes params before body

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ return (
 
 ```tsx
 const update = useFetcher(ArticleResource.updateShape());
-return <ArticleForm onSubmit={data => update(data, { id })} />;
+return <ArticleForm onSubmit={data => update({ id }, data)} />;
 ```
 
 ### And subscriptions

--- a/docs/api/MockProvider.md
+++ b/docs/api/MockProvider.md
@@ -21,7 +21,7 @@ can be tested. This is useful for [storybook](../guides/storybook.md) as well as
 
 ```typescript
 interface Fixture {
-  request: ReadShape<Schema, object, any>;
+  request: ReadShape<Schema, object>;
   params: object;
   result: object | string | number;
 }

--- a/docs/api/useCache.md
+++ b/docs/api/useCache.md
@@ -16,7 +16,7 @@ function useCache(
 
 ```typescript
 function useCache<Params extends Readonly<object>, S extends Schema>(
-  { schema, getFetchKey }: ReadShape<S, Params, any>,
+  { schema, getFetchKey }: ReadShape<S, Params>,
   params: Params | null
 ): SchemaOf<S> | null;
 ```

--- a/docs/api/useFetcher.md
+++ b/docs/api/useFetcher.md
@@ -12,8 +12,8 @@ function useFetcher(
 ): FetchFunction;
 
 type FetchFunction = (
-  body: object | void,
   params: object,
+  body: object | void,
   updateParams?: OptimisticUpdateParams[]
 ) => Promise<any>;
 
@@ -34,16 +34,16 @@ function useFetcher<
 >(
   fetchShape: FetchShape<S, Params, Body>,
   throttle?: boolean = false,
-): Shape extends DeleteShape<any, any>
-  ? (body: BodyFromShape<Shape>, params: ParamsFromShape<Shape>) => Promise<any>
+): Shape extends DeleteShape<any, any, any>
+  ? (params: ParamsFromShape<Shape>, body: BodyFromShape<Shape>) => Promise<any>
   : <
       UpdateParams extends OptimisticUpdateParams<
         SchemaFromShape<Shape>,
         FetchShape<any, any, any>
       >[]
     >(
-      body: BodyFromShape<Shape>,
       params: ParamsFromShape<Shape>,
+      body: BodyFromShape<Shape>,
       updateParams?: UpdateParams | undefined,
     ) => Promise<any>;
 
@@ -82,7 +82,7 @@ function CreatePost() {
   // create as (body: Readonly<Partial<PostResource>>, params?: Readonly<object>) => Promise<any>
 
   return (
-    <form onSubmit={e => create(new FormData(e.target), {})}>{/* ... */}</form>
+    <form onSubmit={e => create({}, new FormData(e.target))}>{/* ... */}</form>
   );
 }
 ```
@@ -93,7 +93,7 @@ function UpdatePost({ id }: { id: string }) {
   // update as (body: Readonly<Partial<PostResource>>, params?: Readonly<object>) => Promise<any>
 
   return (
-    <form onSubmit={e => update(new FormData(e.target), { id })}>
+    <form onSubmit={e => update({ id }, new FormData(e.target))}>
       {/* ... */}
     </form>
   );
@@ -108,7 +108,7 @@ function PostListItem({ post }: { post: PostResource }) {
   return (
     <div>
       <h3>{post.title}</h3>
-      <button onClick={() => del({}, { id: post.id })}>X</button>
+      <button onClick={() => del({ id: post.id })}>X</button>
     </div>
   );
 }
@@ -139,7 +139,7 @@ This will insert the newly created article id onto the end of the listshape with
 ```typescript
 const createArticle = useFetcher(ArticleResource.createShape());
 
-createArticle({ id: 1 }, {}, [
+createArticle({}, { id: 1 }, [
   [
     ArticleResource.listShape(),
     {},
@@ -164,7 +164,7 @@ class ArticlePaginatedResource extends Resource {
 ```typescript
 const createArticle = useFetcher(ArticleResource.createShape());
 
-createArticle({ id: 1 }, {}, [
+createArticle({}, { id: 1 }, [
   [
     ArticlePaginatedResource.listShape(),
     {},

--- a/docs/api/useInvalidator.md
+++ b/docs/api/useInvalidator.md
@@ -15,7 +15,7 @@ function useInvalidator(
 
 ```typescript
 function useInvalidator<Params extends Readonly<object>, S extends Schema>(
-  fetchShape: ReadShape<S, Params, any>,
+  fetchShape: ReadShape<S, Params>,
 ): (params: Params | null) => void;
 ```
 
@@ -56,7 +56,7 @@ export default class ArticleResource extends Resource {
 function useInvalidateOnUnmount<
   Params extends Readonly<object>,
   S extends Schema
->(fetchShape: ReadShape<S, Params, any>, params: Params | null) {
+>(fetchShape: ReadShape<S, Params>, params: Params | null) {
   const invalidate = useInvalidator(fetchShape);
 
   useEffect(() => {

--- a/docs/api/useResource.md
+++ b/docs/api/useResource.md
@@ -19,15 +19,13 @@ function useResource(...[fetchShape: ReadShape, params: object | null]):
 ```typescript
 function useResource<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
->(fetchShape: ReadShape<S, Params, Body>, params: Params | null): SchemaOf<S>;
+>(fetchShape: ReadShape<S, Params>, params: Params | null): SchemaOf<S>;
 
 function useResource<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
->(...[fetchShape: ReadShape<S, Params, Body>, params: Params | null]): SchemaOf<S>[];
+>(...[fetchShape: ReadShape<S, Params>, params: Params | null]): SchemaOf<S>[];
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/api/useResourceNew.md
+++ b/docs/api/useResourceNew.md
@@ -19,15 +19,13 @@ function useResourceNew(...[fetchShape: ReadShape, params: object | null]):
 ```typescript
 function useResourceNew<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
->(fetchShape: ReadShape<S, Params, Body>, params: Params | null): Denormalized<S>;
+>(fetchShape: ReadShape<S, Params>, params: Params | null): Denormalized<S>;
 
 function useResourceNew<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
->(...[fetchShape: ReadShape<S, Params, Body>, params: Params | null]): Denormalized<S>[];
+>(...[fetchShape: ReadShape<S, Params>, params: Params | null]): Denormalized<S>[];
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/api/useResultCache.md
+++ b/docs/api/useResultCache.md
@@ -17,7 +17,7 @@ function useResultCache(
 
 ```typescript
 function useResultCache<Params extends Readonly<object>, D extends object>(
-  { getFetchKey, fetch }: ReadShape<any, Params, any>,
+  { getFetchKey, fetch }: ReadShape<any, Params>,
   params: Params | null,
   defaults?: D,
 ): D extends undefined

--- a/docs/api/useRetrieve.md
+++ b/docs/api/useRetrieve.md
@@ -18,10 +18,9 @@ function useRetrieve(
 ```typescript
 function useRetrieve<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
 >(
-  fetchShape: ReadShape<S, Params, Body>,
+  fetchShape: ReadShape<S, Params>,
   params: Params | null,
   body?: Body,
 ): Promise<any> | undefined;

--- a/docs/api/useSubscription.md
+++ b/docs/api/useSubscription.md
@@ -19,10 +19,9 @@ function useSubscription(
 ```typescript
 function useSubscription<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
 >(
-  fetchShape: ReadShape<S, Params, Body>,
+  fetchShape: ReadShape<S, Params>,
   params: Params | null,
   body?: Body,
   active?: boolean = true,

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -136,7 +136,7 @@ export default function NewArticleForm() {
   const create = useFetcher(ArticleResource.createShape());
   // create as (body: Readonly<Partial<ArticleResource>>, params?: Readonly<object>) => Promise<any>
   return (
-    <Form onSubmit={e => create(new FormData(e.target), {})}>
+    <Form onSubmit={e => create({}, new FormData(e.target))}>
       <FormField name="title" />
       <FormField name="content" type="textarea" />
       <FormField name="tags" type="tag" />
@@ -160,7 +160,7 @@ export default function UpdateArticleForm({ id }: { id: number }) {
   // update as (body: Readonly<Partial<ArticleResource>>, params?: Readonly<object>) => Promise<any>
   return (
     <Form
-      onSubmit={e => update(new FormData(e.target), { id })}
+      onSubmit={e => update({ id }, new FormData(e.target))}
       initialValues={article}
     >
       <FormField name="title" />
@@ -187,7 +187,7 @@ export default function ArticleWithDelete({ article }: { article: ArticleResourc
     <article>
       <h2>{article.title}</h2>
       <div>{article.content}</div>
-      <button onClick={() => del(undefined, { id: article.id })}>Delete</button>
+      <button onClick={() => del({ id: article.id })}>Delete</button>
     </article>
   );
 }

--- a/docs/guides/no-suspense.md
+++ b/docs/guides/no-suspense.md
@@ -19,10 +19,9 @@ import { useRetrieve, useCache, useError, Schema, ReadShape } from 'rest-hooks';
 function hasUsableData<
   S extends Schema,
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void
 >(
-  resource: RequestResource<ReadShape<S, Params, Body>> | null,
-  fetchShape: ReadShape<S, Params, Body>,
+  resource: RequestResource<ReadShape<S, Params>> | null,
+  fetchShape: ReadShape<S, Params>,
 ) {
   return !(
     (fetchShape.options && fetchShape.options.invalidIfStale) ||
@@ -33,9 +32,8 @@ function hasUsableData<
 /** Ensure a resource is available; loading and error returned explicitly. */
 function useStatefulResource<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
->(fetchShape: ReadShape<S, Params, Body>, params: Params | null) {
+>(fetchShape: ReadShape<S, Params>, params: Params | null) {
   let maybePromise = useRetrieve(fetchShape, params);
   const resource = useCache(fetchShape, params);
 

--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -66,8 +66,8 @@ export class ArticleResource extends Resource {
       ...baseShape,
       getFetchKey: (params: Readonly<Record<string, string>>) =>
         baseShape.getFetchKey({ ...params, includeUser: true }),
-      fetch: (params: object, body: object) =>
-        this.fetch('get', this.url({ ...params, includeUser: true }), body),
+      fetch: (params: object) =>
+        this.fetch('get', this.url({ ...params, includeUser: true })),
       schema: this.getNestedEntitySchema(),
     };
   }
@@ -80,12 +80,8 @@ export class ArticleResource extends Resource {
       ...baseShape,
       getFetchKey: (params: Readonly<Record<string, string>>) =>
         baseShape.getFetchKey({ ...params, includeUser: true }),
-      fetch: (params: object, body: object) =>
-        this.fetch(
-          'get',
-          this.listUrl({ ...params, includeUser: 'true' }),
-          body,
-        ),
+      fetch: (params: object) =>
+        this.fetch('get', this.listUrl({ ...params, includeUser: 'true' })),
       schema: [this.getNestedEntitySchema()],
     };
   }
@@ -103,8 +99,7 @@ export class ArticleResourceWithOtherListUrl extends ArticleResource {
     return {
       ...this.listShape(),
       getFetchKey,
-      fetch: (_params: object, body: object) =>
-        this.fetch('get', getFetchKey(), body),
+      fetch: (_params: object) => this.fetch('get', getFetchKey()),
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,8 +63,9 @@ const __INTERNAL__ = {
 
 export type DeleteShape<
   S extends schemas.Entity,
-  Params extends Readonly<object> = Readonly<object>
-> = DeleteShape<S, Params>;
+  Params extends Readonly<object> = Readonly<object>,
+  Body extends Readonly<object | string> | void = undefined
+> = DeleteShape<S, Params, Body>;
 export type MutateShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
@@ -72,9 +73,8 @@ export type MutateShape<
 > = MutateShape<S, Params, Body>;
 export type ReadShape<
   S extends Schema,
-  Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object | string> | void = Readonly<object> | undefined
-> = ReadShape<S, Params, Body>;
+  Params extends Readonly<object> = Readonly<object>
+> = ReadShape<S, Params>;
 export type FetchShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,

--- a/src/react-integration/__tests__/hooks.tsx
+++ b/src/react-integration/__tests__/hooks.tsx
@@ -96,7 +96,7 @@ describe('useFetcher', () => {
 
     function DispatchTester() {
       const a = useFetcher(CoolerArticleResource.createShape());
-      a({ content: 'hi' }, {});
+      a({}, { content: 'hi' });
       return null;
     }
     await testDispatchFetch(DispatchTester, [payload]);
@@ -110,7 +110,7 @@ describe('useFetcher', () => {
     function DispatchTester() {
       const create = useFetcher(CoolerArticleResource.createShape());
       const params = { content: 'hi' };
-      create(params, {}, [
+      create({}, params, [
         [
           CoolerArticleResource.listShape(),
           {},
@@ -130,7 +130,7 @@ describe('useFetcher', () => {
     function DispatchTester() {
       const create = useFetcher(ArticleResourceWithOtherListUrl.createShape());
       const params = { content: 'hi' };
-      create(params, {}, [
+      create({}, params, [
         [
           ArticleResourceWithOtherListUrl.listShape(),
           {},
@@ -152,7 +152,7 @@ describe('useFetcher', () => {
     const spy = (console.error = jest.fn());
     renderHook(() => {
       const a = useFetcher(CoolerArticleResource.createShape());
-      a({ content: 'hi' }, {});
+      a({}, { content: 'hi' });
       return null;
     });
     expect(spy.mock.calls[0]).toMatchInlineSnapshot(`
@@ -171,7 +171,7 @@ describe('useFetcher', () => {
 
     function DispatchTester() {
       const a = useFetcher(CoolerArticleResource.partialUpdateShape());
-      a({ content: 'changed' }, { id: payload.id });
+      a({ id: payload.id }, { content: 'changed' });
       return null;
     }
     await testDispatchFetch(DispatchTester, [payload]);
@@ -184,7 +184,7 @@ describe('useFetcher', () => {
 
     function DispatchTester() {
       const a = useFetcher(CoolerArticleResource.updateShape());
-      a({ content: 'changed' }, { id: payload.id });
+      a({ id: payload.id }, { content: 'changed' });
       return null;
     }
     await testDispatchFetch(DispatchTester, [payload]);

--- a/src/react-integration/__tests__/integration.tsx
+++ b/src/react-integration/__tests__/integration.tsx
@@ -91,7 +91,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       expect(result.current instanceof CoolerArticleResource).toBe(true);
       expect(result.current.title).toBe(payload.title);
 
-      await del({}, payload);
+      await del(payload);
       expect(result.error).toBeDefined();
       expect((result.error as any).status).toBe(404);
     });
@@ -101,7 +101,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         return useFetcher(CoolerArticleResource.detailShape());
       });
 
-      await expect(result.current({}, { id: 666 })).rejects.toThrowError(
+      await expect(result.current({ id: 666 })).rejects.toThrowError(
         'JSON expected but not returned from API',
       );
     });
@@ -115,7 +115,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       });
 
       for (const del of result.current) {
-        await expect(del({}, payload)).resolves.toBeDefined();
+        await expect(del(payload, undefined)).resolves.toBeDefined();
       }
     });
 
@@ -187,7 +187,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         return { articles, createNewArticle };
       });
       await waitForNextUpdate();
-      await result.current.createNewArticle({ id: 1 }, {}, [
+      await result.current.createNewArticle({}, { id: 1 }, [
         [
           CoolerArticleResource.listShape(),
           {},
@@ -218,7 +218,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         return { articles, getNextPage };
       });
       await waitForNextUpdate();
-      await result.current.getNextPage({}, { cursor: 2 }, [
+      await result.current.getNextPage({ cursor: 2 }, {}, [
         [
           PaginatedArticleResource.listShape(),
           {},

--- a/src/react-integration/__tests__/subscriptions.tsx
+++ b/src/react-integration/__tests__/subscriptions.tsx
@@ -53,7 +53,6 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         useSubscription(
           PollingArticleResource.detailShape(),
           articlePayload,
-          undefined,
           active,
         );
         return useCache(PollingArticleResource.detailShape(), articlePayload);

--- a/src/react-integration/hooks/useCache.ts
+++ b/src/react-integration/hooks/useCache.ts
@@ -9,7 +9,7 @@ export default function useCache<
   Params extends Readonly<object>,
   S extends Schema
 >(
-  fetchShape: Pick<ReadShape<S, Params, any>, 'schema' | 'getFetchKey'>,
+  fetchShape: Pick<ReadShape<S, Params>, 'schema' | 'getFetchKey'>,
   params: Params | null,
 ) {
   const state = useContext(StateContext);

--- a/src/react-integration/hooks/useCacheNew.ts
+++ b/src/react-integration/hooks/useCacheNew.ts
@@ -9,7 +9,7 @@ export default function useCacheNew<
   Params extends Readonly<object>,
   S extends Schema
 >(
-  fetchShape: Pick<ReadShape<S, Params, any>, 'schema' | 'getFetchKey'>,
+  fetchShape: Pick<ReadShape<S, Params>, 'schema' | 'getFetchKey'>,
   params: Params | null,
 ) {
   const state = useContext(StateContext);

--- a/src/react-integration/hooks/useError.ts
+++ b/src/react-integration/hooks/useError.ts
@@ -6,10 +6,9 @@ type UseErrorReturn<P> = P extends null ? undefined : Error;
 /** Access a resource or error if failed to get it */
 export default function useError<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
 >(
-  fetchShape: ReadShape<S, Params, Body>,
+  fetchShape: ReadShape<S, Params>,
   params: Params | null,
   cacheReady: boolean,
 ): UseErrorReturn<typeof params> {

--- a/src/react-integration/hooks/useFetcher.ts
+++ b/src/react-integration/hooks/useFetcher.ts
@@ -40,16 +40,16 @@ export default function useFetcher<
 >(
   fetchShape: Shape,
   throttle = false,
-): Shape extends DeleteShape<any, any>
-  ? (body: BodyFromShape<Shape>, params: ParamsFromShape<Shape>) => Promise<any>
+): Shape extends DeleteShape<any, any, any>
+  ? (params: ParamsFromShape<Shape>, body: BodyFromShape<Shape>) => Promise<any>
   : <
       UpdateParams extends OptimisticUpdateParams<
         SchemaFromShape<Shape>,
         FetchShape<any, any, any>
       >[]
     >(
-      body: BodyFromShape<Shape>,
       params: ParamsFromShape<Shape>,
+      body: BodyFromShape<Shape>,
       updateParams?: UpdateParams | undefined,
     ) => Promise<any> {
   const dispatch = useContext(DispatchContext);
@@ -61,8 +61,8 @@ export default function useFetcher<
 
   const fetchDispatcher = useCallback(
     (
-      body: BodyFromShape<Shape>,
       params: ParamsFromShape<Shape>,
+      body: BodyFromShape<Shape>,
       updateParams?:
         | OptimisticUpdateParams<
             SchemaFromShape<Shape>,

--- a/src/react-integration/hooks/useInvalidator.ts
+++ b/src/react-integration/hooks/useInvalidator.ts
@@ -7,7 +7,7 @@ import { DispatchContext } from '~/react-integration/context';
 export default function useInvalidator<
   Params extends Readonly<object>,
   S extends Schema
->(fetchShape: ReadShape<S, Params, any>): (params: Params | null) => void {
+>(fetchShape: ReadShape<S, Params>): (params: Params | null) => void {
   const dispatch = useContext(DispatchContext);
   const getFetchKeyRef = useRef(fetchShape.getFetchKey);
   getFetchKeyRef.current = fetchShape.getFetchKey;

--- a/src/react-integration/hooks/useResource.ts
+++ b/src/react-integration/hooks/useResource.ts
@@ -6,19 +6,14 @@ import { useMemo } from 'react';
 
 import hasUsableData from './hasUsableData';
 
-type ResourceArgs<
-  S extends Schema,
-  Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void
-> = [ReadShape<S, Params, Body>, Params | null];
+type ResourceArgs<S extends Schema, Params extends Readonly<object>> = [
+  ReadShape<S, Params>,
+  Params | null,
+];
 
 /** single form resource */
-function useOneResource<
-  Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
-  S extends Schema
->(
-  fetchShape: ReadShape<S, Params, Body>,
+function useOneResource<Params extends Readonly<object>, S extends Schema>(
+  fetchShape: ReadShape<S, Params>,
   params: Params | null,
 ): CondNull<typeof params, NonNullable<SchemaOf<S>>> {
   // maybePromise is undefined when data is stale or params is null
@@ -35,15 +30,14 @@ function useOneResource<
 }
 
 /** many form resource */
-function useManyResources<A extends ResourceArgs<any, any, any>[]>(
+function useManyResources<A extends ResourceArgs<any, any>[]>(
   ...resourceList: A
 ) {
   const resources = resourceList.map(
-    <
-      Params extends Readonly<object>,
-      Body extends Readonly<object | string> | void,
-      S extends Schema
-    >([fetchShape, params]: ResourceArgs<S, Params, Body>) =>
+    <Params extends Readonly<object>, S extends Schema>([
+      fetchShape,
+      params,
+    ]: ResourceArgs<S, Params>) =>
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useCache(fetchShape, params),
   );
@@ -82,42 +76,35 @@ type CondNull<P, R> = P extends null ? null : R;
 /** Ensure a resource is available; suspending to React until it is. */
 export default function useResource<
   P extends Readonly<object> | null,
-  B extends Readonly<object | string> | void,
   S extends Schema
 >(
-  fetchShape: ReadShape<S, NonNullable<P>, B>,
+  fetchShape: ReadShape<S, NonNullable<P>>,
   params: P,
 ): CondNull<P, SchemaOf<S>>;
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema
->(v1: [ReadShape<S1, NonNullable<P1>, B1>, P1]): [CondNull<P1, SchemaOf<S1>>];
+>(v1: [ReadShape<S1, NonNullable<P1>>, P1]): [CondNull<P1, SchemaOf<S1>>];
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object | string> | void,
   S2 extends Schema
 >(
-  v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
-  v2: [ReadShape<S2, NonNullable<P2>, B2>, P2],
+  v1: [ReadShape<S1, NonNullable<P1>>, P1],
+  v2: [ReadShape<S2, NonNullable<P2>>, P2],
 ): [CondNull<P1, SchemaOf<S1>>, CondNull<P2, SchemaOf<S2>>];
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object | string> | void,
   S2 extends Schema,
   P3 extends Readonly<object> | null,
-  B3 extends Readonly<object | string> | void,
   S3 extends Schema
 >(
-  v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
-  v2: [ReadShape<S2, NonNullable<P2>, B2>, P2],
-  v3: [ReadShape<S3, NonNullable<P3>, B3>, P3],
+  v1: [ReadShape<S1, NonNullable<P1>>, P1],
+  v2: [ReadShape<S2, NonNullable<P2>>, P2],
+  v3: [ReadShape<S3, NonNullable<P3>>, P3],
 ): [
   CondNull<P1, SchemaOf<S1>>,
   CondNull<P2, SchemaOf<S2>>,
@@ -125,22 +112,18 @@ export default function useResource<
 ];
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object | string> | void,
   S2 extends Schema,
   P3 extends Readonly<object> | null,
-  B3 extends Readonly<object | string> | void,
   S3 extends Schema,
   P4 extends Readonly<object> | null,
-  B4 extends Readonly<object | string> | void,
   S4 extends Schema
 >(
-  v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
-  v2: [ReadShape<S2, NonNullable<P2>, B2>, P2],
-  v3: [ReadShape<S3, NonNullable<P3>, B3>, P3],
-  v4: [ReadShape<S4, NonNullable<P4>, B4>, P4],
+  v1: [ReadShape<S1, NonNullable<P1>>, P1],
+  v2: [ReadShape<S2, NonNullable<P2>>, P2],
+  v3: [ReadShape<S3, NonNullable<P3>>, P3],
+  v4: [ReadShape<S4, NonNullable<P4>>, P4],
 ): [
   CondNull<P1, SchemaOf<S1>>,
   CondNull<P2, SchemaOf<S2>>,
@@ -149,26 +132,21 @@ export default function useResource<
 ];
 export default function useResource<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object | string> | void,
   S2 extends Schema,
   P3 extends Readonly<object> | null,
-  B3 extends Readonly<object | string> | void,
   S3 extends Schema,
   P4 extends Readonly<object> | null,
-  B4 extends Readonly<object | string> | void,
   S4 extends Schema,
   P5 extends Readonly<object> | null,
-  B5 extends Readonly<object | string> | void,
   S5 extends Schema
 >(
-  v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
-  v2: [ReadShape<S2, NonNullable<P2>, B2>, P2],
-  v3: [ReadShape<S3, NonNullable<P3>, B3>, P3],
-  v4: [ReadShape<S4, NonNullable<P4>, B4>, P4],
-  v5: [ReadShape<S5, NonNullable<P5>, B5>, P5],
+  v1: [ReadShape<S1, NonNullable<P1>>, P1],
+  v2: [ReadShape<S2, NonNullable<P2>>, P2],
+  v3: [ReadShape<S3, NonNullable<P3>>, P3],
+  v4: [ReadShape<S4, NonNullable<P4>>, P4],
+  v5: [ReadShape<S5, NonNullable<P5>>, P5],
 ): [
   CondNull<P1, SchemaOf<S1>>,
   CondNull<P2, SchemaOf<S2>>,
@@ -178,16 +156,15 @@ export default function useResource<
 ];
 export default function useResource<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
->(...args: ResourceArgs<S, Params, Body> | ResourceArgs<S, Params, Body>[]) {
+>(...args: ResourceArgs<S, Params> | ResourceArgs<S, Params>[]) {
   // this conditional use of hooks is ok as long as the structure of the arguments don't change
   if (Array.isArray(args[0])) {
     // TODO: provide type guard function to detect this
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useManyResources(...(args as ResourceArgs<S, Params, Body>[]));
+    return useManyResources(...(args as ResourceArgs<S, Params>[]));
   }
-  args = args as ResourceArgs<S, Params, Body>;
+  args = args as ResourceArgs<S, Params>;
   // TODO: make return types match up with the branching logic we put in here.
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return useOneResource(args[0], args[1]);

--- a/src/react-integration/hooks/useResourceNew.ts
+++ b/src/react-integration/hooks/useResourceNew.ts
@@ -8,19 +8,14 @@ import { StateContext } from '~/react-integration/context';
 
 import hasUsableData from './hasUsableData';
 
-type ResourceArgs<
-  S extends Schema,
-  Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void
-> = [ReadShape<S, Params, Body>, Params | null];
+type ResourceArgs<S extends Schema, Params extends Readonly<object>> = [
+  ReadShape<S, Params>,
+  Params | null,
+];
 
 /** single form resource */
-function useOneResource<
-  Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
-  S extends Schema
->(
-  fetchShape: ReadShape<S, Params, Body>,
+function useOneResource<Params extends Readonly<object>, S extends Schema>(
+  fetchShape: ReadShape<S, Params>,
   params: Params | null,
 ): CondNull<typeof params, DenormalizedNullable<S>, Denormalized<S>> {
   const maybePromise = useRetrieve(fetchShape, params);
@@ -35,16 +30,15 @@ function useOneResource<
 }
 
 /** many form resource */
-function useManyResources<A extends ResourceArgs<any, any, any>[]>(
+function useManyResources<A extends ResourceArgs<any, any>[]>(
   ...resourceList: A
 ) {
   const state = useContext(StateContext);
   const denormalizedValues = resourceList.map(
-    <
-      Params extends Readonly<object>,
-      Body extends Readonly<object | string> | void,
-      S extends Schema
-    >([fetchShape, params]: ResourceArgs<S, Params, Body>) =>
+    <Params extends Readonly<object>, S extends Schema>([
+      fetchShape,
+      params,
+    ]: ResourceArgs<S, Params>) =>
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useDenormalized(fetchShape, params, state),
   );
@@ -89,44 +83,38 @@ export default function useResourceNew<
   B extends Readonly<object | string> | void,
   S extends Schema
 >(
-  fetchShape: ReadShape<S, NonNullable<P>, B>,
+  fetchShape: ReadShape<S, NonNullable<P>>,
   params: P,
 ): CondNull<P, DenormalizedNullable<S>, Denormalized<S>>;
 export default function useResourceNew<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema
 >(
-  v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
+  v1: [ReadShape<S1, NonNullable<P1>>, P1],
 ): [CondNull<P1, DenormalizedNullable<S1>, Denormalized<S1>>];
 export default function useResourceNew<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object | string> | void,
   S2 extends Schema
 >(
-  v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
-  v2: [ReadShape<S2, NonNullable<P2>, B2>, P2],
+  v1: [ReadShape<S1, NonNullable<P1>>, P1],
+  v2: [ReadShape<S2, NonNullable<P2>>, P2],
 ): [
   CondNull<P1, DenormalizedNullable<S1>, Denormalized<S1>>,
   CondNull<P2, DenormalizedNullable<S2>, Denormalized<S2>>,
 ];
 export default function useResourceNew<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object | string> | void,
   S2 extends Schema,
   P3 extends Readonly<object> | null,
-  B3 extends Readonly<object | string> | void,
   S3 extends Schema
 >(
-  v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
-  v2: [ReadShape<S2, NonNullable<P2>, B2>, P2],
-  v3: [ReadShape<S3, NonNullable<P3>, B3>, P3],
+  v1: [ReadShape<S1, NonNullable<P1>>, P1],
+  v2: [ReadShape<S2, NonNullable<P2>>, P2],
+  v3: [ReadShape<S3, NonNullable<P3>>, P3],
 ): [
   CondNull<P1, DenormalizedNullable<S1>, Denormalized<S1>>,
   CondNull<P2, DenormalizedNullable<S2>, Denormalized<S2>>,
@@ -134,22 +122,18 @@ export default function useResourceNew<
 ];
 export default function useResourceNew<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object | string> | void,
   S2 extends Schema,
   P3 extends Readonly<object> | null,
-  B3 extends Readonly<object | string> | void,
   S3 extends Schema,
   P4 extends Readonly<object> | null,
-  B4 extends Readonly<object | string> | void,
   S4 extends Schema
 >(
-  v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
-  v2: [ReadShape<S2, NonNullable<P2>, B2>, P2],
-  v3: [ReadShape<S3, NonNullable<P3>, B3>, P3],
-  v4: [ReadShape<S4, NonNullable<P4>, B4>, P4],
+  v1: [ReadShape<S1, NonNullable<P1>>, P1],
+  v2: [ReadShape<S2, NonNullable<P2>>, P2],
+  v3: [ReadShape<S3, NonNullable<P3>>, P3],
+  v4: [ReadShape<S4, NonNullable<P4>>, P4],
 ): [
   CondNull<P1, DenormalizedNullable<S1>, Denormalized<S1>>,
   CondNull<P2, DenormalizedNullable<S2>, Denormalized<S2>>,
@@ -158,26 +142,21 @@ export default function useResourceNew<
 ];
 export default function useResourceNew<
   P1 extends Readonly<object> | null,
-  B1 extends Readonly<object | string> | void,
   S1 extends Schema,
   P2 extends Readonly<object> | null,
-  B2 extends Readonly<object | string> | void,
   S2 extends Schema,
   P3 extends Readonly<object> | null,
-  B3 extends Readonly<object | string> | void,
   S3 extends Schema,
   P4 extends Readonly<object> | null,
-  B4 extends Readonly<object | string> | void,
   S4 extends Schema,
   P5 extends Readonly<object> | null,
-  B5 extends Readonly<object | string> | void,
   S5 extends Schema
 >(
-  v1: [ReadShape<S1, NonNullable<P1>, B1>, P1],
-  v2: [ReadShape<S2, NonNullable<P2>, B2>, P2],
-  v3: [ReadShape<S3, NonNullable<P3>, B3>, P3],
-  v4: [ReadShape<S4, NonNullable<P4>, B4>, P4],
-  v5: [ReadShape<S5, NonNullable<P5>, B5>, P5],
+  v1: [ReadShape<S1, NonNullable<P1>>, P1],
+  v2: [ReadShape<S2, NonNullable<P2>>, P2],
+  v3: [ReadShape<S3, NonNullable<P3>>, P3],
+  v4: [ReadShape<S4, NonNullable<P4>>, P4],
+  v5: [ReadShape<S5, NonNullable<P5>>, P5],
 ): [
   CondNull<P1, DenormalizedNullable<S1>, Denormalized<S1>>,
   CondNull<P2, DenormalizedNullable<S2>, Denormalized<S2>>,
@@ -189,14 +168,14 @@ export default function useResourceNew<
   Params extends Readonly<object>,
   Body extends Readonly<object | string> | void,
   S extends Schema
->(...args: ResourceArgs<S, Params, Body> | ResourceArgs<S, Params, Body>[]) {
+>(...args: ResourceArgs<S, Params> | ResourceArgs<S, Params>[]) {
   // this conditional use of hooks is ok as long as the structure of the arguments don't change
   if (Array.isArray(args[0])) {
     // TODO: provide type guard function to detect this
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useManyResources(...(args as ResourceArgs<S, Params, Body>[]));
+    return useManyResources(...(args as ResourceArgs<S, Params>[]));
   }
-  args = args as ResourceArgs<S, Params, Body>;
+  args = args as ResourceArgs<S, Params>;
   // TODO: make return types match up with the branching logic we put in here.
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return useOneResource(args[0], args[1]);

--- a/src/react-integration/hooks/useResultCache.ts
+++ b/src/react-integration/hooks/useResultCache.ts
@@ -14,7 +14,7 @@ export default function useResultCache<
   Params extends Readonly<object>,
   D extends object
 >(
-  { getFetchKey, fetch }: ReadShape<any, Params, any>,
+  { getFetchKey, fetch }: ReadShape<any, Params>,
   params: Params | null,
   defaults?: D,
 ): D extends undefined

--- a/src/react-integration/hooks/useRetrieve.ts
+++ b/src/react-integration/hooks/useRetrieve.ts
@@ -5,11 +5,10 @@ import useFetcher from './useFetcher';
 import useMeta from './useMeta';
 
 /** Returns whether the data at this url is fresh or stale */
-function useExpiresAt<
-  Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
-  S extends Schema
->(fetchShape: ReadShape<S, Params, Body>, params: Params | null): number {
+function useExpiresAt<Params extends Readonly<object>, S extends Schema>(
+  fetchShape: ReadShape<S, Params>,
+  params: Params | null,
+): number {
   const meta = useMeta(fetchShape, params);
   if (!meta) {
     return 0;
@@ -20,9 +19,8 @@ function useExpiresAt<
 /** Request a resource if it is not in cache. */
 export default function useRetrieve<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
->(fetchShape: ReadShape<S, Params, Body>, params: Params | null, body?: Body) {
+>(fetchShape: ReadShape<S, Params>, params: Params | null, body?: Body) {
   const fetch = useFetcher(fetchShape, true);
   const expiresAt = useExpiresAt(fetchShape, params);
 
@@ -31,7 +29,7 @@ export default function useRetrieve<
     if (Date.now() <= expiresAt) return;
     // null params mean don't do anything
     if (!params) return;
-    return fetch(body as Body, params);
+    return fetch(params);
     // we don't care to re-request on body (should we?)
     // we need to check against serialized params, since params can change frequently
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/react-integration/hooks/useSubscription.ts
+++ b/src/react-integration/hooks/useSubscription.ts
@@ -6,14 +6,8 @@ import { ReadShape, Schema } from '~/resource';
 /** Keeps a resource fresh by subscribing to updates. */
 export default function useSubscription<
   Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void,
   S extends Schema
->(
-  fetchShape: ReadShape<S, Params, Body>,
-  params: Params,
-  body?: Body,
-  active = true,
-) {
+>(fetchShape: ReadShape<S, Params>, params: Params, active = true) {
   const dispatch = useContext(DispatchContext);
   /*
   we just want the current values when we dispatch, so
@@ -34,7 +28,7 @@ export default function useSubscription<
       type: 'rest-hooks/subscribe',
       meta: {
         schema,
-        fetch: () => fetch(params, body as Body),
+        fetch: () => fetch(params),
         url,
         frequency: options && options.pollFrequency,
       },
@@ -50,5 +44,5 @@ export default function useSubscription<
     };
     // serialize params
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, body, active, params && fetchShape.getFetchKey(params)]);
+  }, [dispatch, active, params && fetchShape.getFetchKey(params)]);
 }

--- a/src/resource/SimpleResource.ts
+++ b/src/resource/SimpleResource.ts
@@ -199,8 +199,8 @@ export default abstract class SimpleResource {
       schema,
       options,
       getFetchKey,
-      fetch: (params: Readonly<object>, body?: Readonly<object | string>) => {
-        return this.fetch('get', this.url(params), body);
+      fetch: (params: Readonly<object>) => {
+        return this.fetch('get', this.url(params));
       },
     };
   }
@@ -219,11 +219,8 @@ export default abstract class SimpleResource {
       schema,
       options,
       getFetchKey,
-      fetch: (
-        params: Readonly<Record<string, string | number>>,
-        body?: Readonly<object | string>,
-      ) => {
-        return this.fetch('get', this.listUrl(params), body);
+      fetch: (params: Readonly<Record<string, string | number>>) => {
+        return this.fetch('get', this.listUrl(params));
       },
     };
   }

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -29,8 +29,9 @@ export type BodyFromShape<
 /** Purges a value from the server */
 export interface DeleteShape<
   S extends schemas.Entity,
-  Params extends Readonly<object> = Readonly<object>
-> extends FetchShape<S, Params, any> {
+  Params extends Readonly<object> = Readonly<object>,
+  Body extends Readonly<object | string> | void = undefined
+> extends FetchShape<S, Params, Body> {
   readonly type: 'delete';
 }
 
@@ -48,12 +49,10 @@ export interface MutateShape<
 /** For retrieval requests */
 export interface ReadShape<
   S extends Schema,
-  Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object | string> | void =
-    | Readonly<object | string>
-    | undefined
-> extends FetchShape<S, Params, Body> {
+  Params extends Readonly<object> = Readonly<object>
+> extends FetchShape<S, Params, undefined> {
   readonly type: 'read';
+  fetch(params: Params): Promise<any>;
 }
 
 export function isDeleteShape(

--- a/src/state/selectors/useDenormalized.ts
+++ b/src/state/selectors/useDenormalized.ts
@@ -22,10 +22,7 @@ export default function useDenormalized<
   Params extends Readonly<object>,
   S extends Schema
 >(
-  {
-    schema,
-    getFetchKey,
-  }: Pick<ReadShape<S, Params, any>, 'schema' | 'getFetchKey'>,
+  { schema, getFetchKey }: Pick<ReadShape<S, Params>, 'schema' | 'getFetchKey'>,
   params: Params | null,
   state: State<any>,
 ): [

--- a/src/state/selectors/useDenormalizedLegacy.ts
+++ b/src/state/selectors/useDenormalizedLegacy.ts
@@ -20,10 +20,7 @@ export default function useDenormalizedLegacy<
   Params extends Readonly<object>,
   S extends Schema
 >(
-  {
-    schema,
-    getFetchKey,
-  }: Pick<ReadShape<S, Params, any>, 'schema' | 'getFetchKey'>,
+  { schema, getFetchKey }: Pick<ReadShape<S, Params>, 'schema' | 'getFetchKey'>,
   params: Params | null,
   state: State<any>,
 ): Denormalized<typeof schema> | null {

--- a/src/state/selectors/useSchemaSelect.ts
+++ b/src/state/selectors/useSchemaSelect.ts
@@ -9,10 +9,7 @@ export default function useSchemaSelect<
   Params extends Readonly<object>,
   S extends Schema
 >(
-  {
-    schema,
-    getFetchKey,
-  }: Pick<ReadShape<S, Params, any>, 'schema' | 'getFetchKey'>,
+  { schema, getFetchKey }: Pick<ReadShape<S, Params>, 'schema' | 'getFetchKey'>,
   params: Params | null,
   state: State<any>,
 ): typeof params extends null ? null : (SchemaOf<typeof schema> | null) {

--- a/src/test/mockState.ts
+++ b/src/test/mockState.ts
@@ -2,7 +2,7 @@ import { ReadShape, ReceiveAction, Schema, reducer, __INTERNAL__ } from '..';
 const { initialState } = __INTERNAL__;
 
 export interface Fixture {
-  request: ReadShape<Schema, object, any>;
+  request: ReadShape<Schema, object>;
   params: object;
   result: object | string | number;
 }


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #117.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The ordering of params and body for useFetcher() is inconsistent with the rest of Rest Hooks library. Having params first seems to also match the general outside world.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

```typescript
create({}, { title: 'hi', body: 'this content is great' });
update({ id }, { title: 'ho', body: 'this content is mediocre' });
fetchList({});
fetchDetail({ id });
```

Also ReadShape<> now no longer takes a body. However, DeleteShape<> does, but it defaults to undefined.
