### PR TITLE
fix: Normalizr errors reject and throw in useResource()

### DIFF
--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
@@ -23,6 +23,21 @@ Array [
 ]
 `;
 
+exports[` => <Provider /> useResource() should throw errors on malformed response 1`] = `
+[Error: Attempted to initialize CoolerArticleResource with substantially different than expected keys
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+
+  Expected keys:
+    Found: 
+    Missing: id,title,content,author,tags
+  Unexpected keys: 0
+  Value: {
+  "0": 1
+}]
+`;
+
 exports[`makeCacheProvider => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
@@ -44,4 +59,19 @@ Array [
     "title": "the next time",
   },
 ]
+`;
+
+exports[`makeCacheProvider => <Provider /> useResource() should throw errors on malformed response 1`] = `
+[Error: Attempted to initialize CoolerArticleResource with substantially different than expected keys
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+
+  Expected keys:
+    Found: 
+    Missing: id,title,content,author,tags
+  Unexpected keys: 0
+  Value: {
+  "0": 1
+}]
 `;

--- a/packages/core/src/react-integration/__tests__/integration.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration.web.tsx
@@ -178,6 +178,21 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       expect((result.error as any).status).toBe(403);
     });
 
+    it('useResource() should throw errors on malformed response', async () => {
+      const response = [1];
+      mynock.get(`/article-cooler/${878}`).reply(200, response);
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useResource(CoolerArticleResource.detailShape(), {
+          id: 878,
+        });
+      });
+      expect(result.current).toBeNull();
+      await waitForNextUpdate();
+      expect(result.error).toBeDefined();
+      expect((result.error as any).status).toBe(400);
+      expect(result.error).toMatchSnapshot();
+    });
+
     it('should resolve parallel useResource() request', async () => {
       const { result, waitForNextUpdate } = renderRestHook(() => {
         return useResource(

--- a/packages/core/src/state/actions/createReceiveError.ts
+++ b/packages/core/src/state/actions/createReceiveError.ts
@@ -1,8 +1,9 @@
 import { Schema } from '@rest-hooks/normalizr';
 import {
   FetchAction,
-  ResponseActions,
+  ReceiveAction,
   FetchOptions,
+  PurgeAction,
 } from '@rest-hooks/core/types';
 
 import SHAPE_TYPE_TO_RESPONSE_TYPE from './responseTypeMapping';
@@ -15,14 +16,14 @@ interface Options<S extends Schema = any>
 export default function createReceiveError<S extends Schema = any>(
   error: any,
   { schema, key, type, errorExpiryLength }: Options<S>,
-): ResponseActions {
+): typeof type extends 'delete' ? PurgeAction : ReceiveAction {
   /* istanbul ignore next */
   if (process.env.NODE_ENV === 'development' && errorExpiryLength < 0) {
     throw new Error('Negative errorExpiryLength are not allowed.');
   }
   const now = Date.now();
   return {
-    type: SHAPE_TYPE_TO_RESPONSE_TYPE[type] as any,
+    type: (SHAPE_TYPE_TO_RESPONSE_TYPE[type] as any) || type,
     payload: error,
     meta: {
       schema,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Catching errors earlier is helpful when building and understanding network endpoints.
- Also pretty key that normalize gets what it needs, or denormalize won't be able to get the correct results.
- We actually need to ensure we don't throw in the reducer or the provider will unmount.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We *must* handling the error in the reducer, or React gets confused about state updates (we don't want to redispatch in middle of a render). Therefore, we catch processing receives (where normalizr should be able to throw errors) and process those as network errors (setting the meta error). To ensure invariants with usage in functions, we check for this condition in NetworkManager so it can reject the promise.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
We should probably get rid of other error handling routes in NetworkManager for simplicity - since they will all result in state updates.

We need to fix usage of `act` in tests, since we now rely on getState(). Note, this does work properly (to reflect batching behavior) - but `act()` is needed for tests to behave in the same manner.