### PR TITLE
enhance: Rename merge variables to (existing, incoming)

### DIFF
--- a/docs/api/Entity.md
+++ b/docs/api/Entity.md
@@ -117,10 +117,10 @@ pk() {
 This defines the key for the Entity itself, rather than an instance. This needs to be a globally
 unique value.
 
-### static merge(first, second): mergedValue
+### static merge(existing, incoming): mergedValue
 
 ```typescript
-static merge<T extends typeof SimpleRecord>(first: InstanceType<T>, second: InstanceType<T>) => InstanceType<T>
+static merge<T extends typeof SimpleRecord>(existing: InstanceType<T>, incoming: InstanceType<T>) => InstanceType<T>
 ```
 
 > Inherited from [SimpleRecord](./SimpleRecord)
@@ -142,11 +142,11 @@ class LatestPriceEntity extends Entity {
   readonly symbol: string = '';
 
   static merge<T extends typeof SimpleRecord>(
-    first: InstanceType<T>,
-    second: InstanceType<T>,
+    existing: InstanceType<T>,
+    incoming: InstanceType<T>,
   ) {
-    if (first.timestamp > second.timestamp) return first;
-    return second;
+    if (existing.timestamp > incoming.timestamp) return existing;
+    return incoming;
   }
 }
 ```

--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -52,12 +52,12 @@ export default abstract class SimpleRecord {
   /** Creates new instance copying over defined values of arguments */
   static merge<T extends typeof SimpleRecord>(
     this: T,
-    first: AbstractInstanceType<T>,
-    second: AbstractInstanceType<T>,
+    existing: AbstractInstanceType<T>,
+    incoming: AbstractInstanceType<T>,
   ) {
     const props = Object.assign(
-      this.toObjectDefined(first),
-      this.toObjectDefined(second),
+      this.toObjectDefined(existing),
+      this.toObjectDefined(incoming),
     );
     return this.fromJS(props);
   }

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -165,14 +165,14 @@ describe(`${Entity.name} normalization`, () => {
       class MergeTaco extends Tacos {
         static merge<T extends typeof SimpleRecord>(
           this: T,
-          first: AbstractInstanceType<T>,
-          second: AbstractInstanceType<T>,
+          existing: AbstractInstanceType<T>,
+          incoming: AbstractInstanceType<T>,
         ) {
           const props = Object.assign(
             {},
-            this.toObjectDefined(first),
-            this.toObjectDefined(second),
-            { name: (first as MergeTaco).name },
+            this.toObjectDefined(existing),
+            this.toObjectDefined(incoming),
+            { name: (existing as MergeTaco).name },
           );
           return this.fromJS(props);
         }

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -42,7 +42,7 @@ export interface SchemaClass extends SchemaSimple {
 interface EntityInterface<T = any> extends SchemaSimple {
   pk(params: any, parent?: any, key?: string): string | undefined;
   readonly key: string;
-  merge(existing: any, latest: any): any;
+  merge(existing: any, incoming: any): any;
   prototype: T;
 }
 

--- a/packages/normalizr/typescript-tests/entity.ts
+++ b/packages/normalizr/typescript-tests/entity.ts
@@ -42,14 +42,14 @@ class Tweet extends Entity {
 
   static merge<T extends typeof SimpleRecord>(
     this: T,
-    first: AbstractInstanceType<T>,
-    second: AbstractInstanceType<T>,
+    existing: AbstractInstanceType<T>,
+    incoming: AbstractInstanceType<T>,
   ) {
     // Apply everything from entityB over entityA, except for "favorites"
     const props = Object.assign(
-      this.toObjectDefined(first),
-      this.toObjectDefined(second),
-      { favorites: (first as Tweet).favorites },
+      this.toObjectDefined(existing),
+      this.toObjectDefined(incoming),
+      { favorites: (existing as Tweet).favorites },
     );
     return this.fromJS(props);
   }

--- a/packages/normalizr/typescript-tests/relationships.ts
+++ b/packages/normalizr/typescript-tests/relationships.ts
@@ -29,16 +29,16 @@ class User extends IDEntity {
 
   static merge<T extends typeof SimpleRecord>(
     this: T,
-    first: any,
-    second: any,
+    existing: any,
+    incoming: any,
   ) {
     // Apply everything from entityB over entityA, except for "favorites"
     const props = Object.assign(
-      this.toObjectDefined(first),
-      this.toObjectDefined(second),
+      this.toObjectDefined(existing),
+      this.toObjectDefined(incoming),
       {
-        posts: [...(first.posts || []), ...(second.posts || [])],
-        comments: [...(first.comments || []), ...(second.comments || [])],
+        posts: [...(existing.posts || []), ...(incoming.posts || [])],
+        comments: [...(existing.comments || []), ...(incoming.comments || [])],
       },
     );
     return this.fromJS(props);


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
'first', 'second' isn't clear on how the variables are used. Better names helps users understand how they are called, for instance in normalizing:

```ts
    entities[schemaKey][id] = schema.merge(existingEntity, processedEntity);
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
(existing, incoming) implies the procedural nature, without suggesting too much about temporality - which would be dangerous as race conditions cause no guarantees for proper ordering.