### PR TITLE
[bugfix] useStatefulResource: catch maybePromise errors

### DIFF
--- a/packages/legacy/src/index.ts
+++ b/packages/legacy/src/index.ts
@@ -33,6 +33,10 @@ export function useStatefulResource<
     deleted && !error,
   );
 
+  if (maybePromise) {
+    maybePromise.catch(() => {});
+  }
+
   const loading =
     !hasUsableData(
       fetchShape,


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Throwing an error from Resource fetcher is not caught by useStatefulResource. This fix suppresses the uncaught error but still returns it correctly.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Define .catch on maybePromise, if it exists.
