### PR TITLE
enhance: Resource.fetch() is no longer generic

### DIFF
--- a/docs/guides/custom-networking.md
+++ b/docs/guides/custom-networking.md
@@ -46,12 +46,7 @@ export default abstract class Resource extends SimpleResource {
   static fetchOptionsPlugin?: (options: RequestInit) => RequestInit;
 
   /** Perform network request and resolve with json body */
-  static fetch<T extends typeof Resource>(
-    this: T,
-    method: Method,
-    url: string,
-    body?: Readonly<object | string>,
-  ) {
+  static fetch(method: Method, url: string, body?: Readonly<object | string>) {
     let options: RequestInit = {
       method: method.toUpperCase(),
       headers: {
@@ -66,7 +61,7 @@ export default abstract class Resource extends SimpleResource {
         if (!response.ok) {
           throw new NetworkError(response);
         }
-        return resolveValidResponse(response);
+        return this.resolveFetchData(response);
       })
       .catch(error => {
         // ensure CORS, network down, and parse errors are still caught by NetworkErrorBoundary
@@ -76,12 +71,16 @@ export default abstract class Resource extends SimpleResource {
         throw error;
       });
   }
-}
 
-export function resolveValidResponse(res: Response) {
-  if (!res.headers.get('content-type')?.includes('json') || res.status === 204)
-    return res.text();
-  return res.json();
+  /** Resolve response into correct data type */
+  static resolveFetchData(response: Response) {
+    if (
+      !response.headers.get('content-type')?.includes('json') ||
+      response.status === 204
+    )
+      return response.text();
+    return response.json();
+  }
 }
 ```
 
@@ -106,8 +105,7 @@ export default abstract class Resource extends SimpleResource {
   static fetchPlugin?: request.Plugin;
 
   /** Perform network request and resolve with json body */
-  static fetch<T extends typeof Resource>(
-    this: T,
+  static fetch(
     method: Method,
     url: string,
     body?: Readonly<object | string>,
@@ -142,8 +140,7 @@ import axios from 'axios';
 
 export default abstract class AxiosResource extends SimpleResource {
   /** Perform network request and resolve with json body */
-  static async fetch<T extends typeof AxiosResource>(
-    this: T,
+  static async fetch(
     method: Method,
     url: string,
     body?: Readonly<object | string>

--- a/docs/guides/network-transform.md
+++ b/docs/guides/network-transform.md
@@ -31,8 +31,7 @@ function deeplyApplyKeyTransform(obj: any, transform: (key: string) => string) {
 // We can now extend CamelResource instead of Resource to build
 // all of our classes.
 abstract class CamelResource extends Resource {
-  static async fetch<T extends typeof Resource>(
-    this: T,
+  static async fetch(
     method: Method = 'get',
     url: string,
     body?: Readonly<object | string>,
@@ -96,8 +95,7 @@ class ArticleResource extends CamelResource {
   readonly title: string = '';
   readonly carrotsUsed: number = 0;
 
-  static async fetch<T extends typeof Resource>(
-    this: T,
+  static async fetch(
     method: Method = 'get',
     url: string,
     body?: Readonly<object | string>,

--- a/packages/rest-hooks/src/resource/Resource.ts
+++ b/packages/rest-hooks/src/resource/Resource.ts
@@ -22,12 +22,7 @@ export default abstract class Resource extends SimpleResource {
   static fetchOptionsPlugin?: (options: RequestInit) => RequestInit;
 
   /** Perform network request and resolve with json body */
-  static fetch<T extends typeof Resource>(
-    this: T,
-    method: Method,
-    url: string,
-    body?: Readonly<object | string>,
-  ) {
+  static fetch(method: Method, url: string, body?: Readonly<object | string>) {
     let options: RequestInit = {
       method: method.toUpperCase(),
       headers: {
@@ -42,7 +37,7 @@ export default abstract class Resource extends SimpleResource {
         if (!response.ok) {
           throw new NetworkError(response);
         }
-        return (this as any).resolveFetchData(response);
+        return this.resolveFetchData(response);
       })
       .catch(error => {
         // ensure CORS, network down, and parse errors are still caught by NetworkErrorBoundary
@@ -54,7 +49,7 @@ export default abstract class Resource extends SimpleResource {
   }
 
   /** Resolve response into correct data type */
-  static resolveFetchData?(response: Response) {
+  static resolveFetchData(response: Response) {
     if (
       !response.headers.get('content-type')?.includes('json') ||
       response.status === 204

--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -84,13 +84,16 @@ export default abstract class SimpleResource extends SimpleRecord {
   }
 
   /** Perform network request and resolve with json body */
-  static fetch<T extends typeof SimpleResource>(
-    this: T,
+  static fetch(
     method: Method,
     url: string,
     body?: Readonly<object | string>,
   ): Promise<any> {
     // typescript currently doesn't allow abstract static methods
+    throw new Error('not implemented');
+  }
+
+  static resolveFetchData(response: Response): Promise<any> {
     throw new Error('not implemented');
   }
 


### PR DESCRIPTION
BREAKING CHANGE: Remove generic signatures to any Resource.fetch()
overrides

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Generic parameters are useful if they dictate the return value, but in the case of fetch, is Promise<any> so it's completely pointless.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
