### PR TITLE
fix: wrap all dispatches in 'act' so fetches behave

### DIFF
--- a/packages/test/src/ActDispatchManager.ts
+++ b/packages/test/src/ActDispatchManager.ts
@@ -1,0 +1,24 @@
+import { Manager, MiddlewareAPI, Middleware, Dispatch } from 'rest-hooks';
+import { act } from 'react-test-renderer';
+
+export default class ActDispatchManager implements Manager {
+  protected declare middleware: Middleware;
+
+  constructor() {
+    this.middleware = <R extends React.Reducer<any, any>>({
+      dispatch,
+    }: MiddlewareAPI<R>) => {
+      return (next: Dispatch<R>) => (
+        action: React.ReducerAction<R>,
+      ): Promise<void> => {
+        return act(() => next(action));
+      };
+    };
+  }
+
+  cleanup() {}
+
+  getMiddleware<T extends ActDispatchManager>(this: T) {
+    return this.middleware;
+  }
+}

--- a/packages/test/src/makeRenderRestHook.tsx
+++ b/packages/test/src/makeRenderRestHook.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { renderHook, RenderHookOptions } from '@testing-library/react-hooks';
-
 import {
   State,
   SubscriptionManager,
@@ -8,6 +7,7 @@ import {
   Manager,
 } from 'rest-hooks';
 
+import ActDispatchManager from './ActDispatchManager';
 import { MockNetworkManager } from './managers';
 import mockInitialState, { Fixture } from './mockState';
 
@@ -19,6 +19,7 @@ export default function makeRenderRestHook(
 ) {
   const manager = new MockNetworkManager();
   const subManager = new SubscriptionManager(PollingSubscription);
+  const actManager = new ActDispatchManager();
   function renderRestHook<P, R>(
     callback: (props: P) => R,
     options?: {
@@ -29,7 +30,7 @@ export default function makeRenderRestHook(
     const initialState =
       options && options.results && mockInitialState(options.results);
     const Provider: React.ComponentType<any> = makeProvider(
-      [manager, subManager],
+      [manager, subManager, actManager],
       initialState,
     );
     const Wrapper = options && options.wrapper;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Since 'fetch' introduced immediate state updates, it was not wrapped properly in 'act'.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Introduce new manager when building renderRestHook that wraps all dispatches in act.
