### PR TITLE
feat: Add SetShapeParams

### DIFF
--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -40,7 +40,7 @@ export default abstract class SimpleResource extends Entity {
    */
   static url<T extends typeof SimpleResource>(
     this: T,
-    urlParams: Partial<AbstractInstanceType<T>>,
+    urlParams: Readonly<Record<string, any>>,
   ): string {
     if (
       Object.prototype.hasOwnProperty.call(urlParams, 'url') &&
@@ -49,11 +49,11 @@ export default abstract class SimpleResource extends Entity {
     ) {
       return urlParams.url;
     }
-    if (this.pk(urlParams) !== undefined) {
+    if (this.pk(urlParams as any) !== undefined) {
       if (this.urlRoot.endsWith('/')) {
-        return `${this.urlRoot}${this.pk(urlParams)}`;
+        return `${this.urlRoot}${this.pk(urlParams as any)}`;
       }
-      return `${this.urlRoot}/${this.pk(urlParams)}`;
+      return `${this.urlRoot}/${this.pk(urlParams as any)}`;
     }
     return this.urlRoot;
   }

--- a/packages/rest-hooks/src/resource/types.ts
+++ b/packages/rest-hooks/src/resource/types.ts
@@ -5,17 +5,35 @@ import { FetchShape, DeleteShape } from './shapes';
 export type SchemaFromShape<
   F extends FetchShape<any, any, any>
 > = F extends FetchShape<infer S, any, any> ? S : never;
+
 /** Get the Params type for a given Shape */
 export type ParamsFromShape<S> = S extends {
-  fetch: (first: infer A, ...rest: any[]) => any;
+  fetch: (first: infer A, ...rest: any) => any;
 }
   ? A
-  : S extends { getFetchKey: (first: infer A, ...rest: any[]) => any }
+  : S extends { getFetchKey: (first: infer A, ...rest: any) => any }
   ? A
   : never;
+
 export type BodyFromShape<
   F extends FetchShape<any, any, any>
 > = F extends FetchShape<any, any, infer B> ? B : never;
+
+/** Sets a FetchShape's Param type.
+ * Useful to constrain acceptable params (second arg) in hooks like useResource().
+ *
+ * @param [Shape] FetchShape to act upon
+ * @param [Params] what to set the Params to
+ */
+export type SetShapeParams<
+  Shape extends FetchShape<any, any, any>,
+  Params extends Readonly<object>
+> = {
+  [K in keyof Shape]: Shape[K];
+} &
+  (Shape['fetch'] extends (first: any, ...rest: infer Args) => infer Return
+    ? { fetch: (first: Params, ...rest: Args) => Return }
+    : never);
 
 export function isDeleteShape(
   shape: FetchShape<any, any, any>,


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #209 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Constraining acceptable params is an incredibly valuable feature; but arbitrarily defining what should be expected was previously cumbersome.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```typescript
type MyParamType = {
  slug: string,
};

class MyThing extends Resource {
//...
  static detailShape<T extends typeof SimpleResource>(
    this: T,
  ) {
    const shape = super.detailShape();
    return shape as SetShapeParams<typeof shape, MyParamType>;
  }
}
```

```tsx
// fine
const mything = useResource(MyThing.detailShape(), { slug: 'hi' });
// expected number
const mything = useResource(MyThing.detailShape(), { slug: 5 });
// somethingelse not found in type
const mything = useResource(MyThing.detailShape(), { somethingelse: 5 });
// slug expected to be here
const mything = useResource(MyThing.detailShape(), { });
```
