### PR TITLE
feat: Support string schemas

### DIFF
--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -17,6 +17,16 @@ describe('normalize', () => {
     expect(() => normalize(null, mySchema)).toThrow(/null/);
   });
 
+  test('can normalize string', () => {
+    const mySchema = '';
+    expect(normalize('bob', mySchema)).toMatchInlineSnapshot(`
+      Object {
+        "entities": Object {},
+        "result": "bob",
+      }
+    `);
+  });
+
   test('normalizes entities', () => {
     const mySchema = new schema.Entity('tacos');
 
@@ -212,6 +222,10 @@ describe('denormalize', () => {
 
   test('returns the input if undefined', () => {
     expect(denormalize(undefined, {}, {})).toEqual([undefined, false]);
+  });
+
+  test('returns the input if string', () => {
+    expect(denormalize('bob', '', {})).toEqual(['bob', true]);
   });
 
   test('denormalizes entities', () => {

--- a/packages/normalizr/src/index.d.ts
+++ b/packages/normalizr/src/index.d.ts
@@ -346,7 +346,11 @@ export type NormalizeNullable<S> = S extends schema.SchemaClass
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface SchemaArray extends Array<Schema> {}
 
-export type Schema = { [K: string]: any } | SchemaArray | schema.SchemaClass;
+export type Schema =
+  | string
+  | { [K: string]: any }
+  | SchemaArray
+  | schema.SchemaClass;
 
 export type NormalizedSchema<E, R> = { entities: E; result: R };
 

--- a/packages/normalizr/src/index.js
+++ b/packages/normalizr/src/index.js
@@ -68,11 +68,11 @@ export const schema = {
 };
 
 export const normalize = (input, schema) => {
-  if (!input || typeof input !== 'object') {
+  if (input === null || typeof input !== typeof schema) {
     throw new Error(
-      `Unexpected input given to normalize. Expected type to be "object", found "${
-        input === null ? 'null' : typeof input
-      }".`,
+      `Unexpected input given to normalize. Expected type to be "${
+        schema === null ? 'null' : typeof schema
+      }", found "${input === null ? 'null' : typeof input}".`,
     );
   }
 


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #215.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Sometimes APIs have very simple responses. Let's not ban simple strings.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Update types
- Add tests
- Handle strings - even empty ones

Example usage:

```typescript
static updateShape() {
  return {
    ...super.updateShape(),
    schema: '',
  };
}
```