### PR TITLE
internal: Use TypeScript project references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,7 @@ jobs:
 
       # run tests!
       - run: yarn run lint packages/*/src
-      - run:
-          command: |
-            cd packages/rest-hooks
-            yarn run build
-      - run:
-          command: |
-            cd packages/test
-            yarn run build
+      - run: yarn run build
       - run: yarn run test:ci -- -- --maxWorkers=2
 
       # only run coverage if repo token is available (so third parties don't fail the build)

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
     "prettier/react"
   ],
   "parser": "@typescript-eslint/parser",
-  "parserOptions": { "project": "./tsconfig.json" },
+  "parserOptions": { "project": "./packages/**/tsconfig.json" },
   "plugins": ["prettier", "react-hooks"],
   "env": {
     "jest": true

--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,8 @@ typings/
 .env
 
 # build directory
-/lib
-/dist
+**/lib
+**/dist
+
+# build info
+**/tsconfig*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "packages/*"
   ],
   "scripts": {
-    "release": "yarn run build:clean && yarn run build:types && lerna publish",
+    "release": "lerna publish",
     "lint": "eslint --ext .ts,.tsx",
     "format": "eslint --fix \"packages/*/!(node_modules)/**/*.{js,ts,tsx}\"",
     "clean": "lerna clean",
@@ -13,7 +13,8 @@
     "build:types": "ttsc --build",
     "test": "lerna run test --stream",
     "test:ci": "lerna run --stream test:ci",
-    "test:coverage": "lerna run test:coverage --stream"
+    "test:coverage": "lerna run test:coverage --stream",
+    "prepublishOnly": "yarn run build:clean && yarn run build:types"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "lint": "eslint --ext .ts,.tsx",
     "format": "eslint --fix \"packages/*/!(node_modules)/**/*.{js,ts,tsx}\"",
     "clean": "lerna clean",
-    "build": "lerna run build --stream",
+    "build": "ttsc --build && lerna run build --stream",
+    "build:clean": "lerna run build:clean --stream",
+    "build:types": "ttsc --build",
     "test": "lerna run test --stream",
     "test:ci": "lerna run --stream test:ci",
     "test:coverage": "lerna run test:coverage --stream"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "packages/*"
   ],
   "scripts": {
-    "release": "lerna publish",
+    "release": "yarn run build:clean && yarn run build:types && lerna publish",
     "lint": "eslint --ext .ts,.tsx",
     "format": "eslint --fix \"packages/*/!(node_modules)/**/*.{js,ts,tsx}\"",
     "clean": "lerna clean",

--- a/packages/rest-hooks/jest.config.js
+++ b/packages/rest-hooks/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   globals: {
     'ts-jest': {
       babelConfig: 'src/.babelrc',
-      tsConfig: 'src/tsconfig.json',
+      tsConfig: 'tsconfig.json',
     },
   },
   transform: {
@@ -18,11 +18,11 @@ module.exports = {
     '^.+\\.jsx?$': 'babel-jest',
   },
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
-  coveragePathIgnorePatterns: ['react-integration/hooks/useSelection'],
+  coveragePathIgnorePatterns: ['node_modules', 'react-integration/hooks/useSelection'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   moduleNameMapper: {
     ...pathsToModuleNameMapper(compilerOptions.paths, {
-      prefix: '<rootDir>/src/',
+      prefix: '<rootDir>/../../',
     }),
     '^rest-hooks$': '<rootDir>/src/index.ts',
   },

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -17,10 +17,10 @@
   ],
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:types": "ttsc --emitDeclarationOnly -p ./src",
+    "build:types": "ttsc --build",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf lib",
-    "build": "npm run build:lib && npm run build:types && cpy ./src/resource/normal.d.ts ./lib/resource",
+    "build:clean": "rimraf lib tsconfig.compile.tsbuildinfo tsconfig.tsbuildinfo",
+    "build": "npm run build:lib && npm run build:types",
     "dev": "yarn run build:lib -w",
     "prepare": "npm run build:clean && npm run build",
     "prepublishOnly": "npm run build:bundle",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -20,7 +20,7 @@
     "build:lib": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:types": "ttsc --build",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf lib tsconfig.compile.tsbuildinfo tsconfig.tsbuildinfo",
+    "build:clean": "rimraf lib dist *.tsbuildinfo",
     "build": "npm run build:lib && npm run build:types",
     "dev": "yarn run build:lib -w",
     "prepare": "npm run build",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -23,7 +23,7 @@
     "build:clean": "rimraf lib tsconfig.compile.tsbuildinfo tsconfig.tsbuildinfo",
     "build": "npm run build:lib && npm run build:types",
     "dev": "yarn run build:lib -w",
-    "prepare": "npm run build:clean && npm run build",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build:bundle",
     "test": "cross-env NODE_ENV=test jest",
     "test:ci": "npm test -- --ci",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -8,6 +8,7 @@
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
   "files": [
+    "src",
     "dist",
     "lib",
     "LICENSE",

--- a/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
@@ -17,7 +17,7 @@ import {
   makeRenderRestHook,
   makeCacheProvider,
   mockInitialState,
-} from '../../../../test/src';
+} from '../../../../test';
 import { users, articlesPages, payload } from './fixtures';
 
 async function testDispatchFetch(

--- a/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
@@ -12,7 +12,7 @@ import {
   makeRenderRestHook,
   makeCacheProvider,
   makeExternalCacheProvider,
-} from '../../../../test/src';
+} from '../../../../test';
 import {
   payload,
   createPayload,

--- a/packages/rest-hooks/src/react-integration/__tests__/subscriptions.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/subscriptions.tsx
@@ -9,7 +9,7 @@ import {
   makeCacheProvider,
   makeExternalCacheProvider,
   makeRenderRestHook,
-} from '../../../../test/src';
+} from '../../../../test';
 import { DispatchContext } from '../context';
 
 for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {

--- a/packages/rest-hooks/src/react-integration/__tests__/useCache.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/useCache.tsx
@@ -4,7 +4,7 @@ import {
   PaginatedArticleResource,
 } from '../../__tests__/common';
 import { useCache } from '../hooks';
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test/src';
+import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
 import { articlesPages, payload } from './fixtures';
 
 describe('useCache()', () => {

--- a/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
@@ -14,7 +14,7 @@ import {
   makeRenderRestHook,
   makeCacheProvider,
   mockInitialState,
-} from '../../../../test/src';
+} from '../../../../test';
 import { payload, users, nested } from './fixtures';
 
 async function testDispatchFetch(

--- a/packages/rest-hooks/src/tsconfig.json
+++ b/packages/rest-hooks/src/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../tsconfig",
-  "exclude": ["node_modules", "**/__tests__"]
-}

--- a/packages/rest-hooks/tsconfig.compile.json
+++ b/packages/rest-hooks/tsconfig.compile.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["node_modules", "dist", "lib", "**/__tests__"]
+}

--- a/packages/rest-hooks/tsconfig.json
+++ b/packages/rest-hooks/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig-base",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "./src",
-    "baseUrl": "./src",
+    "rootDir": "src",
     "paths": {
-      "~/*": ["*"]
+      "~/*": ["packages/rest-hooks/src/*"],
+      "rest-hooks": ["packages/rest-hooks/src"]
     }
   },
-  "exclude": ["node_modules"]
+  "include": ["src"]
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build:types": "ttsc --build ./tsconfig.compile.json",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf dist tsconfig.compile.tsbuildinfo tsconfig.tsbuildinfo",
+    "build:clean": "rimraf dist *.tsbuildinfo",
     "build": "yarn run build:bundle && yarn run build:types",
     "prepublishOnly": "yarn run build"
   },

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -16,7 +16,7 @@
     "build:bundle": "rollup -c",
     "build:clean": "rimraf dist tsconfig.compile.tsbuildinfo tsconfig.tsbuildinfo",
     "build": "yarn run build:bundle && yarn run build:types",
-    "prepublishOnly": "yarn run build:clean && yarn run build"
+    "prepublishOnly": "yarn run build"
   },
   "keywords": [
     "test",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",
   "files": [
+    "src",
     "dist",
     "LICENSE",
     "README.md"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -11,11 +11,11 @@
     "README.md"
   ],
   "scripts": {
-    "build:types": "ttsc --emitDeclarationOnly --isolatedModules -p ./tsconfig.compile.json",
+    "build:types": "ttsc --build ./tsconfig.compile.json",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf dist",
-    "build": "npm run build:bundle && npm run build:types",
-    "prepublishOnly": "npm run build:clean && npm run build"
+    "build:clean": "rimraf dist tsconfig.compile.tsbuildinfo tsconfig.tsbuildinfo",
+    "build": "yarn run build:bundle && yarn run build:types",
+    "prepublishOnly": "yarn run build:clean && yarn run build"
   },
   "keywords": [
     "test",
@@ -51,6 +51,9 @@
     "not ie<12",
     "not OperaMini all"
   ],
+  "devDependencies": {
+    "rest-hooks": "*"
+  },
   "dependencies": {
     "@testing-library/react-hooks": "^3.2.1"
   },

--- a/packages/test/tsconfig.compile.json
+++ b/packages/test/tsconfig.compile.json
@@ -1,6 +1,4 @@
 {
   "extends": "./tsconfig",
-  "compilerOptions": {
-    "paths": {}
-  }
+  "compilerOptions": { "paths": {} }
 }

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -1,19 +1,9 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig-base",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "./src",
-    "baseUrl": "./src",
-    "paths": {
-      "~/*": ["../../rest-hooks/src/*"],
-      "rest-hooks": ["../../rest-hooks/src/index"]
-    }
+    "rootDir": "src"
   },
