### PR TITLE
docs: Update useStatefulResource() in guides

### DIFF
--- a/docs/guides/no-suspense.md
+++ b/docs/guides/no-suspense.md
@@ -13,21 +13,19 @@ way you please.
 #### `useStatefulResource.tsx`
 
 ```typescript
-import { useRetrieve, useCache, useError, Schema, ReadShape } from 'rest-hooks';
+import { useRetrieve, useCache, useError, Schema, ReadShape, FetchShape } from 'rest-hooks';
 
 /** If the invalidIfStale option is set we suspend if resource has expired */
-function hasUsableData<
-  S extends Schema,
-  Params extends Readonly<object>,
->(
-  resource: RequestResource<ReadShape<S, Params>> | null,
-  fetchShape: ReadShape<S, Params>,
+export default function hasUsableData(
+  cacheReady: boolean,
+  fetchShape: Pick<FetchShape<any>, 'options'>,
 ) {
   return !(
     (fetchShape.options && fetchShape.options.invalidIfStale) ||
-    !resource
+    !cacheReady
   );
 }
+
 
 /** Ensure a resource is available; loading and error returned explicitly. */
 function useStatefulResource<
@@ -45,7 +43,7 @@ function useStatefulResource<
   let error = useError(fetchShape, params, resource);
 
   return {
-    data: resource as NonNullable<typeof resource>,
+    data: resource,
     loading,
     error,
   };

--- a/packages/rest-hooks/src/react-integration/hooks/hasUsableData.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/hasUsableData.ts
@@ -1,13 +1,9 @@
-import { FetchShape, Schema } from '~/resource';
+import { FetchShape } from '~/resource';
 
 /** If the invalidIfStale option is set we suspend if resource has expired */
-export default function hasUsableData<
-  S extends Schema,
-  Params extends Readonly<object>,
-  Body extends Readonly<object | string> | void
->(
+export default function hasUsableData(
   cacheReady: boolean,
-  fetchShape: Pick<FetchShape<S, Params, Body>, 'options'>,
+  fetchShape: Pick<FetchShape<any>, 'options'>,
 ) {
   return !(
     (fetchShape.options && fetchShape.options.invalidIfStale) ||

--- a/website/versioned_docs/version-3.0/guides/no-suspense.md
+++ b/website/versioned_docs/version-3.0/guides/no-suspense.md
@@ -15,21 +15,19 @@ way you please.
 #### `useStatefulResource.tsx`
 
 ```typescript
-import { useRetrieve, useCache, useError, Schema, ReadShape } from 'rest-hooks';
+import { useRetrieve, useCache, useError, Schema, ReadShape, FetchShape } from 'rest-hooks';
 
 /** If the invalidIfStale option is set we suspend if resource has expired */
-function hasUsableData<
-  S extends Schema,
-  Params extends Readonly<object>,
->(
-  resource: RequestResource<ReadShape<S, Params>> | null,
-  fetchShape: ReadShape<S, Params>,
+export default function hasUsableData(
+  cacheReady: boolean,
+  fetchShape: Pick<FetchShape<any>, 'options'>,
 ) {
   return !(
     (fetchShape.options && fetchShape.options.invalidIfStale) ||
-    !resource
+    !cacheReady
   );
 }
+
 
 /** Ensure a resource is available; loading and error returned explicitly. */
 function useStatefulResource<
@@ -47,7 +45,7 @@ function useStatefulResource<
   let error = useError(fetchShape, params, resource);
 
   return {
-    data: resource as NonNullable<typeof resource>,
+    data: resource,
     loading,
     error,
   };


### PR DESCRIPTION
Fixes #181 

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Types were a bit out of date from 3.0 transition. Confirmed this working in both code and types in anansi example project.

### Solution
Update docs in current and 3.0 release. Also remove generics (unnecessary) from hasUsableData()