### PR TITLE
fix: Make SubscriptionManager type compatible with redux-toolkit

### DIFF
--- a/packages/rest-hooks/src/state/SubscriptionManager.ts
+++ b/packages/rest-hooks/src/state/SubscriptionManager.ts
@@ -104,10 +104,10 @@ export default class SubscriptionManager<S extends SubscriptionConstructable>
    *
    */
   getMiddleware<T extends SubscriptionManager<S>>(this: T) {
-    return <R extends React.Reducer<any, A>, A extends Actions>({
+    return <R extends React.Reducer<any, any>>({
       dispatch,
     }: MiddlewareAPI<R>) => {
-      return (next: Dispatch<R>) => (action: Actions) => {
+      return (next: Dispatch<R>) => (action: React.ReducerAction<R>) => {
         switch (action.type) {
           case 'rest-hooks/subscribe':
             this.handleSubscribe(action, dispatch);


### PR DESCRIPTION
Fixes #234 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
[Redux-toolkit](https://redux-toolkit.js.org/) is a fairly popular way to use redux

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Loosen types to be more flexible on actions.