### PR TITLE
fix: Import @rest-hooks/normalizr properly

### DIFF
--- a/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
@@ -8,16 +8,16 @@ import {
   ArticleResourceWithOtherListUrl,
   StaticArticleResource,
 } from '__tests__/common';
+import {
+  makeRenderRestHook,
+  makeCacheProvider,
+  mockInitialState,
+} from '@rest-hooks/test';
 
 import { DispatchContext, StateContext } from '../context';
 import { useFetcher, useRetrieve, useInvalidator, useResetter } from '../hooks';
 import { initialState } from '../../state/reducer';
 import { State, ActionTypes } from '../../types';
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  mockInitialState,
-} from '../../../../test';
 import { users, articlesPages, payload } from './fixtures';
 
 async function testDispatchFetch(

--- a/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
@@ -6,13 +6,13 @@ import {
   PaginatedArticleResource,
   UserResource,
 } from '__tests__/common';
-
-import { useResource, useFetcher } from '../hooks';
 import {
   makeRenderRestHook,
   makeCacheProvider,
   makeExternalCacheProvider,
-} from '../../../../test';
+} from '@rest-hooks/test';
+
+import { useResource, useFetcher } from '../hooks';
 import {
   payload,
   createPayload,

--- a/packages/rest-hooks/src/react-integration/__tests__/subscriptions.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/subscriptions.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import nock from 'nock';
 import { PollingArticleResource } from '__tests__/common';
-
-import { useSubscription, useCache } from '../hooks';
 import {
   makeCacheProvider,
   makeExternalCacheProvider,
   makeRenderRestHook,
-} from '../../../../test';
+} from '@rest-hooks/test';
+
+import { useSubscription, useCache } from '../hooks';
 import { DispatchContext } from '../context';
 
 let mynock: nock.Scope;

--- a/packages/rest-hooks/src/react-integration/__tests__/useCache.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/useCache.tsx
@@ -3,9 +3,9 @@ import {
   CoolerArticleResource,
   PaginatedArticleResource,
 } from '__tests__/common';
+import { makeRenderRestHook, makeCacheProvider } from '@rest-hooks/test';
 
 import { useCache } from '../hooks';
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
 import { articlesPages, payload } from './fixtures';
 
 describe('useCache()', () => {

--- a/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
@@ -6,15 +6,15 @@ import {
   UserResource,
   InvalidIfStaleArticleResource,
 } from '__tests__/common';
-
-import { normalize } from '../../resource';
-import { DispatchContext, StateContext } from '../context';
-import { useResource } from '../hooks';
 import {
   makeRenderRestHook,
   makeCacheProvider,
   mockInitialState,
-} from '../../../../test';
+} from '@rest-hooks/test';
+
+import { normalize } from '../../resource';
+import { DispatchContext, StateContext } from '../context';
+import { useResource } from '../hooks';
 import { payload, users, nested } from './fixtures';
 
 async function testDispatchFetch(

--- a/packages/rest-hooks/tsconfig.compile.json
+++ b/packages/rest-hooks/tsconfig.compile.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig",
-  "paths": {
-    "~/*": ["packages/rest-hooks/src/*"],
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["packages/rest-hooks/src/*"]
+    }
   },
   "exclude": ["node_modules", "dist", "lib", "**/__tests__"]
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Ambient libs for rest-hooks package were importing normalizr using relative path rather than library @rest-hooks/normalizr

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Move tsconfig.compile.json path into 'compilerOptions' as that is it's location.
- Make test imports non-relative as well
