### PR TITLE
enhance: Don't export action types

### DIFF
--- a/packages/rest-hooks/src/actionTypes.ts
+++ b/packages/rest-hooks/src/actionTypes.ts
@@ -1,0 +1,8 @@
+export const FETCH_TYPE = 'rest-hooks/fetch' as const;
+export const RECEIVE_TYPE = 'rest-hooks/receive' as const;
+export const RECEIVE_MUTATE_TYPE = 'rest-hooks/rpc' as const;
+export const RECEIVE_DELETE_TYPE = 'rest-hooks/purge' as const;
+export const RESET_TYPE = 'rest-hooks/reset' as const;
+export const SUBSCRIBE_TYPE = 'rest-hooks/subscribe' as const;
+export const UNSUBSCRIBE_TYPE = 'rest-hook/unsubscribe' as const;
+export const INVALIDATE_TYPE = 'rest-hooks/invalidate' as const;

--- a/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
@@ -18,7 +18,8 @@ import {
 import { DispatchContext, StateContext } from '../context';
 import { useFetcher, useRetrieve, useInvalidator, useResetter } from '../hooks';
 import { initialState } from '../../state/reducer';
-import { State, ActionTypes, INVALIDATE_TYPE, RESET_TYPE } from '../../types';
+import { State, ActionTypes } from '../../types';
+import { INVALIDATE_TYPE, RESET_TYPE } from '../../actionTypes';
 import { users, articlesPages, payload } from './fixtures';
 
 async function testDispatchFetch(

--- a/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
@@ -1,14 +1,12 @@
 import { useContext, useRef, useCallback } from 'react';
 
+import { FetchAction, UpdateFunction, ReceiveTypes } from '~/types';
 import {
-  FetchAction,
-  UpdateFunction,
   RECEIVE_DELETE_TYPE,
   RECEIVE_MUTATE_TYPE,
   RECEIVE_TYPE,
-  ReceiveTypes,
   FETCH_TYPE,
-} from '~/types';
+} from '~/actionTypes';
 import {
   FetchShape,
   DeleteShape,

--- a/packages/rest-hooks/src/react-integration/hooks/useInvalidator.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useInvalidator.ts
@@ -2,7 +2,7 @@ import { useContext, useCallback, useRef } from 'react';
 
 import { ReadShape, Schema } from '~/resource';
 import { DispatchContext } from '~/react-integration/context';
-import { INVALIDATE_TYPE } from '~/types';
+import { INVALIDATE_TYPE } from '~/actionTypes';
 
 /** Invalidate a certain item within the cache */
 export default function useInvalidator<

--- a/packages/rest-hooks/src/react-integration/hooks/useResetter.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useResetter.ts
@@ -1,7 +1,7 @@
 import { useContext, useCallback } from 'react';
 
 import { DispatchContext } from '~/react-integration/context';
-import { RESET_TYPE } from '~/types';
+import { RESET_TYPE } from '~/actionTypes';
 
 /** Returns a function to completely clear the cache of all entries */
 export default function useResetter(): () => void {

--- a/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
@@ -2,7 +2,7 @@ import { useContext, useEffect, useRef } from 'react';
 
 import { DispatchContext } from '~/react-integration/context';
 import { ReadShape, Schema } from '~/resource';
-import { SUBSCRIBE_TYPE, UNSUBSCRIBE_TYPE } from '~/types';
+import { SUBSCRIBE_TYPE, UNSUBSCRIBE_TYPE } from '~/actionTypes';
 
 /** Keeps a resource fresh by subscribing to updates. */
 export default function useSubscription<

--- a/packages/rest-hooks/src/react-integration/provider/__tests__/provider.tsx
+++ b/packages/rest-hooks/src/react-integration/provider/__tests__/provider.tsx
@@ -7,7 +7,8 @@ import CacheProvider from '../CacheProvider';
 import NetworkManager from '../../../state/NetworkManager';
 import SubscriptionManager from '../../../state/SubscriptionManager';
 import PollingSubscription from '../../../state/PollingSubscription';
-import { RECEIVE_TYPE } from '~/types';
+
+import { RECEIVE_TYPE } from '~/actionTypes';
 
 describe('<CacheProvider />', () => {
   it('should not change dispatch function on re-render', () => {

--- a/packages/rest-hooks/src/state/NetworkManager.ts
+++ b/packages/rest-hooks/src/state/NetworkManager.ts
@@ -9,12 +9,14 @@ import {
   Manager,
   PurgeAction,
   Dispatch,
+} from '~/types';
+import {
   RECEIVE_TYPE,
   RECEIVE_MUTATE_TYPE,
   RECEIVE_DELETE_TYPE,
   FETCH_TYPE,
   RESET_TYPE,
-} from '~/types';
+} from '~/actionTypes';
 import { RPCAction } from '..';
 
 /** Handles all async network dispatches

--- a/packages/rest-hooks/src/state/PollingSubscription.ts
+++ b/packages/rest-hooks/src/state/PollingSubscription.ts
@@ -2,7 +2,8 @@ import { Subscription, SubscriptionInit } from './SubscriptionManager';
 import isOnline from './isOnline';
 
 import { Schema } from '~/resource';
-import { Dispatch, FETCH_TYPE, RECEIVE_TYPE } from '~/types';
+import { Dispatch } from '~/types';
+import { FETCH_TYPE, RECEIVE_TYPE } from '~/actionTypes';
 
 /**
  * PollingSubscription keeps a given resource updated by

--- a/packages/rest-hooks/src/state/SubscriptionManager.ts
+++ b/packages/rest-hooks/src/state/SubscriptionManager.ts
@@ -6,9 +6,8 @@ import {
   UnsubscribeAction,
   Manager,
   Dispatch,
-  SUBSCRIBE_TYPE,
-  UNSUBSCRIBE_TYPE,
 } from '~/types';
+import { SUBSCRIBE_TYPE, UNSUBSCRIBE_TYPE } from '~/actionTypes';
 import { Schema } from '~/resource';
 
 type Actions = UnsubscribeAction | SubscribeAction;

--- a/packages/rest-hooks/src/state/__tests__/networkManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/networkManager.ts
@@ -1,14 +1,13 @@
 import { ArticleResource } from '__tests__/common';
 
 import NetworkManager from '../NetworkManager';
+import { FetchAction, ResetAction } from '../../types';
 import {
-  FetchAction,
-  ResetAction,
   FETCH_TYPE,
   RECEIVE_TYPE,
   RECEIVE_MUTATE_TYPE,
   RESET_TYPE,
-} from '../../types';
+} from '../../actionTypes';
 
 describe('NetworkManager', () => {
   const manager = new NetworkManager();

--- a/packages/rest-hooks/src/state/__tests__/reducer.ts
+++ b/packages/rest-hooks/src/state/__tests__/reducer.ts
@@ -13,13 +13,15 @@ import {
   ResetAction,
   InvalidateAction,
   UpdateFunction,
+} from '../../types';
+import {
   RECEIVE_TYPE,
   RECEIVE_MUTATE_TYPE,
   RECEIVE_DELETE_TYPE,
   INVALIDATE_TYPE,
   FETCH_TYPE,
   RESET_TYPE,
-} from '../../types';
+} from '../../actionTypes';
 
 describe('reducer', () => {
   describe('singles', () => {

--- a/packages/rest-hooks/src/state/__tests__/subscriptionManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/subscriptionManager.ts
@@ -1,13 +1,12 @@
 import { PollingArticleResource } from '__tests__/common';
 
 import SubscriptionManager, { Subscription } from '../SubscriptionManager';
+import { SubscribeAction, UnsubscribeAction } from '../../types';
 import {
-  SubscribeAction,
-  UnsubscribeAction,
   UNSUBSCRIBE_TYPE,
   SUBSCRIBE_TYPE,
   RECEIVE_TYPE,
-} from '../../types';
+} from '../../actionTypes';
 
 function onError(e: any) {
   e.preventDefault();

--- a/packages/rest-hooks/src/state/reducer.ts
+++ b/packages/rest-hooks/src/state/reducer.ts
@@ -2,16 +2,15 @@ import mergeDeepCopy from './merge/mergeDeepCopy';
 import applyUpdatersToResults from './applyUpdatersToResults';
 
 import { normalize } from '~/resource';
+import { ActionTypes, State } from '~/types';
 import {
-  ActionTypes,
-  State,
   RECEIVE_TYPE,
   RECEIVE_MUTATE_TYPE,
   RECEIVE_DELETE_TYPE,
   INVALIDATE_TYPE,
   RESET_TYPE,
   FETCH_TYPE,
-} from '~/types';
+} from '~/actionTypes';
 
 export const initialState: State<unknown> = {
   entities: {},

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -3,17 +3,18 @@ import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
 
 import { ErrorableFSAWithPayloadAndMeta, ErrorableFSAWithMeta } from './fsa';
 import { Schema, schemas, Normalize } from './resource';
+import {
+  RECEIVE_TYPE,
+  RECEIVE_MUTATE_TYPE,
+  RECEIVE_DELETE_TYPE,
+  RESET_TYPE,
+  FETCH_TYPE,
+  SUBSCRIBE_TYPE,
+  UNSUBSCRIBE_TYPE,
+  INVALIDATE_TYPE,
+} from './actionTypes';
 
 export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';
-
-export const FETCH_TYPE = 'rest-hooks/fetch' as const;
-export const RECEIVE_TYPE = 'rest-hooks/receive' as const;
-export const RECEIVE_MUTATE_TYPE = 'rest-hooks/rpc' as const;
-export const RECEIVE_DELETE_TYPE = 'rest-hooks/purge' as const;
-export const RESET_TYPE = 'rest-hooks/reset' as const;
-export const SUBSCRIBE_TYPE = 'rest-hooks/subscribe' as const;
-export const UNSUBSCRIBE_TYPE = 'rest-hook/unsubscribe' as const;
-export const INVALIDATE_TYPE = 'rest-hooks/invalidate' as const;
 
 export type ReceiveTypes =
   | typeof RECEIVE_TYPE


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Will export in future `@rest-hooks/core` package, but pollutes namespace in rest-hooks
