### PR TITLE
enhance: Only include DevToolsManager in dev mode

### DIFF
--- a/packages/rest-hooks/src/react-integration/provider/index.ts
+++ b/packages/rest-hooks/src/react-integration/provider/index.ts
@@ -13,10 +13,12 @@ const CacheProvider: typeof CoreCacheProvider = props =>
 CacheProvider.defaultProps = {
   ...CoreCacheProvider.defaultProps,
   managers: [
-    new DevToolsManager(),
     ...CoreCacheProvider.defaultProps.managers,
     new SubscriptionManager(PollingSubscription),
   ],
 };
+/* istanbul ignore next */
+if (process.env.NODE_ENV !== 'production')
+  CacheProvider.defaultProps.managers.unshift(new DevToolsManager());
 
 export { CacheProvider, ExternalCacheProvider, PromiseifyMiddleware };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Even though DevToolsManager is split based on dev mode internally, it's still hooked up. This short circuits that whole operation.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
unshift to plugins list only if NODE_ENV !== 'production'
