### PR TITLE
fix: useCache() with indexes but no entities ever stored

### DIFF
--- a/packages/rest-hooks/src/state/selectors/__tests__/buildInferredResults.ts
+++ b/packages/rest-hooks/src/state/selectors/__tests__/buildInferredResults.ts
@@ -148,4 +148,19 @@ describe('buildInferredResults()', () => {
       data: undefined,
     });
   });
+
+  it('should work with indexes but no indexes stored', () => {
+    const schema = {
+      pagination: { next: '', previous: '' },
+      data: IndexedUserResource.asSchema(),
+    };
+    expect(buildInferredResults(schema, { username: 'bob' }, {})).toEqual({
+      pagination: { next: '', previous: '' },
+      data: undefined,
+    });
+    expect(buildInferredResults(schema, { hover: 'bob' }, {})).toEqual({
+      pagination: { next: '', previous: '' },
+      data: undefined,
+    });
+  });
 });

--- a/packages/rest-hooks/src/state/selectors/buildInferredResults.ts
+++ b/packages/rest-hooks/src/state/selectors/buildInferredResults.ts
@@ -24,7 +24,7 @@ export default function buildInferredResults<
     if (id !== undefined && id !== '') return id as any;
     // now attempt lookup in indexes
     const indexName = indexFromParams(params, schema.indexes);
-    if (indexName) {
+    if (indexName && indexes[schema.key]) {
       // 'as Record<string, any>': indexName can only be found if params is a string key'd object
       return indexes[schema.key][indexName][
         (params as Record<string, any>)[indexName]


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In case absolutely no entities of the requested type have been stored before, the index table for that particular entity will not be set. This means useCache() on index values can sometimes throw if their data isn't loaded.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Simple check addition to the if statement in buildInferredResults.