### PR TITLE
[breaking] Drop IE support (out of the box)

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,13 @@
       "releaseNotes": "npx auto-changelog --stdout --starting-commit \"$(git rev-list --reverse ${latestVersion}...HEAD | head -n 1)\""
     }
   },
+  "browserslist": [
+    "> 1%",
+    "Firefox ESR",
+    "not dead",
+    "not ie<12",
+    "not OperaMini all"
+  ],
   "devDependencies": {
     "@anansi/babel-preset": "^0.18.2",
     "@anansi/eslint-config": "^0.6.6",
@@ -123,7 +130,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.0",
-    "@rest-hooks/normalizr": "^4.0.0-beta.3",
+    "@rest-hooks/normalizr": "^4.0.0-beta.4",
     "@types/superagent": "^4.1.4",
     "flux-standard-action": "^2.1.1",
     "lodash": "^4.17.15",

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -3,7 +3,8 @@
     [
       "@anansi/babel-preset",
       {
-        "typing": "typescript"
+        "typing": "typescript",
+        "legacyDecorators": true
       }
     ]
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,10 +1127,10 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
-"@rest-hooks/normalizr@^4.0.0-beta.3":
-  version "4.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@rest-hooks/normalizr/-/normalizr-4.0.0-beta.3.tgz#02dca2b95e13d5a7bd3ffbbf6d3eac691a87d4e1"
-  integrity sha512-a6WxFUplNIMxJQpmhbOzyNtDPr8g6r1SxNlT5BwkxnkPXBF0Y3n1oz9BXM3TzrOP5yenmxzzzqJfhz+sF8aoHQ==
+"@rest-hooks/normalizr@^4.0.0-beta.4":
+  version "4.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@rest-hooks/normalizr/-/normalizr-4.0.0-beta.4.tgz#8cc84daf85c93988763dfaa2e60035cbc31a4b81"
+  integrity sha512-tWvXVsv5rD0cr/VSTW/nbkWk2ve/GQWV3lumG+pF691SQk+gJtRCBDLuKcZkVvUxP82+hFfM3tTX5/0/OQGz5g==
   dependencies:
     "@babel/runtime" "^7.6.0"
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- IE is becoming less and less common
- Noone uses it out of the box as a developer
- Can still be built to target it by building this package inline
- This has a pretty significant reduction in shipping codesize.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Set browserslist that ignores IE as well as using @rest-hooks/normalizr version that does as well