### PR TITLE
feat: Declarative schema deserialization

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -131,6 +131,17 @@ export class ArticleResource extends Resource {
   }
 }
 
+export class ArticleTimedResource extends ArticleResource {
+  readonly createdAt = new Date(0);
+
+  static schema = {
+    ...ArticleResource.schema,
+    createdAt: Date,
+  };
+
+  static urlRoot = 'http://test.com/article-time/';
+}
+
 export class UrlArticleResource extends ArticleResource {
   readonly url: string = 'happy.com';
 }

--- a/packages/core/src/react-integration/__tests__/useResource.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource.web.tsx
@@ -4,6 +4,7 @@ import {
   InvalidIfStaleArticleResource,
   photoShape,
   noEntitiesShape,
+  ArticleTimedResource,
 } from '__tests__/common';
 import { State } from '@rest-hooks/core';
 import { initialState } from '@rest-hooks/core/state/reducer';
@@ -84,6 +85,8 @@ describe('useResource()', () => {
       .reply(200)
       .get(`/article-cooler/${payload.id}`)
       .reply(200, payload)
+      .get(`/article-time/${payload.id}`)
+      .reply(200, { ...payload, createdAt: '2020-06-07T02:00:15+0000' })
       .delete(`/article-cooler/${payload.id}`)
       .reply(204, '')
       .delete(`/article/${payload.id}`)
@@ -410,5 +413,22 @@ describe('useResource()', () => {
     expect(result.current).toBe(null);
     await waitForNextUpdate();
     expect(result.current).toStrictEqual(response);
+  });
+
+  it('should work with Serializable shapes', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useResource(ArticleTimedResource.detailShape(), payload);
+    });
+    // null means it threw
+    expect(result.current).toBe(null);
+    await waitForNextUpdate();
+    expect(result.current.createdAt.getDate()).toBe(
+      result.current.createdAt.getDate(),
+    );
+    expect(result.current.createdAt).toEqual(
+      new Date('2020-06-07T02:00:15+0000'),
+    );
+    expect(result.current.id).toEqual(payload.id);
+    expect(result.current).toBeInstanceOf(ArticleTimedResource);
   });
 });

