### PR TITLE
fix: SimpleRecord as schema in useDenormalized()

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -6,10 +6,11 @@ import {
   SchemaDetail,
   DeleteShape,
 } from 'rest-hooks';
-import type {
+import {
   AbstractInstanceType,
   FetchOptions,
   MutateShape,
+  SimpleRecord,
 } from '@rest-hooks/core';
 import React from 'react';
 
@@ -219,12 +220,28 @@ export class StaticArticleResource extends ArticleResource {
 
 class OtherArticleResource extends CoolerArticleResource {}
 
+function makePaginatedRecord<T>(entity: T) {
+  return class PaginatedRecord extends SimpleRecord {
+    readonly prevPage = '';
+    readonly nextPage = '';
+    readonly results: AbstractInstanceType<T>[] = [];
+    static schema = { results: [entity] };
+  };
+}
+
 export class PaginatedArticleResource extends OtherArticleResource {
   static urlRoot = 'http://test.com/article-paginated/';
   static listShape<T extends typeof Resource>(this: T) {
     return {
       ...super.listShape(),
       schema: { results: [this], prevPage: '', nextPage: '' },
+    };
+  }
+
+  static listDefaultsShape<T extends typeof Resource>(this: T) {
+    return {
+      ...super.listShape(),
+      schema: makePaginatedRecord(this),
     };
   }
 

--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
+Array [
+  PaginatedArticleResource {
+    "author": "23",
+    "content": "whatever",
+    "id": 5,
+    "tags": Array [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  PaginatedArticleResource {
+    "author": "23",
+    "content": "whatever",
+    "id": 3,
+    "tags": Array [],
+    "title": "the next time",
+  },
+]
+`;
+
+exports[`makeCacheProvider => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
+Array [
+  PaginatedArticleResource {
+    "author": "23",
+    "content": "whatever",
+    "id": 5,
+    "tags": Array [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  PaginatedArticleResource {
+    "author": "23",
+    "content": "whatever",
+    "id": 3,
+    "tags": Array [],
+    "title": "the next time",
+  },
+]
+`;

--- a/packages/core/src/react-integration/__tests__/integration.tsx
+++ b/packages/core/src/react-integration/__tests__/integration.tsx
@@ -10,6 +10,8 @@ import nock from 'nock';
 import { act } from '@testing-library/react-hooks';
 
 // relative imports to avoid circular dependency in tsconfig references
+import { SimpleRecord } from '@rest-hooks/normalizr';
+
 import {
   makeRenderRestHook,
   makeCacheProvider,
@@ -94,6 +96,20 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       expect(result.current.title).toBe(payload.title);
     });
 
+    it('should resolve useResource() with SimpleRecords', async () => {
+      mynock.get(`/article-paginated/`).reply(200, paginatedFirstPage);
+
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useResource(PaginatedArticleResource.listDefaultsShape(), {});
+      });
+      expect(result.current).toBeNull();
+      await waitForNextUpdate();
+      expect(result.current).toBeInstanceOf(SimpleRecord);
+      expect(result.current.nextPage).toBe('');
+      expect(result.current.prevPage).toBe('');
+      expect(result.current.results).toMatchSnapshot();
+    });
+
     it('should throw 404 once deleted', async () => {
       let del: any;
       const { result, waitForNextUpdate } = renderRestHook(() => {
@@ -102,7 +118,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       });
       expect(result.current).toBeNull();
       await waitForNextUpdate();
-      expect(result.current instanceof CoolerArticleResource).toBe(true);
+      expect(result.current).toBeInstanceOf(CoolerArticleResource);
       expect(result.current.title).toBe(payload.title);
 
       await act(() => del(payload));

--- a/packages/core/src/state/selectors/__tests__/buildInferredResults.ts
+++ b/packages/core/src/state/selectors/__tests__/buildInferredResults.ts
@@ -3,7 +3,7 @@ import {
   UnionResource,
   IndexedUserResource,
 } from '__tests__/common';
-import { schema as schemas } from '@rest-hooks/normalizr';
+import { schema as schemas, SimpleRecord } from '@rest-hooks/normalizr';
 
 import buildInferredResults from '../buildInferredResults';
 
@@ -17,6 +17,28 @@ describe('buildInferredResults()', () => {
     expect(buildInferredResults(schema, { id: 5 }, {})).toEqual({
       data: { article: '5' },
     });
+  });
+
+  it('should work with SimpleRecord', () => {
+    class Data extends SimpleRecord {
+      readonly article = CoolerArticleResource.fromJS();
+      readonly otherfield = '';
+      static schema = {
+        article: CoolerArticleResource,
+      };
+    }
+    class Message extends SimpleRecord {
+      readonly data = Data.fromJS();
+      static schema = {
+        data: Data,
+      };
+    }
+    const schema = Message;
+    const results = buildInferredResults(schema, { id: 5 }, {});
+    expect(results).toEqual({
+      data: { article: '5', otherfield: '' },
+    });
+    expect(results).toBeInstanceOf(SimpleRecord);
   });
 
   it('should be undefined with Array', () => {

--- a/packages/core/src/state/selectors/buildInferredResults.ts
+++ b/packages/core/src/state/selectors/buildInferredResults.ts
@@ -51,11 +51,12 @@ export default function buildInferredResults<
   if (schema instanceof schemas.Values) {
     return {} as any;
   }
-  const o = schema instanceof schemas.Object ? (schema as any).schema : schema;
-  const resultObject = {} as any;
+  const o = 'schema' in schema ? (schema as any).schema : schema;
+  let resultObject = {} as any;
   for (const k in o) {
     resultObject[k] = buildInferredResults(o[k], params, indexes);
   }
+  if ('fromJS' in schema) resultObject = schema.fromJS(resultObject);
   return resultObject;
 }
 

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -123,9 +123,12 @@ export default function useDenormalized<
  */
 function schemaHasEntity(schema: Schema): boolean {
   if (isEntity(schema)) return true;
-  if (Array.isArray(schema) && schema.length) return schemaHasEntity(schema[0]);
-  if (schema && typeof schema === 'object' && !('denormalize' in schema)) {
-    return Object.values(schema).reduce(
+  if (Array.isArray(schema))
+    return schema.length !== 0 && schemaHasEntity(schema[0]);
+  if (schema && (typeof schema === 'object' || typeof schema === 'function')) {
+    const nestedSchema =
+      'schema' in schema ? (schema.schema as Record<string, Schema>) : schema;
+    return Object.values(nestedSchema).reduce(
       (prev, cur) => prev || schemaHasEntity(cur),
       false,
     );


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Tests for SimpleRecord had been added for normalize/denormalize - however there are some custom schema integrations in rest hooks core itself.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Updated to work with new cases - also ensured solution was general to match the general pattern rather than special casing SimpleRecord:
- schemaHasEntity
- buildInferredResults

Added test for buildInferredResults as well as an integration test to cover entire useResource() pipeline.
