### PR TITLE
internal: Improve circleci speed by saving yarn cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,17 +15,22 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v2-dependencies-{{ checksum "yarn.lock" }}
+            - v3-dependencies-{{ checksum "yarn.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v2-dependencies-
+            - v3-dependencies-
 
-      - run: yarn install --prefer-offline --frozen-lockfile
+      - run:
+          name: yarn install
+          command: |
+            yarn config set cache-folder .cache/yarn
+            yarn install --prefer-offline --frozen-lockfile
 
       - save_cache:
           paths:
             - node_modules
             - packages/*/node_modules
-          key: v2-dependencies-{{ checksum "yarn.lock" }}
+            - .cache/yarn
+          key: v3-dependencies-{{ checksum "yarn.lock" }}
 
       # run tests!
       - run: yarn run lint packages/*/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10
+FROM node:11.15
 
 WORKDIR /app/website
 


### PR DESCRIPTION
### Motivation

If a package is changed, there still may be related packages that attempt to get installed around it, if those resolve to the same as in the yarn cache speed can improve.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Also save yarn cache folder.
