### PR TITLE
feat: Add DevToolsManager to integrate with redux-devtools

### DIFF
--- a/docs/api/DevToolsManager.md
+++ b/docs/api/DevToolsManager.md
@@ -1,0 +1,20 @@
+---
+title: DevToolsManager implements Manager
+sidebar_label: DevToolsManager
+---
+
+```typescript
+class DevToolsManager implements Manager
+```
+
+Integrates with [Redux DevTools](https://github.com/zalmoxisus/redux-devtools-extension) to track
+state and actions. Note: does not integrate time-travel.
+
+Add the [chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)
+or [firefox extension](https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/) to your
+browser to get started.
+
+## constructor(options: Arguments)
+
+[Arguments](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md)
+to send to redux devtools.

--- a/docs/api/Manager.md
+++ b/docs/api/Manager.md
@@ -26,6 +26,7 @@ type Middleware = <R extends React.Reducer<any, A>, A extends Actions>({
 interface Manager {
   getMiddleware<T extends Manager>(this: T): Middleware;
   cleanup(): void;
+  init?: (state: State<any>) => void;
 }
 ```
 
@@ -46,6 +47,11 @@ To read more about middlewares, see the [redux documentation](https://redux.js.o
 ## cleanup()
 
 Provides any cleanup of dangling resources after manager is no longer in use.
+
+## init()
+
+Called with initial state after provider is mounted. Can be useful to run setup at start that
+relies on state actually existing.
 
 ## Provided managers:
 

--- a/packages/core/src/react-integration/provider/CacheProvider.tsx
+++ b/packages/core/src/react-integration/provider/CacheProvider.tsx
@@ -33,6 +33,9 @@ export default function CacheProvider({
 
   // if we change out the manager we need to make sure it has no hanging async
   useEffect(() => {
+    for (let i = 0; i < managers.length; ++i) {
+      managers[i].init?.(state);
+    }
     return () => {
       for (let i = 0; i < managers.length; ++i) {
         managers[i].cleanup();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -160,4 +160,5 @@ export type ActionTypes =
 export interface Manager {
   getMiddleware(): Middleware;
   cleanup(): void;
+  init?: (state: State<any>) => void;
 }

--- a/packages/rest-hooks/src/manager/DevToolsManager.ts
+++ b/packages/rest-hooks/src/manager/DevToolsManager.ts
@@ -1,0 +1,53 @@
+import {
+  MiddlewareAPI,
+  Middleware,
+  Dispatch,
+  Manager,
+  State,
+} from '@rest-hooks/core';
+
+/** Integrates with https://github.com/zalmoxisus/redux-devtools-extension
+ *
+ * Options: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md
+ */
+export default class DevToolsManager implements Manager {
+  protected declare middleware: Middleware;
+  protected declare devTools: undefined | any;
+
+  constructor(config: any = {}) {
+    this.devTools =
+      process.env.NODE_ENV !== 'production' &&
+      typeof window !== 'undefined' &&
+      (window as any).__REDUX_DEVTOOLS_EXTENSION__ &&
+      (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect(config);
+
+    if (this.devTools) {
+      this.middleware = <R extends React.Reducer<any, any>>({
+        getState,
+      }: MiddlewareAPI<R>) => {
+        return (next: Dispatch<R>) => (action: React.ReducerAction<R>) => {
+          return next(action).then(() => {
+            this.devTools.send(action, getState(), {}, 'REST_HOOKS');
+          });
+        };
+      };
+    } else {
+      this.middleware = () => next => action => next(action);
+    }
+  }
+
+  /** Called when initial state is ready */
+  init(state: State<any>) {
+    if (this.devTools) this.devTools.init(state);
+  }
+
+  /** Ensures all subscriptions are cleaned up. */
+  cleanup() {}
+
+  /** Attaches Manager to store
+   *
+   */
+  getMiddleware<T extends DevToolsManager>(this: T) {
+    return this.middleware;
+  }
+}

--- a/packages/rest-hooks/src/manager/index.ts
+++ b/packages/rest-hooks/src/manager/index.ts
@@ -2,3 +2,4 @@ export type { default as ConnectionListener } from './ConnectionListener';
 export { default as DefaultConnectionListener } from './DefaultConnectionListener';
 export { default as PollingSubscription } from './PollingSubscription';
 export { default as SubscriptionManager } from './SubscriptionManager';
+export { default as DevToolsManager } from './DevToolsManager';

--- a/packages/rest-hooks/src/react-integration/provider/index.ts
+++ b/packages/rest-hooks/src/react-integration/provider/index.ts
@@ -1,5 +1,9 @@
 import { CacheProvider as CoreCacheProvider } from '@rest-hooks/core';
-import { SubscriptionManager, PollingSubscription } from 'rest-hooks/manager';
+import {
+  SubscriptionManager,
+  PollingSubscription,
+  DevToolsManager,
+} from 'rest-hooks/manager';
 
 import PromiseifyMiddleware from './PromiseifyMiddleware';
 import ExternalCacheProvider from './ExternalCacheProvider';
@@ -11,6 +15,7 @@ CacheProvider.defaultProps = {
   managers: [
     ...CoreCacheProvider.defaultProps.managers,
     new SubscriptionManager(PollingSubscription),
+    new DevToolsManager(),
   ],
 };
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -14,6 +14,10 @@
       "api/Delete": {
         "title": "Delete"
       },
+      "api/DevToolsManager": {
+        "title": "DevToolsManager implements Manager",
+        "sidebar_label": "DevToolsManager"
+      },
       "api/Endpoint": {
         "title": "Endpoint"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -130,7 +130,8 @@
           "api/Manager",
           "api/NetworkManager",
           "api/SubscriptionManager",
-          "api/PollingSubscription"
+          "api/PollingSubscription",
+          "api/DevToolsManager"
         ]
       },
       {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Easier for developers to know how information is flowing.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Integration with https://github.com/zalmoxisus/redux-devtools-extension via a new manager. Note this does not
allow for time-travel debugging as unclear how to make this work with react lifecycle. Using ExternalCacheProvider and manual integration still allows for this.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
What about React Native? The tool suggests lookup of window, so not sure how this would be possible.


### Credits
Inspired by @0xcaff 
