### PR TITLE
feat: export SimpleRecord which has the data methods of Resource

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -4,6 +4,7 @@ title: API Reference
 
 ## Interface Definitions
 - [Resource](Resource.md)
+- [SimpleRecord](SimpleRecord.md)
 - [FetchShape](FetchShape.md)
 
 ## Hooks

--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -63,6 +63,8 @@ export default class ArticleResource extends Resource {
 `Resource` is an abstract class that will help you define the data you are working with. There are
 two sides to `Resource` - the static and instance side.
 
+`Resource` extends [SimpleRecord](./SimpleRecord)
+
 ### Static
 
 Is used to define how you retrieve and mutate data across the network. There are several
@@ -168,25 +170,6 @@ static getKey<T extends typeof Resource>(this: T) {
   return this.urlRoot;
 }
 ```
-
-## Data methods
-
-### static merge<T extends typeof Resource>(first: InstanceType<T>, second: InstanceType<T>) => InstanceType<T>
-
-Takes only the defined (non-default) values of first and second and creates a new instance copying them over.
-Second will override values of first. Merge is shallow, so you'll need to override this to do any deep merges.
-
-### static hasDefined<T extends typeof Resource>(instance: InstanceType<T>, key: keyof InstanceType<T>) => boolean
-
-Returns whether provided `key` is defined (non-default) in `instance`.
-
-### static toObjectDefined<T extends typeof Resource>(instance: AbstractInstanceType<T>) => Partial<InstanceType<T>>
-
-Returns an `Object` with only the defined (non-default) members of `instance`.
-
-### static keysDefined<T extends typeof Resource>(instance: InstanceType<T>) => (keyof InstanceType<T>)[]
-
-Returns an `Array` of all defined (non-default) keys of `instance`.
 
 ## Static network methods and properties
 

--- a/docs/api/SimpleRecord.md
+++ b/docs/api/SimpleRecord.md
@@ -1,0 +1,95 @@
+---
+title: SimpleRecord
+---
+
+`SimpleRecord` provides a simple immutable interface to store values that have
+defaults. When constructed it distinguishes between actually set values and ones
+only provided by defaults. This is useful to produce accurate merging algorithms
+when dealing with partial data definitions.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--TypeScript-->
+```typescript
+import { SimpleRecord } from 'rest-hooks';
+
+export default class Article extends SimpleRecord {
+  readonly id: number | undefined = undefined;
+  readonly title: string = '';
+  readonly content: string = '';
+  readonly author: number | null = null;
+  readonly tags: string[] = [];
+}
+```
+<!--Javascript-->
+```js
+import { SimpleRecord } from 'rest-hooks';
+
+export default class Article extends SimpleRecord {
+  id = undefined;
+  title = '';
+  content = '';
+  author = null;
+  tags = [];
+}
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--TypeScript-->
+```typescript
+const articleA = Article.fromJS({ title: 'The best library', tags: ['Immutable'] });
+const articleB = Article.fromJS({ content: 'A long droning paragraph', tags: ['React', 'TypeScript'] });
+const mergedArticle = Article.merge(articleA, articleB);
+console.log(mergedArticle);
+/*
+{
+  id: undefined,
+  title: 'The best library',
+  content: 'A long droning paragraph',
+  author: null,
+  tags: ['React', 'TypeScript'],
+}
+*/
+```
+
+<!--Javascript-->
+```js
+import { SimpleRecord } from 'rest-hooks';
+
+export default class Article extends SimpleRecord {
+  id = undefined;
+  title = '';
+  content = '';
+  author = null;
+  tags = [];
+}
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Factory method
+
+### static fromJS<T extends typeof Resource>(this: T, props: Partial<AbstractInstanceType<T>>): AbstractInstanceType<T>
+
+This is used to create instances of the `Resource` you defined. Will copy over props provided to
+the instance in construction, among other things. *Be sure to always call `super.fromJS()` when
+overriding.*
+
+## Data methods
+
+### static merge<T extends typeof Resource>(first: InstanceType<T>, second: InstanceType<T>) => InstanceType<T>
+
+Takes only the defined (non-default) values of first and second and creates a new instance copying them over.
+Second will override values of first. Merge is shallow, so you'll need to override this to do any deep merges.
+
+### static hasDefined<T extends typeof Resource>(instance: InstanceType<T>, key: keyof InstanceType<T>) => boolean
+
+Returns whether provided `key` is defined (non-default) in `instance`.
+
+### static toObjectDefined<T extends typeof Resource>(instance: AbstractInstanceType<T>) => Partial<InstanceType<T>>
+
+Returns an `Object` with only the defined (non-default) members of `instance`.
+
+### static keysDefined<T extends typeof Resource>(instance: InstanceType<T>) => (keyof InstanceType<T>)[]
+
+Returns an `Array` of all defined (non-default) keys of `instance`.

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -1,4 +1,4 @@
-import { Resource, SimpleResource } from './resource';
+import { Resource, SimpleResource, SimpleRecord } from './resource';
 import NetworkManager from './state/NetworkManager';
 import RIC from './state/RIC';
 import PollingSubscription from './state/PollingSubscription';
@@ -41,6 +41,7 @@ export * from './resource/normal';
 export {
   Resource,
   SimpleResource,
+  SimpleRecord,
   CacheProvider,
   ExternalCacheProvider,
   PromiseifyMiddleware,

--- a/packages/rest-hooks/src/react-integration/index.ts
+++ b/packages/rest-hooks/src/react-integration/index.ts
@@ -1,6 +1,5 @@
-import NetworkErrorBoundary from './NetworkErrorBoundary';
+import NetworkErrorBoundary, { NetworkError } from './NetworkErrorBoundary';
 
 export * from './provider';
 export * from './hooks';
-export * from './NetworkErrorBoundary';
-export { NetworkErrorBoundary };
+export { NetworkErrorBoundary, NetworkError };

--- a/packages/rest-hooks/src/resource/SimpleRecord.ts
+++ b/packages/rest-hooks/src/resource/SimpleRecord.ts
@@ -1,0 +1,82 @@
+import { AbstractInstanceType } from '~/types';
+
+const DefinedMembersKey = Symbol('Defined Members');
+type Filter<T, U> = T extends U ? T : never;
+interface SimpleResourceMembers<T extends typeof SimpleRecord> {
+  [DefinedMembersKey]: Filter<keyof AbstractInstanceType<T>, string>[];
+}
+
+/** Immutable record that keeps track of which members are defined vs defaults. */
+export default abstract class SimpleRecord {
+  /** Factory method. Takes an object of properties to assign. */
+  static fromJS<T extends typeof SimpleRecord>(
+    this: T,
+    props: Partial<AbstractInstanceType<T>>,
+  ) {
+    // we type guarded abstract case above, so ok to force typescript to allow constructor call
+    const instance = new (this as any)(props) as Readonly<
+      AbstractInstanceType<T>
+    >;
+
+    Object.defineProperty(instance, DefinedMembersKey, {
+      value: Object.keys(props),
+      writable: false,
+    });
+
+    Object.assign(instance, props);
+
+    // to trick normalizr into thinking we're Immutable.js does it doesn't copy
+    Object.defineProperty(instance, '__ownerID', {
+      value: 1337,
+      writable: false,
+    });
+    return instance;
+  }
+
+  /** Creates new instance copying over defined values of arguments */
+  static merge<T extends typeof SimpleRecord>(
+    this: T,
+    first: AbstractInstanceType<T>,
+    second: AbstractInstanceType<T>,
+  ) {
+    const props = Object.assign(
+      {},
+      this.toObjectDefined(first),
+      this.toObjectDefined(second),
+    );
+    return this.fromJS(props);
+  }
+
+  /** Whether key is non-default */
+  static hasDefined<T extends typeof SimpleRecord>(
+    this: T,
+    instance: AbstractInstanceType<T>,
+    key: Filter<keyof AbstractInstanceType<T>, string>,
+  ) {
+    return ((instance as any) as SimpleResourceMembers<T>)[
+      DefinedMembersKey
+    ].includes(key);
+  }
+
+  /** Returns simple object with all the non-default members */
+  static toObjectDefined<T extends typeof SimpleRecord>(
+    this: T,
+    instance: AbstractInstanceType<T>,
+  ) {
+    const defined: Partial<AbstractInstanceType<T>> = {};
+    for (const member of ((instance as any) as SimpleResourceMembers<T>)[
+      DefinedMembersKey
+    ]) {
+      defined[member] = instance[member];
+    }
+    return defined;
+  }
+
+  /** Returns array of all keys that have values defined in instance */
+  static keysDefined<T extends typeof SimpleRecord>(
+    this: T,
+    instance: AbstractInstanceType<T>,
+  ) {
+    return ((instance as any) as SimpleResourceMembers<T>)[DefinedMembersKey];
+  }
+}

--- a/packages/rest-hooks/src/resource/index.ts
+++ b/packages/rest-hooks/src/resource/index.ts
@@ -1,7 +1,8 @@
 import Resource from './Resource';
 import SimpleResource from './SimpleResource';
+import SimpleRecord from './SimpleRecord';
 export * from './shapes';
 export * from './types';
 export * from './normal';
 
-export { Resource, SimpleResource };
+export { Resource, SimpleResource, SimpleRecord };

--- a/packages/rest-hooks/src/state/PollingSubscription.ts
+++ b/packages/rest-hooks/src/state/PollingSubscription.ts
@@ -74,8 +74,9 @@ export default class PollingSubscription implements Subscription {
           this.run();
         }
       }
-      /* istanbul ignore next */
-    } else if (process.env.NODE_ENV !== 'production') {
+    } /* istanbul ignore next */ else if (
+      process.env.NODE_ENV !== 'production'
+    ) {
       console.error(
         `Mismatched remove: ${frequency} is not subscribed for ${this.url}`,
       );

--- a/packages/rest-hooks/src/state/SubscriptionManager.ts
+++ b/packages/rest-hooks/src/state/SubscriptionManager.ts
@@ -82,12 +82,12 @@ export default class SubscriptionManager<S extends SubscriptionConstructable>
     dispatch: Dispatch<any>,
   ) {
     const url = action.meta.url;
+    /* istanbul ignore else */
     if (url in this.subscriptions) {
       const empty = this.subscriptions[url].remove(action.meta.frequency);
       if (empty) {
         delete this.subscriptions[url];
       }
-      /* istanbul ignore next */
     } else if (process.env.NODE_ENV !== 'production') {
       console.error(`Mismatched unsubscribe: ${url} is not subscribed`);
     }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -46,6 +46,9 @@
       "api/resource": {
         "title": "Resource"
       },
+      "api/SimpleRecord": {
+        "title": "SimpleRecord"
+      },
       "api/SubscriptionManager": {
         "title": "SubscriptionManager<S extends SubscriptionConstructable> implements Manager",
         "sidebar_label": "SubscriptionManager"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -66,7 +66,7 @@
       {
         "type": "subcategory",
         "label": "Interface Definitions",
-        "ids": ["api/resource", "api/FetchShape"]
+        "ids": ["api/resource", "api/SimpleRecord", "api/FetchShape"]
       },
       {
         "type": "subcategory",


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Resource needs to be split up anyway, and I realized that this is one piece that already works.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Pull data methods into SimpleRecord that SimpleResource extends.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Naming....I don't really like SimpleRecord, but not sure what else to call it. I don't want to call it Record since that's a typescript generic util type.
