### PR TITLE
fix: export PromiseifyMiddleware

### DIFF
--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -17,6 +17,7 @@ import {
   useInvalidator,
   useResetter,
   ExternalCacheProvider,
+  PromiseifyMiddleware,
   NetworkErrorBoundary,
   NetworkError as OGNetworkError,
 } from './react-integration';
@@ -45,6 +46,7 @@ export {
   SuperagentResource,
   CacheProvider,
   ExternalCacheProvider,
+  PromiseifyMiddleware,
   useCache,
   useFetcher,
   useRetrieve,

--- a/packages/rest-hooks/src/react-integration/index.ts
+++ b/packages/rest-hooks/src/react-integration/index.ts
@@ -1,6 +1,6 @@
-import { CacheProvider, ExternalCacheProvider } from './provider';
 import NetworkErrorBoundary from './NetworkErrorBoundary';
 
+export * from './provider';
 export * from './hooks';
 export * from './NetworkErrorBoundary';
-export { CacheProvider, ExternalCacheProvider, NetworkErrorBoundary };
+export { NetworkErrorBoundary };

--- a/packages/rest-hooks/src/react-integration/provider/PromiseifyMiddleware.ts
+++ b/packages/rest-hooks/src/react-integration/provider/PromiseifyMiddleware.ts
@@ -1,0 +1,9 @@
+import { MiddlewareAPI, Dispatch } from '~/types';
+
+const PromiseifyMiddleware = <R extends React.Reducer<any, any>>(
+  _: MiddlewareAPI<R>,
+) => (next: Dispatch<R>) => (action: React.ReducerAction<R>): Promise<void> => {
+  next(action);
+  return Promise.resolve();
+};
+export default PromiseifyMiddleware;

--- a/packages/rest-hooks/src/react-integration/provider/index.ts
+++ b/packages/rest-hooks/src/react-integration/provider/index.ts
@@ -1,4 +1,5 @@
 import CacheProvider from './CacheProvider';
 import ExternalCacheProvider from './ExternalCacheProvider';
+import PromiseifyMiddleware from './PromiseifyMiddleware';
 
-export { CacheProvider, ExternalCacheProvider };
+export { CacheProvider, ExternalCacheProvider, PromiseifyMiddleware };

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -56,7 +56,7 @@
     "@types/react": "^16.8.2",
     "react": "^16.8.2",
     "redux": "^4.0.0",
-    "rest-hooks": "^3.0.0 || ^4.0.0-beta.0"
+    "rest-hooks": "^3.0.2 || ^4.0.0-beta.2"
   },
   "peerDependenciesMeta": {
     "redux": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -56,7 +56,7 @@
     "@types/react": "^16.8.2",
     "react": "^16.8.2",
     "redux": "^4.0.0",
-    "rest-hooks": "^3.0.2 || ^4.0.0-beta.2"
+    "rest-hooks": "^3.0.0 || ^4.0.0-beta.0"
   },
   "peerDependenciesMeta": {
     "redux": {

--- a/packages/test/src/providers.tsx
+++ b/packages/test/src/providers.tsx
@@ -5,8 +5,7 @@ import {
   ExternalCacheProvider,
   CacheProvider,
   Manager,
-  MiddlewareAPI,
-  Dispatch,
+  PromiseifyMiddleware,
 } from 'rest-hooks';
 
 // Extension of the DeepPartial type defined by Redux which handles unknown
@@ -16,13 +15,6 @@ type DeepPartialWithUnknown<T> = {
     : T[K] extends object
     ? DeepPartialWithUnknown<T[K]>
     : T[K];
-};
-
-const PromiseifyMiddleware = <R extends React.Reducer<any, any>>(
-  _: MiddlewareAPI<R>,
-) => (next: Dispatch<R>) => (action: React.ReducerAction<R>): Promise<void> => {
-  next(action);
-  return Promise.resolve();
 };
 
 let makeExternalCacheProvider: (


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #196 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The docs listed importing PromiseifyMiddleware, but this was never exported.
