### PR TITLE
enhance: Improve malformed entity normalization algorithm

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,5 +9,8 @@
     "import/resolver": {
       "node": {}
     }
+  },
+  "globals": {
+    "process": "writable"
   }
 }

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -35,7 +35,7 @@ describe(`${Entity.name} normalization`, () => {
     expect(normalizeBad).toThrowErrorMatchingSnapshot();
   });
 
-  it('should throw a custom error if data loads with unexpected props', () => {
+  it('should throw a custom error if data loads with no matching props', () => {
     class MyEntity extends Entity {
       readonly name: string = '';
       readonly secondthing: string = '';
@@ -45,7 +45,23 @@ describe(`${Entity.name} normalization`, () => {
     }
     const schema = MyEntity;
     function normalizeBad() {
-      normalize({ nonexistantthing: 'hi' }, schema);
+      normalize({}, schema);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw a custom error if data loads with half unexpected props', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ name: 'hoho', nonexistantthing: 'hi' }, schema);
     }
     expect(normalizeBad).toThrowErrorMatchingSnapshot();
   });
@@ -198,6 +214,8 @@ describe(`${Entity.name} normalization`, () => {
     test('can use information from the parent in the process strategy', () => {
       class ChildEntity extends IDEntity {
         readonly content: string = '';
+        readonly parentId: string = '';
+        readonly parentKey: string = '';
 
         static fromJS<T extends typeof SimpleRecord>(
           this: T,

--- a/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
@@ -468,14 +468,31 @@ exports[`Entity normalization should throw a custom error if data does not inclu
   "
 `;
 
-exports[`Entity normalization should throw a custom error if data loads with unexpected props 1`] = `
+exports[`Entity normalization should throw a custom error if data loads with half unexpected props 1`] = `
 "Attempted to initialize MyEntity with substantially different than expected keys
 
   This is likely due to a malformed response.
   Try inspecting the network response or fetch() return value.
 
-  Expected keys: name,secondthing
+  Expected keys:
+    Found: name
+    Missing: secondthing,thirdthing
+  Unexpected keys: nonexistantthing
   Value: {
+  \\"name\\": \\"hoho\\",
   \\"nonexistantthing\\": \\"hi\\"
 }"
+`;
+
+exports[`Entity normalization should throw a custom error if data loads with no matching props 1`] = `
+"Attempted to initialize MyEntity with substantially different than expected keys
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+
+  Expected keys:
+    Found: 
+    Missing: name,secondthing
+  Unexpected keys: 
+  Value: {}"
 `;

--- a/packages/normalizr/src/schemas/__tests__/Object.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Object.test.js
@@ -3,6 +3,7 @@ import { fromJS } from 'immutable';
 
 import { denormalizeSimple as denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
+import Entity from '../../entities/Entity';
 import IDEntity from '../../entities/IDEntity';
 
 describe(`${schema.Object.name} normalization`, () => {
@@ -20,9 +21,16 @@ describe(`${schema.Object.name} normalization`, () => {
   });
 
   test('filters out undefined and null values', () => {
-    class User extends IDEntity {}
+    class User extends Entity {
+      pk() {
+        return this.id;
+      }
+    }
     const users = { foo: User, bar: User, baz: User };
+    const oldenv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
     expect(normalize({ foo: {}, bar: { id: '1' } }, users)).toMatchSnapshot();
+    process.env.NODE_ENV = oldenv;
   });
 });
 

--- a/packages/normalizr/src/schemas/__tests__/Values.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Values.test.js
@@ -5,10 +5,15 @@ import { denormalizeSimple as denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import IDEntity from '../../entities/IDEntity';
 
+class Cat extends IDEntity {
+  type = '';
+}
+class Dog extends IDEntity {
+  type = '';
+}
+
 describe(`${schema.Values.name} normalization`, () => {
   test('normalizes the values of an object with the given schema', () => {
-    class Cat extends IDEntity {}
-    class Dog extends IDEntity {}
     const valuesSchema = new schema.Values(
       {
         dogs: Dog,
@@ -29,8 +34,6 @@ describe(`${schema.Values.name} normalization`, () => {
   });
 
   test('can use a function to determine the schema when normalizing', () => {
-    class Cat extends IDEntity {}
-    class Dog extends IDEntity {}
     const valuesSchema = new schema.Values(
       {
         dogs: Dog,
@@ -52,8 +55,6 @@ describe(`${schema.Values.name} normalization`, () => {
   });
 
   test('filters out null and undefined values', () => {
-    class Cat extends IDEntity {}
-    class Dog extends IDEntity {}
     const valuesSchema = new schema.Values(
       {
         dogs: Dog,
@@ -77,8 +78,6 @@ describe(`${schema.Values.name} normalization`, () => {
 
 describe(`${schema.Values.name} denormalization`, () => {
   test('denormalizes the values of an object with the given schema', () => {
-    class Cat extends IDEntity {}
-    class Dog extends IDEntity {}
     const valuesSchema = new schema.Values(
       {
         dogs: Dog,
@@ -116,8 +115,6 @@ describe(`${schema.Values.name} denormalization`, () => {
   });
 
   test('denormalizes with missing entity should have false second value', () => {
-    class Cat extends IDEntity {}
-    class Dog extends IDEntity {}
     const valuesSchema = new schema.Values(
       {
         dogs: Dog,

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -208,15 +208,11 @@ Object {
       "1": User {
         "id": "1",
       },
-      "undefined": User {
-        "id": undefined,
-      },
     },
   },
   "indexes": Object {},
   "result": Object {
     "bar": "1",
-    "foo": "undefined",
   },
 }
 `;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Missing some parameters in responses is quite normal - both for CSF as well as cases where there are partial responses returned.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- filters out undefined and null pk in production rather than throwing error (this matches previous normalizr behavior)
- Improve message to make it easier to debug malformed by outputting missing, found, and unexpected keys.
- Don't care about missing pieces for triggering error
- Primarily focus on unexpected values - however only trigger if there are many keys defined to allow for usage without predefining keys.
