### PR TITLE
feat: Resource.fetch() arguments reflect browser fetch()

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -79,7 +79,9 @@ export class ArticleResource extends Resource {
       getFetchKey: (params: Readonly<Record<string, string>>) =>
         baseShape.getFetchKey({ ...params, includeUser: true }),
       fetch: (params: object) =>
-        this.fetch('get', this.url({ ...params, includeUser: true })),
+        this.fetch(this.url({ ...params, includeUser: true }), {
+          method: 'get',
+        }),
       schema: this,
     };
   }
@@ -93,7 +95,9 @@ export class ArticleResource extends Resource {
       getFetchKey: (params: Readonly<Record<string, string>>) =>
         baseShape.getFetchKey({ ...params, includeUser: true }),
       fetch: (params: object) =>
-        this.fetch('get', this.listUrl({ ...params, includeUser: 'true' })),
+        this.fetch(this.listUrl({ ...params, includeUser: 'true' }), {
+          method: 'get',
+        }),
       schema: [this],
     };
   }
@@ -153,7 +157,10 @@ export class ArticleResourceWithOtherListUrl extends ArticleResource {
     return {
       ...this.listShape(),
       getFetchKey,
-      fetch: (_params: object) => this.fetch('get', getFetchKey()),
+      fetch: (_params: object) =>
+        this.fetch(getFetchKey(), {
+          method: 'get',
+        }),
     };
   }
 

