### PR TITLE
[breaking] pk() type should be string | number | undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Making dynamic sites performant, scalable, simple to build with any API design.
 
 ```typescript
 class ArticleResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly title: string = '';
   readonly body: string = '';
 

--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -9,7 +9,7 @@ title: Resource
 import { Resource } from 'rest-hooks';
 
 export default class ArticleResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly title: string = '';
   readonly content: string = '';
   readonly author: number | null = null;
@@ -27,7 +27,7 @@ export default class ArticleResource extends Resource {
 import { Resource } from 'rest-hooks';
 
 export default class ArticleResource extends Resource {
-  id = null;
+  id = undefined;
   title = '';
   content = '';
   author = null;
@@ -45,7 +45,7 @@ export default class ArticleResource extends Resource {
 import { Resource } from 'rest-hooks';
 
 export default class ArticleResource extends Resource {
-  +id: ?number = null;
+  +id: ?number = undefined;
   +title: string = '';
   +content: string = '';
   +author: ?number = null;
@@ -96,7 +96,7 @@ the instance in construction.
 
 ## Be sure to always provide:
 
-### pk: () => string | number | null
+### pk: () => string | number | undefined
 
 PK stands for *primary key* and is intended to provide a standard means of retrieving
 a key identifier for any `Resource`. In many cases there will simply be an 'id' field
@@ -110,9 +110,9 @@ pk() {
 }
 ```
 
-#### Null value
+#### undefined value
 
