### PR TITLE
fix: Optimistic updates now trigger for results with empty string

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -5,6 +5,7 @@ import {
   schemas,
   ReadShape,
   SchemaDetail,
+  DeleteShape,
 } from 'rest-hooks';
 import { AbstractInstanceType, FetchOptions, MutateShape } from 'rest-hooks';
 
@@ -108,6 +109,18 @@ export class ArticleResource extends Resource {
           id: params.id,
           ...body,
         }),
+      },
+    };
+  }
+
+  static deleteShape<T extends typeof Resource>(
+    this: T,
+  ): DeleteShape<any, Readonly<object>> {
+    return {
+      ...super.deleteShape(),
+      options: {
+        ...this.getFetchOptions(),
+        optimisticUpdate: (_params: any, _body: any) => '',
       },
     };
   }

--- a/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
@@ -300,6 +300,35 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         );
       });
 
+      it('works with deletes', async () => {
+        const params = { id: payload.id };
+        mynock.delete('/article-cooler/5').reply(200, '');
+
+        const { result, waitForNextUpdate } = renderRestHook(
+          () => {
+            const del = useFetcher(CoolerArticleResource.deleteShape());
+            const articles = useCache(CoolerArticleResource.listShape(), {});
+            return { del, articles };
+          },
+          {
+            results: [
+              {
+                request: CoolerArticleResource.listShape(),
+                params: {},
+                result: [payload],
+              },
+            ],
+          },
+        );
+        expect(result.current.articles).toEqual([
+          CoolerArticleResource.fromJS(payload),
+        ]);
+        const promise = result.current.del(params, undefined);
+        expect(result.current.articles).toEqual([]);
+        await promise;
+        expect(result.current.articles).toEqual([]);
+      });
+
       it('works with eager creates', async () => {
         const body = { id: -1111111111, content: 'hi' };
         const existingItem = ArticleResourceWithOtherListUrl.fromJS({

--- a/packages/rest-hooks/src/state/reducer.ts
+++ b/packages/rest-hooks/src/state/reducer.ts
@@ -39,7 +39,7 @@ export default function reducer(
       }
 
       const optimisticResponse = action.meta.optimisticResponse;
-      if (!optimisticResponse) return state;
+      if (optimisticResponse === undefined) return state;
       return {
         ...state,
         optimistic: [


### PR DESCRIPTION

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Deletes often don't return anything, but our detection for this case falsy thought there was no optimistic

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Check explicitly for undefined rather than falsy
