### PR TITLE
enhance: useCache() and useStatefulResource() respect invalidIfStale

### DIFF
--- a/packages/legacy/src/index.ts
+++ b/packages/legacy/src/index.ts
@@ -6,6 +6,7 @@ import {
   useDenormalized,
   __INTERNAL__,
 } from 'rest-hooks';
+
 import { useContext } from 'react';
 
 /** Ensure a resource is available; loading and error returned explicitly. */
@@ -15,14 +16,15 @@ export function useStatefulResource<
 >(fetchShape: ReadShape<S, Params>, params: Params | null) {
   const maybePromise = useRetrieve(fetchShape, params);
   const state = useContext(__INTERNAL__.StateContext);
-  const [denormalized, ready] = useDenormalized(fetchShape, params, state);
-
-  const loading = Boolean(
-    !__INTERNAL__.hasUsableData(ready, fetchShape) &&
-      maybePromise &&
-      typeof maybePromise.then === 'function',
+  const expired = !!maybePromise && typeof maybePromise.then === 'function';
+  const [denormalized, ready] = useDenormalized(
+    fetchShape,
+    params,
+    state,
+    expired,
   );
 
+  const loading = !__INTERNAL__.hasUsableData(ready, fetchShape) && expired;
   const error = useError(fetchShape, params, ready);
 
   return {

--- a/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
@@ -1,16 +1,17 @@
-import React, { Suspense } from 'react';
-import { render } from '@testing-library/react';
-import nock from 'nock';
 import {
   CoolerArticleResource,
   UserResource,
   InvalidIfStaleArticleResource,
   photoShape,
 } from '__tests__/common';
-
-// relative imports to avoid circular dependency in tsconfig references
 import { State } from 'rest-hooks/types';
 import { initialState } from 'rest-hooks/state/reducer';
+
+import React, { Suspense } from 'react';
+import { render } from '@testing-library/react';
+import nock from 'nock';
+
+// relative imports to avoid circular dependency in tsconfig references
 
 import {
   makeRenderRestHook,

--- a/packages/rest-hooks/src/react-integration/hooks/useCache.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useCache.ts
@@ -1,12 +1,27 @@
 import { StateContext } from 'rest-hooks/react-integration/context';
 import { ReadShape, ParamsFromShape } from 'rest-hooks/resource';
 import { useDenormalized } from 'rest-hooks/state/selectors';
-import { useContext } from 'react';
+
+import { useContext, useMemo } from 'react';
+
+import useExpiresAt from './useExpiresAt';
 
 /** Access a resource if it is available. */
 export default function useCache<
   Shape extends Pick<ReadShape<any, any>, 'getFetchKey' | 'schema'>
 >(fetchShape: Shape, params: ParamsFromShape<Shape> | null) {
+  const expiresAt = useExpiresAt(fetchShape, params);
+  // This computation reflects the behavior of useResource/useRetrive
+  // It only changes the value when expiry or params change.
+  // This way, random unrelated re-renders don't cause the concept of expiry
+  // to change
+  const expired = useMemo(() => {
+    if (Date.now() <= expiresAt || !params) return false;
+    return true;
+    // we need to check against serialized params, since params can change frequently
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expiresAt, params && fetchShape.getFetchKey(params)]);
+
   const state = useContext(StateContext);
-  return useDenormalized(fetchShape, params, state)[0];
+  return useDenormalized(fetchShape, params, state, expired)[0];
 }

--- a/packages/rest-hooks/src/react-integration/hooks/useExpiresAt.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useExpiresAt.ts
@@ -1,0 +1,15 @@
+import { ReadShape } from 'rest-hooks/resource';
+
+import useMeta from './useMeta';
+
+/** Returns whether the data at this url is fresh or stale */
+export default function useExpiresAt<Params extends Readonly<object>>(
+  fetchShape: Pick<ReadShape<any, Params>, 'getFetchKey'>,
+  params: Params | null,
+): number {
+  const meta = useMeta(fetchShape, params);
+  if (!meta) {
+    return 0;
+  }
+  return meta.expiresAt;
+}

--- a/packages/rest-hooks/src/react-integration/hooks/useRetrieve.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useRetrieve.ts
@@ -1,20 +1,9 @@
 import { ReadShape, Schema } from 'rest-hooks/resource';
+
 import { useMemo } from 'react';
 
 import useFetcher from './useFetcher';
-import useMeta from './useMeta';
-
-/** Returns whether the data at this url is fresh or stale */
-function useExpiresAt<Params extends Readonly<object>, S extends Schema>(
-  fetchShape: ReadShape<S, Params>,
-  params: Params | null,
-): number {
-  const meta = useMeta(fetchShape, params);
-  if (!meta) {
-    return 0;
-  }
-  return meta.expiresAt;
-}
+import useExpiresAt from './useExpiresAt';
 
 /** Request a resource if it is not in cache. */
 export default function useRetrieve<
@@ -25,9 +14,8 @@ export default function useRetrieve<
   const expiresAt = useExpiresAt(fetchShape, params);
 
   return useMemo(() => {
-    if (Date.now() <= expiresAt) return;
     // null params mean don't do anything
-    if (!params) return;
+    if (Date.now() <= expiresAt || !params) return;
     return fetch(params);
     // we need to check against serialized params, since params can change frequently
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useSubscription.ts
@@ -1,6 +1,7 @@
 import { DispatchContext } from 'rest-hooks/react-integration/context';
 import { ReadShape, Schema } from 'rest-hooks/resource';
 import { SUBSCRIBE_TYPE, UNSUBSCRIBE_TYPE } from 'rest-hooks/actionTypes';
+
 import { useContext, useEffect, useRef } from 'react';
 
 /** Keeps a resource fresh by subscribing to updates. */

--- a/packages/rest-hooks/src/state/selectors/useDenormalized.ts
+++ b/packages/rest-hooks/src/state/selectors/useDenormalized.ts
@@ -35,6 +35,7 @@ export default function useDenormalized<
   // Select from state
   const entities = state.entities;
   const cacheResults = params && state.results[getFetchKey(params)];
+  const serializedParams = params && getFetchKey(params);
 
   // We can grab entities without actual results if the params compute a primary key
   const results = useMemo(() => {
@@ -44,10 +45,9 @@ export default function useDenormalized<
     // entities[entitySchema.key] === undefined
     return buildInferredResults(schema, params, state.indexes);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cacheResults, state.indexes, params && getFetchKey(params)]);
+  }, [cacheResults, state.indexes, serializedParams]);
   // TODO: only update when relevant indexes change
 
-  const serializedParams = params && getFetchKey(params);
   // Compute denormalized value
   const [denormalized, entitiesFound, entitiesList] = useMemo(() => {
     // Warn users with bad configurations


### PR DESCRIPTION
BREAKING CHANGE: When invalidIfStale is true, useCache() and
useStatefulResource() will no longer return entities, even if they
are in the cache

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`invalidIfStale` was added, and its behavior affected suspense, which is the primary mechanism to use data. However, as other use cases expanded it became clear that equivalent behavior should be reflected in the other hooks. This is especially important when not using suspense at all - for instance when `useStatefulResource()`.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This only changes behavior when invalidIfStale is true.

In this case, we should consider the same case where useResource() would suspend and return 'empty' results. This is key for replicating the same behaviors and patterns with both `useCache()` and `useStatefulResource()`.
