### PR TITLE
enhance: Immediately fetch polling subscriptions

### DIFF
--- a/packages/rest-hooks/src/state/PollingSubscription.ts
+++ b/packages/rest-hooks/src/state/PollingSubscription.ts
@@ -31,6 +31,7 @@ export default class PollingSubscription implements Subscription {
     this.url = url;
     this.frequencyHistogram.set(this.frequency, 1);
     this.dispatch = dispatch;
+    if (isOnline()) this.update();
     this.run();
   }
 

--- a/packages/rest-hooks/src/state/__tests__/pollingSubscription.ts
+++ b/packages/rest-hooks/src/state/__tests__/pollingSubscription.ts
@@ -47,11 +47,12 @@ describe('PollingSubscription', () => {
     ).toThrow();
   });
 
-  it('should not call immediately', () => {
-    expect(dispatch.mock.calls.length).toBe(0);
+  it('should call immediately', () => {
+    expect(dispatch.mock.calls.length).toBe(1);
   });
 
   it('should call after period', () => {
+    dispatch.mockReset();
     jest.advanceTimersByTime(5000);
     expect(dispatch.mock.calls.length).toBe(1);
     expect(dispatch.mock.calls[0]).toMatchSnapshot();

--- a/website/versioned_docs/version-4.0/api/PollingSubscription.md
+++ b/website/versioned_docs/version-4.0/api/PollingSubscription.md
@@ -2,6 +2,8 @@
 title: PollingSubscription implements Subscription
 sidebar_label: PollingSubscription
 hide_title: true
+id: version-4.0-PollingSubscription
+original_id: PollingSubscription
 ---
 
 # PollingSubscription implements [Subscription](./SubscriptionManager.md)


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
When following fetch-then-render pattern, this can simplify usage as a useRetrieve() will not longer be needed together. Is fine to use in conjunction with useResource() since fetches are all deduped.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Immediately call fetch for new subscriptions if online.
