### PR TITLE
fix: Poll fetches while testing should be wrapped in act

### DIFF
--- a/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import nock from 'nock';
+import { act } from '@testing-library/react-hooks';
 import {
   CoolerArticleResource,
   ArticleResource,
@@ -104,7 +105,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       expect(result.current instanceof CoolerArticleResource).toBe(true);
       expect(result.current.title).toBe(payload.title);
 
-      await del(payload);
+      await act(() => del(payload));
       expect(result.error).toBeDefined();
       expect((result.error as any).status).toBe(404);
     });

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,11 +1,10 @@
-import { MockNetworkManager } from './managers';
 import makeRenderRestHook from './makeRenderRestHook';
 import { makeExternalCacheProvider, makeCacheProvider } from './providers';
 import MockProvider from './MockProvider';
 import mockInitialState from './mockState';
+export * from './managers';
 
 export {
-  MockNetworkManager,
   makeRenderRestHook,
   makeExternalCacheProvider,
   makeCacheProvider,

--- a/packages/test/src/makeRenderRestHook.tsx
+++ b/packages/test/src/makeRenderRestHook.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
 import { renderHook, RenderHookOptions } from '@testing-library/react-hooks';
+import { State, SubscriptionManager, Manager } from 'rest-hooks';
 
-import {
-  State,
-  SubscriptionManager,
-  PollingSubscription,
-  Manager,
-} from 'rest-hooks';
-
-import { MockNetworkManager } from './managers';
+import { MockNetworkManager, MockPollingSubscription } from './managers';
 import mockInitialState, { Fixture } from './mockState';
 
 export default function makeRenderRestHook(
@@ -18,7 +12,7 @@ export default function makeRenderRestHook(
   ) => React.ComponentType<{ children: React.ReactChild }>,
 ) {
   const manager = new MockNetworkManager();
-  const subManager = new SubscriptionManager(PollingSubscription);
+  const subManager = new SubscriptionManager(MockPollingSubscription);
   function renderRestHook<P, R>(
     callback: (props: P) => R,
     options?: {

--- a/packages/test/src/managers.ts
+++ b/packages/test/src/managers.ts
@@ -1,10 +1,10 @@
 import { act } from '@testing-library/react-hooks';
-
 import {
   NetworkManager,
   FetchAction,
   ReceiveAction,
   Dispatch,
+  PollingSubscription,
 } from 'rest-hooks';
 
 export class MockNetworkManager extends NetworkManager {
@@ -21,6 +21,15 @@ export class MockNetworkManager extends NetworkManager {
   handleReceive(action: ReceiveAction) {
     act(() => {
       super.handleReceive(action);
+    });
+  }
+}
+
+export class MockPollingSubscription extends PollingSubscription {
+  /** Trigger request for latest resource */
+  protected update() {
+    act(() => {
+      super.update();
     });
   }
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Less spam about needing to wrap in act()

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
