### PR TITLE
fix: Schema can be null (for media)

### DIFF
--- a/packages/normalizr/src/index.d.ts
+++ b/packages/normalizr/src/index.d.ts
@@ -304,6 +304,7 @@ export type NormalizeNullable<S> = S extends schema.SchemaClass
 interface SchemaArray extends Array<Schema> {}
 
 export type Schema =
+  | null
   | string
   | { [K: string]: any }
   | SchemaArray

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -771,8 +771,14 @@
       "version-4.3/guides/version-4.3-url": {
         "title": "URL Patterns"
       },
+      "version-4.5/api/version-4.5-resource": {
+        "title": "Resource"
+      },
       "version-4.5/getting-started/version-4.5-installation": {
         "title": "Installation"
+      },
+      "version-4.5/getting-started/version-4.5-usage": {
+        "title": "Usage"
       },
       "version-4.5/guides/version-4.5-auth": {
         "title": "Authentication"
@@ -788,6 +794,9 @@
       },
       "version-4.5/guides/version-4.5-optimistic-updates": {
         "title": "Optimistic Updates"
+      },
+      "version-4.5/guides/version-4.5-storybook": {
+        "title": "Mocking data for Storybook"
       }
     },
     "links": {


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #286 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://resthooks.io/docs/guides/binary-fetches we recommend null schema, which in JS-land enables getting the results right. However, the typescript types don't match.


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Just add null to the Schema |