### PR TITLE
fix: listUrl() on react native no longer throws error

### DIFF
--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -1,6 +1,7 @@
 import { ReadShape, MutateShape, DeleteShape } from './shapes';
 import { SchemaDetail, SchemaList } from './normal';
 import Entity from './Entity';
+import paramsToString from './paramsToString';
 
 import { NotImplementedError } from '~/errors';
 import { AbstractInstanceType, Method, FetchOptions } from '~/types';
@@ -66,9 +67,7 @@ export default abstract class SimpleResource extends Entity {
     searchParams: Readonly<Record<string, string | number>> = {},
   ): string {
     if (Object.keys(searchParams).length) {
-      const params = new URLSearchParams(searchParams as any);
-      params.sort();
-      return `${this.urlRoot}?${params.toString()}`;
+      return `${this.urlRoot}?${paramsToString(searchParams)}`;
     }
     return this.urlRoot;
   }

--- a/packages/rest-hooks/src/resource/paramsToString.native.ts
+++ b/packages/rest-hooks/src/resource/paramsToString.native.ts
@@ -1,0 +1,6 @@
+export default function paramsToString(
+  searchParams: Readonly<Record<string, string | number>>,
+) {
+  const params = new URLSearchParams(searchParams as any);
+  return params.toString();
+}

--- a/packages/rest-hooks/src/resource/paramsToString.ts
+++ b/packages/rest-hooks/src/resource/paramsToString.ts
@@ -1,0 +1,7 @@
+export default function paramsToString(
+  searchParams: Readonly<Record<string, string | number>>,
+) {
+  const params = new URLSearchParams(searchParams as any);
+  params.sort();
+  return params.toString();
+}


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #260 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
React native throw not implemented error for URLSearchParams.sort().

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Use [.native.js](https://facebook.github.io/react-native/docs/platform-specific-code) extension to make a version of the module with platform specific code
