### PR TITLE
enhance: Schemas with no entities should not infer

### DIFF
--- a/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
+++ b/packages/rest-hooks/src/react-integration/__tests__/useResource.tsx
@@ -391,7 +391,7 @@ describe('useResource()', () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(photoShape, { userId });
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBe(undefined);
     await waitForNextUpdate();
     expect(result.current).toStrictEqual(response);
   });

--- a/packages/rest-hooks/src/state/selectors/__tests__/useDenormalized.ts
+++ b/packages/rest-hooks/src/state/selectors/__tests__/useDenormalized.ts
@@ -4,6 +4,7 @@ import {
   NestedArticleResource,
   UserResource,
   IndexedUserResource,
+  photoShape,
 } from '__tests__/common';
 import { normalize, NormalizedIndex } from 'rest-hooks/resource';
 import { initialState } from 'rest-hooks/state/reducer';
@@ -164,7 +165,7 @@ describe('useDenormalized()', () => {
       });
     });
 
-    describe.only('no result exists but index is used when using nested schema', () => {
+    describe('no result exists but index is used when using nested schema', () => {
       const pageArticle = PaginatedArticleResource.fromJS({
         ...params,
         author: 23,
@@ -588,6 +589,30 @@ describe('useDenormalized()', () => {
           }
         `);
       });
+    });
+
+    it('should not infer with schemas that have no entities', () => {
+      const userId = '5';
+      const { result } = renderHook(() => {
+        return useDenormalized(photoShape, { userId }, initialState as any);
+      });
+      expect(result.current).toStrictEqual([undefined, true]);
+    });
+
+    it('should return results as-is for schemas with no entities', () => {
+      const userId = '5';
+      const results = new ArrayBuffer(10);
+      const state = {
+        ...initialState,
+        results: {
+          ...initialState.results,
+          [photoShape.getFetchKey({ userId })]: results,
+        },
+      };
+      const { result } = renderHook(() => {
+        return useDenormalized(photoShape, { userId }, state);
+      });
+      expect(result.current).toStrictEqual([results, true]);
     });
 
     it('should throw with invalid schemas', () => {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Better support simple response endpoints.

With no entities, denormalization is pointless. However, what's worse is since it found all the entities it needed (since it didn't need any) - it will attempt to infer results. Inferring results is non-nonsensical with no entities as it would just be returning the schema.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add simple schemaHasEntity() algorithm to determine whether a schema has entities. When it doesn't we short-circuit the de-normalization computation.
