### PR TITLE
fix: Handle entities updated with new indexes

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -194,6 +194,16 @@ export const CoolerArticleDetail = new Endpoint(({ id }: { id: number }) => {
 
 export class IndexedUserResource extends UserResource {
   static indexes = ['username' as const];
+
+  static indexShape<T extends typeof IndexedUserResource>(this: T) {
+    return {
+      type: 'read',
+      schema: this,
+      getFetchKey({ username }: { username: string }) {
+        return username;
+      },
+    };
+  }
 }
 
 export class InvalidIfStaleArticleResource extends CoolerArticleResource {

--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
@@ -23,6 +23,24 @@ Array [
 ]
 `;
 
+exports[` => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 1`] = `
+IndexedUserResource {
+  "email": "bob@bob.com",
+  "id": 23,
+  "isAdmin": false,
+  "username": "bob",
+}
+`;
+
+exports[` => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 2`] = `
+IndexedUserResource {
+  "email": "bob@bob.com",
+  "id": 23,
+  "isAdmin": false,
+  "username": "charlie",
+}
+`;
+
 exports[` => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
@@ -97,6 +115,24 @@ Array [
     "title": "the next time",
   },
 ]
+`;
+
+exports[`makeCacheProvider => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 1`] = `
+IndexedUserResource {
+  "email": "bob@bob.com",
+  "id": 23,
+  "isAdmin": false,
+  "username": "bob",
+}
+`;
+
+exports[`makeCacheProvider => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 2`] = `
+IndexedUserResource {
+  "email": "bob@bob.com",
+  "id": 23,
+  "isAdmin": false,
+  "username": "charlie",
+}
 `;
 
 exports[`makeCacheProvider => <Provider /> should resolve useResource() with SimpleRecords 1`] = `

--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -23,6 +23,7 @@ export default function useError<
     // this means the response is missing an expected entity
     if (!meta.error && !meta.invalidated) {
       let error: Error & { status?: number };
+      /* istanbul ignore else */
       if (process.env.NODE_ENV !== 'production') {
         error = new Error(
           `Entity from "${fetchShape.getFetchKey(params)}" not found in cache.
@@ -32,7 +33,7 @@ export default function useError<
 
         Schema: ${JSON.stringify(fetchShape.schema, null, 2)}`,
         );
-      } else {
+      } /* istanbul ignore next */ else {
         error = new Error(
           `Missing required entity in "${fetchShape.getFetchKey(
             params,

--- a/packages/core/src/state/actions/createFetch.ts
+++ b/packages/core/src/state/actions/createFetch.ts
@@ -59,7 +59,10 @@ export default function createFetch<
     resolve,
     reject,
     promise,
-    createdAt: process.env.NODE_ENV === 'test' ? new Date(0) : new Date(),
+    createdAt:
+      process.env.NODE_ENV === 'test'
+        ? new Date(0)
+        : /* istanbul ignore next */ new Date(),
   };
 
   if (updateParams) {

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -60,6 +60,8 @@ export default function reducer(
         const { result, entities, indexes } = normalize(
           action.payload,
           action.meta.schema,
+          state.entities,
+          state.indexes,
         );
         let results = {
           ...state.results,

--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -101,6 +101,7 @@ export default abstract class SimpleResource extends FlatEntity {
 
   /** @deprecated */
   static getFetchOptions() {
+    /* istanbul ignore next */
     return this.getEndpointExtra();
   }
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In case any of the index fields of an entity are updated, the existing entry should be removed.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
To ensure overwriting existing values - use DELETED symbol.
