### PR TITLE
enhance: Polling subscriptions handle offline/online

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -1,0 +1,23 @@
+export function mockEventHandlers() {
+  const eventMap: {
+    [k: string]: Set<EventListener>;
+  } = {};
+  window.addEventListener = jest.fn((event, cb) => {
+    if (!(event in eventMap)) {
+      eventMap[event] = new Set();
+    }
+    eventMap[event].add(cb as any);
+  });
+  window.removeEventListener = jest.fn((event, cb) => {
+    if (event in eventMap) {
+      eventMap[event].delete(cb as any);
+    }
+  });
+  const triggerEvent = (name: string, event: Event) => {
+    if (eventMap[name] === undefined) return;
+    for (const cb of eventMap[name]) {
+      cb(event);
+    }
+  };
+  return triggerEvent;
+}

--- a/docs/api/PollingSubscription.md
+++ b/docs/api/PollingSubscription.md
@@ -7,7 +7,7 @@ hide_title: true
 # PollingSubscription implements [Subscription](./SubscriptionManager.md)
 
 Will dispatch a `fetch` action at the minimum interval of all subscriptions to this
-resource.
+resource. Pauses when offline. Immediately fetches when online status returns.
 
 ```tsx
 import { SubscriptionManager, PollingSubscription, CacheProvider } from 'rest-hooks';

--- a/packages/rest-hooks/src/state/__tests__/isOnline.ts
+++ b/packages/rest-hooks/src/state/__tests__/isOnline.ts
@@ -1,0 +1,16 @@
+import isOnline from '../isOnline';
+
+describe('isOnline', () => {
+  it('should be true when navigator is not set', () => {
+    const oldValue = navigator.onLine;
+    Object.defineProperty(navigator, 'onLine', {
+      value: undefined,
+      writable: true,
+    });
+    expect(isOnline()).toBe(true);
+    Object.defineProperty(navigator, 'onLine', {
+      value: oldValue,
+      writable: false,
+    });
+  });
+});

--- a/packages/rest-hooks/src/state/isOnline.ts
+++ b/packages/rest-hooks/src/state/isOnline.ts
@@ -1,0 +1,6 @@
+export default function isOnline(): boolean {
+  if (navigator.onLine !== undefined) {
+    return navigator.onLine;
+  }
+  return true;
+}


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Fetching while offline is not only wasteful, it will result in a perfectly working website turning into network errors.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Listen to online/offline events.
- When going online immediately dispatch a fetch.