### PR TITLE
docs: Add deserialization fields example

### DIFF
--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -92,7 +92,13 @@ don't use constructors.
 ### static fromJS<T extends typeof Resource>(this: T, props: Partial<AbstractInstanceType<T>>): AbstractInstanceType<T>
 
 This is used to create instances of the `Resource` you defined. Will copy over props provided to
-the instance in construction.
+the instance in construction, among other things. *Be sure to always call `super.fromJS()` when
+overriding.*
+
+Can be useful to override to:
+
+* [Deserialize fields](../guides/network-transform#deserializing-fields)
+* Add runtime field validation
 
 ## Be sure to always provide:
 

--- a/docs/guides/network-transform.md
+++ b/docs/guides/network-transform.md
@@ -49,6 +49,38 @@ abstract class CamelResource extends Resource {
 }
 ```
 
+## Deserializing fields
+
+In many cases, data sent through JSON is serialized into strings since JSON
+only has a few primitive types. Common examples include [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+for dates or even strings for decimals that require high precision ([floats can be lossy](https://floating-point-gui.de/)).
+Keeping data in the serialized form is often fine, especially if it is only being used to
+be displayed. However, this can be problematic when derived data is computed like adding time to a date
+or multiplying two numbers.
+
+In this case override the [fromJS()](../api/resource#static-fromjst-extends-typeof-resourcethis-t-props-partialabstractinstancetypet-abstractinstancetypet)
+factory method, transforming the fields you wish to change.
+
+```typescript
+class MyResource extends Resource {
+  readonly createdAt: Date | null = new Date(0);
+  readonly largeNumber = BigInt(0);
+  // other fields here
+
+  /** MyResource factory. Takes an object of properties to assign to MyResource. */
+  static fromJS<T extends typeof Resource>(
+    this: T,
+    props: Partial<AbstractInstanceType<T>>,
+  ) {
+    return super.fromJS({
+      ...props,
+      createdAt: props.createdAt ? new Date(props.createdAt) : null,
+      largeNumber: BigInt(props.largeNumber):
+    });
+  }
+}
+```
+
 ## Name calling
 
 Sometimes an API might change a key name, or choose one you don't like. Of course


### PR DESCRIPTION
Fixes #185 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Deserializing fields is a common use case when computing derived information
