### PR TITLE
enhance: Commonjs bundle uses native-compatible code

### DIFF
--- a/packages/rest-hooks/rollup.config.js
+++ b/packages/rest-hooks/rollup.config.js
@@ -13,6 +13,7 @@ const dependencies = Object.keys(pkg.dependencies)
   .filter(dep => !['@rest-hooks/normalizr', '@babel/runtime'].includes(dep));
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
+const nativeExtensions = ['.native.ts', ...extensions];
 process.env.NODE_ENV = 'production';
 process.env.BROWSERSLIST_ENV = 'legacy';
 
@@ -34,9 +35,9 @@ export default [
     output: [{ file: pkg.unpkg, format: 'umd', name: 'restHook' }],
     plugins: [
       babel({
-        exclude: ['node_modules/**', '**/__tests__/**'],
+        exclude: ['node_modules/**', '/**__tests__/**'],
         extensions,
-        rootMode: "upward",
+        rootMode: 'upward',
         runtimeHelpers: true,
       }),
       replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
@@ -55,12 +56,13 @@ export default [
     plugins: [
       babel({
         exclude: ['node_modules/**', '**/__tests__/**', '**/*.d.ts'],
-        extensions,
-        rootMode: "upward",
+        extensions: nativeExtensions,
+        rootMode: 'upward',
         runtimeHelpers: true,
       }),
-      resolve({ extensions }),
-      commonjs({ extensions }),
+      replace({ 'process.env.CJS': 'true' }),
+      resolve({ extensions: nativeExtensions }),
+      commonjs({ extensions: nativeExtensions }),
     ],
   },
 ];

--- a/packages/rest-hooks/src/resource/paramsToString.native.ts
+++ b/packages/rest-hooks/src/resource/paramsToString.native.ts
@@ -2,5 +2,9 @@ export default function paramsToString(
   searchParams: Readonly<Record<string, string | number>>,
 ) {
   const params = new URLSearchParams(searchParams as any);
+  try {
+    params.sort();
+    // eslint-disable-next-line no-empty
+  } catch {}
   return params.toString();
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Often metro bundler for react-native will use the common js version - so lets ensure it's maximum compatibility.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Read .native.ts extensions first for module resolution in CJS bundling