### PR TITLE
feat: Add createFetch() action creator

### DIFF
--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -44,6 +44,8 @@ const __INTERNAL__ = {
 
 export type NetworkError = OGNetworkError;
 
+export { default as createFetch } from './state/actions/createFetch';
+export * as actionTypes from './actionTypes';
 export * from '@rest-hooks/use-enhanced-reducer';
 export * from './types';
 export * from './resource/shapes';

--- a/packages/rest-hooks/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
+++ b/packages/rest-hooks/src/react-integration/__tests__/__snapshots__/hooks.tsx.snap
@@ -4,6 +4,7 @@ exports[`useFetcher should dispatch an action that fetches a create 1`] = `
 Object {
   "meta": Object {
     "options": undefined,
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/rpc",
@@ -20,6 +21,7 @@ exports[`useFetcher should dispatch an action that fetches a full update 1`] = `
 Object {
   "meta": Object {
     "options": undefined,
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/rpc",
@@ -42,6 +44,7 @@ Object {
     "options": Object {
       "optimisticUpdate": [Function],
     },
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/rpc",
@@ -63,6 +66,7 @@ Object {
     "options": Object {
       "optimisticUpdate": [Function],
     },
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/rpc",
@@ -83,6 +87,7 @@ exports[`useFetcher should dispatch an action with updater in the meta if update
 Object {
   "meta": Object {
     "options": undefined,
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/rpc",
@@ -102,6 +107,7 @@ exports[`useRetrieve should dispatch singles 1`] = `
 Object {
   "meta": Object {
     "options": undefined,
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/receive",
@@ -120,6 +126,7 @@ Object {
     "options": Object {
       "dataExpiryLength": 3600000,
     },
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/receive",
@@ -139,6 +146,7 @@ Object {
       "dataExpiryLength": Infinity,
       "errorExpiryLength": Infinity,
     },
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/receive",
@@ -157,6 +165,7 @@ Object {
     "options": Object {
       "dataExpiryLength": Infinity,
     },
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/receive",

--- a/packages/rest-hooks/src/react-integration/__tests__/__snapshots__/useResource.tsx.snap
+++ b/packages/rest-hooks/src/react-integration/__tests__/__snapshots__/useResource.tsx.snap
@@ -4,6 +4,7 @@ exports[`useResource() should dispatch an action that fetches 1`] = `
 Object {
   "meta": Object {
     "options": undefined,
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/receive",
@@ -20,6 +21,7 @@ exports[`useResource() should dispatch fetch when sent multiple arguments 1`] = 
 Object {
   "meta": Object {
     "options": undefined,
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/receive",
@@ -36,6 +38,7 @@ exports[`useResource() should dispatch fetch when sent multiple arguments 2`] = 
 Object {
   "meta": Object {
     "options": undefined,
+    "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
     "responseType": "rest-hooks/receive",

--- a/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
+++ b/packages/rest-hooks/src/react-integration/hooks/useFetcher.ts
@@ -1,40 +1,17 @@
-import { FetchAction, UpdateFunction, ReceiveTypes } from 'rest-hooks/types';
-import {
-  RECEIVE_DELETE_TYPE,
-  RECEIVE_MUTATE_TYPE,
-  RECEIVE_TYPE,
-  FETCH_TYPE,
-} from 'rest-hooks/actionTypes';
 import {
   FetchShape,
   DeleteShape,
   Schema,
-  isDeleteShape,
   SchemaFromShape,
   ParamsFromShape,
   BodyFromShape,
 } from 'rest-hooks/resource';
 import { DispatchContext } from 'rest-hooks/react-integration/context';
+import createFetch, {
+  OptimisticUpdateParams,
+} from 'rest-hooks/state/actions/createFetch';
 
 import { useContext, useRef, useCallback } from 'react';
-
-const SHAPE_TYPE_TO_RESPONSE_TYPE: Record<
-  FetchShape<any, any, any>['type'],
-  ReceiveTypes
-> = {
-  read: RECEIVE_TYPE,
-  mutate: RECEIVE_MUTATE_TYPE,
-  delete: RECEIVE_DELETE_TYPE,
-};
-
-type OptimisticUpdateParams<
-  SourceSchema extends Schema,
-  DestShape extends FetchShape<any, any, any>
-> = [
-  DestShape,
-  ParamsFromShape<DestShape>,
-  UpdateFunction<SourceSchema, SchemaFromShape<DestShape>>,
-];
 
 /** Build an imperative dispatcher to issue network requests. */
 export default function useFetcher<
@@ -79,63 +56,15 @@ export default function useFetcher<
           >[]
         | undefined,
     ) => {
-      const { fetch, schema, type, getFetchKey, options } = shapeRef.current;
-      const responseType = SHAPE_TYPE_TO_RESPONSE_TYPE[type];
-
-      const key = getFetchKey(params);
-      /* istanbul ignore next */
-      if (process.env.NODE_ENV !== 'production') {
-        if (
-          isDeleteShape(shapeRef.current) &&
-          typeof shapeRef.current.schema.getId !== 'function'
-        ) {
-          throw new Error(
-            `Request for '${key}' of type delete used, but schema has no pk().
-Schema must be an entity.
-Schema: ${JSON.stringify(shapeRef.current.schema, null, 2)}
-
-Note: Network response is ignored for delete type.`,
-          );
-        }
-      }
-      const identifier = isDeleteShape(shapeRef.current)
-        ? shapeRef.current.schema.getId(params)
-        : key;
-      let resolve: (value?: any | PromiseLike<any>) => void = 0 as any;
-      let reject: (reason?: any) => void = 0 as any;
-      const promise = new Promise<any>((a, b) => {
-        [resolve, reject] = [a, b];
-      });
-      const meta: FetchAction['meta'] = {
-        schema,
-        responseType,
-        url: identifier,
+      const action = createFetch(
+        shapeRef.current,
+        params,
+        body,
         throttle,
-        options,
-        resolve,
-        reject,
-      };
-
-      if (updateParams) {
-        meta.updaters = updateParams.reduce(
-          (accumulator: object, [toShape, toParams, updateFn]) => ({
-            [toShape.getFetchKey(toParams)]: updateFn,
-            ...accumulator,
-          }),
-          {},
-        );
-      }
-
-      if (options && options.optimisticUpdate) {
-        meta.optimisticResponse = options.optimisticUpdate(params, body);
-      }
-
-      dispatch({
-        type: FETCH_TYPE,
-        payload: () => fetch(params, body),
-        meta,
-      });
-      return promise;
+        updateParams,
+      );
+      dispatch(action);
+      return action.meta.promise;
     },
     [dispatch, throttle],
   );

--- a/packages/rest-hooks/src/state/__tests__/networkManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/networkManager.ts
@@ -56,6 +56,7 @@ describe('NetworkManager', () => {
         throttle: false,
         reject: (v: any) => null,
         resolve: (v: any) => null,
+        promise: new Promise((v: any) => null),
       },
     };
     const fetchReceiveWithUpdatersAction: FetchAction = {
@@ -95,6 +96,7 @@ describe('NetworkManager', () => {
         throttle: false,
         reject: (v: any) => null,
         resolve: (v: any) => null,
+        promise: new Promise((v: any) => null),
       },
     };
     it('should handle fetch actions and dispatch on success', async () => {
@@ -321,6 +323,7 @@ describe('NetworkManager', () => {
           throttle: true,
           resolve,
           reject,
+          promise: new Promise((v: any) => null),
         },
       };
 

--- a/packages/rest-hooks/src/state/__tests__/reducer.ts
+++ b/packages/rest-hooks/src/state/__tests__/reducer.ts
@@ -22,6 +22,7 @@ import {
   FETCH_TYPE,
   RESET_TYPE,
 } from '../../actionTypes';
+import createFetch from '../actions/createFetch';
 
 describe('reducer', () => {
   describe('singles', () => {
@@ -431,6 +432,7 @@ describe('reducer', () => {
         throttle: true,
         reject: (v: any) => null,
         resolve: (v: any) => null,
+        promise: new Promise((v: any) => null),
       },
     };
     const iniState = {

--- a/packages/rest-hooks/src/state/actions/createFetch.ts
+++ b/packages/rest-hooks/src/state/actions/createFetch.ts
@@ -1,0 +1,110 @@
+import { FetchAction, UpdateFunction, ReceiveTypes } from 'rest-hooks/types';
+import {
+  RECEIVE_DELETE_TYPE,
+  RECEIVE_MUTATE_TYPE,
+  RECEIVE_TYPE,
+  FETCH_TYPE,
+} from 'rest-hooks/actionTypes';
+import {
+  FetchShape,
+  Schema,
+  isDeleteShape,
+  SchemaFromShape,
+  ParamsFromShape,
+  BodyFromShape,
+} from 'rest-hooks/resource';
+
+const SHAPE_TYPE_TO_RESPONSE_TYPE: Record<
+  FetchShape<any, any, any>['type'],
+  ReceiveTypes
+> = {
+  read: RECEIVE_TYPE,
+  mutate: RECEIVE_MUTATE_TYPE,
+  delete: RECEIVE_DELETE_TYPE,
+};
+
+export type OptimisticUpdateParams<
+  SourceSchema extends Schema,
+  DestShape extends FetchShape<any, any, any>
+> = [
+  DestShape,
+  ParamsFromShape<DestShape>,
+  UpdateFunction<SourceSchema, SchemaFromShape<DestShape>>,
+];
+
+export default function createFetch<
+  Shape extends FetchShape<
+    Schema,
+    Readonly<object>,
+    Readonly<object | string> | void
+  >
+>(
+  fetchShape: Shape,
+  params: ParamsFromShape<Shape>,
+  body: BodyFromShape<Shape>,
+  throttle: boolean,
+  updateParams?:
+    | OptimisticUpdateParams<
+        SchemaFromShape<Shape>,
+        FetchShape<any, any, any>
+      >[]
+    | undefined,
+): FetchAction {
+  const { fetch, schema, type, getFetchKey, options } = fetchShape;
+  const responseType = SHAPE_TYPE_TO_RESPONSE_TYPE[type];
+
+  const key = getFetchKey(params);
+  /* istanbul ignore next */
+  if (process.env.NODE_ENV !== 'production') {
+    if (
+      isDeleteShape(fetchShape) &&
+      typeof fetchShape.schema.getId !== 'function'
+    ) {
+      throw new Error(
+        `Request for '${key}' of type delete used, but schema has no pk().
+Schema must be an entity.
+Schema: ${JSON.stringify(fetchShape.schema, null, 2)}
+
+Note: Network response is ignored for delete type.`,
+      );
+    }
+  }
+  const identifier = isDeleteShape(fetchShape)
+    ? fetchShape.schema.getId(params)
+    : key;
+  let resolve: (value?: any | PromiseLike<any>) => void = 0 as any;
+  let reject: (reason?: any) => void = 0 as any;
+  const promise = new Promise<any>((a, b) => {
+    [resolve, reject] = [a, b];
+  });
+  const meta: FetchAction['meta'] = {
+    schema,
+    responseType,
+    url: identifier,
+    throttle,
+    options,
+    resolve,
+    reject,
+    promise,
+  };
+
+  if (updateParams) {
+    meta.updaters = updateParams.reduce(
+      (accumulator: object, [toShape, toParams, updateFn]) => ({
+        [toShape.getFetchKey(toParams)]: updateFn,
+        ...accumulator,
+      }),
+      {},
+    );
+  }
+
+  if (options && options.optimisticUpdate) {
+    meta.optimisticResponse = options.optimisticUpdate(params, body);
+  }
+
+  return {
+    type: FETCH_TYPE,
+    payload: () => fetch(params, body),
+    meta,
+  };
+}

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -1,5 +1,6 @@
 import { NormalizedIndex } from '@rest-hooks/normalizr';
 import { Middleware } from '@rest-hooks/use-enhanced-reducer';
+
 import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
 
 import { ErrorableFSAWithPayloadAndMeta, ErrorableFSAWithMeta } from './fsa';
@@ -131,6 +132,7 @@ interface FetchMeta<
   options?: FetchOptions;
   resolve: (value?: any | PromiseLike<any>) => void;
   reject: (reason?: any) => void;
+  promise: PromiseLike<any>;
   optimisticResponse?: Payload;
   // indicates whether network manager processed it
   nm?: boolean;


### PR DESCRIPTION
Also export actionTypes with each action string

BREAKING CHANGE: Added promise to FetchAction['meta']

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
This will make creating actions for various other middlewares easier. Other action creators to come.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```ts
dispatch(createFetch(
        fetchShape,
        params,
        body,
        throttle,
        updateParams,
      ));
```

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Should probably try to solidify the interface a bit since this is being exposed.
