### PR TITLE
feat: Support non JSON (aka binary) fetches

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -296,6 +296,20 @@ export class NestedArticleResource extends OtherArticleResource {
   };
 }
 
+export const photoShape = {
+  type: 'read' as const,
+  schema: null as ArrayBuffer | null,
+  getFetchKey({ userId }: { userId: string }) {
+    return `/users/${userId}/photo`;
+  },
+  fetch: async ({ userId }: { userId: string }) => {
+    const response = await fetch(`http://test.com/users/${userId}/photo`);
+    const photoArrayBuffer = await response.arrayBuffer();
+
+    return photoArrayBuffer;
+  },
+};
+
 export function makeErrorBoundary(cb: (error: any) => void) {
   return class ErrorInterceptor extends React.Component<any, { error: any }> {
     state = { error: null };

--- a/docs/guides/binary-fetches.md
+++ b/docs/guides/binary-fetches.md
@@ -1,0 +1,41 @@
+---
+title: Fetching Media
+---
+
+After setting up Rest Hooks for structured data fetching, you might want to incorporate
+some media fetches as well to take advantage of suspense and concurrent mode support.
+
+[Resource](../api/Resource) and [Entity](../api/Entity) should not be used in this case, since they both represent
+string -> value map structures. Instead, we'll define our own simple [FetchShape](../api/FetchShape)
+with a schema set to null, but with a type including what we expect in the response.
+
+Schemas with literal types like null simply pass through the response, but their value is
+used to construct responses when the data does not exist yet (like in [useCache](../api/useCache))
+
+
+```typescript
+export const photoShape = {
+  type: 'read' as const,
+  schema: null as ArrayBuffer | null,
+  getFetchKey({ userId }: { userId: string }) {
+    return `/users/${userId}/photo`;
+  },
+  fetch: async ({ userId }: { userId: string }) => {
+    const response = await fetch(`/users/${userId}/photo`);
+    const photoArrayBuffer = await response.arrayBuffer();
+
+    return photoArrayBuffer;
+  },
+};
+```
+
+```tsx
+// photo is typed as null | ArrayBuffer, but should be an ArrayBuffer
+const photo = useResource(photoShape, { userId });
+```
+
+```tsx
+// photo will be null if the fetch hasn't completed
+// photo will be ArrayBuffer if the fetch has completed
+const photo = useCache(photoShape, { userId });
+```

--- a/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
@@ -5,6 +5,7 @@ import {
   CoolerArticleResource,
   UserResource,
   InvalidIfStaleArticleResource,
+  photoShape,
 } from '__tests__/common';
 
 // relative imports to avoid circular dependency in tsconfig references
@@ -381,5 +382,20 @@ describe('useResource()', () => {
     });
     expect(result.current).toBe('done');
     expect(article).toBeUndefined();
+  });
+
+  it('should work with ArrayBuffer shapes', async () => {
+    const userId = '5';
+    const response = new ArrayBuffer(10);
+    nock(/.*/)
+      .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
+      .get(`/users/${userId}/photo`)
+      .reply(200, response);
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useResource(photoShape, { userId });
+    });
+    expect(result.current).toBe(null);
+    await waitForNextUpdate();
+    expect(result.current).toStrictEqual(response);
   });
 });

--- a/packages/rest-hooks/src/resource/types.ts
+++ b/packages/rest-hooks/src/resource/types.ts
@@ -35,5 +35,5 @@ export type BodyArg<RS> = RS extends {
   : never;
 
 export function isEntity(schema: Schema): schema is typeof Entity {
-  return (schema as any).getId !== undefined;
+  return schema !== null && (schema as any).getId !== undefined;
 }

--- a/packages/rest-hooks/src/state/selectors/buildInferredResults.ts
+++ b/packages/rest-hooks/src/state/selectors/buildInferredResults.ts
@@ -17,6 +17,9 @@ export default function buildInferredResults<
   params: Params | null,
   indexes: NormalizedIndex,
 ): NormalizeNullable<S> {
+  if (!isSchema(schema)) {
+    return schema as any;
+  }
   if (isEntity(schema)) {
     if (!params) return undefined as any;
     const id = schema.getId(params, undefined, '');
@@ -48,11 +51,7 @@ export default function buildInferredResults<
   const o = schema instanceof schemas.Object ? (schema as any).schema : schema;
   const resultObject = {} as any;
   for (const k in o) {
-    if (!isSchema(o[k])) {
-      resultObject[k] = o[k];
-    } else {
-      resultObject[k] = buildInferredResults(o[k], params, indexes);
-    }
+    resultObject[k] = buildInferredResults(o[k], params, indexes);
   }
   return resultObject;
 }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -89,6 +89,9 @@
       "guides/auth": {
         "title": "Authentication"
       },
+      "guides/binary-fetches": {
+        "title": "Fetching Media"
+      },
       "guides/class-components": {
         "title": "Usage with class components"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -36,7 +36,7 @@
       {
         "type": "subcategory",
         "label": "Resource Definitions",
-        "ids": ["guides/custom-networking", "guides/resource-lifetime"]
+        "ids": ["guides/custom-networking", "guides/resource-lifetime", "guides/binary-fetches"]
       },
       {
         "type": "subcategory",


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #266.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
With Rest Hooks already useful for JSON type data, it should allow for other response types like images, ArrayBuffers, etc.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Sample FetchShape:
```typescript
export const photoShape = {
  type: 'read' as const,
  schema: null as ArrayBuffer | null,
  getFetchKey({ userId }: { userId: string }) {
    return `/users/${userId}/photo`;
  },
  fetch: async ({ userId }: { userId: string }) => {
    const response = await fetch(`/users/${userId}/photo`);
    const photoArrayBuffer = await response.arrayBuffer();

    return photoArrayBuffer;
  },
};
```

Usage:
```tsx
const photo = useResource(photoShape, { userId });
```

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
useResource() ensures a response, but we're still stuck with the | null union. This is needed however to have sane defaults. Currently the only distinction is based on entities, which this cannot be so would require some rethinking from normalizr design.

Perhaps a better solution is to simply allow schema to be undefined, and then take the return type of fetch.