### PR TITLE
docs: Make useStatefulResource() work with nested schemas

### DIFF
--- a/docs/guides/no-suspense.md
+++ b/docs/guides/no-suspense.md
@@ -13,7 +13,8 @@ way you please.
 #### `useStatefulResource.tsx`
 
 ```typescript
-import { useRetrieve, useCache, useError, Schema, ReadShape, FetchShape } from 'rest-hooks';
+import { useContext} from 'react';
+import { useRetrieve, useError, Schema, ReadShape, FetchShape, useDenormalized, __INTERNAL__ } from 'rest-hooks';
 
 /** If the invalidIfStale option is set we suspend if resource has expired */
 export default function hasUsableData(
@@ -28,22 +29,23 @@ export default function hasUsableData(
 
 
 /** Ensure a resource is available; loading and error returned explicitly. */
-function useStatefulResource<
+export function useStatefulResource<
   Params extends Readonly<object>,
   S extends Schema
 >(fetchShape: ReadShape<S, Params>, params: Params | null) {
   let maybePromise = useRetrieve(fetchShape, params);
-  const resource = useCache(fetchShape, params);
+  const state = useContext(__INTERNAL__.StateContext);
+  const [denormalized, ready] = useDenormalized(fetchShape, params, state);
 
   const loading =
-    !hasUsableData(resource, fetchShape) &&
+    !hasUsableData(ready, fetchShape) &&
     maybePromise &&
     typeof maybePromise.then === 'function';
 
-  let error = useError(fetchShape, params, resource);
+  let error = useError(fetchShape, params, ready);
 
   return {
-    data: resource,
+    data: denormalized,
     loading,
     error,
   };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
There's a bit more complexity with the 3.0 version of things to detect fully loaded state.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We'll have to pull the `ready` information from useDenormalized() ourselves.