### PR TITLE
enhance: No longer require 'asSchema()'

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -7,7 +7,6 @@ import {
   DeleteShape,
 } from 'rest-hooks';
 import { AbstractInstanceType, FetchOptions, MutateShape } from 'rest-hooks';
-
 import React from 'react';
 
 export class UserResource extends Resource {
@@ -34,7 +33,7 @@ export class ArticleResource extends Resource {
   }
 
   static schema = {
-    author: UserResource.asSchema(),
+    author: UserResource,
   };
 
   static urlRoot = 'http://test.com/article/';
@@ -77,7 +76,7 @@ export class ArticleResource extends Resource {
         baseShape.getFetchKey({ ...params, includeUser: true }),
       fetch: (params: object) =>
         this.fetch('get', this.url({ ...params, includeUser: true })),
-      schema: this.asSchema(),
+      schema: this,
     };
   }
 
@@ -91,7 +90,7 @@ export class ArticleResource extends Resource {
         baseShape.getFetchKey({ ...params, includeUser: true }),
       fetch: (params: object) =>
         this.fetch('get', this.listUrl({ ...params, includeUser: 'true' })),
-      schema: [this.asSchema()],
+      schema: [this],
     };
   }
 
@@ -221,14 +220,14 @@ export class PaginatedArticleResource extends OtherArticleResource {
   static listShape<T extends typeof Resource>(this: T) {
     return {
       ...super.listShape(),
-      schema: { results: [this.asSchema()], prevPage: '', nextPage: '' },
+      schema: { results: [this], prevPage: '', nextPage: '' },
     };
   }
 
   static detailShape<T extends typeof Resource>(this: T) {
     return {
       ...super.listShape(),
-      schema: { data: this.asSchema() },
+      schema: { data: this },
     };
   }
 }
@@ -249,8 +248,8 @@ export class UnionResource extends Resource {
   ): ReadShape<SchemaDetail<AbstractInstanceType<T>>> {
     const schema = new schemas.Union(
       {
-        first: FirstUnionResource.asSchema(),
-        second: SecondUnionResource.asSchema(),
+        first: FirstUnionResource,
+        second: SecondUnionResource,
       },
       'type',
     );
@@ -266,8 +265,8 @@ export class UnionResource extends Resource {
     const schema = [
       new schemas.Union(
         {
-          first: FirstUnionResource.asSchema(),
-          second: SecondUnionResource.asSchema(),
+          first: FirstUnionResource,
+          second: SecondUnionResource,
         },
         (input: FirstUnionResource | SecondUnionResource) => input['type'],
       ),
@@ -292,7 +291,7 @@ export class NestedArticleResource extends OtherArticleResource {
 
   static schema = {
     ...OtherArticleResource.schema,
-    user: UserResource.asSchema(),
+    user: UserResource,
   };
 }
 

--- a/docs/api/Entity.md
+++ b/docs/api/Entity.md
@@ -208,7 +208,7 @@ class AssetResource extends Resource {
   readonly price: string = '';
 
   static schema = {
-    price: LatestPrice.asSchema(),
+    price: LatestPrice,
   };
 }
 ```
@@ -222,7 +222,7 @@ const assets = useResource(AssetResource.listShape(), {});
 Nested below:
 
 ```tsx
-const price = useCache(LatestPrice.asSchema(), { symbol: 'BTC' });
+const price = useCache(LatestPrice, { symbol: 'BTC' });
 ```
 
 ### static schema: { [k: keyof this]: Schema }
@@ -242,7 +242,7 @@ import ArticleEntity from './ArticleEntity';
 
 export const articleListShape = {
   type: 'read',
-  schema: { results: [ArticleEntity.asSchema()], nextPage: '', prevPage: '' },
+  schema: { results: [ArticleEntity], nextPage: '', prevPage: '' },
   getFetchKey(params: Readonly<object>): {return `article/${JSON.stringify(params)}`;},
   fetch: universalFetchFunction,
 }

--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -218,7 +218,7 @@ Use in schemas when referring to this Resource.
   static listShape<T extends typeof Resource>(this: T) {
     return {
       ...super.listShape(),
-      schema: { results: [this.asSchema()], nextPage: '', prevPage: '' },
+      schema: { results: [this], nextPage: '', prevPage: '' },
     };
   }
 ```

--- a/docs/api/useCache.md
+++ b/docs/api/useCache.md
@@ -61,7 +61,7 @@ export class PaginatedPostResource extends Resource {
   static listShape<T extends typeof Resource>(this: T) {
     return {
       ...super.listShape(),
-      schema: { results: [this.asSchema()], nextPage: '', lastPage: '' },
+      schema: { results: [this], nextPage: '', lastPage: '' },
     };
   }
 }

--- a/docs/api/useFetcher.md
+++ b/docs/api/useFetcher.md
@@ -158,7 +158,7 @@ class ArticlePaginatedResource extends Resource {
   static listShape<T extends Resource>() {
     return {
       ...super.listShape(),
-      shape: { results: this.asSchema()[], nextPage: '' },
+      shape: { results: this[], nextPage: '' },
     }
   }
 }

--- a/docs/api/useResource.md
+++ b/docs/api/useResource.md
@@ -104,7 +104,7 @@ export class PaginatedPostResource extends Resource {
   static listShape<T extends typeof Resource>(this: T) {
     return {
       ...super.listShape(),
-      schema: { results: [this.asSchema()], nextPage: '', lastPage: '' },
+      schema: { results: [this], nextPage: '', lastPage: '' },
     };
   }
 }

--- a/docs/guides/endpoints.md
+++ b/docs/guides/endpoints.md
@@ -135,13 +135,13 @@ export default class CommentResource extends Resource {
   static detailShape<T extends typeof Resource>(this: T) {
     return {
       ...super.detailShape(),
-      schema: { data: this.asSchema() },
+      schema: { data: this },
     };
   }
   static listShape<T extends typeof Resource>(this: T) {
     return {
       ...super.listShape(),
-      schema: { data: [this.asSchema()] },
+      schema: { data: [this] },
     };
   }
 }
@@ -271,8 +271,8 @@ export default class BirthdayResource extends BaseResource {
         return this.fetch('post', `/api/birthdays/upcoming/`);
       },
       schema: {
-        withinSevenDays: [this.asSchema()],
-        withinThirtyDays: [this.asSchema()],
+        withinSevenDays: [this],
+        withinThirtyDays: [this],
       },
     };
   }

--- a/docs/guides/infinite-scrolling-pagination.md
+++ b/docs/guides/infinite-scrolling-pagination.md
@@ -12,7 +12,7 @@ abstract class BaseResource extends Resource {
   static listShape<T extends typeof Resource>(this: T) {
     return {
       ...super.listShape(),
-      schema: { results: [this.asSchema()], cursor: null as string | null },
+      schema: { results: [this], cursor: null as string | null },
     };
   }
 

--- a/docs/guides/nested-response.md
+++ b/docs/guides/nested-response.md
@@ -30,8 +30,8 @@ export default class ArticleResource extends Resource {
   static urlRoot = 'http://test.com/article/';
 
   static schema = {
-    author: UserResource.asSchema(),
-    contributors: [UserResource.asSchema()],
+    author: UserResource,
+    contributors: [UserResource],
   };
 }
 ```
@@ -85,13 +85,13 @@ export default class ArticleResource extends Resource {
   static urlRoot = 'http://test.com/article/';
 
   static schema = {
-    author: UserResource.asSchema(),
-    contributors: [UserResource.asSchema()],
+    author: UserResource,
+    contributors: [UserResource],
   };
 }
 
 UserResource.schema = {
-  posts: [ArticleResource.asSchema()],
+  posts: [ArticleResource],
 };
 ```
 

--- a/docs/guides/network-transform.md
+++ b/docs/guides/network-transform.md
@@ -163,7 +163,7 @@ export default class ArticleResource extends Resource {
     return {
       ...super.listShape(),
       fetch,
-      schema: { results: [this.asSchema()], link: '' },
+      schema: { results: [this], link: '' },
     };
   }
 }

--- a/docs/guides/pagination.md
+++ b/docs/guides/pagination.md
@@ -59,7 +59,7 @@ export default class ArticleResource extends Resource {
   static listShape<T extends typeof Resource>(this: T) {
     return {
       ...super.listShape(),
-      schema: { results: [this.asSchema()], nextPage: '', prevPage: '' },
+      schema: { results: [this], nextPage: '', prevPage: '' },
     };
   }
 }
@@ -127,7 +127,7 @@ export default class ArticleResource extends Resource {
     return {
       ...super.listShape(),
       fetch,
-      schema: { results: [this.asSchema()], link: '' },
+      schema: { results: [this], link: '' },
     };
   }
 }