--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -198,18 +198,22 @@ parameters.
 
 Used in [listShape()](#listshape-readshape) and [createShape()](#createshape-mutateshape)
 
-### static fetch(method: "get" | "post" | "put" | "patch" | "delete" | "options", url: string, body?: Readonly\<object | string>) => Promise\<any>
+### static fetch(input: RequestInfo, init: RequestInit) => Promise\<any>
 
 Performs the actual network fetch returning a promise that resolves to the network response or rejects
 on network error. This can be useful to override to really customize your transport.
 
-### static fetchResponse(method: "get" | "post" | "put" | "patch" | "delete" | "options", url: string, body?: Readonly\<object | string>) => Promise\<Response>
+### static fetchResponse(input: RequestInfo, init: RequestInit) => Promise\<Response>
 
 Used in `fetch()`. Resolves the HTTP [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response).
 
-### static getFetchOptions() => [FetchOptions](../api/FetchShape.md#FetchOptions) | undefined
+### static getFetchInit(init: RequestInit): RequestInit
 
-Returns the default request options for this resource. By default this returns undefined
+Allows simple overrides to extend [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) sent to fetch.
+
+### static getFetchOptions() => FetchOptions | undefined
+
+[Returns](../api/FetchShape.md#FetchOptions) the default request options for this resource. By default this returns undefined
 
 ## [Fetch shapes](../api/FetchShape)
 

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -2,7 +2,7 @@
 title: Authentication
 ---
 
-All network requests are run through the `static fetchOptionsPlugin` optionally
+All network requests are run through the `static getFetchInit` optionally
 defined in your `Resource`.
 
 ## Cookie Auth
@@ -14,7 +14,7 @@ Here's an example using simple cookie auth:
 
 ```typescript
 class AuthdResource extends Resource {
-  static fetchOptionsPlugin = (options: RequestInit) => ({
+  static getFetchInit = (init: RequestInit) => ({
     ...options,
     credentials: 'same-origin',
   });
@@ -34,7 +34,7 @@ class AuthdResource extends Resource {
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 You can also do more complex flows (like adding arbitrary headers) to
-the request. Every `fetchOptionsPlugin` takes in the existing [init options](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) of fetch, and returns new init options to be used.
+the request. Every `getFetchInit()` takes in the existing [init options](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) of fetch, and returns new init options to be used.
 
 ## Auth Headers from React Context
 
@@ -43,7 +43,7 @@ called from a React Component. (However, this should be fine since the context w
 
 ```typescript
 class AuthdResource extends Resource {
-  static fetchOptionsPlugin = (options: RequestInit) => {
+  static getFetchInit = (init: RequestInit) => {
     const { session } = useAuthContext();
     return {
     ...options,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,8 +20,6 @@ import {
 
 export type { AbstractInstanceType };
 
-export type Method = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'options';
-
 export type ReceiveTypes = typeof RECEIVE_TYPE;
 
 export type PK = string;

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -33,7 +33,6 @@ export type {
   ParamsFromShape,
   AbstractInstanceType,
   FetchOptions,
-  Method,
   UpdateFunction,
   // TODO: get rid of these exports once core has been out for a while
   FetchAction,

--- a/packages/rest-hooks/src/resource/__tests__/resource.ts
+++ b/packages/rest-hooks/src/resource/__tests__/resource.ts
@@ -274,10 +274,10 @@ describe('Resource', () => {
     it('should throw with SimpleResource', () => {
       expect(() =>
         SimpleResource.fetch(
-          'get',
           CoolerArticleResource.url({
             id: payload.id,
           }),
+          { method: 'GET' },
         ),
       ).toThrow();
     });
@@ -285,20 +285,20 @@ describe('Resource', () => {
     it('fetchResponse() should throw with SimpleResource', () => {
       expect(() =>
         SimpleResource.fetchResponse(
-          'get',
           CoolerArticleResource.url({
             id: payload.id,
           }),
+          { method: 'GET' },
         ),
       ).toThrow();
     });
 
     it('should GET', async () => {
       const article = await CoolerArticleResource.fetch(
-        'get',
         CoolerArticleResource.url({
           id: payload.id,
         }),
+        { method: 'GET' },
       );
       expect(article).toBeDefined();
       if (!article) {
@@ -310,37 +310,40 @@ describe('Resource', () => {
     it('should POST', async () => {
       const payload2 = { id: 20, content: 'better task' };
       const article = await CoolerArticleResource.fetch(
-        'post',
         CoolerArticleResource.listUrl(),
-        payload2,
+        { method: 'POST', body: JSON.stringify(payload2) },
       );
       expect(article).toMatchObject(payload2);
     });
 
     it('should DELETE', async () => {
       const res = await CoolerArticleResource.fetch(
-        'delete',
         CoolerArticleResource.url({
           id: payload.id,
         }),
+        { method: 'DELETE' },
       );
       expect(res).toEqual({});
     });
 
     it('should PUT', async () => {
       const response = await CoolerArticleResource.fetch(
-        'put',
         CoolerArticleResource.url(payload),
-        CoolerArticleResource.fromJS(payload),
+        {
+          method: 'PUT',
+          body: JSON.stringify(CoolerArticleResource.fromJS(payload)),
+        },
       );
       expect(response).toEqual(putResponseBody);
     });
 
     it('should PATCH', async () => {
       const response = await CoolerArticleResource.fetch(
-        'patch',
         CoolerArticleResource.url({ id }),
-        patchPayload,
+        {
+          method: 'PATCH',
+          body: JSON.stringify(patchPayload),
+        },
       );
       expect(response).toEqual(patchResponseBody);
     });
@@ -349,8 +352,8 @@ describe('Resource', () => {
       let error: any;
       try {
         await CoolerArticleResource.fetch(
-          'get',
           CoolerArticleResource.url({ id: idHtml }),
+          { method: 'GET' },
         );
       } catch (e) {
         error = e;
@@ -377,10 +380,9 @@ describe('Resource', () => {
 
       let error: any;
       try {
-        await CoolerArticleResource.fetch(
-          'get',
-          CoolerArticleResource.url({ id }),
-        );
+        await CoolerArticleResource.fetch(CoolerArticleResource.url({ id }), {
+          method: 'GET',
+        });
       } catch (e) {
         error = e;
       }
@@ -393,8 +395,8 @@ describe('Resource', () => {
 
     it('should return raw response if status is 204 No Content', async () => {
       const res = await CoolerArticleResource.fetch(
-        'get',
         CoolerArticleResource.url({ id: idNoContent }),
+        { method: 'GET' },
       );
       expect(res).toBe('');
     });
@@ -411,8 +413,8 @@ describe('Resource', () => {
         .reply(200, text, { 'content-type': 'html/text' });
 
       const res = await CoolerArticleResource.fetch(
-        'get',
         CoolerArticleResource.url({ id }),
+        { method: 'GET' },
       );
       expect(res).toBe('<body>this is html</body>');
     });
@@ -428,26 +430,19 @@ describe('Resource', () => {
         .reply(200, text, {});
 
       const res = await CoolerArticleResource.fetch(
-        'get',
         CoolerArticleResource.url({ id }),
+        { method: 'GET' },
       );
       expect(res).toBe(text);
     });
 
-    it('should use fetchOptionsPlugin if defined', async () => {
+    it('should use getFetchInit if defined', async () => {
       class FetchResource extends CoolerArticleResource {
-        static fetchOptionsPlugin = jest.fn(a => a);
+        static getFetchInit = jest.fn(a => a);
       }
-      const article = await FetchResource.fetch(
-        'get',
-        FetchResource.url({
-          id: payload.id,
-        }),
-      );
+      const article = await FetchResource.detailShape();
       expect(article).toBeDefined();
-      expect(
-        FetchResource.fetchOptionsPlugin.mock.calls.length,
-      ).toBeGreaterThan(0);
+      expect(FetchResource.getFetchInit.mock.calls.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
This allows using hooks in Resource.getFetchInit(), to
make context-based authentication easy.

BREAKING CHANGE:
- Removed Resource.fetchOptionsPlugin()
- Added Resource.getFetchInit() which is called in shape generators
- Resourece.fetch() interface changed to match browser fetch()

<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #273 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- This allows using hooks in Resource.getFetchInit(), to make context-based authentication easy.
- More standardized interface
- Allows for body payloads that aren't just JSON.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Removed Resource.fetchOptionsPlugin()
- Added Resource.getFetchInit() which is called in shape generators
- Changed Resource.fetch() to `static fetch(input: RequestInfo, init: RequestInit): Promise<any>`

```typescript
class AuthdResource extends Resource {
  static getFetchInit = (init: RequestInit) => {
    const { session } = useAuthContext();
    return {
    ...options,
      headers: {
        ...options.headers,
        'Access-Token': session,
      },
    }
  };
}
```

### Open questions

This does make overriding fetch just to change the url kinda annoying.