### PR TITLE
fix: Support extra members of schema that are only sometimes empty

### DIFF
--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -288,6 +288,43 @@ Object {
       2,
     ],
     "extra": "five",
+    "page": Object {
+      "complex": Object {
+        "complex": false,
+        "next": true,
+      },
+      "first": Object {
+        "whenever": "five",
+      },
+      "second": Object {
+        "thing": "two",
+      },
+      "third": 1,
+    },
+  },
+}
+`;
+
+exports[`normalize normalizes schema with extra members but not set 1`] = `
+Object {
+  "entities": Object {
+    "tacos": Object {
+      "1": Object {
+        "id": 1,
+        "type": "foo",
+      },
+      "2": Object {
+        "id": 2,
+        "type": "bar",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Object {
+    "data": Array [
+      1,
+      2,
+    ],
   },
 }
 `;

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -53,8 +53,48 @@ describe('normalize', () => {
             { id: 2, type: 'bar' },
           ],
           extra: 'five',
+          page: {
+            first: { whenever: 'five' },
+            second: { thing: 'two' },
+            third: 1,
+            complex: { complex: false, next: true },
+          },
         },
-        { data: [mySchema], extra: '' },
+        {
+          data: [mySchema],
+          extra: '',
+          page: {
+            first: null,
+            second: undefined,
+            third: 0,
+            complex: { complex: true, next: false },
+          },
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('normalizes schema with extra members but not set', () => {
+    const mySchema = new schema.Entity('tacos');
+
+    expect(
+      normalize(
+        {
+          data: [
+            { id: 1, type: 'foo' },
+            { id: 2, type: 'bar' },
+          ],
+        },
+        {
+          data: [mySchema],
+          extra: '',
+          page: {
+            first: null,
+            second: undefined,
+            third: 0,
+            complex: { complex: true, next: false },
+          },
+        },
       ),
     ).toMatchSnapshot();
   });

--- a/packages/normalizr/src/index.js
+++ b/packages/normalizr/src/index.js
@@ -6,7 +6,7 @@ import ArraySchema, * as ArrayUtils from './schemas/Array';
 import ObjectSchema, * as ObjectUtils from './schemas/Object';
 
 const visit = (value, parent, key, schema, addEntity, visitedEntities) => {
-  if (typeof value !== 'object' || !value) {
+  if (typeof value !== 'object' || !value || !schema) {
     return value;
   }
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Say you have defaults that are null

```typescript
schema = {
  pagination: {
    nextData: null,
    prevData: null,
  },
  data: [EntityThing.asSchema()],
}
```

But then you get a network response like:

```json5
{
  pagination: {
    nextData: { token: 'five' },
    prevData: null,
  },
  data: { id: 'something', title: 'whatever' },
}
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Simply guard against empty schema when visiting