@@ -170,7 +170,7 @@ export default class ArticleResource extends Resource {
     return {
       ...super.listShape(),
       fetch,
-      schema: { results: [this.asSchema()], link: '' },
+      schema: { results: [this], link: '' },
     };
   }
 }

--- a/docs/guides/rpc.md
+++ b/docs/guides/rpc.md
@@ -54,8 +54,8 @@ class TradeResource extends Resource {
     return {
       ...super.createShape(),
       schema: {
-        trade: this.asSchema(),
-        account: AccountResource.asSchema(),
+        trade: this,
+        account: AccountResource,
       },
     };
   }

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -1,4 +1,4 @@
-import SimpleRecord, { SimpleRecordSchema } from './SimpleRecord';
+import SimpleRecord from './SimpleRecord';
 import { isImmutable, denormalizeImmutable } from '../schemas/ImmutableUtils';
 import * as schema from '../schema';
 import { AbstractInstanceType, Schema } from '../types';
@@ -183,8 +183,6 @@ if (process.env.NODE_ENV !== 'production') {
     return SimpleRecord.fromJS.call(this, props) as any;
   };
 }
-
-export type EntitySchema<E extends typeof SimpleRecord> = SimpleRecordSchema<E>;
 
 export function isEntity(schema: Schema | null): schema is typeof Entity {
   return schema !== null && (schema as any).pk !== undefined;

--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -111,27 +111,7 @@ export default abstract class SimpleRecord {
     return [this.fromJS(res) as any, found];
   }
 
-  /** Returns this to be used in a schema definition.
-   * This is essential to capture the correct type to be used in inferencing.
-   */
   static asSchema<T extends typeof SimpleRecord>(this: T) {
-    return this as SimpleRecordSchema<T>;
+    return this;
   }
 }
-
-export type SimpleRecordSchema<E extends typeof SimpleRecord> = E & {
-  normalize(
-    input: any,
-    parent: any,
-    key: any,
-    visit: Function,
-    addEntity: Function,
-    visitedEntities: Record<string, any>,
-  ): any;
-  denormalize(
-    entity: any,
-    unvisit: Function,
-  ): [AbstractInstanceType<E>, boolean];
-  _normalizeNullable(): any | undefined;
-  _denormalizeNullable(): [AbstractInstanceType<E> | undefined, boolean];
-};

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -28,7 +28,7 @@ describe(`${Entity.name} normalization`, () => {
         return this.name;
       }
     }
