### PR TITLE
[pkg] Upgrade TypeScript to 3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,13 +89,13 @@
     "@anansi/eslint-config": "^0.6.6",
     "@babel/cli": "^7.7.0",
     "@babel/core": "^7.7.0",
-    "@testing-library/react": "^9.3.0",
-    "@testing-library/react-hooks": "^3.1.1",
-    "@types/jest": "^24.0.20",
+    "@testing-library/react": "^9.3.2",
+    "@testing-library/react-hooks": "^3.2.1",
+    "@types/jest": "^24.0.22",
     "@types/lodash": "^4.14.144",
     "@types/react": "^16.9.11",
-    "@typescript-eslint/eslint-plugin": "^2.6.0",
-    "@typescript-eslint/parser": "^2.6.0",
+    "@typescript-eslint/eslint-plugin": "^2.6.1",
+    "@typescript-eslint/parser": "^2.6.1",
     "@zerollup/ts-transform-paths": "^1.7.3",
     "auto-changelog": "^1.16.1",
     "babel-core": "^7.0.0-bridge.0",
@@ -126,7 +126,7 @@
     "scheduler": "^0.17.0",
     "ts-jest": "^24.1.0",
     "ttypescript": "^1.5.7",
-    "typescript": "^3.6.4"
+    "typescript": "^3.7.2"
   },
   "dependencies": {
     "@babel/runtime": "^7.7.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,4 @@
-import {
-  Resource,
-  SimpleResource,
-  SuperagentResource,
-  FetchShape,
-  DeleteShape,
-  ReadShape,
-  MutateShape,
-  Schema,
-  SchemaList,
-  SchemaDetail,
-  schemas,
-} from './resource';
+import { Resource, SimpleResource, SuperagentResource } from './resource';
 import NetworkManager from './state/NetworkManager';
 import RIC from './state/RIC';
 import PollingSubscription from './state/PollingSubscription';
@@ -30,24 +18,10 @@ import {
   useResetter,
   ExternalCacheProvider,
   NetworkErrorBoundary,
-  NetworkError,
+  NetworkError as OGNetworkError,
 } from './react-integration';
 import useSelectionUnstable from './react-integration/hooks/useSelection';
 import { Request as RequestType } from 'superagent';
-import {
-  AbstractInstanceType,
-  FetchOptions,
-  Method,
-  State,
-  FetchAction,
-  ReceiveAction,
-  RPCAction,
-  PurgeAction,
-  Dispatch,
-  MiddlewareAPI,
-  Middleware,
-  Manager,
-} from './types';
 import { StateContext, DispatchContext } from './react-integration/context';
 
 const __INTERNAL__ = {
@@ -57,54 +31,12 @@ const __INTERNAL__ = {
   RIC,
 };
 
-export type DeleteShape<
-  S extends schemas.Entity,
-  Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object | string> | void = undefined
-> = DeleteShape<S, Params, Body>;
-export type MutateShape<
-  S extends Schema,
-  Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object | string> | void = Readonly<object> | undefined
-> = MutateShape<S, Params, Body>;
-export type ReadShape<
-  S extends Schema,
-  Params extends Readonly<object> = Readonly<object>
-> = ReadShape<S, Params>;
-export type FetchShape<
-  S extends Schema,
-  Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object | string> | void = Readonly<object> | undefined
-> = FetchShape<S, Params, Body>;
-
-export type State<T> = State<T>;
-export type Schema = Schema;
-export type SchemaList<T> = SchemaList<T>;
-export type SchemaDetail<T> = SchemaDetail<T>;
-export type AbstractInstanceType<T> = AbstractInstanceType<T>;
-export type FetchOptions = FetchOptions;
-export type Method = Method;
-
-export type NetworkError = NetworkError;
+export type NetworkError = OGNetworkError;
 export type Request = RequestType;
-export type FetchAction<
-  Payload extends object | string | number = object | string | number
-> = FetchAction<Payload>;
-export type ReceiveAction<
-  Payload extends object | string | number = object | string | number
-> = ReceiveAction<Payload>;
-export type RPCAction<
-  Payload extends object | string | number = object | string | number
-> = RPCAction<Payload>;
-export type PurgeAction = PurgeAction;
 
-export type Dispatch<R extends React.Reducer<any, any>> = Dispatch<R>;
-export type MiddlewareAPI<
-  R extends React.Reducer<any, any> = React.Reducer<any, any>
-> = MiddlewareAPI<R>;
-export type Middleware = Middleware;
-export type Manager = Manager;
-
+export * from './types';
+export * from './resource/shapes';
+export * from './resource/normal';
 export {
   Resource,
   SimpleResource,
@@ -127,6 +59,5 @@ export {
   PollingSubscription,
   reducer,
   NetworkErrorBoundary,
-  schemas,
   __INTERNAL__,
 };

--- a/src/resource/SimpleResource.ts
+++ b/src/resource/SimpleResource.ts
@@ -1,7 +1,7 @@
 import { memoize } from 'lodash';
 import { AbstractInstanceType, Method, FetchOptions } from '~/types';
 
-import { ReadShape, MutateShape, DeleteShape } from './types';
+import { ReadShape, MutateShape, DeleteShape } from './shapes';
 import { schemas, SchemaDetail, SchemaList } from './normal';
 
 const DefinedMembersKey = Symbol('Defined Members');

--- a/src/resource/index.ts
+++ b/src/resource/index.ts
@@ -1,5 +1,6 @@
 import Resource from './Resource';
 import SimpleResource from './SimpleResource';
+export * from './shapes';
 export * from './types';
 export * from './normal';
 

--- a/src/resource/shapes.ts
+++ b/src/resource/shapes.ts
@@ -1,0 +1,50 @@
+import { schemas, Schema } from './normal';
+import { FetchOptions } from '~/types';
+
+/** Defines the shape of a network request */
+export interface FetchShape<
+  S extends Schema,
+  Params extends Readonly<object> = Readonly<object>,
+  Body extends Readonly<object | string> | void =
+    | Readonly<object | string>
+    | undefined
+> {
+  readonly type: 'read' | 'mutate' | 'delete';
+  fetch(params: Params, body: Body): Promise<any>;
+  getFetchKey(params: Params): string;
+  readonly schema: S;
+  readonly options?: FetchOptions;
+}
+
+/** Purges a value from the server */
+export interface DeleteShape<
+  S extends schemas.Entity,
+  Params extends Readonly<object> = Readonly<object>,
+  Body extends Readonly<object | string> | void = undefined
+> extends FetchShape<S, Params, Body> {
+  readonly type: 'delete';
+}
+
+/** To change values on the server */
+export interface MutateShape<
+  S extends Schema,
+  Params extends Readonly<object> = Readonly<object>,
+  Body extends Readonly<object | string> | void =
+    | Readonly<object | string>
+    | undefined
+> extends FetchShape<S, Params, Body> {
+  readonly type: 'mutate';
+  fetch(
+    params: Params,
+    body: Body,
+  ): Promise<object | string | number | boolean>;
+}
+
+/** For retrieval requests */
+export interface ReadShape<
+  S extends Schema,
+  Params extends Readonly<object> = Readonly<object>
+> extends FetchShape<S, Params, undefined> {
+  readonly type: 'read';
+  fetch(params: Params): Promise<object | string | number | boolean>;
+}

--- a/src/resource/types.ts
+++ b/src/resource/types.ts
@@ -1,20 +1,5 @@
 import { schemas, Schema } from './normal';
-import { FetchOptions } from '~/types';
-
-/** Defines the shape of a network request */
-export interface FetchShape<
-  S extends Schema,
-  Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object | string> | void =
-    | Readonly<object | string>
-    | undefined
-> {
-  readonly type: 'read' | 'mutate' | 'delete';
-  fetch(params: Params, body: Body): Promise<any>;
-  getFetchKey(params: Params): string;
-  readonly schema: S;
-  readonly options?: FetchOptions;
-}
+import { FetchShape, DeleteShape } from './shapes';
 
 export type SchemaFromShape<
   F extends FetchShape<any, any, any>
@@ -25,39 +10,6 @@ export type ParamsFromShape<
 export type BodyFromShape<
   F extends FetchShape<any, any, any>
 > = F extends FetchShape<any, any, infer B> ? B : never;
-
-/** Purges a value from the server */
-export interface DeleteShape<
-  S extends schemas.Entity,
-  Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object | string> | void = undefined
-> extends FetchShape<S, Params, Body> {
-  readonly type: 'delete';
-}
-
-/** To change values on the server */
-export interface MutateShape<
-  S extends Schema,
-  Params extends Readonly<object> = Readonly<object>,
-  Body extends Readonly<object | string> | void =
-    | Readonly<object | string>
-    | undefined
-> extends FetchShape<S, Params, Body> {
-  readonly type: 'mutate';
-  fetch(
-    params: Params,
-    body: Body,
-  ): Promise<object | string | number | boolean>;
-}
-
-/** For retrieval requests */
-export interface ReadShape<
-  S extends Schema,
-  Params extends Readonly<object> = Readonly<object>
-> extends FetchShape<S, Params, undefined> {
-  readonly type: 'read';
-  fetch(params: Params): Promise<object | string | number | boolean>;
-}
 
 export function isDeleteShape(
   shape: FetchShape<any, any, any>,

--- a/src/state/selectors/useDenormalized.ts
+++ b/src/state/selectors/useDenormalized.ts
@@ -1,7 +1,12 @@
 import { useMemo } from 'react';
 import { State } from '~/types';
-import { isEntity, ReadShape } from '~/resource/types';
-import { Schema, denormalize, DenormalizeNullable } from '~/resource';
+import {
+  isEntity,
+  ReadShape,
+  Schema,
+  denormalize,
+  DenormalizeNullable,
+} from '~/resource';
 import buildInferredResults from './buildInferredResults';
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,7 @@ export type PurgeAction = ErrorableFSAWithMeta<
 
 export type ResetAction = FSA<'rest-hooks/reset'>;
 
-export type OptimisticUpdatePayload = {
+type OptimisticUpdatePayload = {
   [key: string]: <T>(result: T | undefined, key: string) => T;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,18 +1356,18 @@
     pretty-format "^24.9.0"
     wait-for-expect "^3.0.0"
 
-"@testing-library/react-hooks@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.1.1.tgz#5c93e463c0252bea6ac237ec8d9c982c27d67208"
-  integrity sha512-HANnmA68/i6RwZn9j7pcbAg438PoDToftRQ1CH0j893WuQGtENFm57GKTagtmXXDN5gKh3rVbN1GH6HDvHbk6A==
+"@testing-library/react-hooks@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz#19b6caa048ef15faa69d439c469033873ea01294"
+  integrity sha512-1OB6Ksvlk6BCJA1xpj8/WWz0XVd1qRcgqdaFAq+xeC6l61Ucj0P6QpA5u+Db/x9gU4DCX8ziR5b66Mlfg0M2RA==
   dependencies:
     "@babel/runtime" "^7.5.4"
-    "@types/testing-library__react-hooks" "^2.0.0"
+    "@types/testing-library__react-hooks" "^3.0.0"
 
-"@testing-library/react@^9.3.0":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.3.1.tgz#96573fb9942e1ca0ed1ec9984ea7b12b66945963"
-  integrity sha512-BXlYrbxTkifNVb7rIC8EHqYXgG/rBeULqG3V0wbEAuSaZ7n5ERX9Bcp0i+9EecrNpLNPwR0cIxdKNp6qVTZS9A==
+"@testing-library/react@^9.3.2":
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.3.2.tgz#418000daa980dafd2d9420cc733d661daece9aa0"
+  integrity sha512-J6ftWtm218tOLS175MF9eWCxGp+X+cUXCpkPIin8KAXWtyZbr9CbqJ8M8QNd6spZxJDAGlw+leLG4MJWLlqVgg==
   dependencies:
     "@babel/runtime" "^7.6.0"
     "@testing-library/dom" "^6.3.0"
@@ -1460,10 +1460,10 @@
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
   integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
 
-"@types/jest@^24.0.20":
-  version "24.0.21"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.21.tgz#2c0a25440e025bb265f4a17d8b79b11b231426bf"
-  integrity sha512-uyqFvx78Tuy0h5iLCPWRCvi5HhWwEqhIj30doitp191oYLqlCxUyAJHdWVm5+Nr271/vPnkyt6rWeEIjGowBTg==
+"@types/jest@^24.0.22":
+  version "24.0.22"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.22.tgz#08a50be08e78aba850a1185626e71d31e2336145"
+  integrity sha512-t2OvhNZnrNjlzi2i0/cxbLVM59WN15I2r1Qtb7wDv28PnV9IzrPtagFRey/S9ezdLD0zyh1XGMQIEQND2YEfrw==
   dependencies:
     "@types/jest-diff" "*"
 
@@ -1541,10 +1541,10 @@
   dependencies:
     pretty-format "^24.3.0"
 
-"@types/testing-library__react-hooks@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-2.0.0.tgz#7b289d64945517ae8ba9cbcb0c5b282432aaeffa"
-  integrity sha512-YUVqXGCChJKEJ4aAnMXqPCq0NfPAFVsJeGIb2y/iiMjxwyu+45+vR+AHOwjJHHKEHeC0ZhOGrZ5gSEmaJe4tyQ==
+"@types/testing-library__react-hooks@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.1.0.tgz#04d174ce767fbcce3ccb5021d7f156e1b06008a9"
+  integrity sha512-QJc1sgH9DD6jbfybzugnP0sY8wPzzIq8sHDBuThzCr2ZEbyHIaAvN9ytx/tHzcWL5MqmeZJqiUm/GsythaGx3g==
   dependencies:
     "@types/react" "*"
     "@types/react-test-renderer" "*"
@@ -1569,12 +1569,23 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.1.0", "@typescript-eslint/eslint-plugin@^2.6.0":
+"@typescript-eslint/eslint-plugin@^2.1.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.0.tgz#e82ed43fc4527b21bfe35c20a2d6e4ed49fc7957"
   integrity sha512-iCcXREU4RciLmLniwKLRPCOFVXrkF7z27XuHq5DrykpREv/mz6ztKAyLg2fdkM0hQC7659p5ZF5uStH7uzAJ/w==
   dependencies:
     "@typescript-eslint/experimental-utils" "2.6.0"
+    eslint-utils "^1.4.2"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/eslint-plugin@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.6.1.tgz#e34972a24f8aba0861f9ccf7130acd74fd11e079"
+  integrity sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.6.1"
     eslint-utils "^1.4.2"
     functional-red-black-tree "^1.0.1"
     regexpp "^2.0.1"
@@ -1589,7 +1600,16 @@
     "@typescript-eslint/typescript-estree" "2.6.0"
     eslint-scope "^5.0.0"
 
-"@typescript-eslint/parser@^2.1.0", "@typescript-eslint/parser@^2.6.0":
+"@typescript-eslint/experimental-utils@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.6.1.tgz#eddaca17a399ebf93a8628923233b4f93793acfd"
+  integrity sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.6.1"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/parser@^2.1.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.6.0.tgz#5106295c6a7056287b4719e24aae8d6293d5af49"
   integrity sha512-AvLejMmkcjRTJ2KD72v565W4slSrrzUIzkReu1JN34b8JnsEsxx7S9Xx/qXEuMQas0mkdUfETr0j3zOhq2DIqQ==
@@ -1597,6 +1617,16 @@
     "@types/eslint-visitor-keys" "^1.0.0"
     "@typescript-eslint/experimental-utils" "2.6.0"
     "@typescript-eslint/typescript-estree" "2.6.0"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/parser@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.6.1.tgz#3c00116baa0d696bc334ca18ac5286b34793993c"
+  integrity sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.6.1"
+    "@typescript-eslint/typescript-estree" "2.6.1"
     eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/typescript-estree@2.6.0":
@@ -1609,6 +1639,18 @@
     is-glob "^4.0.1"
     lodash.unescape "4.0.1"
     semver "^6.3.0"
+
+"@typescript-eslint/typescript-estree@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.6.1.tgz#fb363dd4ca23384745c5ea4b7f4c867432b00d31"
+  integrity sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==
+  dependencies:
+    debug "^4.1.1"
+    glob "^7.1.4"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
 
 "@zerollup/ts-helpers@^1.7.0":
   version "1.7.0"
@@ -7145,10 +7187,15 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
-typescript@^3.5.1, typescript@^3.6.4:
+typescript@^3.5.1:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
   integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+
+typescript@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@^3.1.4:
   version "3.6.7"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
3.7 just released. Ensure compatibility with the latest.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Due to repeat def conflicts https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#local-and-imported-type-declarations-now-conflict I converted more of the re-exports of pure-types to use the `export * from` pattern as the babel code still includes them due to https://github.com/babel/babel/issues/8361