### PR TITLE
feat: SimpleRecord can have optional entities by setting default to null

### DIFF
--- a/docs/api/Entity.md
+++ b/docs/api/Entity.md
@@ -228,3 +228,6 @@ const price = useCache(LatestPrice, { symbol: 'BTC' });
 ### static schema: { [k: keyof this]: Schema }
 
 Set this to [define entities nested](../guides/nested-response) inside this one.
+
+Members with default values set to something falsy (like `null`) will consider the
+members 'optional'.

--- a/docs/api/SimpleRecord.md
+++ b/docs/api/SimpleRecord.md
@@ -113,3 +113,10 @@ Returns an `Array` of all defined (non-default) keys of `instance`.
 console.log(mergedArticle.keysDefined());
 /* ['title', 'content', 'tags'] */
 ```
+
+### static schema: { [k: keyof this]: Schema }
+
+Set this to [define entities nested](../guides/nested-response) inside this one.
+
+Members with default values set to something falsy (like `null`) will consider the
+members 'optional'.

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -161,6 +161,8 @@ export default abstract class Entity extends SimpleRecord {
     entity: AbstractInstanceType<T>,
     unvisit: schema.UnvisitFunction,
   ): [AbstractInstanceType<T>, boolean] {
+    // TODO: this entire function is redundant with SimpleRecord, however right now we're storing the Entity instance
+    // itself in cache. Once we offer full memoization, we will store raw objects and this can be consolidated with SimpleRecord
     if (isImmutable(entity)) {
       const [denormEntity, found] = denormalizeImmutable(
         this.schema,
@@ -169,13 +171,17 @@ export default abstract class Entity extends SimpleRecord {
       );
       return [this.fromJS(denormEntity.toObject()), found];
     }
+    // TODO: This creates unneeded memory pressure
+    const instance = new (this as any)();
     let found = true;
     const denormEntity = entity;
 
     Object.keys(this.schema).forEach(key => {
       const schema = this.schema[key];
       const [value, foundItem] = unvisit(entity[key], schema);
-      if (!foundItem) {
+      // members who default to falsy values are considered 'optional'
+      // if falsy value, and default is actually set then it is optional so pass through
+      if (!foundItem && !(key in instance && !instance[key])) {
         found = false;
       }
       if (this.hasDefined(entity, key as any) && denormEntity[key] !== value) {

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import SimpleRecord from './SimpleRecord';
 import { isImmutable, denormalizeImmutable } from '../schemas/ImmutableUtils';
 import * as schema from '../schema';
@@ -178,7 +179,10 @@ export default abstract class Entity extends SimpleRecord {
 
     Object.keys(this.schema).forEach(key => {
       const schema = this.schema[key];
-      const [value, foundItem] = unvisit(entity[key], schema);
+      const input = this.hasDefined(entity, key as any)
+        ? entity[key]
+        : undefined;
+      const [value, foundItem] = unvisit(input, schema);
       // members who default to falsy values are considered 'optional'
       // if falsy value, and default is actually set then it is optional so pass through
       if (!foundItem && !(key in instance && !instance[key])) {

--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -104,11 +104,27 @@ export default abstract class SimpleRecord {
 
   static denormalize<T extends typeof SimpleRecord>(
     this: T,
-    ...args: any[]
+    input: any,
+    unvisit: any,
   ): [AbstractInstanceType<T>, boolean] {
-    const [res, found] = denormalize(this.schema, ...args);
+    // TODO: This creates unneeded memory pressure
+    const instance = new (this as any)();
+    const object = { ...input };
+    let found = true;
+    Object.keys(this.schema).forEach(key => {
+      const [item, foundItem] = unvisit(object[key], this.schema[key]);
+      if (object[key] !== undefined) {
+        object[key] = item;
+      }
+      // members who default to falsy values are considered 'optional'
+      // if falsy value, and default is actually set then it is optional so pass through
+      if (!foundItem && !(key in instance && !instance[key])) {
+        found = false;
+      }
+    });
+
     // useDenormalized will memo based on entities, so creating a new object each time is fine
-    return [this.fromJS(res) as any, found];
+    return [this.fromJS(object) as any, found];
   }
 
   /* istanbul ignore next */

--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { AbstractInstanceType, Schema, NormalizedEntity } from '../types';
 import { normalize, denormalize } from '../schemas/Object';
 
@@ -33,6 +34,9 @@ export default abstract class SimpleRecord {
   ) {
     // we type guarded abstract case above, so ok to force typescript to allow constructor call
     const instance = new (this as any)(props) as AbstractInstanceType<T>;
+    if (props instanceof SimpleRecord) {
+      props = (props.constructor as any).toObjectDefined(props);
+    }
     Object.assign(instance, props);
 
     Object.defineProperty(instance, DefinedMembersKey, {

--- a/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
+++ b/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
@@ -196,11 +196,15 @@ describe('SimpleRecord', () => {
     it('should be marked as found even when optional is not there', () => {
       const denormalized = denormalize(
         {
-          requiredArticle: ArticleEntity.fromJS({ id: '5' }),
+          requiredArticle: '5',
           nextPage: 'blob',
         },
         WithOptional,
-        {},
+        {
+          [ArticleEntity.key]: {
+            5: ArticleEntity.fromJS({ id: '5' }),
+          },
+        },
       );
       expect(denormalized[1]).toBe(true);
       const response = denormalized[0];
@@ -216,11 +220,15 @@ describe('SimpleRecord', () => {
     it('should be marked as not found when required entity is missing', () => {
       const denormalized = denormalize(
         {
-          article: ArticleEntity.fromJS({ id: '5' }),
+          article: '5',
           nextPage: 'blob',
         },
         WithOptional,
-        {},
+        {
+          [ArticleEntity.key]: {
+            5: ArticleEntity.fromJS({ id: '5' }),
+          },
+        },
       );
       expect(denormalized[1]).toBe(false);
       const response = denormalized[0];

--- a/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
+++ b/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
@@ -31,6 +31,17 @@ class Pagination extends SimpleRecord {
   };
 }
 
+class WithOptional extends SimpleRecord {
+  readonly article: ArticleEntity | null = null;
+  readonly requiredArticle = ArticleEntity.fromJS();
+  readonly nextPage = '';
+
+  static schema = {
+    article: ArticleEntity,
+    requiredArticle: ArticleEntity,
+  };
+}
+
 describe('SimpleRecord', () => {
   it('should init', () => {
     const resource = Article.fromJS({
@@ -178,6 +189,48 @@ describe('SimpleRecord', () => {
       data: undefined,
       nextPage: 'blob',
       lastPage: '',
+    });
+  });
+
+  describe('optional entities', () => {
+    it('should be marked as found even when optional is not there', () => {
+      const denormalized = denormalize(
+        {
+          requiredArticle: ArticleEntity.fromJS({ id: '5' }),
+          nextPage: 'blob',
+        },
+        WithOptional,
+        {},
+      );
+      expect(denormalized[1]).toBe(true);
+      const response = denormalized[0];
+      expect(response).toBeDefined();
+      expect(response).toBeInstanceOf(WithOptional);
+      expect(response).toEqual({
+        article: null,
+        requiredArticle: ArticleEntity.fromJS({ id: '5' }),
+        nextPage: 'blob',
+      });
+    });
+
+    it('should be marked as not found when required entity is missing', () => {
+      const denormalized = denormalize(
+        {
+          article: ArticleEntity.fromJS({ id: '5' }),
+          nextPage: 'blob',
+        },
+        WithOptional,
+        {},
+      );
+      expect(denormalized[1]).toBe(false);
+      const response = denormalized[0];
+      expect(response).toBeDefined();
+      expect(response).toBeInstanceOf(WithOptional);
+      expect(response).toEqual({
+        article: ArticleEntity.fromJS({ id: '5' }),
+        requiredArticle: ArticleEntity.fromJS(),
+        nextPage: 'blob',
+      });
     });
   });
 });

--- a/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
@@ -80,7 +80,7 @@ Array [
     },
     "id": "2",
   },
-  true,
+  false,
 ]
 `;
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
A way to express nested members that aren't required.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
For both Entity, and SimpleRecord:

- for all members of `static schema`, if default is set, and that default is falsy - field is considered optional
- optional fields don't need to be 'found'
- fromJS() works with Records sent

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