-    const schema = MyEntity.asSchema();
+    const schema = MyEntity;
     function normalizeBad() {
       normalize({ secondthing: 'hi' }, schema);
     }
@@ -43,7 +43,7 @@ describe(`${Entity.name} normalization`, () => {
         return this.name;
       }
     }
-    const schema = MyEntity.asSchema();
+    const schema = MyEntity;
     function normalizeBad() {
       normalize({ nonexistantthing: 'hi' }, schema);
     }
@@ -92,7 +92,7 @@ describe(`${Entity.name} normalization`, () => {
         }
       }
       expect(
-        normalize({ idStr: '134351', name: 'Kathy' }, User.asSchema()),
+        normalize({ idStr: '134351', name: 'Kathy' }, User),
       ).toMatchSnapshot();
     });
 
@@ -103,10 +103,7 @@ describe(`${Entity.name} normalization`, () => {
           return key;
         }
       }
-      const inputSchema = new schema.Values(
-        { users: User.asSchema() },
-        () => 'users',
-      );
+      const inputSchema = new schema.Values({ users: User }, () => 'users');
 
       expect(
         normalize(
@@ -124,7 +121,7 @@ describe(`${Entity.name} normalization`, () => {
           return `${parent.name}-${key}-${this.id}`;
         }
       }
-      const inputSchema = new schema.Object({ user: User.asSchema() });
+      const inputSchema = new schema.Object({ user: User });
 
       expect(
         normalize(
@@ -143,7 +140,7 @@ describe(`${Entity.name} normalization`, () => {
             { id: '1', name: 'foo' },
             { id: '1', name: 'bar', alias: 'bar' },
           ],
-          [Tacos.asSchema()],
+          [Tacos],
         ),
       ).toMatchSnapshot();
     });
@@ -171,7 +168,7 @@ describe(`${Entity.name} normalization`, () => {
             { id: '1', name: 'foo' },
             { id: '1', name: 'bar', alias: 'bar' },
           ],
-          [MergeTaco.asSchema()],
+          [MergeTaco],
         ),
       ).toMatchSnapshot();
     });
@@ -194,7 +191,7 @@ describe(`${Entity.name} normalization`, () => {
       }
 
       expect(
-        normalize({ id: '1', name: 'foo' }, ProcessTaco.asSchema()),
+        normalize({ id: '1', name: 'foo' }, ProcessTaco),
       ).toMatchSnapshot();
     });
 
@@ -218,7 +215,7 @@ describe(`${Entity.name} normalization`, () => {
       class ParentEntity extends IDEntity {
         readonly content: string = '';
 
-        static schema = { child: ChildEntity.asSchema() };
+        static schema = { child: ChildEntity };
       }
 
       expect(
@@ -228,7 +225,7 @@ describe(`${Entity.name} normalization`, () => {
             content: 'parent',
             child: { id: '4', content: 'child' },
           },
-          ParentEntity.asSchema(),
+          ParentEntity,
         ),
       ).toMatchSnapshot();
     });