--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -432,7 +432,7 @@ Object {
   "entities": Object {
     "Article": Object {
       "123": Article {
-        "author": 1,
+        "author": "1",
         "id": "123",
         "title": "normalizr is great!",
       },
@@ -440,6 +440,16 @@ Object {
   },
   "indexes": Object {},
   "result": "123",
+}
+`;
+
+exports[`normalize passes over pre-normalized values 2`] = `
+Object {
+  "entities": Object {},
+  "indexes": Object {},
+  "result": Object {
+    "user": "1",
+  },
 }
 `;
 

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -307,10 +307,12 @@ describe('normalize', () => {
 
     expect(
       normalize(
-        { id: '123', title: 'normalizr is great!', author: 1 },
+        { id: '123', title: 'normalizr is great!', author: '1' },
         Article,
       ),
     ).toMatchSnapshot();
+
+    expect(normalize({ user: '1' }, { user: User })).toMatchSnapshot();
   });
 
   test('can normalize object without proper object prototype inheritance', () => {

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -46,14 +46,16 @@ const getUnvisit = (entities: Record<string, any>) => {
     function unvisit(input: any, schema: any): [any, boolean] {
       if (!schema) return [input, true];
 
-      if (
-        typeof schema === 'object' &&
-        (!schema.denormalize || typeof schema.denormalize !== 'function')
-      ) {
-        const method = Array.isArray(schema)
-          ? ArrayUtils.denormalize
-          : ObjectUtils.denormalize;
-        return method(schema, input, unvisit);
+      if (!schema.denormalize || typeof schema.denormalize !== 'function') {
+        if (typeof schema === 'function') {
+          if (input instanceof schema) return [input, true];
+          return [new schema(input), true];
+        } else if (typeof schema === 'object') {
+          const method = Array.isArray(schema)
+            ? ArrayUtils.denormalize
+            : ObjectUtils.denormalize;
+          return method(schema, input, unvisit);
+        }
       }
 
       // null is considered intentional, thus always 'found' as true
@@ -97,6 +99,7 @@ const getEntities = (entities: Record<string, any>) => {
   };
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const denormalize = <S extends Schema>(
   input: any,
   schema: S,

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -54,6 +54,8 @@ export default abstract class Entity extends SimpleRecord {
     addEntity: (...args: any) => any,
     visitedEntities: Record<string, any>,
   ): any {
+    // pass over already processed entities
+    if (typeof input === 'string') return input;
     // TODO: what's store needs to be a differing type from fromJS
     const processedEntity = this.fromJS(input, parent, key);
     /* istanbul ignore else */
@@ -140,10 +142,7 @@ export default abstract class Entity extends SimpleRecord {
     visitedEntities[entityType][id].push(input);
 
     Object.keys(this.schema).forEach(key => {
-      if (
-        Object.hasOwnProperty.call(processedEntity, key) &&
-        typeof processedEntity[key] === 'object'
-      ) {
+      if (Object.hasOwnProperty.call(processedEntity, key)) {
         const schema = this.schema[key];
         processedEntity[key] = visit(
           processedEntity[key],

--- a/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
+++ b/packages/normalizr/src/entities/__tests__/SimpleRecord.test.ts
@@ -35,10 +35,12 @@ class WithOptional extends SimpleRecord {
   readonly article: ArticleEntity | null = null;
   readonly requiredArticle = ArticleEntity.fromJS();
   readonly nextPage = '';
+  readonly createdAt: Date | null = null;
 
   static schema = {
     article: ArticleEntity,
     requiredArticle: ArticleEntity,
+    createdAt: Date,
   };
 }
 
@@ -95,6 +97,33 @@ describe('SimpleRecord', () => {
         },
         schema,
       );
+      expect(normalized).toMatchSnapshot();
+    });
+
+    it('should deserialize Date', () => {
+      const normalized = normalize(
+        {
+          requiredArticle: { id: '5' },
+          nextPage: 'blob',
+          createdAt: '2020-06-07T02:00:15.000Z',
+        },
+        WithOptional,
+      );
+      expect(normalized.result.createdAt.getTime()).toBe(
+        normalized.result.createdAt.getTime(),
+      );
+      expect(normalized).toMatchSnapshot();
+    });
+
+    it('should use default when Date not provided', () => {
+      const normalized = normalize(
+        {
+          requiredArticle: { id: '5' },
+          nextPage: 'blob',
+        },
+        WithOptional,
+      );
+      expect(normalized.result.createdAt).toBeUndefined();
       expect(normalized).toMatchSnapshot();
     });
   });
@@ -198,6 +227,7 @@ describe('SimpleRecord', () => {
         {
           requiredArticle: '5',
           nextPage: 'blob',
+          createdAt: new Date('2020-06-07T02:00:15+0000'),
         },
         WithOptional,
         {
@@ -214,7 +244,13 @@ describe('SimpleRecord', () => {
         article: null,
         requiredArticle: ArticleEntity.fromJS({ id: '5' }),
         nextPage: 'blob',
+        createdAt: new Date('2020-06-07T02:00:15+0000'),
       });
+      // @ts-expect-error
+      response.createdAt.toISOString();
+      expect(response.createdAt?.toISOString()).toBe(
+        '2020-06-07T02:00:15.000Z',
+      );
     });
 
     it('should be marked as not found when required entity is missing', () => {
@@ -238,7 +274,9 @@ describe('SimpleRecord', () => {
         article: ArticleEntity.fromJS({ id: '5' }),
         requiredArticle: ArticleEntity.fromJS(),
         nextPage: 'blob',
+        createdAt: null,
       });
+      expect(response.createdAt).toBeNull();
     });
   });
 });

--- a/packages/normalizr/src/entities/__tests__/__snapshots__/SimpleRecord.test.ts.snap
+++ b/packages/normalizr/src/entities/__tests__/__snapshots__/SimpleRecord.test.ts.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SimpleRecord normalize should deserialize Date 1`] = `
+Object {
+  "entities": Object {
+    "ArticleEntity": Object {
+      "5": ArticleEntity {
+        "author": "",
+        "content": "",
+        "id": "5",
+        "title": "",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Object {
+    "createdAt": 2020-06-07T02:00:15.000Z,
+    "nextPage": "blob",
+    "requiredArticle": "5",
+  },
+}
+`;
+
+exports[`SimpleRecord normalize should use default when Date not provided 1`] = `
+Object {
+  "entities": Object {
+    "ArticleEntity": Object {
+      "5": ArticleEntity {
+        "author": "",
+        "content": "",
+        "id": "5",
+        "title": "",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Object {
+    "nextPage": "blob",
+    "requiredArticle": "5",
+  },
+}
+`;
+
 exports[`SimpleRecord normalize should work on nested 1`] = `
 Object {
   "entities": Object {

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -15,14 +15,15 @@ const visit = (
   addEntity: any,
   visitedEntities: any,
 ) => {
-  if (typeof value !== 'object' || !value || !schema) {
+  if (!value || !schema || !['function', 'object'].includes(typeof schema)) {
     return value;
   }
 
-  if (
-    typeof schema === 'object' &&
-    (!schema.normalize || typeof schema.normalize !== 'function')
-  ) {
+  if (!schema.normalize || typeof schema.normalize !== 'function') {
+    // serializable
+    if (typeof schema === 'function') {
+      return new schema(value);
+    }
     const method = Array.isArray(schema)
       ? ArrayUtils.normalize
       : ObjectUtils.normalize;
@@ -100,6 +101,7 @@ function expectedSchemaType(schema: Schema) {
     : typeof schema;
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const normalize = <
   S extends Schema = Schema,
   E extends Record<string, Record<string, any>> = Record<

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -30,6 +30,12 @@ export type UnionResult<Choices extends EntityMap> = {
   schema: keyof Choices;
 };
 
+export type Serializable<
+  T extends { toJSON(): string } = { toJSON(): string }
+> = {
+  prototype: T;
+};
+
 export interface SchemaSimple {
   normalize(
     input: any,

--- a/packages/normalizr/src/schemas/__tests__/Serializable.test.ts
+++ b/packages/normalizr/src/schemas/__tests__/Serializable.test.ts
@@ -1,0 +1,109 @@
+// eslint-env jest
+import { denormalizeSimple as denormalize } from '../../denormalize';
+import { normalize } from '../../';
+import IDEntity from '../../entities/IDEntity';
+
+class User extends IDEntity {
+  createdAt = new Date(0);
+  name = '';
+  static schema = {
+    createdAt: Date,
+  };
+}
+class Other {
+  thing = 0;
+  constructor(props) {
+    this.thing = props.thing;
+  }
+
+  toJSON() {
+    return { thing: this.thing };
+  }
+}
+const objectSchema = {
+  user: User,
+  anotherItem: Other,
+  time: Date,
+};
+
+describe(`Serializable normalization`, () => {
+  test('normalizes date and custom', () => {
+    const norm = normalize(
+      {
+        user: {
+          id: '1',
+          name: 'Nacho',
+          createdAt: '2020-06-07T02:00:15+0000',
+        },
+        anotherItem: { thing: 500 },
+        time: '2020-06-07T02:00:15+0000',
+      },
+      objectSchema,
+    );
+    expect(norm.result.time.getTime()).toBe(norm.result.time.getTime());
+    expect(norm.result.anotherItem).toBeInstanceOf(Other);
+    expect(norm.entities[User.key]['1'].createdAt).toBe(
+      norm.entities[User.key]['1'].createdAt,
+    );
+    expect(norm).toMatchSnapshot();
+    expect(JSON.stringify(norm)).toMatchSnapshot();
+  });
+});
+
+describe(`Serializable denormalization`, () => {
+  test('denormalizes date and custom', () => {
+    const entities = {
+      User: {
+        '1': {
+          id: '1',
+          name: 'Nacho',
+          createdAt: new Date('2020-06-07T02:00:15+0000'),
+        },
+      },
+    };
+    const [response, found] = denormalize(
+      {
+        user: '1',
+        anotherItem: new Other({ thing: 500 }),
+        time: new Date('2020-06-07T02:00:15+0000'),
+      },
+      objectSchema,
+      entities,
+    );
+    expect(response.anotherItem).toBeInstanceOf(Other);
+    expect(response.time.getTime()).toBe(response.time.getTime());
+    expect(response.user?.createdAt.getTime()).toBe(
+      response.user?.createdAt.getTime(),
+    );
+    expect(found).toBe(true);
+    expect(response).toMatchSnapshot();
+  });
+
+  test('denormalizes as plain', () => {
+    const entities = {
+      User: {
+        '1': {
+          id: '1',
+          name: 'Nacho',
+          createdAt: '2020-06-07T02:00:15+0000',
+        },
+      },
+    };
+    const [response, found] = denormalize(
+      {
+        user: '1',
+        anotherItem: { thing: 500 },
+        time: '2020-06-07T02:00:15+0000',
+      },
+      objectSchema,
+      entities,
+    );
+    expect(response.anotherItem).toBeInstanceOf(Other);
+    expect(response.time.getTime()).toBe(response.time.getTime());
+    expect(response.user?.createdAt.getTime()).toBe(
+      response.user?.createdAt.getTime(),
+    );
+    expect(found).toBe(true);
+    expect(response).toMatchSnapshot();
+  });
+});

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Serializable denormalization denormalizes as plain 1`] = `
+Object {
+  "anotherItem": Object {
+    "thing": 500,
+  },
+  "time": 2020-06-07T02:00:15.000Z,
+  "user": User {
+    "createdAt": 2020-06-07T02:00:15.000Z,
+    "id": "1",
+    "name": "Nacho",
+  },
+}
+`;
+
+exports[`Serializable denormalization denormalizes date and custom 1`] = `
+Object {
+  "anotherItem": Object {
+    "thing": 500,
+  },
+  "time": 2020-06-07T02:00:15.000Z,
+  "user": User {
+    "createdAt": 2020-06-07T02:00:15.000Z,
+    "id": "1",
+    "name": "Nacho",
+  },
+}
+`;
+
+exports[`Serializable normalization normalizes date and custom 1`] = `
+Object {
+  "entities": Object {
+    "User": Object {
+      "1": User {
+        "createdAt": 2020-06-07T02:00:15.000Z,
+        "id": "1",
+        "name": "Nacho",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Object {
+    "anotherItem": Object {
+      "thing": 500,
+    },
+    "time": 2020-06-07T02:00:15.000Z,
+    "user": "1",
+  },
+}
+`;
+
+exports[`Serializable normalization normalizes date and custom 2`] = `"{\\"entities\\":{\\"User\\":{\\"1\\":{\\"id\\":\\"1\\",\\"createdAt\\":\\"2020-06-07T02:00:15.000Z\\",\\"name\\":\\"Nacho\\"}}},\\"indexes\\":{},\\"result\\":{\\"user\\":\\"1\\",\\"anotherItem\\":{\\"thing\\":500},\\"time\\":\\"2020-06-07T02:00:15.000Z\\"}}"`;

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -64,6 +64,8 @@ export type Denormalize<S> = S extends EntityInterface<infer U>
   ? AbstractInstanceType<S>
   : S extends schema.SchemaClass
   ? DenormalizeReturnType<S['denormalize']>
