### PR TITLE
fix: No entity schemas should suspend when they have no results

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -313,6 +313,17 @@ export const photoShape = {
   },
 };
 
+export const noEntitiesShape = {
+  type: 'read' as const,
+  schema: { firstThing: '', someItems: [] as { a: number }[] },
+  getFetchKey({ userId }: { userId: string }) {
+    return `/users/${userId}/simple`;
+  },
+  fetch: async ({ userId }: { userId: string }) => {
+    return await (await fetch(`http://test.com/users/${userId}/simple`)).json();
+  },
+};
+
 export function makeErrorBoundary(cb: (error: any) => void) {
   return class ErrorInterceptor extends React.Component<any, { error: any }> {
     state = { error: null };

--- a/packages/core/src/react-integration/__tests__/useCache.tsx
+++ b/packages/core/src/react-integration/__tests__/useCache.tsx
@@ -2,6 +2,7 @@ import {
   CoolerArticleResource,
   PaginatedArticleResource,
   InvalidIfStaleArticleResource,
+  noEntitiesShape,
 } from '__tests__/common';
 import React, { useEffect } from 'react';
 
@@ -23,6 +24,14 @@ describe('useCache()', () => {
     const { result } = renderRestHook(() => {
       return useCache(CoolerArticleResource.detailShape(), payload);
     }, {});
+    expect(result.current).toBe(undefined);
+  });
+
+  it('should return undefined for no entity shapes when results are not found', async () => {
+    const userId = '5';
+    const { result } = renderRestHook(() => {
+      return useCache(noEntitiesShape, { userId });
+    });
     expect(result.current).toBe(undefined);
   });
 

--- a/packages/core/src/react-integration/__tests__/useResource.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource.tsx
@@ -3,6 +3,7 @@ import {
   UserResource,
   InvalidIfStaleArticleResource,
   photoShape,
+  noEntitiesShape,
 } from '__tests__/common';
 import { State } from '@rest-hooks/core';
 import { initialState } from '@rest-hooks/core/state/reducer';
@@ -379,6 +380,22 @@ describe('useResource()', () => {
     expect(article).toBeUndefined();
   });
 
+  it('should work with shapes with no entities', async () => {
+    const userId = '5';
+    const response = { firstThing: '', someItems: [{ a: 5 }] };
+    nock(/.*/)
+      .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
+      .get(`/users/${userId}/simple`)
+      .reply(200, response);
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useResource(noEntitiesShape, { userId });
+    });
+    // null means it threw
+    expect(result.current).toBe(null);
+    await waitForNextUpdate();
+    expect(result.current).toStrictEqual(response);
+  });
+
   it('should work with ArrayBuffer shapes', async () => {
     const userId = '5';
     const response = new ArrayBuffer(10);
@@ -389,7 +406,8 @@ describe('useResource()', () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(photoShape, { userId });
     });
-    expect(result.current).toBe(undefined);
+    // null means it threw
+    expect(result.current).toBe(null);
     await waitForNextUpdate();
     expect(result.current).toStrictEqual(response);
   });

--- a/packages/core/src/state/selectors/__tests__/useDenormalized.ts
+++ b/packages/core/src/state/selectors/__tests__/useDenormalized.ts
@@ -596,7 +596,7 @@ describe('useDenormalized()', () => {
       const { result } = renderHook(() => {
         return useDenormalized(photoShape, { userId }, initialState as any);
       });
-      expect(result.current).toStrictEqual([undefined, true]);
+      expect(result.current).toStrictEqual([undefined, false]);
     });
 
     it('should return results as-is for schemas with no entities', () => {

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -17,7 +17,7 @@ import buildInferredResults from './buildInferredResults';
  * using params and schema. This increases cache hit rate for many
  * detail shapes.
  *
- * @returns [denormalizedValue, allEntitiesFound]
+ * @returns [denormalizedValue, ready]
  */
 export default function useDenormalized<
   Shape extends Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>
@@ -51,7 +51,7 @@ export default function useDenormalized<
   // Compute denormalized value
   const [denormalized, entitiesFound, entitiesList] = useMemo(() => {
     if (!needsDenormalization)
-      return [cacheResults, true, ''] as [
+      return [cacheResults, cacheResults !== undefined, ''] as [
         DenormalizeNullable<Shape['schema']>,
         any,
         string,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Support schemas with no entities properly - even complex objects like { nextPage: '', array: [] }

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We need to ensure we are still throwing a promise when there is no entry in the results table. This is in addition to already not inferring results.

To do this we will return `cacheResults !== undefined` for the second useDenormalized() return value. This means it is 'ready' vs previous expressed allEntitiesFound. The latter wasn't correct since it was simply passed into hasUsableData()

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Types for useCache() will be wrong, since we return undefined when it isn't available. We somehow need to detect schemas that have no entities for this to work.