@@ -239,7 +236,7 @@ describe(`${Entity.name} normalization`, () => {
         readonly type: string = '';
 
         static schema = {
-          data: { attachment: AttachmentsEntity.asSchema() },
+          data: { attachment: AttachmentsEntity },
         };
 
         static fromJS<T extends typeof SimpleRecord>(
@@ -258,7 +255,7 @@ describe(`${Entity.name} normalization`, () => {
       expect(
         normalize(
           { message: { id: '123', data: { attachment: { id: '456' } } } },
-          EntriesEntity.asSchema(),
+          EntriesEntity,
         ),
       ).toMatchSnapshot();
     });
@@ -272,17 +269,15 @@ describe(`${Entity.name} denormalization`, () => {
         '1': { id: '1', type: 'foo' },
       },
     };
-    expect(denormalize('1', Tacos.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('1', Tacos.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('1', Tacos, entities)).toMatchSnapshot();
+    expect(denormalize('1', Tacos, fromJS(entities))).toMatchSnapshot();
   });
 
   class Food extends IDEntity {}
   class Menu extends IDEntity {
     readonly food: Food = Food.fromJS();
 
-    static schema = { food: Food.asSchema() };
+    static schema = { food: Food };
   }
 
   test('denormalizes deep entities', () => {
@@ -296,15 +291,11 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
 
-    expect(denormalize('1', Menu.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('1', Menu.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
 
-    expect(denormalize('2', Menu.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('2', Menu.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
   });
 
   test('denormalizes to undefined for missing data', () => {
@@ -317,15 +308,11 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
 
-    expect(denormalize('1', Menu.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('1', Menu.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
 
-    expect(denormalize('2', Menu.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('2', Menu.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
   });
 
   test('denormalizes deep entities with records', () => {
@@ -342,15 +329,11 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
 
-    expect(denormalize('1', Menu.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('1', Menu.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
 
-    expect(denormalize('2', Menu.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('2', Menu.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
   });
 
   test('can denormalize already partially denormalized data', () => {
@@ -363,10 +346,8 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
 
-    expect(denormalize('1', Menu.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('1', Menu.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
   });
 
   class User extends IDEntity {
@@ -406,15 +387,11 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
 
-    expect(denormalize('123', Report.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('123', Report.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('123', Report, entities)).toMatchSnapshot();
+    expect(denormalize('123', Report, fromJS(entities))).toMatchSnapshot();
 
-    expect(denormalize('456', User.asSchema(), entities)).toMatchSnapshot();
-    expect(
-      denormalize('456', User.asSchema(), fromJS(entities)),
-    ).toMatchSnapshot();
+    expect(denormalize('456', User, entities)).toMatchSnapshot();
+    expect(denormalize('456', User, fromJS(entities))).toMatchSnapshot();
   });
 
   test('denormalizes entities with referential equality', () => {
@@ -436,11 +413,7 @@ describe(`${Entity.name} denormalization`, () => {
       },
     };
 
-    const [denormalizedReport] = denormalize(
-      '123',
-      Report.asSchema(),
-      entities,
-    );
+    const [denormalizedReport] = denormalize('123', Report, entities);
 
     expect(denormalizedReport).toBeDefined();
     // This is just for TypeScript, the above line actually determines this

--- a/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
+++ b/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
@@ -1,4 +1,4 @@
-import { SimpleRecord, denormalize } from '../..';
+import { SimpleRecord, denormalize, Entity } from '../..';
 import { normalize } from '../../normalize';
 
 class Article extends SimpleRecord {
@@ -6,6 +6,24 @@ class Article extends SimpleRecord {
   readonly title: string = '';
   readonly author: string = '';
   readonly content: string = '';
+}
+class ArticleEntity extends Entity {
+  readonly id: string = '';
+  readonly title: string = '';
+  readonly author: string = '';
+  readonly content: string = '';
+  pk() {
+    return this.id;
+  }
+}
+
+class Pagination extends SimpleRecord {
+  readonly data = ArticleEntity.fromJS();
+  readonly nextPage: string = '';
+  readonly lastPage: string = '';
+  static schema = {
+    data: ArticleEntity,
+  };
 }
 
 describe('SimpleRecord', () => {
@@ -31,7 +49,7 @@ describe('SimpleRecord', () => {
 
   describe('normalize', () => {
     it('should normalize into plain object', () => {
-      const schema = Article.asSchema();
+      const schema = Article;
       const normalized = normalize(
         {
           id: '5',
@@ -48,7 +66,7 @@ describe('SimpleRecord', () => {
     });
 
     it('should denormalize with defaults', () => {
-      const schema = Article.asSchema();
+      const schema = Article;
       const denormalized = denormalize(
         {
           id: '5',

--- a/packages/normalizr/src/index.ts
+++ b/packages/normalizr/src/index.ts
@@ -1,7 +1,6 @@
 import { denormalize } from './denormalize';
 import { normalize } from './normalize';
 import * as schema from './schema';
-export type { EntitySchema } from './entities/Entity';
 import Entity, { isEntity } from './entities/Entity';
 import SimpleRecord from './entities/SimpleRecord';
 export { default as FlatEntity } from './entities/FlatEntity';

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -1,5 +1,5 @@
 import { Schema, AbstractInstanceType } from './types';
-import { EntitySchema } from './entities/Entity';
+import Entity from './entities/Entity';
 
 export type StrategyFunction<T> = (value: any, parent: any, key: string) => T;
 export type SchemaFunction<K = string> = (
@@ -13,7 +13,7 @@ export type SchemaAttributeFunction<S extends Schema> = (
   parent: any,
   key: string,
 ) => S;
-export type EntityMap<T = any> = Record<string, EntitySchema<T>>;
+export type EntityMap<T = any> = Record<string, EntityInterface<T>>;
 export type UnvisitFunction = (input: any, schema: any) => [any, boolean];
 export type UnionResult<Choices extends EntityMap> = {
   id: string;
@@ -42,15 +42,7 @@ export interface SchemaClass extends SchemaSimple {
 interface EntityInterface<T = any> extends SchemaSimple {
   pk(params: any, parent?: any, key?: string): string | undefined;
   readonly key: string;
-  normalize(
-    input: any,
-    parent: any,
-    key: any,
-    visit: Function,
-    addEntity: Function,
-    visitedEntities: Record<string, any>,
-  ): string;
-  denormalize(entity: any, unvisit: Function): [T, boolean];
+  prototype: T;
 }
 
 export class Array<S extends Schema = Schema> implements SchemaClass {

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -1,4 +1,5 @@
 import type { default as schema } from './schema';
+import { Entity } from '.';
 
 export type AbstractInstanceType<T> = T extends { prototype: infer U }
   ? U
@@ -37,7 +38,15 @@ export type NormalizeReturnType<T> = T extends (...args: any) => infer R
   ? R
   : never;
 
-export type Denormalize<S> = S extends schema.SchemaClass
+export type Denormalize<S> = S extends {
+  pk(): string;
+  fromJS: Function;
+  prototype: infer U;
+}
+  ? U
+  : S extends { schema: Record<string, Schema>; fromJS: Function }
+  ? AbstractInstanceType<S>
+  : S extends schema.SchemaClass
   ? DenormalizeReturnType<S['denormalize']>
   : S extends Array<infer F>
   ? Denormalize<F>[]
@@ -45,7 +54,11 @@ export type Denormalize<S> = S extends schema.SchemaClass
   ? DenormalizeObject<S>
   : S;
 
-export type DenormalizeNullable<S> = S extends schema.SchemaClass
+export type DenormalizeNullable<S> = S extends typeof Entity
+  ? AbstractInstanceType<S> | undefined
+  : S extends { schema: Record<string, Schema>; fromJS: Function }
+  ? AbstractInstanceType<S>
+  : S extends schema.SchemaClass
   ? DenormalizeReturnType<S['_denormalizeNullable']>
   : S extends Array<infer F>
   ? Denormalize<F>[] | undefined
@@ -53,7 +66,14 @@ export type DenormalizeNullable<S> = S extends schema.SchemaClass
   ? DenormalizeNullableObject<S>
   : S;
 
-export type Normalize<S> = S extends schema.SchemaClass
+export type Normalize<S> = S extends {
+  pk(): string;
+  fromJS: Function;
+}
+  ? string
+  : S extends { schema: Record<string, Schema>; fromJS: Function }
+  ? NormalizeObject<S['schema']>
+  : S extends schema.SchemaClass
   ? NormalizeReturnType<S['normalize']>
   : S extends Array<infer F>
   ? Normalize<F>[]
@@ -61,7 +81,14 @@ export type Normalize<S> = S extends schema.SchemaClass
   ? NormalizeObject<S>
   : S;
 
-export type NormalizeNullable<S> = S extends schema.SchemaClass
+export type NormalizeNullable<S> = S extends {
+  pk(): string;
+  fromJS: Function;
+}
+  ? string | undefined
+  : S extends { schema: Record<string, Schema>; fromJS: Function }
+  ? NormalizedNullableObject<S['schema']>
+  : S extends schema.SchemaClass
   ? NormalizeReturnType<S['_normalizeNullable']>
   : S extends Array<infer F>
   ? Normalize<F>[] | undefined
@@ -74,7 +101,7 @@ export type Schema =
   | string
   | { [K: string]: any }
   | Schema[]
-  | schema.SchemaClass;
+  | schema.SchemaSimple;
 
 export type NormalizedIndex = {
   readonly [entityKey: string]: {

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -1,4 +1,4 @@
-import type { default as schema } from './schema';
+import type { default as schema, EntityInterface } from './schema';
 import { Entity } from '.';
 
 export type AbstractInstanceType<T> = T extends { prototype: infer U }
@@ -38,11 +38,7 @@ export type NormalizeReturnType<T> = T extends (...args: any) => infer R
   ? R
   : never;
 
-export type Denormalize<S> = S extends {
-  pk(): string;
-  fromJS: Function;
-  prototype: infer U;
-}
+export type Denormalize<S> = S extends EntityInterface<infer U>
   ? U
   : S extends { schema: Record<string, Schema>; fromJS: Function }
   ? AbstractInstanceType<S>
@@ -54,8 +50,8 @@ export type Denormalize<S> = S extends {
   ? DenormalizeObject<S>
   : S;
 
-export type DenormalizeNullable<S> = S extends typeof Entity
-  ? AbstractInstanceType<S> | undefined
+export type DenormalizeNullable<S> = S extends EntityInterface<infer U>
+  ? U | undefined
   : S extends { schema: Record<string, Schema>; fromJS: Function }
   ? AbstractInstanceType<S>
   : S extends schema.SchemaClass
@@ -66,10 +62,7 @@ export type DenormalizeNullable<S> = S extends typeof Entity
   ? DenormalizeNullableObject<S>
   : S;
 
-export type Normalize<S> = S extends {
-  pk(): string;
-  fromJS: Function;
-}
+export type Normalize<S> = S extends EntityInterface
   ? string
   : S extends { schema: Record<string, Schema>; fromJS: Function }
   ? NormalizeObject<S['schema']>
@@ -81,10 +74,7 @@ export type Normalize<S> = S extends {
   ? NormalizeObject<S>
   : S;
 
-export type NormalizeNullable<S> = S extends {
-  pk(): string;
-  fromJS: Function;
-}
+export type NormalizeNullable<S> = S extends EntityInterface
   ? string | undefined
   : S extends { schema: Record<string, Schema>; fromJS: Function }
   ? NormalizedNullableObject<S['schema']>

--- a/packages/normalizr/typescript-tests/denormalize.ts
+++ b/packages/normalizr/typescript-tests/denormalize.ts
@@ -4,6 +4,7 @@ import {
   schema,
   DenormalizeNullable,
   Normalize,
+  Denormalize,
 } from '../src';
 import IDEntity from '../src/entities/IDEntity';
 
@@ -16,8 +17,8 @@ class Magic2 extends IDEntity {
   readonly a = 'second' as const;
   private b3 = false;
 }
-const magicSchema = Magic.asSchema();
-const magic2Schema = Magic2.asSchema();
+const magicSchema = Magic;
+const magic2Schema = Magic2;
 
 const unionSchema = new schema.Union(
   {
@@ -35,7 +36,7 @@ const errorUnionSchema = new schema.Union(
   'notexistant',
 );
 const scheme = {
-  thing: { data: unionSchema, members: [Magic.asSchema()] },
+  thing: { data: unionSchema, members: [Magic] },
   first: '',
   second: '',
 };
@@ -47,7 +48,8 @@ const r = normalize({}, scheme);
 type A = DenormalizeNullable<typeof scheme>;
 type B = A['thing']['members'];
 type C = DenormalizeNullable<typeof schemeEntity>;
-type D = ReturnType<typeof magicSchema['_denormalizeNullable']>;
+type D = ReturnType<typeof unionSchema['_denormalizeNullable']>;
+type F = Denormalize<typeof unionSchema>;
 type E = Normalize<typeof scheme>['thing']['data'];
 
 if (de[1]) {

--- a/packages/normalizr/typescript-tests/entity.ts
+++ b/packages/normalizr/typescript-tests/entity.ts
@@ -26,7 +26,7 @@ class Tweet extends Entity {
     return this.id_str;
   }
 
-  static schema = { user: User.asSchema() };
+  static schema = { user: User };
 
   static fromJS<T extends typeof SimpleRecord>(
     this: T,
@@ -58,8 +58,8 @@ class Tweet extends Entity {
 const data = {
   /* ...*/
 };
-const user = User.asSchema();
-const tweet = Tweet.asSchema();
+const user = User;
+const tweet = Tweet;
 
 const normalizedData = normalize(data, tweet);
 const denormalizedData = denormalize(

--- a/packages/normalizr/typescript-tests/github.ts
+++ b/packages/normalizr/typescript-tests/github.ts
@@ -31,8 +31,8 @@ class PullRequest extends IDEntity {
 
 const issueOrPullRequest = new schema.Array(
   {
-    issues: Issue.asSchema(),
-    pullRequests: PullRequest.asSchema(),
+    issues: Issue,
+    pullRequests: PullRequest,
   },
   (entity: any) => (entity.pull_request ? 'pullRequests' : 'issues'),
 );

--- a/packages/normalizr/typescript-tests/object.ts
+++ b/packages/normalizr/typescript-tests/object.ts
@@ -7,9 +7,9 @@ const data = {
 class User extends IDEntity {}
 
 const responseSchema = new schema.Object({
-  users: new schema.Array(User.asSchema()),
+  users: new schema.Array(User,
 });
 const normalizedData = normalize(data, responseSchema);
 
-const responseSchemaAlt = { users: new schema.Array(User.asSchema()) };
+const responseSchemaAlt = { users: new schema.Array(User };
 const normalizedDataAlt = normalize(data, responseSchemaAlt);

--- a/packages/normalizr/typescript-tests/object.ts
+++ b/packages/normalizr/typescript-tests/object.ts
@@ -7,9 +7,9 @@ const data = {
 class User extends IDEntity {}
 
 const responseSchema = new schema.Object({
-  users: new schema.Array(User,
+  users: new schema.Array(User),
 });
 const normalizedData = normalize(data, responseSchema);
 
-const responseSchemaAlt = { users: new schema.Array(User };
+const responseSchemaAlt = { users: new schema.Array(User) };
 const normalizedDataAlt = normalize(data, responseSchemaAlt);

--- a/packages/normalizr/typescript-tests/relationships.ts
+++ b/packages/normalizr/typescript-tests/relationships.ts
@@ -46,7 +46,7 @@ class User extends IDEntity {
 }
 
 class Comment extends IDEntity {
-  static schema = { commenter: User.asSchema() };
+  static schema = { commenter: User };
 
   static fromJS<T extends typeof SimpleRecord>(
     this: T,
@@ -60,8 +60,8 @@ class Comment extends IDEntity {
 
 class Post extends IDEntity {
   static schema = {
-    author: User.asSchema(),
-    comments: [Comment.asSchema()],
+    author: User,
+    comments: [Comment],
   };
 }
 

--- a/packages/normalizr/typescript-tests/union.ts
+++ b/packages/normalizr/typescript-tests/union.ts
@@ -12,16 +12,16 @@ class Group extends IDEntity {
 
 const unionSchema = new schema.Union(
   {
-    user: User.asSchema(),
-    group: Group.asSchema(),
+    user: User,
+    group: Group,
   },
   'type',
 );
 
 const errorUnionSchema = new schema.Union(
   {
-    user: User.asSchema(),
-    group: Group.asSchema(),
+    user: User,
+    group: Group,
   },
   // @ts-expect-error
   'blob',

--- a/packages/normalizr/typescript-tests/values.ts
+++ b/packages/normalizr/typescript-tests/values.ts
@@ -4,6 +4,6 @@ import IDEntity from '../src/entities/IDEntity';
 const data = { firstThing: { id: 1 }, secondThing: { id: 2 } };
 
 class Item extends IDEntity {}
-const valuesSchema = new schema.Values(Item.asSchema());
+const valuesSchema = new schema.Values(Item);
 
 const normalizedData = normalize(data, valuesSchema);

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -56,7 +56,6 @@ export type {
 } from './resource/shapes';
 export * from './resource/normal';
 export type { SetShapeParams, ParamsFromShape } from './resource/publicTypes';
-export type { EntitySchema } from '@rest-hooks/normalizr';
 export {
   Resource,
   SimpleResource,

--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -97,10 +97,10 @@ export default abstract class SimpleResource extends FlatEntity {
     /* istanbul ignore next */
     if (process.env.NODE_ENV === 'development') {
       console.error(
-        'getEntitySchema() is deprecated - use asSchema() instead.',
+        'getEntitySchema() is deprecated - use Entity directly instead.',
       );
     }
-    return this.asSchema();
+    return this;
   }
 
   /** Get the request options for this SimpleResource  */
@@ -119,7 +119,7 @@ export default abstract class SimpleResource extends FlatEntity {
     const options = this.getFetchOptions();
     return {
       type: 'read',
-      schema: this.asSchema(),
+      schema: this,
       options,
       getFetchKey,
       fetch: (params: Readonly<object>) => {
@@ -138,7 +138,7 @@ export default abstract class SimpleResource extends FlatEntity {
     const options = this.getFetchOptions();
     return {
       type: 'read',
-      schema: [this.asSchema()],
+      schema: [this],
       options,
       getFetchKey,
       fetch: (params: Readonly<Record<string, string | number>>) => {
@@ -158,7 +158,7 @@ export default abstract class SimpleResource extends FlatEntity {
     const options = this.getFetchOptions();
     return {
       type: 'mutate',
-      schema: this.asSchema(),
+      schema: this,
       options,
       getFetchKey: (params: Readonly<Record<string, string>>) => {
         return 'POST ' + this.listUrl(params);
@@ -183,7 +183,7 @@ export default abstract class SimpleResource extends FlatEntity {
     const options = this.getFetchOptions();
     return {
       type: 'mutate',
-      schema: this.asSchema(),
+      schema: this,
       options,
       getFetchKey: (params: object) => {
         return 'PUT ' + this.url(params);
@@ -208,7 +208,7 @@ export default abstract class SimpleResource extends FlatEntity {
     const options = this.getFetchOptions();
     return {
       type: 'mutate',
-      schema: this.asSchema(),
+      schema: this,
       options,
       getFetchKey: (params: Readonly<object>) => {
         return 'PATCH ' + this.url(params);
@@ -229,7 +229,7 @@ export default abstract class SimpleResource extends FlatEntity {
     const options = this.getFetchOptions();
     return {
       type: 'delete',
-      schema: this.asSchema(),
+      schema: this,
       options,
       getFetchKey: (params: object) => {
         return 'DELETE ' + this.url(params);

--- a/packages/rest-hooks/src/resource/__tests__/resource.ts
+++ b/packages/rest-hooks/src/resource/__tests__/resource.ts
@@ -496,7 +496,7 @@ describe('Resource', () => {
     });
 
     it('should throw a custom error if data does not include pk', () => {
-      const schema = CoolerArticleResource.asSchema();
+      const schema = CoolerArticleResource;
       function normalizeBad() {
         normalize({ content: 'hi' }, schema);
       }

--- a/packages/rest-hooks/src/state/__tests__/networkManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/networkManager.ts
@@ -327,7 +327,7 @@ describe('NetworkManager', () => {
         type: FETCH_TYPE,
         payload: () => promise,
         meta: {
-          schema: ArticleResource.getEntitySchema(),
+          schema: ArticleResource,
           key: ArticleResource.url({ id: 5 }),
           type: ArticleResource.detailShape().type,
           throttle: true,

--- a/packages/rest-hooks/src/state/__tests__/pollingSubscription.ts
+++ b/packages/rest-hooks/src/state/__tests__/pollingSubscription.ts
@@ -73,7 +73,7 @@ describe('PollingSubscription', () => {
   const sub = new PollingSubscription(
     {
       key: 'test.com',
-      schema: PollingArticleResource.getEntitySchema(),
+      schema: PollingArticleResource,
       fetch,
       frequency: 5000,
     },
@@ -90,7 +90,7 @@ describe('PollingSubscription', () => {
         new PollingSubscription(
           {
             key: 'test.com',
-            schema: PollingArticleResource.getEntitySchema(),
+            schema: PollingArticleResource,
             fetch,
           },
           dispatch,
@@ -193,7 +193,7 @@ describe('PollingSubscription', () => {
       const sub = new PollingSubscription(
         {
           key: 'test.com',
-          schema: PollingArticleResource.getEntitySchema(),
+          schema: PollingArticleResource,
           fetch,
           frequency: 5000,
         },
@@ -230,7 +230,7 @@ describe('PollingSubscription', () => {
       const pollingSubscription = new PollingSubscription(
         {
           key: 'test.com',
-          schema: PollingArticleResource.getEntitySchema(),
+          schema: PollingArticleResource,
           fetch,
           frequency: 5000,
         },

--- a/packages/rest-hooks/src/state/__tests__/reducer.ts
+++ b/packages/rest-hooks/src/state/__tests__/reducer.ts
@@ -30,7 +30,7 @@ describe('reducer', () => {
       type: RECEIVE_TYPE,
       payload,
       meta: {
-        schema: ArticleResource.getEntitySchema(),
+        schema: ArticleResource,
         key: ArticleResource.url({ id }),
         date: 5000000000,
         expiresAt: 5000500000,
@@ -83,7 +83,7 @@ describe('reducer', () => {
       type: RECEIVE_TYPE,
       payload,
       meta: {
-        schema: ArticleResource.getEntitySchema(),
+        schema: ArticleResource,
         key: ArticleResource.listUrl(payload),
         date: 0,
         expiresAt: 1000000000000,
@@ -101,7 +101,7 @@ describe('reducer', () => {
     const action: PurgeAction = {
       type: RECEIVE_DELETE_TYPE,
       meta: {
-        schema: ArticleResource.getEntitySchema(),
+        schema: ArticleResource,
         key: id.toString(),
         date: 0,
       },
@@ -226,7 +226,7 @@ describe('reducer', () => {
         updaters: {
           [key: string]: UpdateFunction<
             typeof createShape['schema'],
-            ReturnType<typeof ArticleResource.getEntitySchema>[]
+            typeof ArticleResource[]
           >;
         },
       ) {
@@ -234,7 +234,7 @@ describe('reducer', () => {
           type: RECEIVE_TYPE,
           payload,
           meta: {
-            schema: ArticleResource.getEntitySchema(),
+            schema: ArticleResource,
             key: ArticleResource.createShape().getFetchKey({}),
             updaters,
             date: 0,
@@ -365,7 +365,7 @@ describe('reducer', () => {
       type: RECEIVE_TYPE,
       payload: error,
       meta: {
-        schema: ArticleResource.getEntitySchema(),
+        schema: ArticleResource,
         key: ArticleResource.url({ id }),
         date: 5000000000,
         expiresAt: 5000500000,
@@ -383,7 +383,7 @@ describe('reducer', () => {
       type: RECEIVE_TYPE,
       payload: error,
       meta: {
-        schema: ArticleResource.getEntitySchema(),
+        schema: ArticleResource,
         key: ArticleResource.url({ id }),
         date: 0,
         expiresAt: 10000000000000000000,
@@ -402,7 +402,7 @@ describe('reducer', () => {
       type: RECEIVE_DELETE_TYPE,
       payload: error,
       meta: {
-        schema: ArticleResource.getEntitySchema(),
+        schema: ArticleResource,
         key: ArticleResource.url({ id }),
         date: 0,
       },
@@ -428,7 +428,7 @@ describe('reducer', () => {
       type: FETCH_TYPE,
       payload: () => new Promise<any>(() => null),
       meta: {
-        schema: ArticleResource.getEntitySchema(),
+        schema: ArticleResource,
         key: ArticleResource.url({ id: 5 }),
         type: 'read' as const,
         throttle: true,

--- a/packages/rest-hooks/src/state/__tests__/subscriptionManager.ts
+++ b/packages/rest-hooks/src/state/__tests__/subscriptionManager.ts
@@ -57,7 +57,7 @@ describe('SubscriptionManager', () => {
       return {
         type: SUBSCRIBE_TYPE,
         meta: {
-          schema: PollingArticleResource.getEntitySchema(),
+          schema: PollingArticleResource,
           key: PollingArticleResource.url(payload),
           fetch,
           options: { pollFrequency: 1000 },

--- a/packages/rest-hooks/src/state/selectors/__tests__/buildInferredResults.ts
+++ b/packages/rest-hooks/src/state/selectors/__tests__/buildInferredResults.ts
@@ -74,7 +74,7 @@ describe('buildInferredResults()', () => {
   it('should work with indexes', () => {
     const schema = {
       pagination: { next: '', previous: '' },
-      data: IndexedUserResource.asSchema(),
+      data: IndexedUserResource,
     };
     expect(
       buildInferredResults(
@@ -113,7 +113,7 @@ describe('buildInferredResults()', () => {
   it('should work with indexes but none set', () => {
     const schema = {
       pagination: { next: '', previous: '' },
-      data: IndexedUserResource.asSchema(),
+      data: IndexedUserResource,
     };
     expect(
       buildInferredResults(
@@ -152,7 +152,7 @@ describe('buildInferredResults()', () => {
   it('should work with indexes but no indexes stored', () => {
     const schema = {
       pagination: { next: '', previous: '' },
-      data: IndexedUserResource.asSchema(),
+      data: IndexedUserResource,
     };
     expect(buildInferredResults(schema, { username: 'bob' }, {})).toEqual({
       pagination: { next: '', previous: '' },

--- a/packages/rest-hooks/src/state/selectors/__tests__/buildInferredResults.ts
+++ b/packages/rest-hooks/src/state/selectors/__tests__/buildInferredResults.ts
@@ -11,7 +11,7 @@ describe('buildInferredResults()', () => {
   it('should work with Object', () => {
     const schema = new schemas.Object({
       data: new schemas.Object({
-        article: CoolerArticleResource.getEntitySchema(),
+        article: CoolerArticleResource,
       }),
     });
     expect(buildInferredResults(schema, { id: 5 }, {})).toEqual({
@@ -21,14 +21,14 @@ describe('buildInferredResults()', () => {
 
   it('should be undefined with Array', () => {
     const schema = {
-      data: new schemas.Array(CoolerArticleResource.getEntitySchema()),
+      data: new schemas.Array(CoolerArticleResource),
     };
     expect(buildInferredResults(schema, { id: 5 }, {})).toStrictEqual({
       data: undefined,
     });
 
     const schema2 = {
-      data: [CoolerArticleResource.getEntitySchema()],
+      data: [CoolerArticleResource],
     };
     expect(buildInferredResults(schema2, { id: 5 }, {})).toStrictEqual({
       data: undefined,
@@ -37,7 +37,7 @@ describe('buildInferredResults()', () => {
 
   it('should be {} with Values', () => {
     const schema = {
-      data: new schemas.Values(CoolerArticleResource.getEntitySchema()),
+      data: new schemas.Values(CoolerArticleResource),
     };
     expect(buildInferredResults(schema, { id: 5 }, {})).toStrictEqual({
       data: {},
@@ -63,7 +63,7 @@ describe('buildInferredResults()', () => {
   it('should work with primitive defaults', () => {
     const schema = {
       pagination: { next: '', previous: '' },
-      data: CoolerArticleResource.getEntitySchema(),
+      data: CoolerArticleResource,
     };
     expect(buildInferredResults(schema, { id: 5 }, {})).toEqual({
       pagination: { next: '', previous: '' },

--- a/packages/rest-hooks/src/state/selectors/__tests__/getEntityPath.ts
+++ b/packages/rest-hooks/src/state/selectors/__tests__/getEntityPath.ts
@@ -4,7 +4,7 @@ import { schemas } from '../../../resource/normal';
 import getEntityPath from '../getEntityPath';
 
 describe('getEntityPath()', () => {
-  const entity = CoolerArticleResource.getEntitySchema();
+  const entity = CoolerArticleResource;
   it('should find base Entity', () => {
     const path = getEntityPath(entity);
 

--- a/packages/rest-hooks/src/state/selectors/__tests__/useDenormalized.ts
+++ b/packages/rest-hooks/src/state/selectors/__tests__/useDenormalized.ts
@@ -178,7 +178,7 @@ describe('useDenormalized()', () => {
         },
         schema: {
           pagination: { next: '', previous: '' },
-          data: IndexedUserResource.asSchema(),
+          data: IndexedUserResource,
         },
       };
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Having to put `.asSchema()` is not only verbose, it's a hurdle for learning.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Originally this was decided to enable maximum simplicity of the denormalize/normalize type algorithm. However, this seems like a more optimal tradeoff