+  : S extends schema.Serializable<infer T>
+  ? T
   : S extends Array<infer F>
   ? Denormalize<F>[]
   : S extends { [K: string]: any }
@@ -76,6 +78,8 @@ export type DenormalizeNullable<S> = S extends EntityInterface<any>
   ? DenormalizeNullableNestedSchema<S>
   : S extends schema.SchemaClass
   ? DenormalizeReturnType<S['_denormalizeNullable']>
+  : S extends schema.Serializable<infer T>
+  ? T
   : S extends Array<infer F>
   ? Denormalize<F>[] | undefined
   : S extends { [K: string]: any }
@@ -88,6 +92,8 @@ export type Normalize<S> = S extends EntityInterface
   ? NormalizeObject<S['schema']>
   : S extends schema.SchemaClass
   ? NormalizeReturnType<S['normalize']>
+  : S extends schema.Serializable<infer T>
+  ? T
   : S extends Array<infer F>
   ? Normalize<F>[]
   : S extends { [K: string]: any }
@@ -100,6 +106,8 @@ export type NormalizeNullable<S> = S extends EntityInterface
   ? NormalizedNullableObject<S['schema']>
   : S extends schema.SchemaClass
   ? NormalizeReturnType<S['_normalizeNullable']>
+  : S extends schema.Serializable<infer T>
+  ? T
   : S extends Array<infer F>
   ? Normalize<F>[] | undefined
   : S extends { [K: string]: any }