-  "include": [
-    "./src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+  "include": ["src"],
+  "references": [{ "path": "../rest-hooks" }]
 }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,0 +1,74 @@
+{
+  "compilerOptions": {
+    "plugins": [{ "transform": "@zerollup/ts-transform-paths" }],
+    "emitDeclarationOnly": true,
+    /* Basic Options */
+    "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "esnext",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "lib": ["dom", "esnext"],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    //"outDir": "lib",                         /* Redirect output structure to the directory. */
+    //"rootDir": "packages/rest-hooks/src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "composite": true,                     /* Enable project compilation */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    //"baseUrl": "packages/rest-hooks/src",                       /* Base directory to resolve non-absolute module names. */
+    // "rootDirs": ["./src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    "baseUrl": ".",
+    "rootDir": ".",
+    "outDir": "lib",
+    "paths": {
+      "@rest-hooks/*": ["packages/*/src"],
+      "rest-hooks": ["packages/rest-hooks/src"]
+    },
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    "emitDecoratorMetadata": true         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "include": ["packages/*/src"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "lib"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,63 +1,8 @@
 {
-  "compilerOptions": {
-    "plugins": [{ "transform": "@zerollup/ts-transform-paths" }],
-    /* Basic Options */
-    "target": "esnext",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    //"outDir": "lib",                         /* Redirect output structure to the directory. */
-    //"rootDir": "packages/rest-hooks/src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    //"baseUrl": "packages/rest-hooks/src",                       /* Base directory to resolve non-absolute module names. */
-    // "rootDirs": ["./src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    "emitDecoratorMetadata": true         /* Enables experimental support for emitting type metadata for decorators. */
-  },
-  "exclude": [
-    "node_modules"
+  "files": [],
+  "include": [],
+  "references": [
+      { "path": "./packages/rest-hooks/tsconfig.compile.json" },
+      { "path": "./packages/test/tsconfig.compile.json" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2316,7 +2316,7 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@rest-hooks/normalizr@^4.0.0":
+"@rest-hooks/normalizr@^4.0.0", "@rest-hooks/normalizr@^4.0.0-beta.3":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@rest-hooks/normalizr/-/normalizr-4.0.0.tgz#5707d1291546c17db39ab94639b2dcc6a859d4d4"
   integrity sha512-0nvJjk7ff21tctjJ44WTOZn1jTHCEz8EjssD5WNaKL61rgnIoV65mJxDBGB5K2sOyOjYXgs8sntbuoqK8XrC7A==
@@ -8170,6 +8170,18 @@ resolve@1.x, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0,
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
+
+rest-hooks@*:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rest-hooks/-/rest-hooks-3.0.0.tgz#47188880d84b9f80c771e045ecaec5d018ea1c76"
+  integrity sha512-SRMpbFb8JkmlO75j1vnhXIfwWoCPl/L8Tx09V7Bx37/mwXylYbHYOZyQKsvO1Pd1e5K5XEWlXhvvoCdZwRpbgw==
+  dependencies:
+    "@babel/runtime" "^7.6.0"
+    "@rest-hooks/normalizr" "^4.0.0-beta.3"
+    "@types/superagent" "^4.1.4"
+    flux-standard-action "^2.1.1"
+    lodash "^4.17.15"
+    superagent "^5.1.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This simplifies and makes more robust monorepo configuration


### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Remapping based on /src was weird. Now paths are only needed for IDE integration, and should be ignored at build.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
https://www.typescriptlang.org/docs/handbook/project-references.html improve typescript speed, while eliminating the need for weird src remapping. TypeScript source maps allow editors to reference the .d.ts files while still going to the ./src when looking up in IDEs.

- lint: use wildcard tsconfig to pick up each directory's config
- circle: build from root and let tsc orchestrate build order for types via `--build` option
- publishing: run `ttsc --build` before lerna publish to build types first
  - OPEN QUESTION: perhaps entire build should be done first in publish script and no build done in each dir?
- add src to published dirs: `--build` option adds sourcemaps that are used to return actual source from ambient declaration files. this will improve user EXP
- `build:clean` needs to delete .tsbuildinfo  files else types won't be regen.

#### Footnote

Getting this right will help make the migration of coinbase/www to TypeScript smooth