### PR TITLE
fix: Protect against invalidIfStale with || request

### DIFF
--- a/packages/core/src/react-integration/hooks/useExpiresAt.ts
+++ b/packages/core/src/react-integration/hooks/useExpiresAt.ts
@@ -4,12 +4,19 @@ import useMeta from './useMeta';
 
 /** Returns whether the data at this url is fresh or stale */
 export default function useExpiresAt<Params extends Readonly<object>>(
-  fetchShape: Pick<ReadShape<any, Params>, 'getFetchKey'>,
+  fetchShape: Pick<ReadShape<any, Params>, 'getFetchKey' | 'options'>,
   params: Params | null,
 ): number {
   const meta = useMeta(fetchShape, params);
   if (!meta) {
     return 0;
   }
+  // Temporarily prevent infinite loops until invalidIfStale is revised
+  if (
+    fetchShape.options?.invalidIfStale &&
+    meta.prevExpiresAt &&
+    meta.expiresAt - meta.prevExpiresAt < 1000
+  )
+    return Number.POSITIVE_INFINITY;
   return meta.expiresAt;
 }

--- a/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
@@ -18,6 +18,7 @@ Object {
     "http://test.com/article-cooler/5": Object {
       "date": 50,
       "expiresAt": 55,
+      "prevExpiresAt": undefined,
     },
   },
   "optimistic": Array [],

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -34,6 +34,7 @@ Object {
     "http://test.com/article/20": Object {
       "date": 5000000000,
       "expiresAt": 5000500000,
+      "prevExpiresAt": undefined,
     },
   },
   "optimistic": Array [],

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -81,6 +81,7 @@ export default function reducer(
             [action.meta.key]: {
               date: action.meta.date,
               expiresAt: action.meta.expiresAt,
+              prevExpiresAt: state.meta[action.meta.key]?.expiresAt,
             },
           },
           optimistic: filterOptimistic(state, action),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,6 +39,7 @@ export type State<T> = Readonly<{
       readonly date: number;
       readonly error?: Error;
       readonly expiresAt: number;
+      readonly prevExpiresAt?: number;
     };
   };
   optimistic: ResponseActions[];


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
To simulate non-caching, we set invalidIfStale to true in addition to a lower dataExpiryTime. Since suspense remounts components, if there are more than one requests like this in one suspense boundary the component might not remount until one or many of the requests have already become stale again.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This is a temporary solution since in the future we will be simply making useInvalidator trigger any shape.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
