### PR TITLE
feat: Allow SimpleRecords to be schemas

### DIFF
--- a/packages/normalizr/src/entities/FlatEntity.ts
+++ b/packages/normalizr/src/entities/FlatEntity.ts
@@ -1,9 +1,10 @@
 import Entity from './Entity';
 import * as schema from '../schema';
 import { AbstractInstanceType } from '../types';
+import { SimpleRecord } from '..';
 
 export default abstract class FlatEntity extends Entity {
-  static denormalize<T extends typeof Entity>(
+  static denormalize<T extends typeof SimpleRecord>(
     this: T,
     entity: any,
     unvisit: schema.UnvisitFunction,

--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -106,8 +106,9 @@ export default abstract class SimpleRecord {
     this: T,
     ...args: any[]
   ): [AbstractInstanceType<T>, boolean] {
+    const [res, found] = denormalize(this.schema, ...args);
     // useDenormalized will memo based on entities, so creating a new object each time is fine
-    return this.fromJS(denormalize(this.schema, ...args)) as any;
+    return [this.fromJS(res) as any, found];
   }
 
   /** Returns this to be used in a schema definition.

--- a/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
+++ b/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
@@ -1,0 +1,77 @@
+import { SimpleRecord, denormalize } from '../..';
+import { normalize } from '../../normalize';
+
+class Article extends SimpleRecord {
+  readonly id: string = '';
+  readonly title: string = '';
+  readonly author: string = '';
+  readonly content: string = '';
+}
+
+describe('SimpleRecord', () => {
+  it('should init', () => {
+    const resource = Article.fromJS({
+      id: '5',
+      title: 'happy',
+      author: '5',
+    });
+    expect(resource.title).toBe('happy');
+    expect(resource.author).toBe('5');
+  });
+
+  it('should not allow init with wrong types', () => {
+    Article.fromJS({
+      // @ts-expect-error
+      id: 5,
+      title: 'happy',
+      // @ts-expect-error
+      author: 5,
+    });
+  });
+
+  describe('normalize', () => {
+    it('should normalize into plain object', () => {
+      const schema = Article.asSchema();
+      const normalized = normalize(
+        {
+          id: '5',
+          title: 'happy',
+          author: '5',
+        },
+        schema,
+      );
+      expect(normalized.result).toEqual({
+        id: '5',
+        title: 'happy',
+        author: '5',
+      });
+    });
+
+    it('should denormalize with defaults', () => {
+      const schema = Article.asSchema();
+      const denormalized = denormalize(
+        {
+          id: '5',
+          title: 'happy',
+          author: '5',
+        },
+        schema,
+        {},
+      );
+      const article = denormalized[0];
+      expect(article).toBeDefined();
+      expect(article).toBeInstanceOf(Article);
+      expect(article).toEqual({
+        id: '5',
+        title: 'happy',
+        author: '5',
+        content: '',
+      });
+      // typing of members that it has
+      article?.content;
+      article?.author;
+      // @ts-expect-error - fails when it doesn't
+      article?.bob;
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Plain objects assume the value is there. SimpleRecords allow for defaults to be provided. There are times when we want to use these on things that aren't entities (with proto3).

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add normalize/denormalize that just pulls on 'object' version.

```ts
const schema = {
  cards: [] as LoyaltyCard[],
  pageDescription: new PageDescription(),
  cardLocation: LoyaltyCardLocation.HOME_CAROUSEL,
}
```
to

```ts
class ListLoyaltyCards extends SimpleRecord {
  readonly cards: LoyaltyCard[] = [];
  readonly pageDescription = new PageDescription();
  readonly cardLocation = LoyaltyCardLocation.HOME_CAROUSEL;
}
const schema = ListLoyaltyCards.asSchema();
```
