### PR TITLE
internal: Remove devDep of rest-hooks from test

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -46,9 +46,6 @@
   "bugs": {
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
-  "devDependencies": {
-    "rest-hooks": "^4.2.1"
-  },
   "dependencies": {
     "@testing-library/react-hooks": "^3.2.1"
   },


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
New package bumps every rest-hooks release for test, and only dev env is the monorepo so the peerdep will be there.
