### PR TITLE
fix: Tests run in node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:11.10
+      - image: circleci/node:12.13
 
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.15
+FROM node:12.13
 
 WORKDIR /app/website
 

--- a/packages/rest-hooks/src/state/__tests__/networkManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/networkManager.ts
@@ -198,9 +198,8 @@ describe('NetworkManager', () => {
       const next = jest.fn();
       const dispatch = jest.fn();
 
-      middleware({ dispatch, getState })(next)(fetchRejectAction);
       try {
-        await fetchRejectAction.payload();
+        await middleware({ dispatch, getState })(next)(fetchRejectAction);
       } catch (error) {
         expect(next).not.toHaveBeenCalled();
         expect(dispatch).toHaveBeenCalledWith({
@@ -221,16 +220,14 @@ describe('NetworkManager', () => {
 
       const dispatch = jest.fn();
 
-      middleware({ dispatch, getState })(() => Promise.resolve())({
-        ...fetchRejectAction,
-        meta: {
-          ...fetchRejectAction.meta,
-          options: { errorExpiryLength: 1234 },
-        },
-      });
-
       try {
-        await fetchRejectAction.payload();
+        await middleware({ dispatch, getState })(() => Promise.resolve())({
+          ...fetchRejectAction,
+          meta: {
+            ...fetchRejectAction.meta,
+            options: { errorExpiryLength: 1234 },
+          },
+        });
       } catch (error) {
         expect(dispatch).toHaveBeenCalled();
         const { meta } = dispatch.mock.calls[0][0];
@@ -242,16 +239,14 @@ describe('NetworkManager', () => {
 
       const dispatch = jest.fn();
 
-      middleware({ dispatch, getState })(() => Promise.resolve())({
-        ...fetchRejectAction,
-        meta: {
-          ...fetchRejectAction.meta,
-          options: { errorExpiryLength: undefined },
-        },
-      });
-
       try {
-        await fetchRejectAction.payload();
+        await middleware({ dispatch, getState })(() => Promise.resolve())({
+          ...fetchRejectAction,
+          meta: {
+            ...fetchRejectAction.meta,
+            options: { errorExpiryLength: undefined },
+          },
+        });
       } catch (error) {
         expect(dispatch).toHaveBeenCalled();
         const { meta } = dispatch.mock.calls[0][0];


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Node 12 is in LTS, people will want to run it.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Rely on async middleware api for promise resolution as batching logic is not as consistent
