### PR TITLE
enhance: Better dev error messaging with unexpected string to normalize

### DIFF
--- a/packages/normalizr/src/schemas/__tests__/Array.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Array.test.js
@@ -7,11 +7,20 @@ import IDEntity from '../../entities/IDEntity';
 
 describe(`${schema.Array.name} normalization`, () => {
   describe('Object', () => {
-    test('should throw a custom error if data loads with unexpected value', () => {
+    test('should throw a custom error if data loads with string unexpected value', () => {
       class User extends IDEntity {}
       const schema = [User];
       function normalizeBad() {
-        normalize('5', schema);
+        normalize('abc', schema);
+      }
+      expect(normalizeBad).toThrowErrorMatchingSnapshot();
+    });
+
+    test('should throw a custom error if data loads with json string unexpected value', () => {
+      class User extends IDEntity {}
+      const schema = [User];
+      function normalizeBad() {
+        normalize('[{"id":5}]', schema);
       }
       expect(normalizeBad).toThrowErrorMatchingSnapshot();
     });

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -1042,4 +1042,24 @@ Object {
 }
 `;
 
-exports[`ArraySchema normalization Object should throw a custom error if data loads with unexpected value 1`] = `"Unexpected input given to normalize. Expected type to be \\"object\\", found \\"string\\"."`;
+exports[`ArraySchema normalization Object should throw a custom error if data loads with json string unexpected value 1`] = `
+"Normalizing a string, but this does match schema.
+
+Parsing this input string as JSON worked. This likely indicates fetch function did not parse
+the JSON. By default, this only happens if \\"content-type\\" header includes \\"json\\".
+See https://resthooks.io/docs/guides/custom-networking for more information
+
+  Schema: [
+  null
+]
+  Input: \\"[{\\"id\\":5}]\\""
+`;
+
+exports[`ArraySchema normalization Object should throw a custom error if data loads with string unexpected value 1`] = `
+"Unexpected input given to normalize. Expected type to be \\"object\\", found \\"string\\".
+
+          Schema: [
+  null
+]
+          Input: \\"abc\\""
+`;


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #341  .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
If an api returns json, but doesn't set content-type, the default fetch function in Resource will not json parse. This might be surprising for some - so give some clear messaging around this case.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
