### PR TITLE
enhance: Easier to handle http fetch headers in response

### DIFF
--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -189,10 +189,14 @@ parameters.
 
 Used in [listShape()](#listshape-readshape) and [createShape()](#createshape-mutateshape)
 
-### static fetch\<T extends typeof Resource>(method: "get" | "post" | "put" | "patch" | "delete" | "options", url: string, body?: Readonly\<object | string>) => Promise\<any>
+### static fetch(method: "get" | "post" | "put" | "patch" | "delete" | "options", url: string, body?: Readonly\<object | string>) => Promise\<any>
 
 Performs the actual network fetch returning a promise that resolves to the network response or rejects
 on network error. This can be useful to override to really customize your transport.
+
+### static fetchResponse(method: "get" | "post" | "put" | "patch" | "delete" | "options", url: string, body?: Readonly\<object | string>) => Promise\<Response>
+
+Used in `fetch()`. Resolves the HTTP [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
 ### static getEntitySchema() => [schema.Entity](https://github.com/ntucker/normalizr/blob/master/docs/api.md#entitykey-definition---options--)
 

--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -47,22 +47,20 @@ export default abstract class SimpleResource extends SimpleRecord {
    */
   static url<T extends typeof SimpleResource>(
     this: T,
-    urlParams?: Partial<AbstractInstanceType<T>>,
+    urlParams: Partial<AbstractInstanceType<T>>,
   ): string {
-    if (urlParams) {
-      if (
-        Object.prototype.hasOwnProperty.call(urlParams, 'url') &&
-        urlParams.url &&
-        typeof urlParams.url === 'string'
-      ) {
-        return urlParams.url;
+    if (
+      Object.prototype.hasOwnProperty.call(urlParams, 'url') &&
+      urlParams.url &&
+      typeof urlParams.url === 'string'
+    ) {
+      return urlParams.url;
+    }
+    if (this.pk(urlParams) !== undefined) {
+      if (this.urlRoot.endsWith('/')) {
+        return `${this.urlRoot}${this.pk(urlParams)}`;
       }
-      if (this.pk(urlParams) !== null) {
-        if (this.urlRoot.endsWith('/')) {
-          return `${this.urlRoot}${this.pk(urlParams)}`;
-        }
-        return `${this.urlRoot}/${this.pk(urlParams)}`;
-      }
+      return `${this.urlRoot}/${this.pk(urlParams)}`;
     }
     return this.urlRoot;
   }
@@ -73,9 +71,9 @@ export default abstract class SimpleResource extends SimpleRecord {
    */
   static listUrl<T extends typeof SimpleResource>(
     this: T,
-    searchParams?: Readonly<Record<string, string | number>>,
+    searchParams: Readonly<Record<string, string | number>> = {},
   ): string {
-    if (searchParams && Object.keys(searchParams).length) {
+    if (Object.keys(searchParams).length) {
       const params = new URLSearchParams(searchParams as any);
       params.sort();
       return `${this.urlRoot}?${params.toString()}`;
@@ -93,7 +91,13 @@ export default abstract class SimpleResource extends SimpleRecord {
     throw new Error('not implemented');
   }
 
-  static resolveFetchData(response: Response): Promise<any> {
+  /** Perform network request and resolve with HTTP Response */
+  static fetchResponse(
+    method: Method,
+    url: string,
+    body?: Readonly<object | string>,
+  ): Promise<Response> {
+    // typescript currently doesn't allow abstract static methods
     throw new Error('not implemented');
   }
 


### PR DESCRIPTION
BREAKING CHANGE:
* url() and listUrl() params are no longer optional
* Removed resolveFetchData() in favor of fetchResponse().
  * fetch() now calls fetchResponse()
  * This means custom use of Response can be achieved by calling
fetchResponse() in custom FetchShape.fetch

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Custom use of Response like for grabbing headers tends to be on a per-shape basis. This design better suites building custom fetch() functions for FetchShape.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
