### PR TITLE
feat: Ability to dynamically set nested schema type

### DIFF
--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -163,6 +163,49 @@ Array [
 ]
 `;
 
+exports[`normalize can normalize entity nested inside entity using property from parent 1`] = `
+Object {
+  "entities": Object {
+    "linkables": Object {
+      "1": Object {
+        "data": 2,
+        "id": 1,
+        "module_type": "article",
+        "schema_type": "media",
+      },
+    },
+    "media": Object {
+      "2": Object {
+        "id": 2,
+        "url": "catimage.jpg",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": 1,
+}
+`;
+
+exports[`normalize can normalize entity nested inside object using property from parent 1`] = `
+Object {
+  "entities": Object {
+    "media": Object {
+      "2": Object {
+        "id": 2,
+        "url": "catimage.jpg",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Object {
+    "data": 2,
+    "id": 1,
+    "module_type": "article",
+    "schema_type": "media",
+  },
+}
+`;
+
 exports[`normalize can use fully custom entity classes 1`] = `
 Object {
   "entities": Object {

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -305,6 +305,59 @@ describe('normalize', () => {
 
     expect(() => normalize(test, testEntity)).not.toThrow();
   });
+
+  test('can normalize entity nested inside entity using property from parent', () => {
+    const linkablesSchema = new schema.Entity('linkables');
+    const mediaSchema = new schema.Entity('media');
+    const listsSchema = new schema.Entity('lists');
+
+    const schemaMap = {
+      media: mediaSchema,
+      lists: listsSchema,
+    };
+
+    linkablesSchema.define({
+      data: parent => schemaMap[parent.schema_type],
+    });
+
+    const input = {
+      id: 1,
+      module_type: 'article',
+      schema_type: 'media',
+      data: {
+        id: 2,
+        url: 'catimage.jpg',
+      },
+    };
+
+    expect(normalize(input, linkablesSchema)).toMatchSnapshot();
+  });
+
+  test('can normalize entity nested inside object using property from parent', () => {
+    const mediaSchema = new schema.Entity('media');
+    const listsSchema = new schema.Entity('lists');
+
+    const schemaMap = {
+      media: mediaSchema,
+      lists: listsSchema,
+    };
+
+    const linkablesSchema = {
+      data: parent => schemaMap[parent.schema_type],
+    };
+
+    const input = {
+      id: 1,
+      module_type: 'article',
+      schema_type: 'media',
+      data: {
+        id: 2,
+        url: 'catimage.jpg',
+      },
+    };
+
+    expect(normalize(input, linkablesSchema)).toMatchSnapshot();
+  });
 });
 
 describe('denormalize', () => {

--- a/packages/normalizr/src/index.d.ts
+++ b/packages/normalizr/src/index.d.ts
@@ -106,7 +106,9 @@ declare namespace schema {
   }
 
   export class Object<
-    O extends { [key: string]: any } = { [key: string]: Schema }
+    O extends { [key: string]: any } = {
+      [key: string]: Schema | ((t: any) => Schema);
+    }
   > implements SchemaClass {
     constructor(definition: O);
     define(definition: Schema): void;
@@ -235,19 +237,35 @@ declare namespace schema {
 }
 
 type DenormalizeObject<S extends { [key: string]: any }> = {
-  [K in keyof S]: S[K] extends Schema ? Denormalize<S[K]> : S[K];
+  [K in keyof S]: S[K] extends Schema
+    ? Denormalize<S[K]>
+    : S[K] extends (v: any) => infer R
+    ? Denormalize<R>
+    : S[K];
 };
 
 type DenormalizeNullableObject<S extends { [key: string]: any }> = {
-  [K in keyof S]: S[K] extends Schema ? DenormalizeNullable<S[K]> : S[K];
+  [K in keyof S]: S[K] extends Schema
+    ? DenormalizeNullable<S[K]>
+    : S[K] extends (v: any) => infer R
+    ? DenormalizeNullable<R>
+    : S[K];
 };
 
 type NormalizeObject<S extends { [key: string]: any }> = {
-  [K in keyof S]: S[K] extends Schema ? Normalize<S[K]> : S[K];
+  [K in keyof S]: S[K] extends Schema
+    ? Normalize<S[K]>
+    : S[K] extends (v: any) => infer R
+    ? Normalize<R>
+    : S[K];
 };
 
 type NormalizedNullableObject<S extends { [key: string]: any }> = {
-  [K in keyof S]: S[K] extends Schema ? NormalizeNullable<S[K]> : S[K];
+  [K in keyof S]: S[K] extends Schema
+    ? NormalizeNullable<S[K]>
+    : S[K] extends (v: any) => infer R
+    ? NormalizeNullable<R>
+    : S[K];
 };
 
 export type DenormalizeReturnType<T> = T extends (

--- a/packages/normalizr/src/index.js
+++ b/packages/normalizr/src/index.js
@@ -94,7 +94,8 @@ export const schema = {
 };
 
 function expectedSchemaType(schema) {
-  return ['object', 'function'].includes(typeof schema)
+  return ['object', 'function'].includes(typeof schema) &&
+    Object.keys(schema).length
     ? 'object'
     : typeof schema;
 }

--- a/packages/normalizr/src/schemas/Entity.js
+++ b/packages/normalizr/src/schemas/Entity.js
@@ -75,11 +75,15 @@ export default class EntitySchema {
         typeof processedEntity[key] === 'object'
       ) {
         const schema = this.schema[key];
+        const resolvedSchema =
+          typeof schema === 'function' && !Object.keys(schema).length
+            ? schema(input)
+            : schema;
         processedEntity[key] = visit(
           processedEntity[key],
           processedEntity,
           key,
-          schema,
+          resolvedSchema,
           addEntity,
           visitedEntities,
         );

--- a/packages/normalizr/src/schemas/Object.js
+++ b/packages/normalizr/src/schemas/Object.js
@@ -12,11 +12,15 @@ export const normalize = (
   const object = { ...input };
   Object.keys(schema).forEach(key => {
     const localSchema = schema[key];
+    const resolvedLocalSchema =
+      typeof localSchema === 'function' && !Object.keys(schema).length
+        ? localSchema(input)
+        : localSchema;
     const value = visit(
       input[key],
       input,
       key,
-      localSchema,
+      resolvedLocalSchema,
       addEntity,
       visitedEntities,
     );

--- a/packages/normalizr/typescript-tests/object.ts
+++ b/packages/normalizr/typescript-tests/object.ts
@@ -1,12 +1,22 @@
 import { normalize, schema } from '../src'
 
-const data = {
-  /* ...*/
-};
+type Response = {
+  users: Array<{ id: string }>
+}
+const data: Response = { users: [ { id: 'foo' } ] };
 const user = new schema.Entity('users');
 
-const responseSchema = new schema.Object({ users: new schema.Array(user) });
-const normalizedData = normalize(data, responseSchema);
+{
+  const responseSchema = new schema.Object({ users: new schema.Array(user) });
+  const normalizedData = normalize(data, responseSchema);
+}
 
-const responseSchemaAlt = { users: new schema.Array(user) };
-const normalizedDataAlt = normalize(data, responseSchemaAlt);
+{
+  const responseSchema = new schema.Object({ users: (response: Response) => new schema.Array(user) });
+  const normalizedData = normalize(data, responseSchema);
+}
+
+{
+  const responseSchema = { users: new schema.Array(user) };
+  const normalizedData = normalize(data, responseSchema);
+}

--- a/packages/rest-hooks/src/resource/Entity.ts
+++ b/packages/rest-hooks/src/resource/Entity.ts
@@ -98,11 +98,15 @@ export default abstract class Entity extends SimpleRecord {
         typeof processedEntity[key] === 'object'
       ) {
         const schema = this.schema[key];
+        const resolvedSchema =
+          typeof schema === 'function' && !Object.keys(schema).length
+            ? schema(input)
+            : schema;
         processedEntity[key] = visit(
           processedEntity[key],
           processedEntity,
           key,
-          schema,
+          resolvedSchema,
           addEntity,
           visitedEntities,
         );


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://github.com/paularmstrong/normalizr/pull/415

Ability to 'normalize entity nested inside object using property from parent'

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
In Object (or plain) the members can be functions that resolve to schemas based on the input.