-A `null` can be used as a default to indicate the resource has not been created yet.
+A `undefined` can be used as a default to indicate the resource has not been created yet.
 This is useful when initializing a creation form using [Resource.fromJS()](./api/resource#static-fromjs-t-extends-typeof-resource-this-t-props-partial-abstractinstancetype-t-abstractinstancetype-t)
 directly. If `pk()` resolves to null it is considered not persisted to the server,
 and thus will not be kept in the cache.

--- a/docs/api/useSubscription.md
+++ b/docs/api/useSubscription.md
@@ -42,7 +42,7 @@ Frequency must be set in [FetchShape](./FetchShape.md), otherwise will have no e
 import { Resource, FetchOptions } from 'rest-hooks';
 
 export default class PriceResource extends Resource {
-  readonly symbol: string | null = null;
+  readonly symbol: string | undefined = undefined;
   readonly price: string = '0.0';
   // ...
 

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -14,7 +14,7 @@ title: Usage
 import { Resource } from 'rest-hooks';
 
 export default class ArticleResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly title: string = '';
   readonly content: string = '';
   readonly author: number | null = null;
@@ -34,7 +34,7 @@ export default class ArticleResource extends Resource {
 import { Resource } from 'rest-hooks';
 
 export default class ArticleResource extends Resource {
-  id = null;
+  id = undefined;
   title = '';
   content = '';
   author = null;
@@ -54,7 +54,7 @@ export default class ArticleResource extends Resource {
 import { Resource } from 'rest-hooks';
 
 export default class ArticleResource extends Resource {
-  +id: ?number = null;
+  +id: ?number = undefined;
   +title: string = '';
   +content: string = '';
   +author: ?number = null;

--- a/docs/guides/computed-properties.md
+++ b/docs/guides/computed-properties.md
@@ -8,7 +8,7 @@ getters to the class itself.
 import { Resource } from 'rest-hooks';
 
 class User extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly firstName: string = '';
   readonly lastName: string = '';
   readonly username: string = '';

--- a/docs/guides/jsonp.md
+++ b/docs/guides/jsonp.md
@@ -11,7 +11,7 @@ import jsonp from 'superagent-jsonp';
 import { Resource } from 'rest-hooks';
 
 export default class ArticleResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly content: string = '';
 
   pk() {

--- a/docs/guides/multi-pk.md
+++ b/docs/guides/multi-pk.md
@@ -4,14 +4,14 @@ title: Multi-column primary key
 Sometimes you have a resource that doesn't have its own primary key. This is typically
 found in `join tables` that express `many-to-many` relationships.
 
-Since the pk() method must return either a number, string or null, make sure to
+Since the pk() method must return either a number, string or undefined, make sure to
 do a simple serialization. A simple join on the values should work. Be care to
 make sure your join value can't be a part of the id.
 
 ```typescript
 export class VoteResource extends Resource {
-  readonly userId: number | null = null;
-  readonly postId: number | null = null;
+  readonly userId: number | undefined = undefined;
+  readonly postId: number | undefined = undefined;
   readonly createdAt: string = '1900-01-01T01:01:01Z';
 
   pk() {

--- a/docs/guides/nested-response.md
+++ b/docs/guides/nested-response.md
@@ -19,7 +19,7 @@ import { Resource } from 'rest-hooks';
 import { UserResource } from 'resources';
 
 export default class ArticleResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly content: string = '';
   readonly author: number | null = null;
   readonly contributors: number[] = [];
@@ -79,7 +79,7 @@ import { Resource } from 'rest-hooks';
 import { UserResource } from 'resources';
 
 export default class ArticleResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly content: string = '';
   readonly author: number | null = null;
   readonly contributors: number[] = [];
@@ -117,7 +117,7 @@ import { Resource } from 'rest-hooks';
 // no need to import ArticleResource as the getEntitySchema() override happens there.
 
 export default class UserResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly name: string = '';
   readonly posts: number[] = [];
 

--- a/docs/guides/no-suspense.md
+++ b/docs/guides/no-suspense.md
@@ -58,7 +58,7 @@ function useStatefulResource<
 
 ```typescript
 export default class ProfileResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly img: string = '';
   readonly fullName: string = '';
   readonly bio: string = '';

--- a/docs/guides/pagination.md
+++ b/docs/guides/pagination.md
@@ -40,7 +40,7 @@ import { Resource, SchemaList, ReadShape, AbstractInstanceType } from 'rest-hook
 import { UserResource } from 'resources';
 
 export default class ArticleResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly content: string = '';
   readonly author: number | null = null;
   readonly contributors: number[] = [];

--- a/docs/guides/resource-types.md
+++ b/docs/guides/resource-types.md
@@ -27,7 +27,7 @@ export interface Address {
 export type Status = 'pending' | 'rejected' | 'accepted';
 
 export class UserResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly name: string = '';
   readonly username: string = '';
   readonly email: string = '';
@@ -45,7 +45,7 @@ export class UserResource extends Resource {
 <!--Javascript-->
 ```js
 export class UserResource extends Resource {
-  id = null;
+  id = undefined;
   name = '';
   username = '';
   email = '';

--- a/docs/guides/storybook.md
+++ b/docs/guides/storybook.md
@@ -15,7 +15,7 @@ happy path of components. Loading state is bypassed by initializing the cache ah
 
 ```typescript
 export default class ArticleResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly content: string = '';
   readonly author: number | null = null;
   readonly contributors: number[] = [];

--- a/docs/guides/url.md
+++ b/docs/guides/url.md
@@ -74,7 +74,7 @@ export default class CommentResource extends Resource {
     urlParams?: { articleId: string } & Partial<AbstractInstanceType<T>>,
   ): string {
     if (urlParams) {
-      if (this.pk(urlParams) !== null) {
+      if (this.pk(urlParams) !== undefined) {
         return `/articles/${articleId}/comments/${this.pk(urlParams)}`;
       }
     }

--- a/src/__tests__/common.ts
+++ b/src/__tests__/common.ts
@@ -9,7 +9,7 @@ import {
 import { AbstractInstanceType, FetchOptions } from '../types';
 
 export class ArticleResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly title: string = '';
   readonly content: string = '';
   readonly author: number | null = null;
@@ -147,7 +147,7 @@ export class StaticArticleResource extends ArticleResource {
 }
 
 export class UserResource extends Resource {
-  readonly id: number | null = null;
+  readonly id: number | undefined = undefined;
   readonly username: string = '';
   readonly email: string = '';
   readonly isAdmin: boolean = false;

--- a/src/resource/SimpleResource.ts
+++ b/src/resource/SimpleResource.ts
@@ -16,7 +16,7 @@ export default abstract class SimpleResource {
   /** Used as base of url construction */
   static readonly urlRoot: string;
   /** A unique identifier for this SimpleResource */
-  abstract pk(): string | number | null;
+  abstract pk(): string | number | undefined;
 
   /** SimpleResource factory. Takes an object of properties to assign to SimpleResource. */
   static fromJS<T extends typeof SimpleResource>(
@@ -104,7 +104,7 @@ export default abstract class SimpleResource {
   static pk<T extends typeof SimpleResource>(
     this: T,
     params: Partial<AbstractInstanceType<T>>,
-  ): string | number | null {
+  ): string | number | undefined {
     return this.prototype.pk.call(params);
   }
 


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #118.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
One of the main purposes of SimpleResource.pk() is to pass as a key in React. However, React types keys as possibly being undefined - not null so the type should reflect that here.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Switch type of pk to include undefined instead of null.
