### PR TITLE
feat: Add optimistic updates

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import {
   Resource,
   SchemaList,
@@ -7,7 +6,7 @@ import {
   ReadShape,
   SchemaDetail,
 } from 'rest-hooks';
-import { AbstractInstanceType, FetchOptions } from 'rest-hooks';
+import { AbstractInstanceType, FetchOptions, MutateShape } from 'rest-hooks';
 
 export class UserResource extends Resource {
   readonly id: number | undefined = undefined;
@@ -93,6 +92,25 @@ export class ArticleResource extends Resource {
       schema: [this.asSchema()],
     };
   }
+
+  static partialUpdateShape<T extends typeof Resource>(
+    this: T,
+  ): MutateShape<
+    SchemaDetail<Readonly<AbstractInstanceType<T>>>,
+    Readonly<object>,
+    Partial<AbstractInstanceType<T>>
+  > {
+    return {
+      ...super.partialUpdateShape(),
+      options: {
+        ...this.getFetchOptions(),
+        optimisticUpdate: (params: any, body: any) => ({
+          id: params.id,
+          ...body,
+        }),
+      },
+    };
+  }
 }
 
 export class UrlArticleResource extends ArticleResource {
@@ -113,6 +131,19 @@ export class ArticleResourceWithOtherListUrl extends ArticleResource {
 
   static otherListUrl<T extends typeof ArticleResource>(this: T): string {
     return this.urlRoot + 'some-list-url';
+  }
+
+  static createShape<T extends typeof Resource>(this: T) {
+    return {
+      ...super.createShape(),
+      options: {
+        ...this.getFetchOptions(),
+        optimisticUpdate: (
+          params: Readonly<object>,
+          body: Readonly<object | string> | void,
+        ) => body,
+      },
+    };
   }
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@
 
 ## Soon
 
-- [ ] Optimistic query update on create
+- [x] Optimistic query update on create
 - [x] Optional redux-integration
 - [x] Polling based subscriptions
 - [ ] Automatic batching

--- a/docs/api/FetchShape.md
+++ b/docs/api/FetchShape.md
@@ -89,6 +89,10 @@ export interface FetchOptions {
   readonly errorExpiryLength?: number;
   readonly pollFrequency?: number;
   readonly invalidIfStale?: boolean;
+  readonly optimisticUpdate?: (
+    params: Readonly<object>,
+    body: Readonly<object | string> | void,
+  ) => any;
 }
 ```
 
@@ -110,8 +114,15 @@ an effect.
 Indicates stale data should be considered unusable and thus not be returned from the cache. This means
 that useResource() will suspend when data is stale even if it already exists in cache.
 
+#### optimisticUpdate: (params, body) => fakePayload
+
+When provided, any fetches with this shape will behave as though the `fakePayload` return value
+from this function was a succesful network response. When the actual fetch completes (regardless
+of failure or success), the optimistic update will be replaced with the actual network response.
+
 ## Examples
 
 - [Custom endpoints](../guides/endpoints)
 - [Pagination](../guides/pagination)
 - [Mocking unfinished endpoints](../guides/mocking-unfinished)
+- [Optimistic updates](../guides/optimistic-updates)

--- a/docs/guides/optimistic-updates.md
+++ b/docs/guides/optimistic-updates.md
@@ -1,0 +1,148 @@
+---
+title: Optimistic Updates
+---
+
+Optimistic updates enable highly responsive and fast interfaces by avoiding network wait times.
+An update is optimistic by assuming the network is successful. In the case of any errors, Rest
+Hooks will then roll back any changes in a way that deals with all possible race conditions.
+
+## Partial updates
+
+One common use case is for quick toggles. Here we demonstrate a publish button for an
+article. Note that we need to include the primary key (`id` in this case) in the response
+body to ensure the normalized cache gets updated correctly.
+
+### ArticleResource.ts
+
+```typescript
+import { Resource, MutateShape, SchemaDetail, AbstractInstanceType } from 'rest-hooks';
+
+export default class ArticleResource extends Resource {
+  readonly id: string | undefined = undefined;
+  readonly title: string = '';
+  readonly content: string = '';
+  readonly published: boolean = false;
+
+  pk() {
+    return this.id;
+  }
+
+  static partialUpdateShape<T extends typeof Resource>(
+    this: T,
+  ): MutateShape<
+    SchemaDetail<Readonly<AbstractInstanceType<T>>>,
+    Readonly<object>,
+    Partial<AbstractInstanceType<T>>
+  > {
+    return {
+      ...super.partialUpdateShape(),
+      options: {
+        ...this.getFetchOptions(),
+        optimisticUpdate: (params: any, body: any) => ({
+          // we absolutely need the primary key here,
+          // but won't be sent in a partial update
+          id: params.id,
+          ...body,
+        }),
+      },
+    };
+  }
+}
+```
+
+### PublishButton.tsx
+
+```typescript
+import { useFetcher } from 'rest-hooks';
+import ArticleResource from 'ArticleResource';
+
+export default function PublishButton({ id }: { id: string }) {
+  const update = useFetcher(ArticleResource.partialUpdateShape());
+
+  return (
+    <button onClick={() => update({ id }, { published: true })}>Publish</button>
+  );
+}
+```
+
+## Optimistic create with eager updates
+
+Optimistic updates can also be combined with [eager updates](./eager-updates), enabling updates to
+other endpoints instantly. This is most commonly seen when creating new items
+while viewing a list of them.
+
+Here we demonstrate what could be used in a list of articles with a modal
+to create a new article. On submission of the form it would instantly
+add to the list of articles the newly created article - without waiting on a network response.
+
+### ArticleResource.ts
+
+```typescript
+import { Resource, MutateShape, SchemaDetail, AbstractInstanceType } from 'rest-hooks';
+
+export default class ArticleResource extends Resource {
+  readonly id: string | undefined = undefined;
+  readonly title: string = '';
+  readonly content: string = '';
+  readonly published: boolean = false;
+
+  pk() {
+    return this.id;
+  }
+
+  static createShape<T extends typeof SimpleResource>(
+    this: T,
+  ): MutateShape<
+    SchemaDetail<Readonly<AbstractInstanceType<T>>>,
+    Readonly<object>,
+    Partial<AbstractInstanceType<T>>
+  > {
+    return {
+      ...super.createShape(),
+      options: {
+        ...this.getFetchOptions(),
+        optimisticUpdate: (
+          params: Readonly<object>,
+          body: Readonly<object | string> | void,
+        ) => body,
+      },
+    };
+  }
+}
+
+export const appendUpdater = (
+  newArticleID: string,
+  articleIDs: string[] | undefined,
+) => [...(articleIDs || []), newArticleID];
+```
+
+### CreateArticle.tsx
+
+Since the actual `id` of the article is created on the server, we will need to fill
+in a temporary fake `id` here, so the `primary key` can be generated. This is needed
+to properly normalize the article to be looked up in the cache.
+
+Once the network responds, it will have a different `id`, which will replace the existing
+data. This is often seamless, but care should be taken if the fake `id` is used in any
+renders - like to issue subsequent requests. We recommend disabling `edit` type features
+that rely on the `primary key` until the network fetch completes.
+
+```typescript
+import { useFetcher } from 'rest-hooks';
+import uuid from 'uuid/v4';
+import ArticleResource from 'ArticleResource';
+
+export default function CreateArticle() {
+  const create = useFetcher(ArticleResource.createShape());
+  const submitHandler = useCallback(
+    data =>
+      // note the fake id we create.
+      create({}, { id: uuid(), ...data }, [
+        [ArticleResource.listShape(), {}, appendUpdater],
+      ]),
+    [create],
+  );
+
+  return <Form onSubmit={submitHandler}>{/* rest of form */}</Form>;
+}
+```

--- a/packages/rest-hooks/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
+++ b/packages/rest-hooks/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
@@ -35,7 +35,13 @@ Object {
 exports[`useFetcher should dispatch an action that fetches a partial update 1`] = `
 Object {
   "meta": Object {
-    "options": undefined,
+    "optimisticResponse": Object {
+      "content": "changed",
+      "id": 1,
+    },
+    "options": Object {
+      "optimisticUpdate": [Function],
+    },
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/rpc",
@@ -51,7 +57,12 @@ Object {
 exports[`useFetcher should dispatch an action with multiple updaters in the meta if update shapes params are passed in 1`] = `
 Object {
   "meta": Object {
-    "options": undefined,
+    "optimisticResponse": Object {
+      "content": "hi",
+    },
+    "options": Object {
+      "optimisticUpdate": [Function],
+    },
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/rpc",

--- a/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
@@ -5,6 +5,7 @@ import {
   ArticleResource,
   PaginatedArticleResource,
   UserResource,
+  ArticleResourceWithOtherListUrl,
 } from '__tests__/common';
 
 // relative imports to avoid circular dependency in tsconfig references
@@ -13,7 +14,7 @@ import {
   makeCacheProvider,
   makeExternalCacheProvider,
 } from '../../../../test';
-import { useResource, useFetcher } from '../hooks';
+import { useResource, useFetcher, useCache } from '../hooks';
 import {
   payload,
   createPayload,
@@ -248,6 +249,142 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           ({ id }: Partial<PaginatedArticleResource>) => id,
         ),
       ).toEqual([5, 3, 7, 8]);
+    });
+
+    describe('Optimistic Updates', () => {
+      it('works with partial update', async () => {
+        const params = { id: payload.id };
+        mynock.patch('/article-cooler/5').reply(200, {
+          ...payload,
+          title: 'some other title',
+          content: 'real response',
+        });
+
+        const { result, waitForNextUpdate } = renderRestHook(
+          () => {
+            const put = useFetcher(CoolerArticleResource.partialUpdateShape());
+            const article = useCache(
+              CoolerArticleResource.detailShape(),
+              params,
+            );
+            return { put, article };
+          },
+          {
+            results: [
+              {
+                request: CoolerArticleResource.detailShape(),
+                params,
+                result: payload,
+              },
+            ],
+          },
+        );
+        expect(result.current.article).toEqual(
+          CoolerArticleResource.fromJS(payload),
+        );
+        const promise = result.current.put(params, { content: 'changed' });
+        expect(result.current.article).toBeInstanceOf(CoolerArticleResource);
+        expect(result.current.article).toEqual(
+          CoolerArticleResource.fromJS({
+            ...payload,
+            content: 'changed',
+          }),
+        );
+        await promise;
+        expect(result.current.article).toEqual(
+          CoolerArticleResource.fromJS({
+            ...payload,
+            title: 'some other title',
+            content: 'real response',
+          }),
+        );
+      });
+
+      it('works with eager creates', async () => {
+        const body = { id: -1111111111, content: 'hi' };
+        const existingItem = ArticleResourceWithOtherListUrl.fromJS({
+          id: 100,
+          content: 'something',
+        });
+
+        mynock.post(`/article/`).reply(201, {
+          ...payload,
+          title: 'some other title',
+          content: 'real response',
+        });
+
+        const { result, waitForNextUpdate } = renderRestHook(
+          () => {
+            const create = useFetcher(
+              ArticleResourceWithOtherListUrl.createShape(),
+            );
+            const listA = useCache(
+              ArticleResourceWithOtherListUrl.listShape(),
+              {},
+            );
+            const listB = useCache(
+              ArticleResourceWithOtherListUrl.otherListShape(),
+              {},
+            );
+            return { create, listA, listB };
+          },
+          {
+            results: [
+              {
+                request: ArticleResourceWithOtherListUrl.otherListShape(),
+                params: {},
+                result: [{ id: 100, content: 'something' }],
+              },
+            ],
+          },
+        );
+
+        expect(result.current.listA).toEqual(undefined);
+        expect(result.current.listB).toEqual([existingItem]);
+
+        const promise = result.current.create({}, body, [
+          [
+            ArticleResourceWithOtherListUrl.listShape(),
+            {},
+            (newArticleID: string, articleIDs: string[] | undefined) => [
+              ...(articleIDs || []),
+              newArticleID,
+            ],
+          ],
+          [
+            ArticleResourceWithOtherListUrl.otherListShape(),
+            {},
+            (newArticleID: string, articleIDs: string[] | undefined) => [
+              ...(articleIDs || []),
+              newArticleID,
+            ],
+          ],
+        ]);
+
+        expect(result.current.listA).toEqual([
+          CoolerArticleResource.fromJS(body),
+        ]);
+        expect(result.current.listB).toEqual([
+          existingItem,
+          CoolerArticleResource.fromJS(body),
+        ]);
+        await promise;
+        expect(result.current.listA).toEqual([
+          CoolerArticleResource.fromJS({
+            ...payload,
+            title: 'some other title',
+            content: 'real response',
+          }),
+        ]);
+        expect(result.current.listB).toEqual([
+          existingItem,
+          CoolerArticleResource.fromJS({
+            ...payload,
+            title: 'some other title',
+            content: 'real response',
+          }),
+        ]);
+      });
     });
   });
 }

--- a/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
@@ -19,6 +19,7 @@ import { useResource } from '../hooks';
 import { payload, users, nested } from './fixtures';
 
 import { State } from '~/types';
+import { initialState } from '~/state/reducer';
 
 async function testDispatchFetch(
   Component: React.FunctionComponent<any>,
@@ -225,11 +226,11 @@ describe('useResource()', () => {
     );
     const fetchKey = CoolerArticleResource.detailShape().getFetchKey(payload);
     const state = {
+      ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
-      indexes: {},
       meta: {
         [fetchKey]: {
           date: 0,
@@ -262,11 +263,11 @@ describe('useResource()', () => {
       payload,
     );
     const state = {
+      ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
-      indexes: {},
       meta: {
         [fetchKey]: {
           date: Infinity,
@@ -297,11 +298,11 @@ describe('useResource()', () => {
       payload,
     );
     const state = {
+      ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
-      indexes: {},
       meta: {
         [fetchKey]: {
           date: 0,

--- a/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
@@ -123,6 +123,10 @@ Note: Network response is ignored for delete type.`,
         );
       }
 
+      if (options && options.optimisticUpdate) {
+        meta.optimisticResponse = options.optimisticUpdate(params, body);
+      }
+
       dispatch({
         type: FETCH_TYPE,
         payload: () => fetch(params, body),

--- a/packages/rest-hooks/src/react-integration/provider/CacheProvider.tsx
+++ b/packages/rest-hooks/src/react-integration/provider/CacheProvider.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect, useMemo } from 'react';
 
 import createEnhancedReducerHook from './middleware';
 
@@ -26,6 +26,11 @@ export default function CacheProvider({
   );
   const [state, dispatch] = useEnhancedReducer(masterReducer, initialState);
 
+  const optimisticState = useMemo(
+    () => state.optimistic.reduce(masterReducer, state),
+    [state],
+  );
+
   // if we change out the manager we need to make sure it has no hanging async
   useEffect(() => {
     return () => {
@@ -38,7 +43,9 @@ export default function CacheProvider({
 
   return (
     <DispatchContext.Provider value={dispatch}>
-      <StateContext.Provider value={state}>{children}</StateContext.Provider>
+      <StateContext.Provider value={optimisticState}>
+        {children}
+      </StateContext.Provider>
     </DispatchContext.Provider>
   );
 }

--- a/packages/rest-hooks/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/rest-hooks/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
@@ -20,6 +20,7 @@ Object {
       "expiresAt": 55,
     },
   },
+  "optimistic": Array [],
   "results": Object {
     "http://test.com/article-cooler/5": "5",
   },

--- a/packages/rest-hooks/src/state/NetworkManager.ts
+++ b/packages/rest-hooks/src/state/NetworkManager.ts
@@ -122,7 +122,7 @@ export default class NetworkManager implements Manager {
         switch (action.type) {
           case FETCH_TYPE:
             this.handleFetch(action, dispatch);
-            return Promise.resolve();
+            return next(action);
           case RECEIVE_DELETE_TYPE:
           case RECEIVE_MUTATE_TYPE:
           case RECEIVE_TYPE:

--- a/packages/rest-hooks/src/state/NetworkManager.ts
+++ b/packages/rest-hooks/src/state/NetworkManager.ts
@@ -122,6 +122,7 @@ export default class NetworkManager implements Manager {
         switch (action.type) {
           case FETCH_TYPE:
             this.handleFetch(action, dispatch);
+            action.meta.nm = true;
             return next(action);
           case RECEIVE_DELETE_TYPE:
           case RECEIVE_MUTATE_TYPE:

--- a/packages/rest-hooks/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/rest-hooks/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -11,6 +11,7 @@ Object {
       "expiresAt": 5000500000,
     },
   },
+  "optimistic": Array [],
   "results": Object {},
 }
 `;
@@ -35,6 +36,7 @@ Object {
       "expiresAt": 5000500000,
     },
   },
+  "optimistic": Array [],
   "results": Object {
     "http://test.com/article/20": "20",
   },

--- a/packages/rest-hooks/src/state/__tests__/networkManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/networkManager.ts
@@ -99,7 +99,7 @@ describe('NetworkManager', () => {
 
       const data = await fetchResolveAction.payload();
 
-      expect(next).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
       expect(dispatch).toHaveBeenCalledWith({
         type: fetchResolveAction.meta.responseType,
         payload: data,
@@ -121,7 +121,7 @@ describe('NetworkManager', () => {
 
       const data = await fetchReceiveWithUpdatersAction.payload();
 
-      expect(next).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
       expect(dispatch).toHaveBeenCalledWith({
         type: fetchReceiveWithUpdatersAction.meta.responseType,
         payload: data,
@@ -146,7 +146,7 @@ describe('NetworkManager', () => {
 
       const data = await fetchRpcWithUpdatersAction.payload();
 
-      expect(next).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
       expect(dispatch).toHaveBeenCalledWith({
         type: fetchRpcWithUpdatersAction.meta.responseType,
         payload: data,

--- a/packages/rest-hooks/src/state/__tests__/reducer.ts
+++ b/packages/rest-hooks/src/state/__tests__/reducer.ts
@@ -419,7 +419,7 @@ describe('reducer', () => {
     const newState = reducer(iniState, action);
     expect(newState).toEqual(iniState);
   });
-  /*it('rest-hooks/fetch should console.warn()', () => {
+  it('rest-hooks/fetch should console.warn()', () => {
     global.console.warn = jest.fn();
     const action: FetchAction = {
       type: FETCH_TYPE,
@@ -440,7 +440,7 @@ describe('reducer', () => {
     const newState = reducer(iniState, action);
     expect(newState).toBe(iniState);
     expect((global.console.warn as jest.Mock).mock.calls.length).toBe(2);
-  });*/
+  });
   it('other types should do nothing', () => {
     const action: any = {
       type: 'whatever',

--- a/packages/rest-hooks/src/state/__tests__/reducer.ts
+++ b/packages/rest-hooks/src/state/__tests__/reducer.ts
@@ -89,10 +89,8 @@ describe('reducer', () => {
       },
     };
     const iniState = {
-      entities: {},
-      indexes: {},
+      ...initialState,
       results: { abc: '5' },
-      meta: {},
     };
     const newState = reducer(iniState, action);
     expect(newState.results).toBe(iniState.results);
@@ -107,6 +105,7 @@ describe('reducer', () => {
       },
     };
     const iniState: any = {
+      ...initialState,
       entities: {
         [ArticleResource.key]: {
           '10': ArticleResource.fromJS({ id: 10 }),
@@ -119,7 +118,6 @@ describe('reducer', () => {
         '5': undefined,
       },
       results: { abc: '20' },
-      meta: {},
     };
     const newState = reducer(iniState, action);
     expect(newState.results).toBe(iniState.results);
@@ -177,6 +175,7 @@ describe('reducer', () => {
       });
 
       const iniState: any = {
+        ...initialState,
         entities: {
           [PaginatedArticleResource.key]: {
             '10': PaginatedArticleResource.fromJS({ id: 10 }),
@@ -185,7 +184,6 @@ describe('reducer', () => {
         results: {
           [PaginatedArticleResource.listUrl()]: { results: ['10'] },
         },
-        meta: {},
       };
 
       it('should insert a new page of resources into a list request', () => {
@@ -252,6 +250,7 @@ describe('reducer', () => {
       ) => [result, ...(oldResults || [])];
 
       const iniState: any = {
+        ...initialState,
         entities: {
           [ArticleResourceWithOtherListUrl.key]: {
             '10': ArticleResourceWithOtherListUrl.fromJS({ id: 10 }),
@@ -262,7 +261,6 @@ describe('reducer', () => {
           [ArticleResourceWithOtherListUrl.listUrl()]: ['10'],
           [ArticleResourceWithOtherListUrl.otherListUrl()]: ['21'],
         },
-        meta: {},
       };
 
       it('it should run inserts for a simple resource after the existing list entities', () => {
@@ -327,6 +325,7 @@ describe('reducer', () => {
       },
     };
     const iniState: any = {
+      ...initialState,
       entities: {
         [ArticleResource.key]: {
           '10': ArticleResource.fromJS({ id: 10 }),
@@ -369,12 +368,7 @@ describe('reducer', () => {
       },
       error: true,
     };
-    const iniState = {
-      entities: {},
-      results: {},
-      indexes: {},
-      meta: {},
-    };
+    const iniState = initialState;
     const newState = reducer(iniState, action);
     expect(newState).toMatchSnapshot();
   });
@@ -390,12 +384,7 @@ describe('reducer', () => {
       },
       error: true,
     };
-    const iniState = {
-      entities: {},
-      results: {},
-      indexes: {},
-      meta: {},
-    };
+    const iniState = initialState;
     const newState = reducer(iniState, action);
     expect(newState).toEqual(iniState);
   });
@@ -412,6 +401,7 @@ describe('reducer', () => {
       error: true,
     };
     const iniState = {
+      ...initialState,
       entities: {
         [ArticleResource.key]: {
           [id]: ArticleResource.fromJS({}),
@@ -420,13 +410,11 @@ describe('reducer', () => {
       results: {
         [ArticleResource.url({ id })]: id,
       },
-      indexes: {},
-      meta: {},
     };
     const newState = reducer(iniState, action);
     expect(newState).toEqual(iniState);
   });
-  it('rest-hooks/fetch should console.warn()', () => {
+  /*it('rest-hooks/fetch should console.warn()', () => {
     global.console.warn = jest.fn();
     const action: FetchAction = {
       type: FETCH_TYPE,
@@ -441,24 +429,20 @@ describe('reducer', () => {
       },
     };
     const iniState = {
-      entities: {},
+      ...initialState,
       results: { abc: '5' },
-      indexes: {},
-      meta: {},
     };
     const newState = reducer(iniState, action);
     expect(newState).toBe(iniState);
     expect((global.console.warn as jest.Mock).mock.calls.length).toBe(2);
-  });
+  });*/
   it('other types should do nothing', () => {
     const action: any = {
       type: 'whatever',
     };
     const iniState = {
-      entities: {},
+      ...initialState,
       results: { abc: '5' },
-      indexes: {},
-      meta: {},
     };
     const newState = reducer(iniState, action);
     expect(newState).toBe(iniState);
@@ -468,6 +452,7 @@ describe('reducer', () => {
       type: RESET_TYPE,
     };
     const iniState: any = {
+      ...initialState,
       entities: {
         [ArticleResource.key]: {
           '10': ArticleResource.fromJS({ id: 10 }),
@@ -480,8 +465,6 @@ describe('reducer', () => {
         '5': undefined,
       },
       results: { abc: '20' },
-      indexes: {},
-      meta: {},
     };
     const newState = reducer(iniState, action);
     expect(newState.results).toEqual({});

--- a/packages/rest-hooks/src/state/__tests__/reducer.ts
+++ b/packages/rest-hooks/src/state/__tests__/reducer.ts
@@ -86,6 +86,7 @@ describe('reducer', () => {
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.listUrl(payload),
+        date: 0,
       },
     };
     const iniState = {
@@ -102,6 +103,7 @@ describe('reducer', () => {
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: id.toString(),
+        date: 0,
       },
     };
     const iniState: any = {
@@ -235,6 +237,7 @@ describe('reducer', () => {
             schema: ArticleResource.getEntitySchema(),
             url: ArticleResource.createShape().getFetchKey({}),
             updaters,
+            date: 0,
           },
         };
       }
@@ -381,6 +384,7 @@ describe('reducer', () => {
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.url({ id }),
+        date: 0,
       },
       error: true,
     };
@@ -397,6 +401,7 @@ describe('reducer', () => {
       meta: {
         schema: ArticleResource.getEntitySchema(),
         url: ArticleResource.url({ id }),
+        date: 0,
       },
       error: true,
     };

--- a/packages/rest-hooks/src/state/reducer.ts
+++ b/packages/rest-hooks/src/state/reducer.ts
@@ -142,9 +142,15 @@ export default function reducer(
 
 type Writable<T> = { [P in keyof T]: NonNullable<T[P]> };
 
-function filterOptimistic(state: State<unknown>, action: ResponseActions) {
+/** Filter all requests with same serialization that did not start after the resolving request */
+function filterOptimistic(
+  state: State<unknown>,
+  resolvingAction: ResponseActions,
+) {
   return state.optimistic.filter(
-    optimisticAction => optimisticAction.meta.url !== action.meta.url,
+    optimisticAction =>
+      optimisticAction.meta.url !== resolvingAction.meta.url ||
+      optimisticAction.meta.date > resolvingAction.meta.date,
   );
 }
 

--- a/packages/rest-hooks/src/state/reducer.ts
+++ b/packages/rest-hooks/src/state/reducer.ts
@@ -28,6 +28,16 @@ export default function reducer(
   if (!state) state = initialState;
   switch (action.type) {
     case FETCH_TYPE: {
+      // If 'fetch' action reaches the reducer there are no middlewares installed to handle it
+      if (process.env.NODE_ENV !== 'production' && !action.meta.nm) {
+        console.warn(
+          'Fetch appears unhandled - you are likely missing the NetworkManager middleware',
+        );
+        console.warn(
+          'See https://resthooks.io/docs/guides/redux#indextsx for hooking up redux',
+        );
+      }
+
       const optimisticResponse = action.meta.optimisticResponse;
       if (!optimisticResponse) return state;
       return {
@@ -125,15 +135,6 @@ export default function reducer(
       return initialState;
 
     default:
-      // If 'fetch' action reaches the reducer there are no middlewares installed to handle it
-      /*if (process.env.NODE_ENV !== 'production' && action.type === FETCH_TYPE) {
-        console.warn(
-          'Reducer recieved fetch action - you are likely missing the NetworkManager middleware',
-        );
-        console.warn(
-          'See https://resthooks.io/docs/guides/redux#indextsx for hooking up redux',
-        );
-      }*/
       // A reducer must always return a valid state.
       // Alternatively you can throw an error if an invalid action is dispatched.
       return state;

--- a/packages/rest-hooks/src/state/selectors/__tests__/useDenormalized.ts
+++ b/packages/rest-hooks/src/state/selectors/__tests__/useDenormalized.ts
@@ -6,15 +6,17 @@ import {
   UserResource,
 } from '__tests__/common';
 
-import { normalize } from '../../../resource';
 import useDenormalized from '../useDenormalized';
+
+import { normalize } from '~/resource';
+import { initialState } from '~/state/reducer';
 
 describe('useDenormalized()', () => {
   describe('Single', () => {
     const params = { id: 5, title: 'bob', content: 'head' };
     const article = CoolerArticleResource.fromJS(params);
     describe('state is empty', () => {
-      const state = { entities: {}, results: {}, indexes: {}, meta: {} };
+      const state = initialState;
       const { result } = renderHook(() =>
         useDenormalized(CoolerArticleResource.detailShape(), { id: 5 }, state),
       );
@@ -29,6 +31,7 @@ describe('useDenormalized()', () => {
     });
     describe('state is populated just not with our query', () => {
       const state = {
+        ...initialState,
         entities: {
           [CoolerArticleResource.key]: {
             [params.id]: article,
@@ -37,8 +40,6 @@ describe('useDenormalized()', () => {
         results: {
           [CoolerArticleResource.detailShape().getFetchKey(params)]: params.id,
         },
-        indexes: {},
-        meta: {},
       };
       const { result } = renderHook(() =>
         useDenormalized(
@@ -60,6 +61,7 @@ describe('useDenormalized()', () => {
     });
     describe('when state exists', () => {
       const state = {
+        ...initialState,
         entities: {
           [CoolerArticleResource.key]: {
             [params.id]: article,
@@ -68,8 +70,6 @@ describe('useDenormalized()', () => {
         results: {
           [CoolerArticleResource.detailShape().getFetchKey(params)]: params.id,
         },
-        indexes: {},
-        meta: {},
       };
       const {
         result: {
@@ -89,12 +89,11 @@ describe('useDenormalized()', () => {
     });
     describe('without entity with defined results', () => {
       const state = {
+        ...initialState,
         entities: { [CoolerArticleResource.key]: {} },
         results: {
           [CoolerArticleResource.detailShape().getFetchKey(params)]: params.id,
         },
-        indexes: {},
-        meta: {},
       };
       const {
         result: {
@@ -114,14 +113,12 @@ describe('useDenormalized()', () => {
     });
     describe('no result exists but primary key is used', () => {
       const state = {
+        ...initialState,
         entities: {
           [CoolerArticleResource.key]: {
             [params.id]: article,
           },
         },
-        results: {},
-        indexes: {},
-        meta: {},
       };
       const {
         result: {
@@ -142,14 +139,12 @@ describe('useDenormalized()', () => {
     describe('no result exists but primary key is used when using nested schema', () => {
       const pageArticle = PaginatedArticleResource.fromJS(article);
       const state = {
+        ...initialState,
         entities: {
           [PaginatedArticleResource.key]: {
             [params.id]: pageArticle,
           },
         },
-        indexes: {},
-        results: {},
-        meta: {},
       };
       const {
         result: {
@@ -170,6 +165,7 @@ describe('useDenormalized()', () => {
     describe('not using primary key as param', () => {
       const urlParams = { title: 'bob' };
       const state = {
+        ...initialState,
         entities: {
           [CoolerArticleResource.key]: {
             [params.id]: article,
@@ -180,8 +176,6 @@ describe('useDenormalized()', () => {
             urlParams,
           )]: params.id,
         },
-        indexes: {},
-        meta: {},
       };
       const {
         result: {
@@ -202,12 +196,10 @@ describe('useDenormalized()', () => {
     it('should throw when results are Array', () => {
       const params = { title: 'bob' };
       const state = {
-        entities: {},
+        ...initialState,
         results: {
           [CoolerArticleResource.detailShape().getFetchKey(params)]: [5, 6, 7],
         },
-        indexes: {},
-        meta: {},
       };
       const { result } = renderHook(() =>
         useDenormalized(CoolerArticleResource.detailShape(), params, state),
@@ -217,14 +209,12 @@ describe('useDenormalized()', () => {
     it('should throw when results are Object', () => {
       const params = { title: 'bob' };
       const state = {
-        entities: {},
+        ...initialState,
         results: {
           [CoolerArticleResource.detailShape().getFetchKey(params)]: {
             results: [5, 6, 7],
           },
         },
-        indexes: {},
-        meta: {},
       };
       const { result } = renderHook(() =>
         useDenormalized(CoolerArticleResource.detailShape(), params, state),
@@ -239,15 +229,13 @@ describe('useDenormalized()', () => {
       const user = UserResource.fromJS({ id: 23, username: 'anne' });
 
       const state = {
+        ...initialState,
         entities: {
           [NestedArticleResource.key]: {
             [`${nestedArticle.pk()}`]: nestedArticle,
           },
           [UserResource.key]: { [`${user.pk()}`]: user },
         },
-        results: {},
-        indexes: {},
-        meta: {},
       };
       const {
         result: {
@@ -283,7 +271,7 @@ describe('useDenormalized()', () => {
       CoolerArticleResource.fromJS({ id: 34, title: 'five' }),
     ];
     describe('state is empty', () => {
-      const state = { entities: {}, results: {}, indexes: {}, meta: {} };
+      const state = initialState;
       const {
         result: {
           current: [value, found],
@@ -311,7 +299,7 @@ describe('useDenormalized()', () => {
         articles,
         CoolerArticleResource.listShape().schema,
       );
-      const state = { entities, results: {}, indexes: {}, meta: {} };
+      const state = initialState;
       const {
         result: {
           current: [value, found],
@@ -334,12 +322,11 @@ describe('useDenormalized()', () => {
         CoolerArticleResource.listShape().schema,
       );
       const state = {
+        ...initialState,
         entities,
         results: {
           [CoolerArticleResource.listShape().getFetchKey(params)]: resultState,
         },
-        indexes: {},
-        meta: {},
       };
       const {
         result: {
@@ -364,12 +351,11 @@ describe('useDenormalized()', () => {
       );
       delete entities[CoolerArticleResource.key]['5'];
       const state = {
+        ...initialState,
         entities,
         results: {
           [CoolerArticleResource.listShape().getFetchKey(params)]: resultState,
         },
-        indexes: {},
-        meta: {},
       };
       const {
         result: {
@@ -396,14 +382,13 @@ describe('useDenormalized()', () => {
       );
       delete entities[PaginatedArticleResource.key]['5'];
       const state = {
+        ...initialState,
         entities,
         results: {
           [PaginatedArticleResource.listShape().getFetchKey(
             params,
           )]: resultState,
         },
-        indexes: {},
-        meta: {},
       };
       const {
         result: {
@@ -428,14 +413,13 @@ describe('useDenormalized()', () => {
         PaginatedArticleResource.listShape().schema,
       );
       const state = {
+        ...initialState,
         entities,
         results: {
           [PaginatedArticleResource.listShape().getFetchKey(
             params,
           )]: resultState,
         },
-        indexes: {},
-        meta: {},
       };
       const {
         result: {
@@ -459,10 +443,8 @@ describe('useDenormalized()', () => {
         PaginatedArticleResource.listShape().schema,
       );
       const state = {
+        ...initialState,
         entities,
-        results: {},
-        indexes: {},
-        meta: {},
       };
       const {
         result: {

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -122,6 +122,8 @@ interface FetchMeta<
   resolve: (value?: any | PromiseLike<any>) => void;
   reject: (reason?: any) => void;
   optimisticResponse?: Payload;
+  // indicates whether network manager processed it
+  nm?: boolean;
 }
 
 export interface FetchAction<

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -74,6 +74,7 @@ export type ReceiveAction<
 interface RPCMeta<S extends Schema> {
   schema: S;
   url: string;
+  date: number;
   updaters?: { [key: string]: UpdateFunction<S, any> };
 }
 
@@ -89,6 +90,7 @@ export type RPCAction<
 interface PurgeMeta {
   schema: schemas.EntityInterface<any>;
   url: string;
+  date: number;
 }
 
 export type PurgeAction = ErrorableFSAWithMeta<

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -35,6 +35,7 @@ export type State<T> = Readonly<{
   meta: Readonly<{
     [url: string]: { date: number; error?: Error; expiresAt: number };
   }>;
+  optimistic: ResponseActions[];
 }>;
 
 export interface FetchOptions {
@@ -46,6 +47,11 @@ export interface FetchOptions {
   readonly pollFrequency?: number;
   /** Marks cached resources as invalid if they are stale */
   readonly invalidIfStale?: boolean;
+  /** Enables optimistic updates for this request - uses return value as assumed network response */
+  readonly optimisticUpdate?: (
+    params: Readonly<object>,
+    body: Readonly<object | string> | void,
+  ) => any;
 }
 
 interface ReceiveMeta<S extends Schema> {
@@ -101,7 +107,10 @@ export type UpdateFunction<
   destResults: Normalize<DestSchema> | undefined,
 ) => Normalize<DestSchema>;
 
-interface FetchMeta<S extends Schema> {
+interface FetchMeta<
+  Payload extends object | string | number = object | string | number,
+  S extends Schema = any
+> {
   responseType: ReceiveTypes;
   url: string;
   schema: S;
@@ -110,6 +119,7 @@ interface FetchMeta<S extends Schema> {
   options?: FetchOptions;
   resolve: (value?: any | PromiseLike<any>) => void;
   reject: (reason?: any) => void;
+  optimisticResponse?: Payload;
 }
 
 export interface FetchAction<
@@ -119,9 +129,9 @@ export interface FetchAction<
   extends FSAWithPayloadAndMeta<
     typeof FETCH_TYPE,
     () => Promise<Payload>,
-    FetchMeta<any>
+    FetchMeta<any, any>
   > {
-  meta: FetchMeta<S>;
+  meta: FetchMeta<Payload, S>;
 }
 
 export interface SubscribeAction

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -137,6 +137,9 @@
       "guides/no-suspense": {
         "title": "Usage without Suspense"
       },
+      "guides/optimistic-updates": {
+        "title": "Optimistic Updates"
+      },
       "guides/pagination": {
         "title": "Pagination"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -50,7 +50,11 @@
       {
         "type": "subcategory",
         "label": "Performance",
-        "ids": ["guides/fetch-then-render", "guides/eager-updates"]
+        "ids": [
+          "guides/fetch-then-render",
+          "guides/eager-updates",
+          "guides/optimistic-updates"
+        ]
       },
       {
         "type": "subcategory",


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Closes #191, #179.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Make sites faster.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```typescript
class ArticleResource extends Resource {
  static partialUpdateShape<T extends typeof Resource>(
    this: T,
  ): MutateShape<
    SchemaDetail<Readonly<AbstractInstanceType<T>>>,
    Readonly<object>,
    Partial<AbstractInstanceType<T>>
  > {
    return {
      ...super.partialUpdateShape(),
      options: {
        ...this.getFetchOptions(),
        optimisticUpdate: (params: any, body: any) => ({
          id: params.id,
          ...body,
        }),
      },
    };
  }
  static createShape<T extends typeof Resource>(this: T) {
    return {
      ...super.createShape(),
      options: {
        ...this.getFetchOptions(),
        optimisticUpdate: (
          params: Readonly<object>,
          body: Readonly<object | string> | void,
        ) => body,
      },
    };
  }
}

const appendUpdater = (
  newArticleID: string,
  articleIDs: string[] | undefined,
) => [...(articleIDs || []), newArticleID];
```

#### Partial updates
```typescript
const update = useFetcher(ArticleResource.partialUpdateShape());

update({ id: '5' }, { isStaff: true });
```

#### Optimistic create with eager updates

This lets you eagerly insert into a list.

You'll need to make a fake id that won't collide so it can put it in the cache somewhere.

```typescript
const create = useFetcher(ArticleResource.createShape());

create({}, { id: 'made up temp id', content: 'fun times' }, [
  [ArticleResource.listShape(), {}, appendUpdater],
]);
```

#### Race conditions
Since optimistic updates are applied after all realized updates, all optimistic updates with a date equal to or before the currently realizing update should be removed. Note: this still potentially creates a problem when multiple endpoints interact on the same entity, but there is no clear way to realize that solution and this problem is far less likely. Mostly the expected issue is toggling a single control over quickly.

#### Update NetworkManager detection mechanism
Since we're now passing `fetch` actions through to the reducer to handle, we need a new mechanism to detect if NetworkManager isn't setup. This is a common error for those attempting to use redux.

We will add a flag to the meta named `nm` that is set to true when the action passes through NetworkManager.