### PR TITLE
[breaking] ReadShape and MutateShape fetch resolve to valid JSON non-void

### DIFF
--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -44,6 +44,10 @@ export interface MutateShape<
     | undefined
 > extends FetchShape<S, Params, Body> {
   readonly type: 'mutate';
+  fetch(
+    params: Params,
+    body: Body,
+  ): Promise<object | string | number | boolean>;
 }
 
 /** For retrieval requests */
@@ -52,7 +56,7 @@ export interface ReadShape<
   Params extends Readonly<object> = Readonly<object>
 > extends FetchShape<S, Params, undefined> {
   readonly type: 'read';
-  fetch(params: Params): Promise<any>;
+  fetch(params: Params): Promise<object | string | number | boolean>;
 }
 
 export function isDeleteShape(


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #120.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Void types are only valid in delete

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
object | string | number | boolean represents all possible JSON values.
