### PR TITLE
feat: Include all FetchOptions in subscribe action

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -195,8 +195,9 @@ export class PollingArticleResource extends ArticleResource {
     return {
       ...this.detailShape(),
       options: {
-        eventType: 'PollingArticleResource:fetch',
-        pollFrequency: 0,
+        extra: {
+          eventType: 'PollingArticleResource:fetch',
+        },
       },
     };
   }

--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {
   Resource,
   SchemaList,
@@ -187,6 +188,16 @@ export class PollingArticleResource extends ArticleResource {
     return {
       ...super.getFetchOptions(),
       pollFrequency: 5000,
+    };
+  }
+
+  static pusherShape<T extends typeof PollingArticleResource>(this: T) {
+    return {
+      ...this.detailShape(),
+      options: {
+        eventType: 'PollingArticleResource:fetch',
+        pollFrequency: 0,
+      },
     };
   }
 }

--- a/packages/rest-hooks/src/react-integration/__tests__/subscriptions.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/subscriptions.tsx
@@ -133,6 +133,28 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       expect(fakeDispatch.mock.calls.length).toBe(1);
     });
   });
+
+  it('useSubscription() should include options in dispatched meta', () => {
+    const fakeDispatch = jest.fn();
+
+    renderHook(
+      () => {
+        useSubscription(PollingArticleResource.pusherShape(), {});
+      },
+      {
+        wrapper: function Wrapper({ children }: any) {
+          return (
+            <DispatchContext.Provider value={fakeDispatch}>
+              {children}
+            </DispatchContext.Provider>
+          );
+        },
+      },
+    );
+
+    const spy = fakeDispatch.mock.calls[0][0];
+    expect(spy.meta.eventType).toEqual('PollingArticleResource:fetch');
+  });
 }
 
 async function validateSubscription(

--- a/packages/rest-hooks/src/react-integration/__tests__/subscriptions.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/subscriptions.tsx
@@ -134,7 +134,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
     });
   });
 
-  it('useSubscription() should include options in dispatched meta', () => {
+  it('useSubscription() should include extra options in dispatched meta', () => {
     const fakeDispatch = jest.fn();
 
     renderHook(
@@ -153,7 +153,9 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
     );
 
     const spy = fakeDispatch.mock.calls[0][0];
-    expect(spy.meta.eventType).toEqual('PollingArticleResource:fetch');
+    expect(spy.meta.options.extra.eventType).toEqual(
+      'PollingArticleResource:fetch',
+    );
   });
 }
 

--- a/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
@@ -22,7 +22,8 @@ export default function useSubscription<
 
   useEffect(() => {
     if (!params) return;
-    const { fetch, schema, getFetchKey, options } = shapeRef.current;
+    const { fetch, schema, getFetchKey, options = {} } = shapeRef.current;
+    const { pollFrequency: frequency, ...otherOptions } = options;
     const url = getFetchKey(params);
 
     dispatch({
@@ -31,7 +32,8 @@ export default function useSubscription<
         schema,
         fetch: () => fetch(params),
         url,
-        frequency: options && options.pollFrequency,
+        frequency,
+        ...otherOptions
       },
     });
     return () => {
@@ -39,7 +41,8 @@ export default function useSubscription<
         type: UNSUBSCRIBE_TYPE,
         meta: {
           url,
-          frequency: options && options.pollFrequency,
+          frequency,
+          ...otherOptions
         },
       });
     };

--- a/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
@@ -22,8 +22,7 @@ export default function useSubscription<
 
   useEffect(() => {
     if (!params) return;
-    const { fetch, schema, getFetchKey, options = {} } = shapeRef.current;
-    const { pollFrequency: frequency, ...otherOptions } = options;
+    const { fetch, schema, getFetchKey, options } = shapeRef.current;
     const url = getFetchKey(params);
 
     dispatch({
@@ -32,8 +31,7 @@ export default function useSubscription<
         schema,
         fetch: () => fetch(params),
         url,
-        frequency,
-        ...otherOptions
+        options,
       },
     });
     return () => {
@@ -41,8 +39,7 @@ export default function useSubscription<
         type: UNSUBSCRIBE_TYPE,
         meta: {
           url,
-          frequency,
-          ...otherOptions
+          options,
         },
       });
     };

--- a/packages/rest-hooks/src/state/SubscriptionManager.ts
+++ b/packages/rest-hooks/src/state/SubscriptionManager.ts
@@ -78,14 +78,16 @@ export default class SubscriptionManager<S extends SubscriptionConstructable>
    */
   protected handleSubscribe(action: SubscribeAction, dispatch: Dispatch<any>) {
     const url = action.meta.url;
+    const frequency = action.meta.options?.pollFrequency;
+
     if (url in this.subscriptions) {
-      this.subscriptions[url].add(action.meta.frequency);
+      this.subscriptions[url].add(frequency);
     } else {
       this.subscriptions[url] = new this.Subscription(
         {
           schema: action.meta.schema,
           fetch: action.meta.fetch,
-          frequency: action.meta.frequency,
+          frequency,
           url,
         },
         dispatch,
@@ -101,9 +103,11 @@ export default class SubscriptionManager<S extends SubscriptionConstructable>
     dispatch: Dispatch<any>,
   ) {
     const url = action.meta.url;
+    const frequency = action.meta.options?.pollFrequency;
+
     /* istanbul ignore else */
     if (url in this.subscriptions) {
-      const empty = this.subscriptions[url].remove(action.meta.frequency);
+      const empty = this.subscriptions[url].remove(frequency);
       if (empty) {
         delete this.subscriptions[url];
       }

--- a/packages/rest-hooks/src/state/__tests__/subscriptionManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/subscriptionManager.ts
@@ -60,7 +60,7 @@ describe('SubscriptionManager', () => {
           schema: PollingArticleResource.getEntitySchema(),
           url: PollingArticleResource.url(payload),
           fetch,
-          frequency: 1000,
+          options: { pollFrequency: 1000 },
         },
       };
     }
@@ -69,7 +69,7 @@ describe('SubscriptionManager', () => {
         type: UNSUBSCRIBE_TYPE,
         meta: {
           url: PollingArticleResource.url(payload),
-          frequency: 1000,
+          options: { pollFrequency: 1000 },
         },
       };
     }

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
+
 import { NormalizedIndex } from '@rest-hooks/normalizr';
 
 import { ErrorableFSAWithPayloadAndMeta, ErrorableFSAWithMeta } from './fsa';
@@ -54,6 +55,8 @@ export interface FetchOptions {
     params: Readonly<object>,
     body: Readonly<object | string> | void,
   ) => any;
+  /** User-land extra data to send */
+  readonly extra?: any;
 }
 
 interface ReceiveMeta<S extends Schema> {
@@ -146,7 +149,7 @@ export interface SubscribeAction
     schema: Schema;
     fetch: () => Promise<any>;
     url: string;
-    frequency?: number;
+    options: FetchOptions | undefined;
   };
 }
 
@@ -154,7 +157,7 @@ export interface UnsubscribeAction
   extends FSAWithMeta<typeof UNSUBSCRIBE_TYPE, undefined, any> {
   meta: {
     url: string;
-    frequency?: number;
+    options: FetchOptions | undefined;
   };
 }
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- This allows custom FetchShapes to include options that a custom Middleware can hook into. useSubscription was previously only pulling `pollFrequency` from options. This now includes all options in meta object.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

- subscribe/unsubscribe actions now include all FetchOptions, rather than just frequency (BREAKING)
- Add 'extra' member to FetchOptions