### PR TITLE
internal: readonly should exist on all levels of internal state

### DIFF
--- a/packages/normalizr/src/index.d.ts
+++ b/packages/normalizr/src/index.d.ts
@@ -310,7 +310,9 @@ export type Schema =
   | schema.SchemaClass;
 
 export type NormalizedIndex = {
-  [entityKey: string]: { [indexName: string]: { [lookup: string]: string } };
+  readonly [entityKey: string]: {
+    readonly [indexName: string]: { readonly [lookup: string]: string };
+  };
 };
 
 export type NormalizedSchema<E, R> = {

--- a/packages/rest-hooks/src/state/reducer.ts
+++ b/packages/rest-hooks/src/state/reducer.ts
@@ -141,7 +141,7 @@ export default function reducer(
   }
 }
 
-type Writable<T> = { [P in keyof T]: NonNullable<T[P]> };
+type Writable<T> = { [P in keyof T]: NonNullable<Writable<T[P]>> };
 
 /** Filter all requests with same serialization that did not start after the resolving request */
 function filterOptimistic(

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -1,6 +1,5 @@
 import { NormalizedIndex } from '@rest-hooks/normalizr';
 import { Middleware } from '@rest-hooks/use-enhanced-reducer';
-
 import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
 
 import { ErrorableFSAWithPayloadAndMeta, ErrorableFSAWithMeta } from './fsa';
@@ -29,15 +28,21 @@ export type AbstractInstanceType<T> = T extends { prototype: infer U }
 
 export type EntityInstance<T> = Readonly<AbstractInstanceType<T>>;
 
-export type PK = string | number;
+export type PK = string;
 
 export type State<T> = Readonly<{
-  entities: Readonly<{ [entityKey: string]: { [pk: string]: T } | undefined }>;
-  indexes: Readonly<NormalizedIndex>;
-  results: Readonly<{ [url: string]: unknown | PK[] | PK | undefined }>;
-  meta: Readonly<{
-    [url: string]: { date: number; error?: Error; expiresAt: number };
-  }>;
+  entities: {
+    readonly [entityKey: string]: { readonly [pk: string]: T } | undefined;
+  };
+  indexes: NormalizedIndex;
+  results: { readonly [url: string]: unknown | PK[] | PK | undefined };
+  meta: {
+    readonly [url: string]: {
+      readonly date: number;
+      readonly error?: Error;
+      readonly expiresAt: number;
+    };
+  };
   optimistic: ResponseActions[];
 }>;
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Redux state should never be modified

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
