### PR TITLE
docs: Get rid of all references to asSchema()

### DIFF
--- a/docs/api/Entity.md
+++ b/docs/api/Entity.md
@@ -228,22 +228,3 @@ const price = useCache(LatestPrice, { symbol: 'BTC' });
 ### static schema: { [k: keyof this]: Schema }
 
 Set this to [define entities nested](../guides/nested-response) inside this one.
-
-### static asSchema() => [Entity](./Entity)
-
-Returns this `Entity` with the TypeScript type set properly. Using `asSchema()` instead of
-`this` directly is key to getting correct typing from the hooks.
-
-This can be used as a [Schema](./FetchShape#schema-schema) or to build other [Schema](./FetchShape#schema-schema)s.
-
-```typescript
-import { universalFetchFunction } from 'utils';
-import ArticleEntity from './ArticleEntity';
-
-export const articleListShape = {
-  type: 'read',
-  schema: { results: [ArticleEntity], nextPage: '', prevPage: '' },
-  getFetchKey(params: Readonly<object>): {return `article/${JSON.stringify(params)}`;},
-  fetch: universalFetchFunction,
-}
-```

--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -207,22 +207,6 @@ on network error. This can be useful to override to really customize your transp
 
 Used in `fetch()`. Resolves the HTTP [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
-### static asSchema() => [Entity](./Entity)
-
-Returns this Resource as an [Entity](./Entity) with the TypeScript type set properly. Using
-`asSchema()` instead of `this` directly is key to getting correct typing from the hooks.
-
-Use in schemas when referring to this Resource.
-
-```typescript
-  static listShape<T extends typeof Resource>(this: T) {
-    return {
-      ...super.listShape(),
-      schema: { results: [this], nextPage: '', prevPage: '' },
-    };
-  }
-```
-
 ### static getFetchOptions() => [FetchOptions](../api/FetchShape.md#FetchOptions) | undefined
 
 Returns the default request options for this resource. By default this returns undefined

--- a/docs/guides/nested-response.md
+++ b/docs/guides/nested-response.md
@@ -8,9 +8,9 @@ Say you have a foreignkey author, and an array of foreign keys to contributors.
 First we need to model what this will look like by adding members to our [Resource][1] defintion.
 These should be the primary keys of the entities we care about.
 
-Next we'll need to extend the schema definition provided by [asSchema()][3].
+Next we'll provide a definition of nested members in the [schema][3] member.
 
-## asSchema
+## static schema
 
 #### `resources/ArticleResource.ts`
 
@@ -65,7 +65,7 @@ function ArticleInline({ article }: { article: ArticleResource }) {
 ## Circular dependencies
 
 If two or more [Resources][1] include each other in their schema, you can dynamically override
-one of their [asSchema()][3] to avoid circular imports.
+one of their [schema][3] to avoid circular imports.
 
 #### `resources/ArticleResource.ts`
 
@@ -99,7 +99,7 @@ UserResource.schema = {
 
 ```typescript
 import { Resource } from 'rest-hooks';
-// no need to import ArticleResource as the asSchema() override happens there.
+// no need to import ArticleResource as the schema override happens there.
 
 export default class UserResource extends Resource {
   readonly id: number | undefined = undefined;
@@ -115,4 +115,4 @@ export default class UserResource extends Resource {
 
 [1]: ../api/Resource.md
 [2]: ../api/useCache.md
-[3]: ../api/Resource.md#static-getentityschema-schemaentity-https-githubcom-ntucker-normalizr-blob-master-docs-apimd-entitykey-definition-options
+[3]: ../api/Entity#static-schema--k-keyof-this-schema-

--- a/packages/core/src/react-integration/__tests__/hooks.tsx
+++ b/packages/core/src/react-integration/__tests__/hooks.tsx
@@ -160,7 +160,7 @@ describe('useFetcher', () => {
   it('should throw when providing a delete shape without an entity schema', () => {
     const badDeleteShape = {
       ...CoolerArticleResource.deleteShape(),
-      schema: { data: CoolerArticleResource.asSchema(), other: 5 },
+      schema: { data: CoolerArticleResource, other: 5 },
     };
     const { result } = renderHook(() => {
       const a = useFetcher(badDeleteShape);

--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -111,11 +111,13 @@ export default abstract class SimpleRecord {
     return [this.fromJS(res) as any, found];
   }
 
+  /* istanbul ignore next */
   static asSchema<T extends typeof SimpleRecord>(this: T) {
     /* istanbul ignore next */
     if (process.env.NODE_ENV === 'development') {
       console.error('asSchema() is deprecated - use Entity directly instead.');
     }
+    /* istanbul ignore next */
     return this;
   }
 }

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -42,7 +42,7 @@ export interface SchemaClass extends SchemaSimple {
 interface EntityInterface<T = any> extends SchemaSimple {
   pk(params: any, parent?: any, key?: string): string | undefined;
   readonly key: string;
-  merge(a: any, b: any): any;
+  merge(existing: any, latest: any): any;
   prototype: T;
 }
 

--- a/packages/normalizr/src/schemas/__tests__/Array.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Array.test.js
@@ -9,7 +9,7 @@ describe(`${schema.Array.name} normalization`, () => {
   describe('Object', () => {
     test('should throw a custom error if data loads with unexpected value', () => {
       class User extends IDEntity {}
-      const schema = [User.asSchema()];
+      const schema = [User];
       function normalizeBad() {
         normalize('5', schema);
       }
@@ -18,17 +18,13 @@ describe(`${schema.Array.name} normalization`, () => {
 
     test(`normalizes plain arrays as shorthand for ${schema.Array.name}`, () => {
       class User extends IDEntity {}
-      expect(
-        normalize([{ id: '1' }, { id: '2' }], [User.asSchema()]),
-      ).toMatchSnapshot();
+      expect(normalize([{ id: '1' }, { id: '2' }], [User])).toMatchSnapshot();
     });
 
     test('throws an error if created with more than one schema', () => {
       class User extends IDEntity {}
       class Cat extends IDEntity {}
-      expect(() =>
-        normalize([{ id: '1' }], [Cat.asSchema(), User.asSchema()]),
-      ).toThrow();
+      expect(() => normalize([{ id: '1' }], [Cat, User])).toThrow();
     });
 
     test('passes its parent to its children when normalizing', () => {
@@ -48,7 +44,7 @@ describe(`${schema.Array.name} normalization`, () => {
         children = [];
 
         static schema = {
-          children: [Child.asSchema()],
+          children: [Child],
         };
       }
 
@@ -59,7 +55,7 @@ describe(`${schema.Array.name} normalization`, () => {
             content: 'parent',
             children: [{ id: 4, content: 'child' }],
           },
-          Parent.asSchema(),
+          Parent,
         ),
       ).toMatchSnapshot();
     });
@@ -67,7 +63,7 @@ describe(`${schema.Array.name} normalization`, () => {
     test('normalizes Objects using their values', () => {
       class User extends IDEntity {}
       expect(
-        normalize({ foo: { id: '1' }, bar: { id: '2' } }, [User.asSchema()]),
+        normalize({ foo: { id: '1' }, bar: { id: '2' } }, [User]),
       ).toMatchSnapshot();
     });
   });
@@ -75,7 +71,7 @@ describe(`${schema.Array.name} normalization`, () => {
   describe('Class', () => {
     class Cats extends IDEntity {}
     test('normalizes a single entity', () => {
-      const listSchema = new schema.Array(Cats.asSchema());
+      const listSchema = new schema.Array(Cats);
       expect(
         normalize([{ id: '1' }, { id: '2' }], listSchema),
       ).toMatchSnapshot();

--- a/packages/rest-hooks/src/resource/__tests__/__snapshots__/resource.ts.snap
+++ b/packages/rest-hooks/src/resource/__tests__/__snapshots__/resource.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Resource asSchema() merging should match snapshot 1`] = `
+exports[`Resource nested schema merging should match snapshot 1`] = `
 Object {
   "entities": Object {
     "http://test.com/article-cooler/": Object {
@@ -40,7 +40,7 @@ Object {
 }
 `;
 
-exports[`Resource asSchema() should throw a custom error if data does not include pk 1`] = `
+exports[`Resource nested schema should throw a custom error if data does not include pk 1`] = `
 "Missing usable resource key when normalizing response.
 
   This is likely due to a malformed response.

--- a/packages/rest-hooks/src/resource/__tests__/resource.ts
+++ b/packages/rest-hooks/src/resource/__tests__/resource.ts
@@ -446,7 +446,7 @@ describe('Resource', () => {
     });
   });
 
-  describe('asSchema()', () => {
+  describe('nested schema', () => {
     describe('merging', () => {
       const nested = [
         {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
asSchema() is deprecated, let's not references it anymore
