### PR TITLE
enhance: Devmode: Throw error if delete shape fetched with wrong schema

### DIFF
--- a/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
@@ -157,6 +157,27 @@ describe('useFetcher', () => {
     console.error = oldError;
   });
 
+  it.only('should throw when providing a delete shape without an entity schema', () => {
+    const badDeleteShape = {
+      ...CoolerArticleResource.deleteShape(),
+      schema: { data: CoolerArticleResource.asSchema(), other: 5 },
+    };
+    const { result } = renderHook(() => {
+      const a = useFetcher(badDeleteShape);
+      a({ id: 5 }, undefined);
+      return null;
+    });
+    expect(result.error).toMatchInlineSnapshot(`
+      [Error: Request for 'DELETE http://test.com/article-cooler/5' of type delete used, but schema has no pk().
+      Schema must be an entity.
+      Schema: {
+        "other": 5
+      }
+
+      Note: Network response is ignored for delete type.]
+    `);
+  });
+
   it('should dispatch an action that fetches a partial update', async () => {
     mynock.patch(`/article-cooler/1`).reply(200, payload);
 

--- a/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
@@ -80,6 +80,21 @@ export default function useFetcher<
       const responseType = SHAPE_TYPE_TO_RESPONSE_TYPE[type];
 
       const key = getFetchKey(params);
+      /* istanbul ignore next */
+      if (process.env.NODE_ENV !== 'production') {
+        if (
+          isDeleteShape(shapeRef.current) &&
+          typeof shapeRef.current.schema.getId !== 'function'
+        ) {
+          throw new Error(
+            `Request for '${key}' of type delete used, but schema has no pk().
+Schema must be an entity.
+Schema: ${JSON.stringify(shapeRef.current.schema, null, 2)}
+
+Note: Network response is ignored for delete type.`,
+          );
+        }
+      }
       const identifier = isDeleteShape(shapeRef.current)
         ? shapeRef.current.schema.getId(params)
         : key;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Delete shapes are special in that they ignore the actual fetch response, and simply use the Entity definition to lookup what entries to delete in the entities cache.

This could be confusing for those defining delete shapes, so it's important to give a heads up in this case - especially if TypeScript is not used.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
throw error