### PR TITLE
[fix] schemaLegacy TypeScript import

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:types": "ttsc --emitDeclarationOnly -p ./src",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib",
-    "build": "npm run build:lib && npm run build:types && cpy ./src/resource/normal.d.ts ./lib/resource",
+    "build": "npm run build:lib && npm run build:types && cpy ./src/resource/schemaLegacy.d.ts ./lib/resource",
     "dev": "yarn run build:lib -w",
     "prepare": "npm run build:clean && npm run build",
     "prepublishOnly": "npm run build:bundle",


### PR DESCRIPTION
normal.d.ts was renamed to schemaLegacy.d.ts in #167, but the build script was not updated

<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #192  .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
