### PR TITLE
fix: Don't throw when RN tries to poll

### DIFF
--- a/packages/rest-hooks/src/state/PollingSubscription.ts
+++ b/packages/rest-hooks/src/state/PollingSubscription.ts
@@ -150,7 +150,9 @@ export default class PollingSubscription implements Subscription {
         }
         this.update();
       }, this.frequency);
-      addEventListener('offline', this.offlineListener);
+      // react native does not support addEventListener
+      if (typeof addEventListener === 'function')
+        addEventListener('offline', this.offlineListener);
     } else {
       addEventListener('online', this.onlineListener);
     }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
React Native doesn't have addEventListener. Furthermore, it has it's own way of detecting online/offline. 

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
For now we'll just not activate offline/online detection when addEventListener isn't available.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
- How can we cleanly add online/offline detection for RN
- We should figure out how to run the tests in a React Native environment so things like this never happen again.