@@ -111,7 +119,8 @@ export type Schema =
   | string
   | { [K: string]: any }
   | Schema[]
-  | schema.SchemaSimple;
+  | schema.SchemaSimple
+  | schema.Serializable;
 
 export type NormalizedIndex = {
   readonly [entityKey: string]: {


### PR DESCRIPTION
### Prior Art
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse Reviver arg in JSON.parse. This has the limitation of only having local context (immediate key and value), rather than full recursive context.

## Motivation
There are many types that would be much easier to operate on. Having to do this programmatically in fromJS() can not only be quite annoying and error-prone, but this limits the abilities to things inside Entities. If a simple, predictable pattern could be introduced to make this declarative, it would greatly enhance the utility of Rest Hooks.

This desire has both been expressed by the custody team, as well as RN project.
## Solution
### Schema
The first premise is that we want to use the 'schema' to declare transforms. This means schema will now be used to serialize/deserialize in addition to already finding entities, and providing defaults when inferring results.

- Locate entities
- Provide defaults
- Serialize/deserialize***

### Key Types to support

Javascript already has some extremely common types included. A good solution would support these with little or no modification to make them as intuitive as possible.

- Date
- BigInt
- Custom classes (like BigNumber)
- Future: https://github.com/tc39/proposal-record-tuple

### A note about serialization
There is an expectation that the data passed around here can simply be reversed to be sent back over the wire (like for mutations). JSON.stringify() actually automatically supports any custom classes, so long as they implement toJSON(). Therefore, we should require any custom class to have this method implemented.
BigInt is a bit problematic. It doesn't implement toJSON() by default, even though it has toString(). MDN suggests to simply set the BigInt.prototype. We could do that upon import, but this seems slightly problematic. We need a solution for this. BigInt
### Usage
Entity/Resources



```ts
class PriceInfo extends SimpleRecord {
  latestPrice = new BigNumber();
  currency = 'usd';
  static schema = {
    latestPrice: BigNumber,
  }
}
class MyResource extends Resource {
  readonly createdAt: Date | null = new Date(0);
  readonly largeNumber = BigInt(0);
  readonly latestPrice = PriceInfo.fromJS();
  // other fields here

  static schema = {
    createdAt: Date,
    largeNumber: BigInt,
    latestPrice: PriceInfo,
  }
}
```

simple objects

```ts
const schema = {
  createdAt: Date,
  largeNumber: BigInt,
  largeDecimal: BigNumber,
}
```

### Detection and Algorithm
Schemas can now be any class with both a constructor, and toJSON() method.

```ts
interface Serializable<T extends { toJSON(): string; } = { toJSON(): string; }> { prototype: T; }
```

- Denormalize will call constructor on input
- Normalize is just pass-through
- toJSON() is automatically called when the used value is serialized, so this should work. Ensuring this exists is key to providing that guarantee for both the cache (cache must be serializable) as well as the used pieces (components using the hooks).
- Schema type for constructor and toJSON() should be enforced in both type-land and runtime. Runtime will give more descriptive error in dev mode.

## An alternative
We could instead opt to attempt using defaults themselves to know how to construct. This could even be extended to nested entities.
#### Pros
- Slick and minimal
#### Cons
- Unclear how to support things that can be more than one type, or complex schemas like Union, Values, etc
- Perhaps we could simply only require static schema annotation for those cases?
- Probably unclear that this is happening, might be confusing
- Opt-out would be hard
- Any object or array types would always have to be recursed to see if they have entities, making this more expensive computationally
- Would only work with objects that take a single arg for their constructor...would have to do some detection to opt-out

Can’t have defaults that are null - this isn’t CSF compatible

```ts
class PriceInfo extends SimpleRecord {
  latestPrice = new BigNumber();
  currency = 'usd';
}
class MyResource extends Resource {
  readonly createdAt = Date | null = new Date(0);
  readonly largeNumber = BigInt(0);
  readonly latestPrice = PriceInfo.fromJS();
}
```

## Supplementary
### What wasn’t this already built-in?
Rest Hooks started off using the existing normalizr package. This accelerated its development allowing me to build a full prototype in one weekend, and offer complete mutation support in a second weekend - enabling completion of the entire library in two weekends. This was critical to actually allowing me to speed up my work instead of having to justify such an investment.

In this package not only did they not support this concept, but there was no clear place to add customizations like this, as the concepts for typing information, defaults, etc were all custom to Rest Hooks (Resources).

Since 4.0, we have forked normalizer, and further customized what is an Entity. This means we now have a static schema member that can easily operate as a place to hold information about processing types like serialize/deserialize - not just diving in to find entities to extract.

### Should this be included in Rest Hooks - or is it doing too much?
Rest Hooks is already content-aware, and using that information to process data. Therefore, this is already a natural function - and any external solutions would thus be repeating information about this structure.
