### PR TITLE
enhance: Add optional generic for FetchShape['fetch'] response

### DIFF
--- a/packages/rest-hooks/src/resource/shapes.ts
+++ b/packages/rest-hooks/src/resource/shapes.ts
@@ -9,10 +9,10 @@ export interface FetchShape<
   Body extends Readonly<object | string> | void =
     | Readonly<object | string>
     | undefined,
-  ReturnPromise extends Promise<any> = Promise<any>
+  Response = any
 > {
   readonly type: 'read' | 'mutate' | 'delete';
-  fetch(params: Params, body: Body): ReturnPromise;
+  fetch(params: Params, body: Body): Promise<Response>;
   getFetchKey(params: Params): string;
   readonly schema: S;
   readonly options?: FetchOptions;
@@ -34,22 +34,26 @@ export interface MutateShape<
   Body extends Readonly<object | string> | void =
     | Readonly<object | string>
     | undefined,
-  ReturnPromise extends Promise<object | string | number | boolean> = Promise<
-    object | string | number | boolean
-  >
-> extends FetchShape<S, Params, Body, ReturnPromise> {
+  Response extends object | string | number | boolean =
+    | object
+    | string
+    | number
+    | boolean
+> extends FetchShape<S, Params, Body, Response> {
   readonly type: 'mutate';
-  fetch(params: Params, body: Body): ReturnPromise;
+  fetch(params: Params, body: Body): Promise<Response>;
 }
 
 /** For retrieval requests */
 export interface ReadShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  ReturnPromise extends Promise<object | string | number | boolean> = Promise<
-    object | string | number | boolean
-  >
+  Response extends object | string | number | boolean =
+    | object
+    | string
+    | number
+    | boolean
 > extends FetchShape<S, Params, undefined> {
   readonly type: 'read';
-  fetch(params: Params): ReturnPromise;
+  fetch(params: Params): Promise<Response>;
 }

--- a/packages/rest-hooks/src/resource/shapes.ts
+++ b/packages/rest-hooks/src/resource/shapes.ts
@@ -2,16 +2,19 @@ import { schemas, Schema } from './normal';
 
 import { FetchOptions } from '~/types';
 
+type DefaultPromise = Promise<object | string | number | boolean>;
+
 /** Defines the shape of a network request */
 export interface FetchShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
   Body extends Readonly<object | string> | void =
     | Readonly<object | string>
-    | undefined
+    | undefined,
+  ReturnPromise extends Promise<any> = Promise<any>
 > {
   readonly type: 'read' | 'mutate' | 'delete';
-  fetch(params: Params, body: Body): Promise<any>;
+  fetch(params: Params, body: Body): ReturnPromise;
   getFetchKey(params: Params): string;
   readonly schema: S;
   readonly options?: FetchOptions;
@@ -32,20 +35,19 @@ export interface MutateShape<
   Params extends Readonly<object> = Readonly<object>,
   Body extends Readonly<object | string> | void =
     | Readonly<object | string>
-    | undefined
-> extends FetchShape<S, Params, Body> {
+    | undefined,
+  ReturnPromise extends DefaultPromise = DefaultPromise
+> extends FetchShape<S, Params, Body, ReturnPromise> {
   readonly type: 'mutate';
-  fetch(
-    params: Params,
-    body: Body,
-  ): Promise<object | string | number | boolean>;
+  fetch(params: Params, body: Body): ReturnPromise;
 }
 
 /** For retrieval requests */
 export interface ReadShape<
   S extends Schema,
-  Params extends Readonly<object> = Readonly<object>
+  Params extends Readonly<object> = Readonly<object>,
+  ReturnPromise extends DefaultPromise = DefaultPromise
 > extends FetchShape<S, Params, undefined> {
   readonly type: 'read';
-  fetch(params: Params): Promise<object | string | number | boolean>;
+  fetch(params: Params): ReturnPromise;
 }

--- a/packages/rest-hooks/src/resource/shapes.ts
+++ b/packages/rest-hooks/src/resource/shapes.ts
@@ -2,8 +2,6 @@ import { schemas, Schema } from './normal';
 
 import { FetchOptions } from '~/types';
 
-type DefaultPromise = Promise<object | string | number | boolean>;
-
 /** Defines the shape of a network request */
 export interface FetchShape<
   S extends Schema,
@@ -36,7 +34,9 @@ export interface MutateShape<
   Body extends Readonly<object | string> | void =
     | Readonly<object | string>
     | undefined,
-  ReturnPromise extends DefaultPromise = DefaultPromise
+  ReturnPromise extends Promise<object | string | number | boolean> = Promise<
+    object | string | number | boolean
+  >
 > extends FetchShape<S, Params, Body, ReturnPromise> {
   readonly type: 'mutate';
   fetch(params: Params, body: Body): ReturnPromise;
@@ -46,7 +46,9 @@ export interface MutateShape<
 export interface ReadShape<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
-  ReturnPromise extends DefaultPromise = DefaultPromise
+  ReturnPromise extends Promise<object | string | number | boolean> = Promise<
+    object | string | number | boolean
+  >
 > extends FetchShape<S, Params, undefined> {
   readonly type: 'read';
   fetch(params: Params): ReturnPromise;


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Using the exported shapes from Rest Hooks, such as ReadShape, is really helpful and simplifies the process of creating custom shapes. However, if you want to have a more strongly typed return value of your FetchShape fetch function you'll run into type conflicts and will have to create override to make work.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Keep the same defaults each shape previously had, but allow fourth optional generic for fetch response

```
static detailShape<T extends typeof SimpleResource>(this: T): DetailShape<T, {}, { data: User }> {
  
    const shape = (super.detailShape() as any) as DetailShape<T, {}, { data: User | null }>
    
    return {
      ...shape,
      fetch: async params => {
        
        // data is typed correctly as User | null
        const { data } = await shape.fetch(params);

        if (!data) {
          throw new Error()
        }
        
        // Now return value will be typed as Promise<{ data: User }> 
        // when used in useFetcher or called directly
        return data;
      },
    };
  }
```
 