### PR TITLE
fix: ES export is non-min version

### DIFF
--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -26,13 +26,15 @@
     "README.md"
   ],
   "main": "dist/normalizr.js",
-  "module": "dist/normalizr.es.min.js",
+  "module": "dist/normalizr.es.js",
   "typings": "src/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "build": "npm run clean && run-p build:*",
     "build:development": "NODE_ENV=development rollup -c",
     "build:production": "NODE_ENV=production rollup -c",
+    "build:es_development": "BROWSERSLIST_ENV=production NODE_ENV=development rollup -c",
+    "build:es_production": "BROWSERSLIST_ENV=production NODE_ENV=production rollup -c",
     "clean": "rimraf dist",
     "lint": "yarn lint:cmd --fix",
     "lint:ci": "yarn lint:cmd",

--- a/packages/normalizr/rollup.config.js
+++ b/packages/normalizr/rollup.config.js
@@ -1,9 +1,11 @@
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import filesize from 'rollup-plugin-filesize';
-import { name } from './package.json';
 import resolve from 'rollup-plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
+
+import { name } from './package.json';
+
 const { presets } = require('./.babelrc');
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -16,30 +18,46 @@ function snakeCase(id) {
   return id.replace(/(-|\/)/g, '_').replace(/@/g, '');
 }
 
-export default [
-  {
+const configs = [];
+
+if (process.env.BROWSERSLIST_ENV === 'production') {
+  configs.push({
+    input: 'src/index.js',
+    output: [{ file: `${destBase}.es${destExtension}`, format: 'es' }],
+    plugins: [
+      babel({ runtimeHelpers: true, presets }),
+      isProduction && terser(),
+      filesize(),
+    ].filter(Boolean),
+  });
+} else {
+  configs.push({
     input: 'src/index.js',
     output: [
       { file: `${destBase}${destExtension}`, format: 'cjs' },
-      { file: `${destBase}.umd${destExtension}`, format: 'umd', name: snakeCase(name) },
-      { file: `${destBase}.amd${destExtension}`, format: 'amd', name: snakeCase(name) },
-      { file: `${destBase}.browser${destExtension}`, format: 'iife', name: snakeCase(name) }
+      {
+        file: `${destBase}.umd${destExtension}`,
+        format: 'umd',
+        name: snakeCase(name),
+      },
+      {
+        file: `${destBase}.amd${destExtension}`,
+        format: 'amd',
+        name: snakeCase(name),
+      },
+      {
+        file: `${destBase}.browser${destExtension}`,
+        format: 'iife',
+        name: snakeCase(name),
+      },
     ],
     plugins: [
       babel({ runtimeHelpers: true }),
       resolve({ extensions }),
       commonjs({ extensions }),
       isProduction && terser(),
-      filesize()
-    ].filter(Boolean)
-  },
-  {
-    input: 'src/index.js',
-    output: [{ file: `${destBase}.es${destExtension}`, format: 'es' }],
-    plugins: [
-      babel({ runtimeHelpers: true, presets }),
-      isProduction && terser(),
-      filesize()
-    ].filter(Boolean)
-  }
-];
+      filesize(),
+    ].filter(Boolean),
+  });
+}
+export default configs;

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -727,6 +727,21 @@
       },
       "version-4.2/api/version-4.2-Entity": {
         "title": "Entity"
+      },
+      "version-4.3/api/version-4.3-Entity": {
+        "title": "Entity"
+      },
+      "version-4.3/api/version-4.3-FetchShape": {
+        "title": "FetchShape"
+      },
+      "version-4.3/getting-started/version-4.3-usage": {
+        "title": "Usage"
+      },
+      "version-4.3/guides/version-4.3-optimistic-updates": {
+        "title": "Optimistic Updates"
+      },
+      "version-4.3/guides/version-4.3-url": {
+        "title": "URL Patterns"
       }
     },
     "links": {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Pointing to minified version breaks bundleaphobia (see more https://github.com/pastelsky/bundlephobia/issues/246)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Separate es builds so browser target can be latest while still targeting min/non-min for es.
