### PR TITLE
fix: Index updates should possibly rerender

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   Resource,
   SchemaList,
@@ -9,6 +7,8 @@ import {
   DeleteShape,
 } from 'rest-hooks';
 import { AbstractInstanceType, FetchOptions, MutateShape } from 'rest-hooks';
+
+import React from 'react';
 
 export class UserResource extends Resource {
   readonly id: number | undefined = undefined;
@@ -169,7 +169,7 @@ export class CoolerArticleResource extends ArticleResource {
 }
 
 export class IndexedUserResource extends UserResource {
-  static indexes = ['username'];
+  static indexes = ['username' as const];
 }
 
 export class InvalidIfStaleArticleResource extends CoolerArticleResource {

--- a/docs/api/Entity.md
+++ b/docs/api/Entity.md
@@ -181,7 +181,7 @@ export class UserResource extends Resource {
   static urlRoot = 'http://test.com/user/';
 
   // right here
-  static indexes = ['username'];
+  static indexes = ['username' as const];
 }
 ```
 

--- a/packages/rest-hooks/src/state/selectors/useDenormalized.ts
+++ b/packages/rest-hooks/src/state/selectors/useDenormalized.ts
@@ -42,7 +42,8 @@ export default function useDenormalized<
     // entities[entitySchema.key] === undefined
     return buildInferredResults(schema, params, state.indexes);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cacheResults, params && getFetchKey(params)]);
+  }, [cacheResults, state.indexes, params && getFetchKey(params)]);
+  // TODO: only update when relevant indexes change
 
   // Compute denormalized value
   const [denormalized, entitiesFound, entitiesList] = useMemo(() => {

--- a/website/versioned_docs/version-4.2/api/Entity.md
+++ b/website/versioned_docs/version-4.2/api/Entity.md
@@ -175,7 +175,7 @@ export class UserResource extends Resource {
   static urlRoot = 'http://test.com/user/';
 
   // right here
-  static indexes = ['username'];
+  static indexes = ['username' as const];
 }
 ```
 

--- a/website/versioned_docs/version-4.3/api/Entity.md
+++ b/website/versioned_docs/version-4.3/api/Entity.md
@@ -183,7 +183,7 @@ export class UserResource extends Resource {
   static urlRoot = 'http://test.com/user/';
 
   // right here
-  static indexes = ['username'];
+  static indexes = ['username' as const];
 }
 ```
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Using indexes often means results will never appear and thus never update. buildInferredResults() thus needs to run based on new index changes.

Sidenote: This would have been caught with exhaustive-deps, but the plugin had to be disabled to make the params && getFetchKey() serialization work.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add state.indexes to useMemo() dependency list.
