### PR TITLE
docs: Add example for infinite scrolling pagination

### DIFF
--- a/docs/guides/infinite-scrolling-pagination.md
+++ b/docs/guides/infinite-scrolling-pagination.md
@@ -1,0 +1,113 @@
+---
+title: Infinite Scrolling
+---
+
+## Add Update Function matching network schema
+
+If your API follows a common pattern, adding the [update function](../api/useFetcher#updatefunction-sourceresults-destresults--destresults)
+to a base class can make adding pagination behavior to any of your endpoints quite easy.
+
+```typescript
+abstract class BaseResource extends Resource {
+  static listShape<T extends typeof Resource>(this: T) {
+    return {
+      ...super.listShape(),
+      schema: { results: [this.asSchema()], cursor: null as string | null },
+    };
+  }
+
+  static appendList(
+    newResults: { results: string[] },
+    existingResults: { results: string[] } | undefined,
+  ) {
+    // In case there are duplicates, Set will eliminate them.
+    const set = new Set([
+      ...(existingResults?.results ?? []),
+      ...newResults.results,
+    ]);
+    return {
+      ...newResults,
+      results: [...set.values()],
+    };
+  }
+}
+```
+
+## Create pagination hook
+
+Here we'll define a helper hook for pagination that uses the BaseResource
+[update function](../api/useFetcher#updatefunction-sourceresults-destresults--destresults).
+This can then be used for any Resources that conform to this schema. Most likely
+that is the same as those extending from BaseResource.
+
+```typescript
+import { ReadShape, ParamsFromShape, useFetcher } from 'rest-hooks';
+import BaseResource from 'resources/BaseResource';
+
+function usePaginator<
+  S extends ReadShape<any, any>,
+  P extends Omit<ParamsFromShape<S>, 'cursor'> | null
+>(fetchShape: Shape, params: Params) {
+  // the second argument here is really important - it indicates that requests should be deduped!
+  const getNextPage = useFetcher(fetchShape, true);
+
+  return useCallback(
+    (cursor: string) => {
+      return getNextPage({ ...params, cursor }, undefined, [
+        // this instructs Rest Hooks to update the cache results specified by the first two members
+        // with the merge algorithm of the third.
+        [fetchShape, params, BaseResource.appendList],
+      ]);
+      // "params && fetchShape.getFetchKey(params)" is a method to serialize params
+    },
+    [getNextPage, params && fetchShape.getFetchKey(params)],
+  );
+}
+```
+
+## NewsList example
+
+We'll extend the `BaseResource` created above, to define the correct
+schema for listShape().
+
+```typescript
+class NewsResource extends BaseResource {
+  readonly id: string | undefined = undefined;
+  readonly title = '';
+  readonly url = '';
+  readonly previewImage = '';
+
+  pk() {
+    return this.id;
+  }
+  static urlRoot = '/news';
+}
+```
+
+Now we can declare our data depency to get list results with [useResource](../api/useresource),
+and get an imperative handler `getNextPage` using our new hook.
+
+Since UI behaviors vary widely, and implementations vary from platform (react-native or web),
+we'll just assume a `Pagination` component is built, that uses a callback to trigger next
+page fetching. On web, it is recommended to use something based on [Intersection Observers](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
+
+`<Pagination />` is assumed to call its `onPaginate` prop when a user scrolls and its
+`nextCursor` is not falsy. It will then pass the nextCursor prop as the sole argument to
+`onPaginate`.
+
+```tsx
+import { useResource } from 'rest-hooks';
+import NewsResource from 'resources/NewsResource';
+import usePaginator from 'resources/basePaginator';
+
+function NewsList() {
+  const { results, cursor } = useResource(NewsResource.listShape(), {});
+  const getNextPage = usePaginator(NewsResource.listShape(), {});
+
+  return (
+    <Pagination onPaginate={getNextPage} nextCursor={cursor}>
+      <NewsList data={results} />
+    </Pagination>
+  );
+}
+```

--- a/website/blog/2019-10-28-Rest-Hooks-2.2-Released.md
+++ b/website/blog/2019-10-28-Rest-Hooks-2.2-Released.md
@@ -48,7 +48,7 @@ createArticle({ id: 1 }, {}, [
 
 ### Pagination
 
-This can also be used to support pagination. Every time a new page is called, the results of that
+This can also be used to support [pagination](/docs/guides/infinite-scrolling-pagination). Every time a new page is called, the results of that
 page can be aggregated on one result list. Here's the rough idea (this code hasn't been tested):
 
 ```typescript

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -118,6 +118,9 @@
         "title": "Understanding Immutability",
         "sidebar_label": "Understanding Immutability"
       },
+      "guides/infinite-scrolling-pagination": {
+        "title": "Infinite Scrolling"
+      },
       "guides/loading-state": {
         "title": "Handling loading state"
       },
@@ -591,6 +594,9 @@
       },
       "version-3.0/guides/version-3.0-fetch-then-render": {
         "title": "Fetch then Render"
+      },
+      "version-3.0/guides/version-3.0-infinite-scrolling-pagination": {
+        "title": "Infinite Scrolling"
       },
       "version-3.0/guides/version-3.0-jsonp": {
         "title": "Cross-orgin requests with JSONP"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -40,6 +40,13 @@
       },
       {
         "type": "subcategory",
+        "label": "Components",
+        "ids": [
+          "guides/infinite-scrolling-pagination"
+        ]
+      },
+      {
+        "type": "subcategory",
         "label": "Testing",
         "ids": [
           "guides/storybook",

--- a/website/versioned_docs/version-3.0/guides/infinite-scrolling-pagination.md
+++ b/website/versioned_docs/version-3.0/guides/infinite-scrolling-pagination.md
@@ -1,0 +1,115 @@
+---
+title: Infinite Scrolling
+id: version-3.0-infinite-scrolling-pagination
+original_id: infinite-scrolling-pagination
+---
+
+## Add Update Function matching network schema
+
+If your API follows a common pattern, adding the [update function](../api/useFetcher#updatefunction-sourceresults-destresults--destresults)
+to a base class can make adding pagination behavior to any of your endpoints quite easy.
+
+```typescript
+abstract class BaseResource extends Resource {
+  static listShape<T extends typeof Resource>(this: T) {
+    return {
+      ...super.listShape(),
+      schema: { results: [this.asSchema()], cursor: null as string | null },
+    };
+  }
+
+  static appendList(
+    newResults: { results: string[] },
+    existingResults: { results: string[] } | undefined,
+  ) {
+    // In case there are duplicates, Set will eliminate them.
+    const set = new Set([
+      ...(existingResults?.results ?? []),
+      ...newResults.results,
+    ]);
+    return {
+      ...newResults,
+      results: [...set.values()],
+    };
+  }
+}
+```
+
+## Create pagination hook
+
+Here we'll define a helper hook for pagination that uses the BaseResource
+[update function](../api/useFetcher#updatefunction-sourceresults-destresults--destresults).
+This can then be used for any Resources that conform to this schema. Most likely
+that is the same as those extending from BaseResource.
+
+```typescript
+import { ReadShape, ParamsFromShape, useFetcher } from 'rest-hooks';
+import BaseResource from 'resources/BaseResource';
+
+function usePaginator<
+  S extends ReadShape<any, any>,
+  P extends Omit<ParamsFromShape<S>, 'cursor'> | null
+>(fetchShape: Shape, params: Params) {
+  // the second argument here is really important - it indicates that requests should be deduped!
+  const getNextPage = useFetcher(fetchShape, true);
+
+  return useCallback(
+    (cursor: string) => {
+      return getNextPage({ ...params, cursor }, undefined, [
+        // this instructs Rest Hooks to update the cache results specified by the first two members
+        // with the merge algorithm of the third.
+        [fetchShape, params, BaseResource.appendList],
+      ]);
+      // "params && fetchShape.getFetchKey(params)" is a method to serialize params
+    },
+    [getNextPage, params && fetchShape.getFetchKey(params)],
+  );
+}
+```
+
+## NewsList example
+
+We'll extend the `BaseResource` created above, to define the correct
+schema for listShape().
+
+```typescript
+class NewsResource extends BaseResource {
+  readonly id: string | undefined = undefined;
+  readonly title = '';
+  readonly url = '';
+  readonly previewImage = '';
+
+  pk() {
+    return this.id;
+  }
+  static urlRoot = '/news';
+}
+```
+
+Now we can declare our data depency to get list results with [useResource](../api/useresource),
+and get an imperative handler `getNextPage` using our new hook.
+
+Since UI behaviors vary widely, and implementations vary from platform (react-native or web),
+we'll just assume a `Pagination` component is built, that uses a callback to trigger next
+page fetching. On web, it is recommended to use something based on [Intersection Observers](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
+
+`<Pagination />` is assumed to call its `onPaginate` prop when a user scrolls and its
+`nextCursor` is not falsy. It will then pass the nextCursor prop as the sole argument to
+`onPaginate`.
+
+```tsx
+import { useResource } from 'rest-hooks';
+import NewsResource from 'resources/NewsResource';
+import usePaginator from 'resources/basePaginator';
+
+function NewsList() {
+  const { results, cursor } = useResource(NewsResource.listShape(), {});
+  const getNextPage = usePaginator(NewsResource.listShape(), {});
+
+  return (
+    <Pagination onPaginate={getNextPage} nextCursor={cursor}>
+      <NewsList data={results} />
+    </Pagination>
+  );
+}
+```

--- a/website/versioned_sidebars/version-3.0-sidebars.json
+++ b/website/versioned_sidebars/version-3.0-sidebars.json
@@ -50,6 +50,13 @@
       },
       {
         "type": "subcategory",
+        "label": "Components",
+        "ids": [
+          "version-3.0-guides/infinite-scrolling-pagination"
+        ]
+      },
+      {
+        "type": "subcategory",
         "label": "Testing",
         "ids": [
           "version-3.0-guides/storybook",

--- a/website/versioned_sidebars/version-4.0-sidebars.json
+++ b/website/versioned_sidebars/version-4.0-sidebars.json
@@ -49,6 +49,13 @@
       },
       {
         "type": "subcategory",
+        "label": "Components",
+        "ids": [
+          "version-4.0-guides/infinite-scrolling-pagination"
+        ]
+      },
+      {
+        "type": "subcategory",
         "label": "Testing",
         "ids": [
           "version-4.0-guides/storybook",

--- a/website/versioned_sidebars/version-4.1-sidebars.json
+++ b/website/versioned_sidebars/version-4.1-sidebars.json
@@ -49,6 +49,13 @@
       },
       {
         "type": "subcategory",
+        "label": "Components",
+        "ids": [
+          "version-4.1-guides/infinite-scrolling-pagination"
+        ]
+      },
+      {
+        "type": "subcategory",
         "label": "Testing",
         "ids": [
           "version-4.1-guides/storybook",

--- a/website/versioned_sidebars/version-4.3-sidebars.json
+++ b/website/versioned_sidebars/version-4.3-sidebars.json
@@ -49,6 +49,13 @@
       },
       {
         "type": "subcategory",
+        "label": "Components",
+        "ids": [
+          "version-4.3-guides/infinite-scrolling-pagination"
+        ]
+      },
+      {
+        "type": "subcategory",
         "label": "Testing",
         "ids": [
           "version-4.3-guides/storybook",

--- a/website/versioned_sidebars/version-4.5-sidebars.json
+++ b/website/versioned_sidebars/version-4.5-sidebars.json
@@ -50,6 +50,13 @@
       },
       {
         "type": "subcategory",
+        "label": "Components",
+        "ids": [
+          "version-4.5-guides/infinite-scrolling-pagination"
+        ]
+      },
+      {
+        "type": "subcategory",
         "label": "Testing",
         "ids": [
           "version-4.5-guides/storybook",


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #128

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Infinite scrolling pagination is a common pattern, and is not immediately obvious how to implement.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Outline an example with a representative theoretical API.

This adds the docs to all versions since 3.0 (even tho this feature was added in 2.2 - specifying extra primitive args was not supported at the time).

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Should we bother recommending UI libs for the other half?