### PR TITLE
[breaking] RequestOptions -> FetchOptions

### DIFF
--- a/docs/api/FetchShape.md
+++ b/docs/api/FetchShape.md
@@ -21,7 +21,7 @@ interface FetchShape {
   fetch(params: Readonly<object>, body: Readonly<object> | void): Promise<any>;
   getFetchKey(params: Readonly<object>): string;
   readonly schema: Schema;
-  readonly options?: RequestOptions;
+  readonly options?: FetchOptions;
 }
 ```
 
@@ -37,7 +37,7 @@ interface FetchShape<
   fetch(params: Params, body: Body): Promise<any>;
   getFetchKey(params: Params): string;
   readonly schema: S;
-  readonly options?: RequestOptions;
+  readonly options?: FetchOptions;
 }
 ```
 
@@ -77,14 +77,14 @@ table in the normalized cache.
 Schemas define the shape of the response data and are used to parse and update
 the normalized cache. Read more about [schemas at the normalizr documentation](https://github.com/paularmstrong/normalizr/blob/master/docs/api.md#schema).
 
-## options?: RequestOptions
+## options?: FetchOptions
 
-### RequestOptions
+### FetchOptions
 
 Additional optional request options passed on to network manager and reducer.
 
 ```typescript
-export interface RequestOptions {
+export interface FetchOptions {
   readonly dataExpiryLength?: number;
   readonly errorExpiryLength?: number;
   readonly pollFrequency?: number;

--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -211,7 +211,7 @@ Returns the [shape of the data](https://github.com/paularmstrong/normalizr/blob/
 when requesting one resource at a time. Defaults to a plain object
 containing the keys. This can be useful to override if your response is in a different form.
 
-### static getRequestOptions() => [RequestOptions](../api/FetchShape.md#RequestOptions) | undefined
+### static getFetchOptions() => [FetchOptions](../api/FetchShape.md#FetchOptions) | undefined
 
 Returns the default request options for this resource. By default this returns undefined
 

--- a/docs/api/useInvalidator.md
+++ b/docs/api/useInvalidator.md
@@ -35,7 +35,7 @@ has never tried to fetch the resource before and trigger a fetch with suspense.
 ## Example
 
 ```typescript
-import { Resource, RequestOptions } from 'rest-hooks';
+import { Resource, FetchOptions } from 'rest-hooks';
 
 export default class ArticleResource extends Resource {
   readonly id: string = null;
@@ -43,7 +43,7 @@ export default class ArticleResource extends Resource {
   // ...
 
   /** Used as default options for every FetchShape */
-  static getRequestOptions(): RequestOptions {
+  static getFetchOptions(): FetchOptions {
     return {
       invalidIfStale: true,
     };

--- a/docs/api/useResetter.md
+++ b/docs/api/useResetter.md
@@ -17,7 +17,7 @@ retrieved again.
 ## Example
 
 ```typescript
-import { Resource, RequestOptions } from 'rest-hooks';
+import { Resource } from 'rest-hooks';
 
 // Server returns the logged in user
 export default class CurrentUserResource extends Resource {

--- a/docs/api/useSubscription.md
+++ b/docs/api/useSubscription.md
@@ -39,7 +39,7 @@ Frequency must be set in [FetchShape](./FetchShape.md), otherwise will have no e
 `PriceResource.ts`
 
 ```typescript
-import { Resource, RequestOptions } from 'rest-hooks';
+import { Resource, FetchOptions } from 'rest-hooks';
 
 export default class PriceResource extends Resource {
   readonly symbol: string | null = null;
@@ -52,7 +52,7 @@ export default class PriceResource extends Resource {
   static urlRoot = 'http://test.com/price/';
 
   /** Used as default options for every FetchShape */
-  static getRequestOptions(): RequestOptions {
+  static getFetchOptions(): FetchOptions {
     return {
       pollFrequency: 5000, // every 5 seconds
     };

--- a/docs/guides/mocking-unfinished.md
+++ b/docs/guides/mocking-unfinished.md
@@ -14,7 +14,7 @@ import {
   ReadShape,
   SchemaList,
   AbstractInstanceType,
-  RequestOptions,
+  FetchOptions,
 } from 'rest-hooks';
 
 export default class RatingResource extends Resource {
@@ -29,7 +29,7 @@ export default class RatingResource extends Resource {
 
   static urlRoot = '/ratings';
 
-  static getRequestOptions(): RequestOptions {
+  static getFetchOptions(): FetchOptions {
     return {
       dataExpiryLength: 10 * 60 * 1000, // 10 minutes
     };

--- a/docs/guides/resource-lifetime.md
+++ b/docs/guides/resource-lifetime.md
@@ -15,9 +15,9 @@ which will be passed on to all [fetch shape](../api/FetchShape.md) creator funct
 ```typescript
 // We can now extend LongLivingResource to get a resource that will be cached for one hour
 abstract class LongLivingResource extends Resource {
-  static getRequestOptions() {
+  static getFetchOptions() {
     return {
-      ...super.getRequestOptions(),
+      ...super.getFetchOptions(),
       dataExpiryLength: 60 * 60 * 1000, // one hour
     };
   }
@@ -31,9 +31,9 @@ abstract class LongLivingResource extends Resource {
 ```typescript
 // We can now extend NoRetryResource to get a resource that will never retry on network error
 abstract class NoRetryResource extends Resource {
-  static getRequestOptions() {
+  static getFetchOptions() {
     return {
-      ...super.getRequestOptions(),
+      ...super.getFetchOptions(),
       errorExpiryLength: Infinity,
     };
   }

--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -6,7 +6,7 @@ import {
   ReadShape,
   SchemaDetail,
 } from '../resource';
-import { AbstractInstanceType, RequestOptions } from '../types';
+import { AbstractInstanceType, FetchOptions } from '../types';
 
 export class ArticleResource extends Resource {
   readonly id: number | null = null;
@@ -116,9 +116,9 @@ export class CoolerArticleResource extends ArticleResource {
 }
 
 export class InvalidIfStaleArticleResource extends CoolerArticleResource {
-  static getRequestOptions(): RequestOptions {
+  static getFetchOptions(): FetchOptions {
     return {
-      ...super.getRequestOptions(),
+      ...super.getFetchOptions(),
       dataExpiryLength: 5000,
       errorExpiryLength: 5000,
       invalidIfStale: true,
@@ -127,9 +127,9 @@ export class InvalidIfStaleArticleResource extends CoolerArticleResource {
 }
 
 export class PollingArticleResource extends ArticleResource {
-  static getRequestOptions(): RequestOptions {
+  static getFetchOptions(): FetchOptions {
     return {
-      ...super.getRequestOptions(),
+      ...super.getFetchOptions(),
       pollFrequency: 5000,
     };
   }
@@ -138,9 +138,9 @@ export class PollingArticleResource extends ArticleResource {
 export class StaticArticleResource extends ArticleResource {
   static urlRoot = 'http://test.com/article-static/';
 
-  static getRequestOptions() {
+  static getFetchOptions() {
     return {
-      ...super.getRequestOptions(),
+      ...super.getFetchOptions(),
       dataExpiryLength: Infinity,
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ import useSelectionUnstable from './react-integration/hooks/useSelection';
 import { Request as RequestType } from 'superagent';
 import {
   AbstractInstanceType,
-  RequestOptions,
+  FetchOptions,
   Method,
   State,
   FetchAction,
@@ -87,7 +87,7 @@ export type SchemaList<T> = SchemaList<T>;
 export type SchemaDetail<T> = SchemaDetail<T>;
 export type SchemaOf<T> = SchemaOf<T>;
 export type AbstractInstanceType<T> = AbstractInstanceType<T>;
-export type RequestOptions = RequestOptions;
+export type FetchOptions = FetchOptions;
 export type Method = Method;
 
 export type NetworkError = NetworkError;

--- a/src/resource/SimpleResource.ts
+++ b/src/resource/SimpleResource.ts
@@ -1,5 +1,5 @@
 import { memoize } from 'lodash';
-import { AbstractInstanceType, Method, RequestOptions } from '~/types';
+import { AbstractInstanceType, Method, FetchOptions } from '~/types';
 
 import { ReadShape, MutateShape, DeleteShape } from './types';
 import { schemas, SchemaDetail, SchemaList } from './normal';
@@ -178,9 +178,9 @@ export default abstract class SimpleResource {
   }
 
   /** Get the request options for this SimpleResource  */
-  static getRequestOptions<T extends typeof SimpleResource>(
+  static getFetchOptions<T extends typeof SimpleResource>(
     this: T,
-  ): RequestOptions | undefined {
+  ): FetchOptions | undefined {
     return;
   }
 
@@ -193,7 +193,7 @@ export default abstract class SimpleResource {
       return 'GET ' + this.url(params);
     };
     const schema = this.getEntitySchema();
-    const options = this.getRequestOptions();
+    const options = this.getFetchOptions();
     return {
       type: 'read',
       schema,
@@ -213,7 +213,7 @@ export default abstract class SimpleResource {
       return 'GET ' + this.listUrl(params);
     };
     const schema = [this.getEntitySchema()];
-    const options = this.getRequestOptions();
+    const options = this.getFetchOptions();
     return {
       type: 'read',
       schema,
@@ -233,7 +233,7 @@ export default abstract class SimpleResource {
     Readonly<object>,
     Partial<AbstractInstanceType<T>>
   > {
-    const options = this.getRequestOptions();
+    const options = this.getFetchOptions();
     return {
       type: 'mutate',
       schema: this.getEntitySchema(),
@@ -258,7 +258,7 @@ export default abstract class SimpleResource {
     Readonly<object>,
     Partial<AbstractInstanceType<T>>
   > {
-    const options = this.getRequestOptions();
+    const options = this.getFetchOptions();
     return {
       type: 'mutate',
       schema: this.getEntitySchema(),
@@ -283,7 +283,7 @@ export default abstract class SimpleResource {
     Readonly<object>,
     Partial<AbstractInstanceType<T>>
   > {
-    const options = this.getRequestOptions();
+    const options = this.getFetchOptions();
     return {
       type: 'mutate',
       schema: this.getEntitySchema(), //TODO: change merge strategy in case we want to handle partial returns
@@ -304,7 +304,7 @@ export default abstract class SimpleResource {
   static deleteShape<T extends typeof SimpleResource>(
     this: T,
   ): DeleteShape<any, Readonly<object>> {
-    const options = this.getRequestOptions();
+    const options = this.getFetchOptions();
     return {
       type: 'delete',
       schema: this.getEntitySchema(),

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -1,5 +1,5 @@
 import { schemas, Schema, SchemaList, SchemaDetail } from './normal';
-import { RequestOptions } from '~/types';
+import { FetchOptions } from '~/types';
 
 /** Defines the shape of a network request */
 export interface FetchShape<
@@ -13,7 +13,7 @@ export interface FetchShape<
   fetch(params: Params, body: Body): Promise<any>;
   getFetchKey(params: Params): string;
   readonly schema: S;
-  readonly options?: RequestOptions;
+  readonly options?: FetchOptions;
 }
 
 export type SchemaFromShape<

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export type State<T> = Readonly<{
   }>;
 }>;
 
-export interface RequestOptions {
+export interface FetchOptions {
   /** Default data expiry length, will fall back to NetworkManager default if not defined */
   readonly dataExpiryLength?: number;
   /** Default error expiry length, will fall back to NetworkManager default if not defined */
@@ -99,7 +99,7 @@ interface FetchMeta<S extends Schema> {
   schema: S;
   throttle: boolean;
   updaters?: { [key: string]: UpdateFunction<S, any> };
-  options?: RequestOptions;
+  options?: FetchOptions;
   resolve: (value?: any | PromiseLike<any>) => void;
   reject: (reason?: any) => void;
 }


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #144.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
RequestShape was renamed FetchShape, so should its options.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- RequestOptions -> FetchOptions
- SimpleResource.getRequestOptions() -> SimpleResource.getFetchOptions() 
