### PR TITLE
enhance: Keep referential equality in list views

### DIFF
--- a/packages/normalizr/src/index.d.ts
+++ b/packages/normalizr/src/index.d.ts
@@ -333,3 +333,11 @@ export function denormalize<S extends Schema>(
   schema: S,
   entities: any,
 ): [Denormalize<S>, true] | [DenormalizeNullable<S>, false];
+
+export function denormalizeAndTracked<S extends Schema>(
+  input: any,
+  schema: S,
+  entities: any,
+):
+  | [Denormalize<S>, true, { [key: string]: { [key: string]: any } }]
+  | [DenormalizeNullable<S>, false, { [key: string]: { [key: string]: any } }];

--- a/packages/rest-hooks/src/resource/SimpleRecord.ts
+++ b/packages/rest-hooks/src/resource/SimpleRecord.ts
@@ -8,6 +8,13 @@ interface SimpleResourceMembers<T extends typeof SimpleRecord> {
 
 /** Immutable record that keeps track of which members are defined vs defaults. */
 export default abstract class SimpleRecord {
+  // a 'unique' identifier to make referential equality comparisons easy
+  declare readonly _unq: string;
+
+  toString(): string {
+    return this._unq;
+  }
+
   /** Factory method to convert from Plain JS Objects.
    *
    * @param [props] Plain Object of properties to assign.
@@ -30,9 +37,16 @@ export default abstract class SimpleRecord {
       writable: false,
     });
 
+    // a 'unique' identifier to make referential equality comparisons easy
+    Object.defineProperty(instance, '_unq', {
+      value: `${Math.random()}`,
+      writable: false,
+    });
+
     Object.assign(instance, props);
 
     // to trick normalizr into thinking we're Immutable.js does it doesn't copy
+    // TODO: remove when schemas.EntitySchema is deleted as this will not longer be needed
     Object.defineProperty(instance, '__ownerID', {
       value: 1337,
       writable: false,

--- a/packages/rest-hooks/src/state/selectors/__tests__/__snapshots__/useDenormalized.ts.snap
+++ b/packages/rest-hooks/src/state/selectors/__tests__/__snapshots__/useDenormalized.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useDenormalized() List paginated results should referentially change when the result extends 1`] = `
+Object {
+  "results": Array [
+    PaginatedArticleResource {
+      "author": null,
+      "content": "",
+      "id": 5,
+      "tags": Array [],
+      "title": "",
+    },
+    PaginatedArticleResource {
+      "author": null,
+      "content": "",
+      "id": 6,
+      "tags": Array [],
+      "title": "",
+    },
+    PaginatedArticleResource {
+      "author": null,
+      "content": "",
+      "id": 34,
+      "tags": Array [],
+      "title": "five",
+    },
+    PaginatedArticleResource {
+      "author": null,
+      "content": "",
+      "id": 5,
+      "tags": Array [],
+      "title": "",
+    },
+  ],
+}
+`;


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #249 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Performance
- Hooks world expects this - like useEffect, etc

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Track all entities captured in denormalize
- Serialize them
- Use that serialization as memo check for results

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
How does this affect performance overall? Could this be degrading non-list cases?