### PR TITLE
enhance: State updates from mutate/read now the same

### DIFF
--- a/packages/rest-hooks/src/state/__tests__/reducer.ts
+++ b/packages/rest-hooks/src/state/__tests__/reducer.ts
@@ -88,14 +88,15 @@ describe('reducer', () => {
         schema: ArticleResource.getEntitySchema(),
         key: ArticleResource.listUrl(payload),
         date: 0,
+        expiresAt: 1000000000000,
       },
     };
     const iniState = {
       ...initialState,
-      results: { abc: '5' },
+      results: { abc: '5', [ArticleResource.listUrl(payload)]: `${id}` },
     };
     const newState = reducer(iniState, action);
-    expect(newState.results).toBe(iniState.results);
+    expect(newState.results).toStrictEqual(iniState.results);
   });
   it('purge should delete entities', () => {
     const id = 20;
@@ -239,6 +240,7 @@ describe('reducer', () => {
             key: ArticleResource.createShape().getFetchKey({}),
             updaters,
             date: 0,
+            expiresAt: 100000000000,
           },
         };
       }
@@ -386,12 +388,14 @@ describe('reducer', () => {
         schema: ArticleResource.getEntitySchema(),
         key: ArticleResource.url({ id }),
         date: 0,
+        expiresAt: 10000000000000000000,
       },
       error: true,
     };
     const iniState = initialState;
     const newState = reducer(iniState, action);
-    expect(newState).toEqual(iniState);
+    // ignore meta for this check
+    expect({ ...newState, meta: {} }).toEqual(iniState);
   });
   it('should not delete on error for "purge"', () => {
     const id = 20;

--- a/packages/rest-hooks/src/state/reducer.ts
+++ b/packages/rest-hooks/src/state/reducer.ts
@@ -52,6 +52,7 @@ export default function reducer(
         ],
       };
     }
+    case RECEIVE_MUTATE_TYPE:
     case RECEIVE_TYPE: {
       if (action.error) {
         return {
@@ -87,26 +88,6 @@ export default function reducer(
             expiresAt: action.meta.expiresAt,
           },
         },
-        optimistic: filterOptimistic(state, action),
-      };
-    }
-    case RECEIVE_MUTATE_TYPE: {
-      if (action.error)
-        return { ...state, optimistic: filterOptimistic(state, action) };
-      const { entities, result, indexes } = normalize(
-        action.payload,
-        action.meta.schema,
-      );
-      const results = applyUpdatersToResults(
-        state.results,
-        result,
-        action.meta.updaters,
-      );
-      return {
-        ...state,
-        entities: mergeDeepCopy(state.entities, entities),
-        indexes: mergeDeepCopy(state.indexes, indexes),
-        results,
         optimistic: filterOptimistic(state, action),
       };
     }

--- a/packages/rest-hooks/src/types.ts
+++ b/packages/rest-hooks/src/types.ts
@@ -83,6 +83,7 @@ interface RPCMeta<S extends Schema> {
   key: string;
   date: number;
   updaters?: Record<string, UpdateFunction<S, any>>;
+  expiresAt: number;
 }
 
 export type RPCAction<


### PR DESCRIPTION
BREAKING CHANGE: Mutation fetches now result in:
- meta entries
- results entries

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Previously fetch keys were simply urls (pre 1.0), so a distinction was needed between mutate and read types. However, for some time now these have serialized to their own unique value. This is the first stage for heavily simplifying the codepaths.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This means mutates now result in new entries in the state: meta, results. This is likely valuable in some cases.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Future path to unify deletes as well?
