### PR TITLE
fix: Do not run reducer on non-optimistic fetches

### DIFF
--- a/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/integration.tsx
@@ -1,6 +1,3 @@
-import React from 'react';
-import nock from 'nock';
-import { act } from '@testing-library/react-hooks';
 import {
   CoolerArticleResource,
   ArticleResource,
@@ -8,6 +5,10 @@ import {
   UserResource,
   ArticleResourceWithOtherListUrl,
 } from '__tests__/common';
+
+import React from 'react';
+import nock from 'nock';
+import { act } from '@testing-library/react-hooks';
 
 // relative imports to avoid circular dependency in tsconfig references
 import {

--- a/packages/rest-hooks/src/react-integration/__tests__/useError.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/useError.tsx
@@ -1,0 +1,38 @@
+import { CoolerArticleResource } from '__tests__/common';
+
+// relative imports to avoid circular dependency in tsconfig references
+import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { useError } from '../hooks';
+import { payload } from './fixtures';
+
+describe('useError()', () => {
+  let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+  beforeEach(() => {
+    renderRestHook = makeRenderRestHook(makeCacheProvider);
+  });
+  afterEach(() => {
+    renderRestHook.cleanup();
+  });
+
+  it('should return 404 when cache not ready and no error in meta', () => {
+    const results = [
+      {
+        request: CoolerArticleResource.detailShape(),
+        params: payload,
+        result: payload,
+      },
+    ];
+    const { result } = renderRestHook(
+      () => {
+        return useError(CoolerArticleResource.detailShape(), payload, false);
+      },
+      { results },
+    );
+
+    expect(result.current).toBeDefined();
+    expect((result.current as any).status).toBe(404);
+    expect(result.current).toMatchInlineSnapshot(
+      `[Error: Resource not found in cache GET http://test.com/article-cooler/5]`,
+    );
+  });
+});

--- a/packages/rest-hooks/src/react-integration/hooks/useError.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useError.ts
@@ -20,9 +20,7 @@ export default function useError<
     if (!meta.error) {
       // this means we probably deleted the entity found in this result
       const err: any = new Error(
-        `Resource not found in cache ${
-          params ? fetchShape.getFetchKey(params) : ''
-        }`,
+        `Resource not found in cache ${fetchShape.getFetchKey(params)}`,
       );
       err.status = 404;
       return err;


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #300  .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Even though the state does not update, React will warn about the reducer running from render (triggered from useRetrieve()). Although React should short-circuit and not actually re-render, it doesn't harm for us to short-circuit even earlier - after all it will run less code!

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Intercept all fetch dispatches in the NetworkManager that cannot cause state updates. (No optimistic response)