### PR TITLE
fix: Allow for multiple pk methods

### DIFF
--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -145,7 +145,7 @@ export default abstract class Entity extends SimpleRecord {
       }
     });
 
-    addEntity(this, processedEntity, input, parent, key);
+    addEntity(this, processedEntity, processedEntity, parent, key);
     return id;
   }
 

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -55,7 +55,7 @@ const addEntities = (entities: Record<string, any>, indexes: any) => (
   key: string,
 ) => {
   const schemaKey = schema.key;
-  const id = schema.pk(processedEntity, parent, key);
+  const id = schema.pk(value, parent, key);
   if (!(schemaKey in entities)) {
     entities[schemaKey] = {};
   }


### PR DESCRIPTION


### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Allow for multiple methods of choosing value to send to pk when normalizing

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
