### PR TITLE
feat: Export __INTERNAL__.actionTypes

### DIFF
--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -31,6 +31,7 @@ import {
 import useSelectionUnstable from './react-integration/hooks/useSelection';
 import hasUsableData from './react-integration/hooks/hasUsableData';
 import { StateContext, DispatchContext } from './react-integration/context';
+import * as actionTypes from './actionTypes';
 
 const __INTERNAL__ = {
   initialState,
@@ -39,6 +40,7 @@ const __INTERNAL__ = {
   RIC,
   hasUsableData,
   buildInferredResults,
+  actionTypes,
   isEntity,
 };
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Building custom Managers

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Exported under \_\_INTERNAL__ because action structure is still considered somewhat unstable.