### PR TITLE
fix: Inferred return of useCache()

### DIFF
--- a/packages/core/src/react-integration/__tests__/integration.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration.web.tsx
@@ -423,6 +423,8 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
               CoolerArticleResource.detailShape(),
               params,
             );
+            // @ts-expect-error
+            article.doesnotexist;
             return { put, article };
           },
           {

--- a/packages/core/src/react-integration/__tests__/useCache.tsx
+++ b/packages/core/src/react-integration/__tests__/useCache.tsx
@@ -24,6 +24,8 @@ describe('useCache()', () => {
     const { result } = renderRestHook(() => {
       return useCache(CoolerArticleResource.detailShape(), payload);
     }, {});
+    // @ts-expect-error
+    result.current?.doesnotexist;
     expect(result.current).toBe(undefined);
   });
 

--- a/packages/core/src/react-integration/hooks/useCache.ts
+++ b/packages/core/src/react-integration/hooks/useCache.ts
@@ -1,4 +1,8 @@
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import {
+  ReadShape,
+  ParamsFromShape,
+  DenormalizeNullable,
+} from '@rest-hooks/core/endpoint';
 import { useDenormalized } from '@rest-hooks/core/state/selectors';
 import { useContext, useMemo } from 'react';
 import { StateContext } from '@rest-hooks/core/react-integration/context';
@@ -15,7 +19,10 @@ import useExpiresAt from './useExpiresAt';
 /** Access a resource if it is available. */
 export default function useCache<
   Shape extends Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>
->(fetchShape: Shape, params: ParamsFromShape<Shape> | null) {
+>(
+  fetchShape: Shape,
+  params: ParamsFromShape<Shape> | null,
+): DenormalizeNullable<Shape['schema']> {
   const expiresAt = useExpiresAt(fetchShape, params);
 
   const state = useContext(StateContext);


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
useCache() was returning any type in many cases.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Explicit about return type so there are less levels of inferrencing.
