### PR TITLE
enhance: Centralize action type string definitions

### DIFF
--- a/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
@@ -18,7 +18,7 @@ import {
 import { DispatchContext, StateContext } from '../context';
 import { useFetcher, useRetrieve, useInvalidator, useResetter } from '../hooks';
 import { initialState } from '../../state/reducer';
-import { State, ActionTypes } from '../../types';
+import { State, ActionTypes, INVALIDATE_TYPE, RESET_TYPE } from '../../types';
 import { users, articlesPages, payload } from './fixtures';
 
 async function testDispatchFetch(
@@ -219,7 +219,7 @@ describe('useInvalidate', () => {
     );
     invalidate({});
     expect(dispatch).toHaveBeenCalledWith({
-      type: 'rest-hooks/invalidate',
+      type: INVALIDATE_TYPE,
       meta: {
         url: 'GET http://test.com/article-paginated/',
       },
@@ -260,7 +260,7 @@ describe('useResetter', () => {
     );
     reset({});
     expect(dispatch).toHaveBeenCalledWith({
-      type: 'rest-hooks/reset',
+      type: RESET_TYPE,
     });
   });
   it('should return the same === function each time', () => {

--- a/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
@@ -1,6 +1,14 @@
 import { useContext, useRef, useCallback } from 'react';
 
-import { FetchAction, UpdateFunction } from '~/types';
+import {
+  FetchAction,
+  UpdateFunction,
+  RECEIVE_DELETE_TYPE,
+  RECEIVE_MUTATE_TYPE,
+  RECEIVE_TYPE,
+  ReceiveTypes,
+  FETCH_TYPE,
+} from '~/types';
 import {
   FetchShape,
   DeleteShape,
@@ -14,11 +22,11 @@ import { DispatchContext } from '~/react-integration/context';
 
 const SHAPE_TYPE_TO_RESPONSE_TYPE: Record<
   FetchShape<any, any, any>['type'],
-  'rest-hooks/receive' | 'rest-hooks/rpc' | 'rest-hooks/purge'
+  ReceiveTypes
 > = {
-  read: 'rest-hooks/receive',
-  mutate: 'rest-hooks/rpc',
-  delete: 'rest-hooks/purge',
+  read: RECEIVE_TYPE,
+  mutate: RECEIVE_MUTATE_TYPE,
+  delete: RECEIVE_DELETE_TYPE,
 };
 
 type OptimisticUpdateParams<
@@ -103,7 +111,7 @@ export default function useFetcher<
       }
 
       dispatch({
-        type: 'rest-hooks/fetch',
+        type: FETCH_TYPE,
         payload: () => fetch(params, body),
         meta,
       });

--- a/packages/rest-hooks/src/react-integration/hooks/useInvalidator.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useInvalidator.ts
@@ -2,6 +2,7 @@ import { useContext, useCallback, useRef } from 'react';
 
 import { ReadShape, Schema } from '~/resource';
 import { DispatchContext } from '~/react-integration/context';
+import { INVALIDATE_TYPE } from '~/types';
 
 /** Invalidate a certain item within the cache */
 export default function useInvalidator<
@@ -16,7 +17,7 @@ export default function useInvalidator<
     (params: Params | null) => {
       if (!params) return;
       dispatch({
-        type: 'rest-hooks/invalidate',
+        type: INVALIDATE_TYPE,
         meta: {
           url: getFetchKeyRef.current(params),
         },

--- a/packages/rest-hooks/src/react-integration/hooks/useResetter.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useResetter.ts
@@ -1,6 +1,7 @@
 import { useContext, useCallback } from 'react';
 
 import { DispatchContext } from '~/react-integration/context';
+import { RESET_TYPE } from '~/types';
 
 /** Returns a function to completely clear the cache of all entries */
 export default function useResetter(): () => void {
@@ -8,7 +9,7 @@ export default function useResetter(): () => void {
 
   const resetDispatcher = useCallback(() => {
     dispatch({
-      type: 'rest-hooks/reset',
+      type: RESET_TYPE,
     });
   }, [dispatch]);
 

--- a/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
@@ -2,6 +2,7 @@ import { useContext, useEffect, useRef } from 'react';
 
 import { DispatchContext } from '~/react-integration/context';
 import { ReadShape, Schema } from '~/resource';
+import { SUBSCRIBE_TYPE, UNSUBSCRIBE_TYPE } from '~/types';
 
 /** Keeps a resource fresh by subscribing to updates. */
 export default function useSubscription<
@@ -25,7 +26,7 @@ export default function useSubscription<
     const url = getFetchKey(params);
 
     dispatch({
-      type: 'rest-hooks/subscribe',
+      type: SUBSCRIBE_TYPE,
       meta: {
         schema,
         fetch: () => fetch(params),
@@ -35,7 +36,7 @@ export default function useSubscription<
     });
     return () => {
       dispatch({
-        type: 'rest-hooks/unsubscribe',
+        type: UNSUBSCRIBE_TYPE,
         meta: {
           url,
           frequency: options && options.pollFrequency,

--- a/packages/rest-hooks/src/react-integration/provider/__tests__/provider.tsx
+++ b/packages/rest-hooks/src/react-integration/provider/__tests__/provider.tsx
@@ -7,6 +7,7 @@ import CacheProvider from '../CacheProvider';
 import NetworkManager from '../../../state/NetworkManager';
 import SubscriptionManager from '../../../state/SubscriptionManager';
 import PollingSubscription from '../../../state/PollingSubscription';
+import { RECEIVE_TYPE } from '~/types';
 
 describe('<CacheProvider />', () => {
   it('should not change dispatch function on re-render', () => {
@@ -58,7 +59,7 @@ describe('<CacheProvider />', () => {
     expect(dispatch).toBeDefined();
     expect(state).toBeDefined();
     const action = {
-      type: 'rest-hooks/receive',
+      type: RECEIVE_TYPE,
       payload: { id: 5, title: 'hi', content: 'more things here' },
       meta: {
         schema: CoolerArticleResource.getEntitySchema(),

--- a/packages/rest-hooks/src/state/NetworkManager.ts
+++ b/packages/rest-hooks/src/state/NetworkManager.ts
@@ -9,6 +9,11 @@ import {
   Manager,
   PurgeAction,
   Dispatch,
+  RECEIVE_TYPE,
+  RECEIVE_MUTATE_TYPE,
+  RECEIVE_DELETE_TYPE,
+  FETCH_TYPE,
+  RESET_TYPE,
 } from '~/types';
 import { RPCAction } from '..';
 
@@ -84,7 +89,11 @@ export default class NetworkManager implements Manager {
             date: now,
             expiresAt: now + dataExpiryLength,
           };
-          if (['rest-hooks/receive', 'rest-hooks/rpc'].includes(responseType)) {
+          if (
+            ([RECEIVE_TYPE, RECEIVE_MUTATE_TYPE] as string[]).includes(
+              responseType,
+            )
+          ) {
             meta.updaters = updaters;
           }
           dispatch({
@@ -154,19 +163,19 @@ export default class NetworkManager implements Manager {
         action: React.ReducerAction<R>,
       ): Promise<void> => {
         switch (action.type) {
-          case 'rest-hooks/fetch':
+          case FETCH_TYPE:
             this.handleFetch(action, dispatch);
             return Promise.resolve();
-          case 'rest-hooks/purge':
-          case 'rest-hooks/rpc':
-          case 'rest-hooks/receive':
+          case RECEIVE_DELETE_TYPE:
+          case RECEIVE_MUTATE_TYPE:
+          case RECEIVE_TYPE:
             // only receive after new state is computed
             return next(action).then(() => {
               if (action.meta.url in this.fetched) {
                 this.handleReceive(action);
               }
             });
-          case 'rest-hooks/reset':
+          case RESET_TYPE:
             this.cleanup();
             return next(action);
           default:

--- a/packages/rest-hooks/src/state/PollingSubscription.ts
+++ b/packages/rest-hooks/src/state/PollingSubscription.ts
@@ -2,7 +2,7 @@ import { Subscription, SubscriptionInit } from './SubscriptionManager';
 import isOnline from './isOnline';
 
 import { Schema } from '~/resource';
-import { Dispatch } from '~/types';
+import { Dispatch, FETCH_TYPE, RECEIVE_TYPE } from '~/types';
 
 /**
  * PollingSubscription keeps a given resource updated by
@@ -104,12 +104,12 @@ export default class PollingSubscription implements Subscription {
   /** Trigger request for latest resource */
   protected update() {
     this.dispatch({
-      type: 'rest-hooks/fetch',
+      type: FETCH_TYPE,
       payload: this.fetch,
       meta: {
         schema: this.schema,
         url: this.url,
-        responseType: 'rest-hooks/receive',
+        responseType: RECEIVE_TYPE,
         throttle: true,
         options: {
           dataExpiryLength: this.frequency / 2,

--- a/packages/rest-hooks/src/state/SubscriptionManager.ts
+++ b/packages/rest-hooks/src/state/SubscriptionManager.ts
@@ -6,6 +6,8 @@ import {
   UnsubscribeAction,
   Manager,
   Dispatch,
+  SUBSCRIBE_TYPE,
+  UNSUBSCRIBE_TYPE,
 } from '~/types';
 import { Schema } from '~/resource';
 
@@ -109,10 +111,10 @@ export default class SubscriptionManager<S extends SubscriptionConstructable>
     }: MiddlewareAPI<R>) => {
       return (next: Dispatch<R>) => (action: React.ReducerAction<R>) => {
         switch (action.type) {
-          case 'rest-hooks/subscribe':
+          case SUBSCRIBE_TYPE:
             this.handleSubscribe(action, dispatch);
             return Promise.resolve();
-          case 'rest-hooks/unsubscribe':
+          case UNSUBSCRIBE_TYPE:
             this.handleUnsubscribe(action, dispatch);
             return Promise.resolve();
           default:

--- a/packages/rest-hooks/src/state/__tests__/networkManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/networkManager.ts
@@ -1,7 +1,14 @@
 import { ArticleResource } from '__tests__/common';
 
 import NetworkManager from '../NetworkManager';
-import { FetchAction, ResetAction } from '../../types';
+import {
+  FetchAction,
+  ResetAction,
+  FETCH_TYPE,
+  RECEIVE_TYPE,
+  RECEIVE_MUTATE_TYPE,
+  RESET_TYPE,
+} from '../../types';
 
 describe('NetworkManager', () => {
   const manager = new NetworkManager();
@@ -41,12 +48,12 @@ describe('NetworkManager', () => {
   });
   describe('middleware', () => {
     const fetchResolveAction: FetchAction = {
-      type: 'rest-hooks/fetch',
+      type: FETCH_TYPE,
       payload: () => Promise.resolve({ id: 5, title: 'hi' }),
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.url({ id: 5 }),
-        responseType: 'rest-hooks/receive',
+        responseType: RECEIVE_TYPE,
         throttle: false,
         reject: (v: any) => null,
         resolve: (v: any) => null,
@@ -68,16 +75,16 @@ describe('NetworkManager', () => {
       ...fetchReceiveWithUpdatersAction,
       meta: {
         ...fetchReceiveWithUpdatersAction.meta,
-        responseType: 'rest-hooks/rpc',
+        responseType: RECEIVE_MUTATE_TYPE,
       },
     };
     const fetchRejectAction: FetchAction = {
-      type: 'rest-hooks/fetch',
+      type: FETCH_TYPE,
       payload: () => Promise.reject(new Error('Failed')),
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.url({ id: 5 }),
-        responseType: 'rest-hooks/receive',
+        responseType: RECEIVE_TYPE,
         throttle: false,
         reject: (v: any) => null,
         resolve: (v: any) => null,
@@ -255,7 +262,7 @@ describe('NetworkManager', () => {
       }
     });
     it('should reject current promises on rest-hooks/reset', async () => {
-      const resetAction: ResetAction = { type: 'rest-hooks/reset' };
+      const resetAction: ResetAction = { type: RESET_TYPE };
       const manager = new NetworkManager(42, 7);
       const middleware = manager.getMiddleware();
       let rejection: any;
@@ -271,12 +278,12 @@ describe('NetworkManager', () => {
       });
 
       const fetchResolveAction: FetchAction = {
-        type: 'rest-hooks/fetch',
+        type: FETCH_TYPE,
         payload: () => promise,
         meta: {
           schema: ArticleResource.getEntitySchema(),
           url: ArticleResource.url({ id: 5 }),
-          responseType: 'rest-hooks/receive',
+          responseType: RECEIVE_TYPE,
           throttle: true,
           resolve,
           reject,

--- a/packages/rest-hooks/src/state/__tests__/reducer.ts
+++ b/packages/rest-hooks/src/state/__tests__/reducer.ts
@@ -13,6 +13,12 @@ import {
   ResetAction,
   InvalidateAction,
   UpdateFunction,
+  RECEIVE_TYPE,
+  RECEIVE_MUTATE_TYPE,
+  RECEIVE_DELETE_TYPE,
+  INVALIDATE_TYPE,
+  FETCH_TYPE,
+  RESET_TYPE,
 } from '../../types';
 
 describe('reducer', () => {
@@ -20,7 +26,7 @@ describe('reducer', () => {
     const id = 20;
     const payload = { id, title: 'hi', content: 'this is the content' };
     const action: ReceiveAction<typeof payload> = {
-      type: 'rest-hooks/receive',
+      type: RECEIVE_TYPE,
       payload,
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -77,7 +83,7 @@ describe('reducer', () => {
     const id = 20;
     const payload = { id, title: 'hi', content: 'this is the content' };
     const action: RPCAction = {
-      type: 'rest-hooks/rpc',
+      type: RECEIVE_MUTATE_TYPE,
       payload,
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -95,7 +101,7 @@ describe('reducer', () => {
   it('purge should delete entities', () => {
     const id = 20;
     const action: PurgeAction = {
-      type: 'rest-hooks/purge',
+      type: RECEIVE_DELETE_TYPE,
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: id.toString(),
@@ -139,7 +145,7 @@ describe('reducer', () => {
         },
       ) {
         return {
-          type: 'rest-hooks/receive' as const,
+          type: RECEIVE_TYPE,
           payload,
           meta: {
             schema: PaginatedArticleResource.listShape().schema,
@@ -226,7 +232,7 @@ describe('reducer', () => {
         },
       ) {
         return {
-          type: 'rest-hooks/rpc' as const,
+          type: RECEIVE_MUTATE_TYPE,
           payload,
           meta: {
             schema: ArticleResource.getEntitySchema(),
@@ -316,7 +322,7 @@ describe('reducer', () => {
   it('invalidates resources correctly', () => {
     const id = 20;
     const action: InvalidateAction = {
-      type: 'rest-hooks/invalidate',
+      type: INVALIDATE_TYPE,
       meta: {
         url: id.toString(),
       },
@@ -354,7 +360,7 @@ describe('reducer', () => {
     const id = 20;
     const error = new Error('hi');
     const action: ReceiveAction = {
-      type: 'rest-hooks/receive',
+      type: RECEIVE_TYPE,
       payload: error,
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -376,7 +382,7 @@ describe('reducer', () => {
     const id = 20;
     const error = new Error('hi');
     const action: RPCAction = {
-      type: 'rest-hooks/rpc',
+      type: RECEIVE_MUTATE_TYPE,
       payload: error,
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -396,7 +402,7 @@ describe('reducer', () => {
     const id = 20;
     const error = new Error('hi');
     const action: PurgeAction = {
-      type: 'rest-hooks/purge',
+      type: RECEIVE_DELETE_TYPE,
       payload: error,
       meta: {
         schema: ArticleResource.getEntitySchema(),
@@ -421,12 +427,12 @@ describe('reducer', () => {
   it('rest-hooks/fetch should console.warn()', () => {
     global.console.warn = jest.fn();
     const action: FetchAction = {
-      type: 'rest-hooks/fetch',
+      type: FETCH_TYPE,
       payload: () => new Promise<any>(() => null),
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.url({ id: 5 }),
-        responseType: 'rest-hooks/rpc',
+        responseType: RECEIVE_MUTATE_TYPE,
         throttle: true,
         reject: (v: any) => null,
         resolve: (v: any) => null,
@@ -455,7 +461,7 @@ describe('reducer', () => {
   });
   it('reset should delete all entries', () => {
     const action: ResetAction = {
-      type: 'rest-hooks/reset',
+      type: RESET_TYPE,
     };
     const iniState: any = {
       entities: {

--- a/packages/rest-hooks/src/state/__tests__/subscriptionManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/subscriptionManager.ts
@@ -1,7 +1,13 @@
 import { PollingArticleResource } from '__tests__/common';
 
 import SubscriptionManager, { Subscription } from '../SubscriptionManager';
-import { SubscribeAction, UnsubscribeAction } from '../../types';
+import {
+  SubscribeAction,
+  UnsubscribeAction,
+  UNSUBSCRIBE_TYPE,
+  SUBSCRIBE_TYPE,
+  RECEIVE_TYPE,
+} from '../../types';
 
 function onError(e: any) {
   e.preventDefault();
@@ -50,7 +56,7 @@ describe('SubscriptionManager', () => {
         ? () => Promise.reject(new Error('Failed'))
         : () => Promise.resolve(payload);
       return {
-        type: 'rest-hooks/subscribe',
+        type: SUBSCRIBE_TYPE,
         meta: {
           schema: PollingArticleResource.getEntitySchema(),
           url: PollingArticleResource.url(payload),
@@ -61,7 +67,7 @@ describe('SubscriptionManager', () => {
     }
     function createUnsubscribeAction(payload: {}): UnsubscribeAction {
       return {
-        type: 'rest-hooks/unsubscribe',
+        type: UNSUBSCRIBE_TYPE,
         meta: {
           url: PollingArticleResource.url(payload),
           frequency: 1000,
@@ -154,7 +160,7 @@ describe('SubscriptionManager', () => {
     });
 
     it('should let other actions pass through', () => {
-      const action = { type: 'rest-hooks/receive' };
+      const action = { type: RECEIVE_TYPE };
       next.mockReset();
 
       middleware({ dispatch, getState })(next)(action as any);

--- a/packages/rest-hooks/src/state/reducer.ts
+++ b/packages/rest-hooks/src/state/reducer.ts
@@ -2,7 +2,16 @@ import mergeDeepCopy from './merge/mergeDeepCopy';
 import applyUpdatersToResults from './applyUpdatersToResults';
 
 import { normalize } from '~/resource';
-import { ActionTypes, State } from '~/types';
+import {
+  ActionTypes,
+  State,
+  RECEIVE_TYPE,
+  RECEIVE_MUTATE_TYPE,
+  RECEIVE_DELETE_TYPE,
+  INVALIDATE_TYPE,
+  RESET_TYPE,
+  FETCH_TYPE,
+} from '~/types';
 
 export const initialState: State<unknown> = {
   entities: {},
@@ -16,7 +25,7 @@ export default function reducer(
 ): State<unknown> {
   if (!state) state = initialState;
   switch (action.type) {
-    case 'rest-hooks/receive': {
+    case RECEIVE_TYPE: {
       if (action.error) {
         return {
           ...state,
@@ -51,7 +60,7 @@ export default function reducer(
         },
       };
     }
-    case 'rest-hooks/rpc': {
+    case RECEIVE_MUTATE_TYPE: {
       if (action.error) return state;
       const { entities, result } = normalize(
         action.payload,
@@ -68,7 +77,7 @@ export default function reducer(
         results,
       };
     }
-    case 'rest-hooks/purge': {
+    case RECEIVE_DELETE_TYPE: {
       if (action.error) return state;
       const key = action.meta.schema.key;
       const pk = action.meta.url;
@@ -78,7 +87,7 @@ export default function reducer(
         entities,
       };
     }
-    case 'rest-hooks/invalidate':
+    case INVALIDATE_TYPE:
       return {
         ...state,
         meta: {
@@ -89,15 +98,12 @@ export default function reducer(
           },
         },
       };
-    case 'rest-hooks/reset':
+    case RESET_TYPE:
       return initialState;
 
     default:
       // If 'fetch' action reaches the reducer there are no middlewares installed to handle it
-      if (
-        process.env.NODE_ENV !== 'production' &&
-        action.type === 'rest-hooks/fetch'
-      ) {
+      if (process.env.NODE_ENV !== 'production' && action.type === FETCH_TYPE) {
         console.warn(
           'Reducer recieved fetch action - you are likely missing the NetworkManager middleware',
         );


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- This ensures type-enforceability against any potential typos.
- This also allows minifiers to reduce bundle size.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Put all action type strings at the top of types.ts file.
This also exports the action types. (This increases bundle size for non-es case, but also makes easier to build custom managers)


#### New exports:

```typescript
export const FETCH_TYPE = 'rest-hooks/fetch' as const;
export const RECEIVE_TYPE = 'rest-hooks/receive' as const;
export const RECEIVE_MUTATE_TYPE = 'rest-hooks/rpc' as const;
export const RECEIVE_DELETE_TYPE = 'rest-hooks/purge' as const;
export const RESET_TYPE = 'rest-hooks/reset' as const;
export const SUBSCRIBE_TYPE = 'rest-hooks/subscribe' as const;
export const UNSUBSCRIBE_TYPE = 'rest-hook/unsubscribe' as const;
export const INVALIDATE_TYPE = 'rest-hooks/invalidate' as const;

export type ReceiveTypes =
  | typeof RECEIVE_TYPE
  | typeof RECEIVE_MUTATE_TYPE
  | typeof RECEIVE_DELETE_TYPE;
```
