### PR TITLE
fix: Support extra members of schema that are empty in denormalize

### DIFF
--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -89,6 +89,35 @@ Array [
       },
     ],
     "extra": "5",
+    "page": Object {
+      "complex": Object {
+        "complex": false,
+        "next": true,
+      },
+      "first": null,
+      "second": Object {
+        "thing": "two",
+      },
+      "third": 1,
+    },
+  },
+  true,
+]
+`;
+
+exports[`denormalize denormalizes schema with extra members but not set 1`] = `
+Array [
+  Object {
+    "data": Array [
+      Object {
+        "id": 1,
+        "type": "foo",
+      },
+      Object {
+        "id": 2,
+        "type": "bar",
+      },
+    ],
   },
   true,
 ]
@@ -292,9 +321,6 @@ Object {
       "complex": Object {
         "complex": false,
         "next": true,
-      },
-      "first": Object {
-        "whenever": "five",
       },
       "second": Object {
         "thing": "two",

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -54,7 +54,7 @@ describe('normalize', () => {
           ],
           extra: 'five',
           page: {
-            first: { whenever: 'five' },
+            first: null,
             second: { thing: 'two' },
             third: 1,
             complex: { complex: false, next: true },
@@ -379,8 +379,54 @@ describe('denormalize', () => {
     };
     expect(
       denormalize(
-        { data: [1, 2], extra: '5' },
-        { data: [mySchema], extra: '' },
+        {
+          data: [1, 2],
+          extra: '5',
+          page: {
+            first: null,
+            second: { thing: 'two' },
+            third: 1,
+            complex: { complex: false, next: true },
+          },
+        },
+        {
+          data: [mySchema],
+          extra: '',
+          page: {
+            first: null,
+            second: undefined,
+            third: 0,
+            complex: { complex: true, next: false },
+          },
+        },
+        entities,
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('denormalizes schema with extra members but not set', () => {
+    const mySchema = new schema.Entity('tacos');
+    const entities = {
+      tacos: {
+        1: { id: 1, type: 'foo' },
+        2: { id: 2, type: 'bar' },
+      },
+    };
+    expect(
+      denormalize(
+        {
+          data: [1, 2],
+        },
+        {
+          data: [mySchema],
+          extra: '',
+          page: {
+            first: null,
+            second: undefined,
+            third: 0,
+            complex: { complex: true, next: false },
+          },
+        },
         entities,
       ),
     ).toMatchSnapshot();

--- a/packages/normalizr/src/index.js
+++ b/packages/normalizr/src/index.js
@@ -156,6 +156,8 @@ const getUnvisit = entities => {
   const getEntity = getEntities(entities);
 
   return function unvisit(input, schema) {
+    if (!schema) return [input, true];
+
     if (
       typeof schema === 'object' &&
       (!schema.denormalize || typeof schema.denormalize !== 'function')
@@ -209,6 +211,10 @@ const getEntities = entities => {
 };
 
 export const denormalize = (input, schema, entities) => {
+  /* istanbul ignore next */
+  // eslint-disable-next-line no-undef
+  if (process.env.NODE_ENV !== 'production' && schema === undefined)
+    throw new Error('shema needed');
   if (typeof input !== 'undefined') {
     return getUnvisit(entities)(input, schema);
   }

--- a/packages/normalizr/src/schemas/Object.js
+++ b/packages/normalizr/src/schemas/Object.js
@@ -38,7 +38,7 @@ export const denormalize = (schema, input, unvisit) => {
   let found = true;
   Object.keys(schema).forEach(key => {
     const [item, foundItem] = unvisit(object[key], schema[key]);
-    if (object[key] != null) {
+    if (object[key] !== undefined) {
       object[key] = item;
     }
     if (!foundItem) {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Say you have defaults that are null

```typescript
schema = {
  pagination: {
    nextData: null,
    prevData: null,
  },
  data: [EntityThing.asSchema()],
}
```

But then you get a network response like:

```json5
{
  pagination: {
    nextData: { token: 'five' },
    prevData: null,
  },
  data: { id: 'something', title: 'whatever' },
}
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Make denormalize ok with empty schemas.