### PR TITLE
[breaking] useSubscription() with params being null is considered 'in…

### DIFF
--- a/docs/api/useSubscription.md
+++ b/docs/api/useSubscription.md
@@ -9,7 +9,6 @@ title: useSubscription()
 function useSubscription(
   fetchShape: ReadShape,
   params: object | null,
-  active?: boolean = true,
 ): void;
 ```
 
@@ -22,7 +21,6 @@ function useSubscription<
 >(
   fetchShape: ReadShape<S, Params>,
   params: Params | null,
-  active?: boolean = true,
 ): void;
 ```
 
@@ -30,7 +28,10 @@ function useSubscription<
 
 Great for keeping resources up-to-date with frequent changes.
 
-Frequency must be set in [FetchShape](./FetchShape.md), otherwise will have no effect.
+When using the default [polling subscriptions](./PollingSubscription), frequency must be set in
+[FetchShape](./FetchShape.md), otherwise will have no effect.
+
+> Send `null` to params to unsubscribe.
 
 ## Example
 
@@ -84,7 +85,8 @@ function MasterPrice({ symbol }: { symbol: string }) {
   const price = useResource(PriceResource.detailShape(), { symbol });
   const ref = useRef();
   const onScreen = useOnScreen(ref);
-  useSubscription(PriceResource.detailShape(), { symbol }, undefined, onScreen);
+  // null params means don't subscribe
+  useSubscription(PriceResource.detailShape(), onScreen ? null : { symbol });
 
   return (
     <div ref={ref}>{price.value.toLocaleString('en', { currency: 'USD' })}</div>

--- a/src/react-integration/__tests__/subscriptions.tsx
+++ b/src/react-integration/__tests__/subscriptions.tsx
@@ -52,8 +52,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       const { result, waitForNextUpdate, rerender } = renderRestHook(() => {
         useSubscription(
           PollingArticleResource.detailShape(),
-          articlePayload,
-          active,
+          active ? articlePayload : null,
         );
         return useCache(PollingArticleResource.detailShape(), articlePayload);
       });

--- a/src/react-integration/hooks/useSubscription.ts
+++ b/src/react-integration/hooks/useSubscription.ts
@@ -7,7 +7,7 @@ import { ReadShape, Schema } from '~/resource';
 export default function useSubscription<
   Params extends Readonly<object>,
   S extends Schema
->(fetchShape: ReadShape<S, Params>, params: Params, active = true) {
+>(fetchShape: ReadShape<S, Params>, params: Params | null) {
   const dispatch = useContext(DispatchContext);
   /*
   we just want the current values when we dispatch, so
@@ -20,7 +20,7 @@ export default function useSubscription<
   shapeRef.current = fetchShape;
 
   useEffect(() => {
-    if (!active) return;
+    if (!params) return;
     const { fetch, schema, getFetchKey, options } = shapeRef.current;
     const url = getFetchKey(params);
 
@@ -44,5 +44,5 @@ export default function useSubscription<
     };
     // serialize params
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, active, params && fetchShape.getFetchKey(params)]);
+  }, [dispatch, params && fetchShape.getFetchKey(params)]);
 }


### PR DESCRIPTION
…active'

<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #156.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Makes API consistent with useResource() and useRetrieve().

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Remove 'active' boolean param in favor of simply checking if params is defined.
