### PR TITLE
fix: Add lodash types

### DIFF
--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@rest-hooks/normalizr": "^4.0.0",
+    "@types/lodash": "^4.14.149",
     "@types/superagent": "^4.1.4",
     "flux-standard-action": "^2.1.1",
     "lodash": "^4.17.15",

--- a/salus.yaml
+++ b/salus.yaml
@@ -1,3 +1,7 @@
+scanner_configs:
+  YarnAudit:
+    exclude_groups:
+    - devDependencies
 active_scanners:
   - RepoNotEmpty
   - Brakeman


### PR DESCRIPTION
If a user doesn't install their type checks can fail