### PR TITLE
docs: Add imperative (mutate) error handling example)

### DIFF
--- a/docs/guides/extending-endpoints.md
+++ b/docs/guides/extending-endpoints.md
@@ -133,16 +133,14 @@ import { Resource } from 'rest-hooks';
 
 export default class CommentResource extends Resource {
   static detail<T extends typeof Resource>(this: T) {
-    return {
-      ...super.detail(),
+    return super.detail.extend({
       schema: { data: this },
-    };
+    });
   }
   static list<T extends typeof Resource>(this: T) {
-    return {
-      ...super.list(),
+    return super.list().extend({
       schema: { data: [this] },
-    };
+    });
   }
 }
 ```

--- a/docs/guides/network-errors.md
+++ b/docs/guides/network-errors.md
@@ -41,3 +41,60 @@ type and handle network errors there.
 Error boundaries provide elegant ways to reduce complexity by handling many
 errors in the react tree in one location. However, if you find yourself wanting to handle
 error state manually you can adapt the [useStatefulResource()](./no-suspense.md) hook.
+
+## Errors from Mutates (imperative)
+
+Since mutations are called imperatively, their function will throw an error if there
+is a network error like 400 because the form values were invalid.
+
+Let's look at the update form example from the introduction.
+
+```tsx
+import { useFetcher } from 'rest-hooks';
+import ArticleResource from 'resources/article';
+
+export default function UpdateArticleForm({ id }: { id: number }) {
+  const article = useResource(ArticleResource.detail(), { id });
+  const update = useFetcher(ArticleResource.update());
+  // update as (body: Readonly<Partial<ArticleResource>>, params?: Readonly<object>) => Promise<any>
+  return (
+    <Form
+      onSubmit={e => update({ id }, new FormData(e.target))}
+      initialValues={article}
+    >
+      <FormField name="title" />
+      <FormField name="content" type="textarea" />
+      <FormField name="tags" type="tag" />
+    </Form>
+  );
+}
+```
+
+The function we pass to `<Form />` calls the update fetch. This means that it
+will pass through any errors that occur with that fetch.
+
+To handle this the Form component should control form error state.
+
+```tsx
+function Form({ onSubmit, initialValues, children }: FormState) {
+  const [errors, setErrors] = useState<null | Error>(null);
+  const formData = useFormData(); // this is an example interface
+
+  const handleSubmit = useCallback(() => {
+    try {
+      return onSubmit(formData);
+    } catch(e) {
+      // We set the form error state when we catch an error from our network call
+      setErrors(e);
+    }
+  }, [setErrors, onSubmit]);
+
+  return (
+    <form onSubmit={handleSubmit}>
+      {/* Show the form errors at the top */}
+      <FormError error={error} />
+      {children}
+    </form>
+  )
+}
+```


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #287 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
We talk about declarative (read) api errors, but never imperative (mutate) errors.
