### PR TITLE
enhance: Simplify online/offline polling logic

### DIFF
--- a/packages/rest-hooks/src/state/DefaultConnectionListener.ts
+++ b/packages/rest-hooks/src/state/DefaultConnectionListener.ts
@@ -1,30 +1,45 @@
 import { ConnectionListener } from './ConnectionListener';
 
-export default class DefaultConnectionListener implements ConnectionListener {
+export class BrowserConnectionListener implements ConnectionListener {
   isOnline() {
-    if (navigator.onLine !== undefined) {
-      return navigator.onLine;
-    }
-    return true;
+    return navigator.onLine;
   }
 
   addOnlineListener(handler: () => void) {
-    if (typeof addEventListener === 'function')
-      addEventListener('online', handler);
+    addEventListener('online', handler);
   }
 
   removeOnlineListener(handler: () => void) {
-    if (typeof removeEventListener === 'function')
-      removeEventListener('online', handler);
+    removeEventListener('online', handler);
   }
 
   addOfflineListener(handler: () => void) {
-    if (typeof addEventListener === 'function')
-      addEventListener('offline', handler);
+    addEventListener('offline', handler);
   }
 
   removeOfflineListener(handler: () => void) {
-    if (typeof removeEventListener === 'function')
-      removeEventListener('offline', handler);
+    removeEventListener('offline', handler);
   }
 }
+
+export class AlwaysOnlineConnectionListener implements ConnectionListener {
+  isOnline() {
+    return true;
+  }
+
+  addOnlineListener() {}
+
+  removeOnlineListener() {}
+
+  addOfflineListener() {}
+
+  removeOfflineListener() {}
+}
+
+let DefaultConnectionListener: { new (): ConnectionListener };
+if (navigator.onLine !== undefined && typeof addEventListener === 'function') {
+  DefaultConnectionListener = BrowserConnectionListener;
+} else {
+  DefaultConnectionListener = AlwaysOnlineConnectionListener;
+}
+export default DefaultConnectionListener;

--- a/packages/rest-hooks/src/state/PollingSubscription.ts
+++ b/packages/rest-hooks/src/state/PollingSubscription.ts
@@ -134,21 +134,17 @@ export default class PollingSubscription implements Subscription {
 
   /** What happens when browser goes offline */
   protected offlineListener = () => {
+    // this clears existing listeners, so no need to clear offline listener
     this.cleanup();
-    this.connectionListener.removeOfflineListener(this.offlineListener);
     this.connectionListener.addOnlineListener(this.onlineListener);
   };
 
   /** What happens when browser comes online */
   protected onlineListener = () => {
     this.connectionListener.removeOnlineListener(this.onlineListener);
-    if (this.connectionListener.isOnline()) {
-      this.update();
-      this.run();
-      this.connectionListener.addOfflineListener(this.offlineListener);
-    } else {
-      this.connectionListener.addOnlineListener(this.onlineListener);
-    }
+    this.update();
+    this.run();
+    this.connectionListener.addOfflineListener(this.offlineListener);
   };
 
   /** Run polling process with current frequency
@@ -156,17 +152,15 @@ export default class PollingSubscription implements Subscription {
    * Will clean up old poll interval on next run
    */
   protected run() {
-    if (this.connectionListener.isOnline()) {
-      this.lastIntervalId = this.intervalId;
-      this.intervalId = setInterval(() => {
-        // since we don't know how long into the last poll it was before resetting
-        // we wait til the next fetch to clear old intervals
-        if (this.lastIntervalId) {
-          clearInterval(this.lastIntervalId);
-          this.lastIntervalId = undefined;
-        }
-        this.update();
-      }, this.frequency);
-    }
+    this.lastIntervalId = this.intervalId;
+    this.intervalId = setInterval(() => {
+      // since we don't know how long into the last poll it was before resetting
+      // we wait til the next fetch to clear old intervals
+      if (this.lastIntervalId) {
+        clearInterval(this.lastIntervalId);
+        this.lastIntervalId = undefined;
+      }
+      this.update();
+    }, this.frequency);
   }
 }


### PR DESCRIPTION
## Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Smaller bundle size, less paths to test.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Also make a clear BrowserConnectionListener so split is only done once.