### PR TITLE
fix: Fix commonjs bundle

### DIFF
--- a/packages/rest-hooks/rollup.config.js
+++ b/packages/rest-hooks/rollup.config.js
@@ -10,7 +10,14 @@ import pkg from './package.json';
 
 const dependencies = Object.keys(pkg.dependencies)
   .concat(Object.keys(pkg.peerDependencies))
-  .filter(dep => !['@rest-hooks/normalizr', '@babel/runtime'].includes(dep));
+  .filter(
+    dep =>
+      ![
+        '@rest-hooks/normalizr',
+        '@rest-hooks/use-enhanced-reducer',
+        '@babel/runtime',
+      ].includes(dep),
+  );
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
 const nativeExtensions = ['.native.ts', ...extensions];

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -1,10 +1,4 @@
 import {
-  MiddlewareAPI,
-  Middleware,
-  Dispatch,
-} from '@rest-hooks/use-enhanced-reducer';
-
-import {
   Resource,
   SimpleResource,
   SimpleRecord,
@@ -50,15 +44,13 @@ const __INTERNAL__ = {
 
 export type NetworkError = OGNetworkError;
 
+export * from '@rest-hooks/use-enhanced-reducer';
 export * from './types';
 export * from './resource/shapes';
 export * from './resource/normal';
 export * from './resource/publicTypes';
 export * from './resource/Entity';
 export {
-  MiddlewareAPI,
-  Middleware,
-  Dispatch,
   Resource,
   SimpleResource,
   Entity,

--- a/packages/rest-hooks/src/react-integration/provider/ExternalCacheProvider.tsx
+++ b/packages/rest-hooks/src/react-integration/provider/ExternalCacheProvider.tsx
@@ -5,7 +5,6 @@ import {
 import masterReducer from 'rest-hooks/state/reducer';
 import { State, ActionTypes } from 'rest-hooks/types';
 import { usePromisifiedDispatch } from '@rest-hooks/use-enhanced-reducer';
-
 import React, { ReactNode, useEffect, useState, useMemo } from 'react';
 
 interface Store<S> {

--- a/packages/rest-hooks/src/react-integration/provider/PromiseifyMiddleware.ts
+++ b/packages/rest-hooks/src/react-integration/provider/PromiseifyMiddleware.ts
@@ -1,4 +1,5 @@
-import { MiddlewareAPI, Dispatch } from './types';
+import React from 'react';
+import { MiddlewareAPI, Dispatch } from '@rest-hooks/use-enhanced-reducer';
 
 const PromiseifyMiddleware = <R extends React.Reducer<any, any>>(
   _: MiddlewareAPI<R>,

--- a/packages/rest-hooks/src/react-integration/provider/index.ts
+++ b/packages/rest-hooks/src/react-integration/provider/index.ts
@@ -1,5 +1,4 @@
-import { PromiseifyMiddleware } from '@rest-hooks/use-enhanced-reducer';
-
+import PromiseifyMiddleware from './PromiseifyMiddleware';
 import CacheProvider from './CacheProvider';
 import ExternalCacheProvider from './ExternalCacheProvider';
 

--- a/packages/use-enhanced-reducer/rollup.config.js
+++ b/packages/use-enhanced-reducer/rollup.config.js
@@ -14,6 +14,8 @@ const dependencies = Object.keys(pkg.peerDependencies).filter(
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
 process.env.NODE_ENV = 'production';
+process.env.BROWSERSLIST_ENV = 'legacy';
+process.env.ROOT_PATH_PREFIX = '@rest-hooks/use-enhanced-reducer';
 
 function isExternal(id) {
   const ret = dependencies.includes(id);

--- a/packages/use-enhanced-reducer/src/index.ts
+++ b/packages/use-enhanced-reducer/src/index.ts
@@ -1,6 +1,5 @@
 import useEnhancedReducer from './useEnhancedReducer';
 export * from './types';
 export { default as usePromisifiedDispatch } from './usePromisifiedDispatch';
-export { default as PromiseifyMiddleware } from './PromiseifyMiddleware';
 
 export default useEnhancedReducer;

--- a/packages/use-enhanced-reducer/src/types.ts
+++ b/packages/use-enhanced-reducer/src/types.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export interface MiddlewareAPI<
   R extends React.Reducer<any, any> = React.Reducer<any, any>
 > {

--- a/packages/use-enhanced-reducer/src/useEnhancedReducer.ts
+++ b/packages/use-enhanced-reducer/src/useEnhancedReducer.ts
@@ -1,4 +1,4 @@
-import { useReducer, useMemo, useRef, useEffect } from 'react';
+import React, { useReducer, useMemo, useRef, useEffect } from 'react';
 
 import { Middleware, Dispatch } from './types';
 import usePromisifiedDispatch from './usePromisifiedDispatch';

--- a/packages/use-enhanced-reducer/src/usePromisifiedDispatch.ts
+++ b/packages/use-enhanced-reducer/src/usePromisifiedDispatch.ts
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
 
 type PromiseHolder = { promise: Promise<void>; resolve: () => void };
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -111,12 +111,12 @@
       "guides/fetch-then-render": {
         "title": "Fetch then Render"
       },
+      "guides/immediate-updates": {
+        "title": "Immediate Mutation Updates"
+      },
       "guides/immutability": {
         "title": "Understanding Immutability",
         "sidebar_label": "Understanding Immutability"
-      },
-      "guides/instant-updates": {
-        "title": "Instant Mutation Updates"
       },
       "guides/loading-state": {
         "title": "Handling loading state"
@@ -771,8 +771,8 @@
       "version-4.5/guides/version-4.5-binary-fetches": {
         "title": "Fetching Media"
       },
-      "version-4.5/guides/version-4.5-instant-updates": {
-        "title": "Instant Mutation Updates"
+      "version-4.5/guides/version-4.5-immediate-updates": {
+        "title": "Immediate Mutation Updates"
       },
       "version-4.5/guides/version-4.5-optimistic-updates": {
         "title": "Optimistic Updates"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Had some weird edge cases in testing

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Inline use-enhanced-reducer into rest-hooks
- Target legacy for cjs bundle in use-enhanced-reducer
- Move PromiseifyMiddleware back into rest-hooks since it's only useful for externalcacheprovider
