### PR TITLE
enhance: Remove lodash dependency, reducing total bundle size

### DIFF
--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -67,9 +67,7 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@rest-hooks/normalizr": "^4.3.2",
-    "@types/lodash": "^4.14.149",
-    "flux-standard-action": "^2.1.1",
-    "lodash": "^4.17.15"
+    "flux-standard-action": "^2.1.1"
   },
   "peerDependencies": {
     "@types/react": "^16.8.2",


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #129.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Lodash is bloated and fairly outdated. Modern applications should exploit modern browser features or core-js polyfills.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Last usage of memoize is replaced by simple constructor creation
