### PR TITLE
fix: type SimpleRecord._unq should be private

### DIFF
--- a/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/hooks.tsx
@@ -1,13 +1,14 @@
-import React, { Suspense, useEffect } from 'react';
-import { render } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
-import nock from 'nock';
 import {
   CoolerArticleResource,
   PaginatedArticleResource,
   ArticleResourceWithOtherListUrl,
   StaticArticleResource,
 } from '__tests__/common';
+
+import React, { Suspense, useEffect } from 'react';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import nock from 'nock';
 
 // relative imports to avoid circular dependency in tsconfig references
 import {

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -1,7 +1,6 @@
 import { NormalizedIndex } from '@rest-hooks/normalizr';
 import { Middleware } from '@rest-hooks/use-enhanced-reducer';
 
-import React from 'react';
 import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
 
 import { ErrorableFSAWithPayloadAndMeta, ErrorableFSAWithMeta } from './fsa';


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
SimpleRecord._unq is a tracker used in toString() to make referential comparisoins easier (#251 ).

Exposing this is problematic as it pollutes the structural definition of any classes inheriting from SimpleRecord. This might have been done previously due to limitations of parsing declare lines - but this seems to work now.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Removing the type declaration altogether is necessary to avoid its pollution of type compatibility

https://www.typescriptlang.org/docs/handbook/type-compatibility.html#private-and-protected-members-in-classes

Technically this is a breaking change, but it increases compatibility rather than restricts it, so it likely won't cause issues.