### PR TITLE
feat: Support extra endpoint members and inheritance

### DIFF
--- a/docs/guides/extending-endpoints.md
+++ b/docs/guides/extending-endpoints.md
@@ -170,12 +170,10 @@ import { Resource } from '@rest-hooks/rest';
 export default class UserResource extends Resource {
   static makeManager<T extends typeof Resource>(this: T) {
     return this.create().extend({
-      key: ({ id }: { id: number }) => {
-        return `/users/${id}/make_manager`;
-      },
-      fetch: ({ id }: { id: number }, body?: Readonly<object | string>) => {
-        return this.fetch('post', `/users/${id}/make_manager`, body);
-      },
+      url({ id }: { id: number }) { return `/users/${id}/make_manager` },
+      fetch({ id }: { id: number }) {
+        return this.constructor.prototype.fetch.call(this, { id });
+      }
     });
   }
 }
@@ -185,7 +183,7 @@ We customized the following:
 
 - Custom type:
   - Params of { id: number }
-  - Body (payload) of {}
+  - No Body
 - Custom url
 
 ### Custom GET
@@ -201,10 +199,9 @@ import { Resource } from '@rest-hooks/rest';
 export default class UserResource extends Resource {
   /** Retrieves current logged in user */
   static current<T extends typeof Resource>(this: T) {
-    const init = this.getFetchInit({ method: 'GET' });
     return this.detail().extend({
-      key: () => '/current_user/';
-      fetch: () => this.fetch(`/current_user/`, init),
+      fetch() { return this.constructor.prototype.call(this); }
+      url() { return '/current_user/' },
     })
   }
 }
@@ -255,10 +252,9 @@ export default class BirthdayResource extends BaseResource {
 
   /** Lists all upcoming birthdays */
   static upcoming<T extends typeof Resource>(this: T) {
-    const init = this.getFetchInit({ method: 'GET' });
     return this.list().extend({
-      key: () => '/api/birthdays/upcoming/',
-      fetch: () => this.fetch('/api/birthdays/upcoming/', init),
+      fetch() { return this.constructor.prototype.call(this); }
+      url() { return '/current_user/' },
       schema: {
         withinSevenDays: [this],
         withinThirtyDays: [this],

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
@@ -5,7 +5,13 @@ Object {
   "meta": Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
-    "options": undefined,
+    "options": Object {
+      "init": Object {
+        "method": "POST",
+      },
+      "type": "mutate",
+      "url": [Function],
+    },
     "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
@@ -23,7 +29,12 @@ Object {
   "meta": Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PUT http://test.com/article-cooler/1",
-    "options": undefined,
+    "options": Object {
+      "init": Object {
+        "method": "PUT",
+      },
+      "type": "mutate",
+    },
     "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
@@ -92,7 +103,13 @@ Object {
   "meta": Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
-    "options": undefined,
+    "options": Object {
+      "init": Object {
+        "method": "POST",
+      },
+      "type": "mutate",
+      "url": [Function],
+    },
     "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
@@ -113,7 +130,13 @@ Object {
   "meta": Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/1",
-    "options": undefined,
+    "options": Object {
+      "init": Object {
+        "method": "GET",
+      },
+      "type": "read",
+      "url": [Function],
+    },
     "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
@@ -131,7 +154,13 @@ Object {
   "meta": Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
-    "options": undefined,
+    "options": Object {
+      "init": Object {
+        "method": "GET",
+      },
+      "type": "read",
+      "url": [Function],
+    },
     "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
@@ -151,6 +180,11 @@ Object {
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "dataExpiryLength": 3600000,
+      "init": Object {
+        "method": "GET",
+      },
+      "type": "read",
+      "url": [Function],
     },
     "promise": Promise {},
     "reject": [Function],
@@ -171,6 +205,11 @@ Object {
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "errorExpiryLength": Infinity,
+      "init": Object {
+        "method": "GET",
+      },
+      "type": "read",
+      "url": [Function],
     },
     "promise": Promise {},
     "reject": [Function],
@@ -189,7 +228,13 @@ Object {
   "meta": Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
-    "options": undefined,
+    "options": Object {
+      "init": Object {
+        "method": "GET",
+      },
+      "type": "read",
+      "url": [Function],
+    },
     "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
@@ -5,7 +5,13 @@ Object {
   "meta": Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
-    "options": undefined,
+    "options": Object {
+      "init": Object {
+        "method": "GET",
+      },
+      "type": "read",
+      "url": [Function],
+    },
     "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
@@ -23,7 +29,13 @@ Object {
   "meta": Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
-    "options": undefined,
+    "options": Object {
+      "init": Object {
+        "method": "GET",
+      },
+      "type": "read",
+      "url": [Function],
+    },
     "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],
@@ -41,7 +53,13 @@ Object {
   "meta": Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/user/",
-    "options": undefined,
+    "options": Object {
+      "init": Object {
+        "method": "GET",
+      },
+      "type": "read",
+      "url": [Function],
+    },
     "promise": Promise {},
     "reject": [Function],
     "resolve": [Function],

--- a/packages/rest/src/__tests__/resource.ts
+++ b/packages/rest/src/__tests__/resource.ts
@@ -2,12 +2,14 @@ import {
   CoolerArticleResource,
   UserResource,
   UrlArticleResource,
+  ArticleResource,
 } from '__tests__/common';
 import nock from 'nock';
-import { normalize } from '@rest-hooks/normalizr';
+import { normalize, Schema } from '@rest-hooks/normalizr';
 
 import Resource from '../Resource';
 import SimpleResource from '../SimpleResource';
+import { FetchShape } from '../legacy';
 
 function onError(e: any) {
   e.preventDefault();
@@ -501,6 +503,75 @@ describe('Resource', () => {
         normalize({ content: 'hi' }, schema);
       }
       expect(normalizeBad).toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('legacy shapes', () => {
+    const expectFetchShape = (shape: FetchShape<Schema>, type = 'read') => {
+      expect(shape.fetch).toBeDefined();
+      expect(shape.getFetchKey).toBeDefined();
+      expect(shape.schema).toBeDefined();
+      expect(shape.type).toBe(type);
+    };
+
+    it('detailShape should have correct members', () => {
+      const shape = ArticleResource.detailShape();
+      const copy = { ...shape };
+
+      expectFetchShape(copy);
+      expect(copy.getFetchKey({ id: '5' })).toMatchInlineSnapshot(
+        `"GET http://test.com/article/5"`,
+      );
+    });
+
+    it('listShape should have correct members', () => {
+      const shape = ArticleResource.listShape();
+      const copy = { ...shape };
+
+      expectFetchShape(copy);
+      expect(copy.getFetchKey({})).toMatchInlineSnapshot(
+        `"GET http://test.com/article/"`,
+      );
+    });
+
+    it('createShape should have correct members', () => {
+      const shape = ArticleResource.createShape();
+      const copy = { ...shape };
+
+      expectFetchShape(copy, 'mutate');
+      expect(copy.getFetchKey({})).toMatchInlineSnapshot(
+        `"POST http://test.com/article/"`,
+      );
+    });
+
+    it('updateShape should have correct members', () => {
+      const shape = ArticleResource.updateShape();
+      const copy = { ...shape };
+
+      expectFetchShape(copy, 'mutate');
+      expect(copy.getFetchKey({ id: '6' })).toMatchInlineSnapshot(
+        `"PUT http://test.com/article/6"`,
+      );
+    });
+
+    it('partialUpdateShape should have correct members', () => {
+      const shape = ArticleResource.partialUpdateShape();
+      const copy = { ...shape };
+
+      expectFetchShape(copy, 'mutate');
+      expect(copy.getFetchKey({ id: '6' })).toMatchInlineSnapshot(
+        `"PATCH http://test.com/article/6"`,
+      );
+    });
+
+    it('deleteShape should have correct members', () => {
+      const shape = ArticleResource.deleteShape();
+      const copy = { ...shape };
+
+      expectFetchShape(copy, 'mutate');
+      expect(copy.getFetchKey({ id: '6' })).toMatchInlineSnapshot(
+        `"DELETE http://test.com/article/6"`,
+      );
     });
   });
 });


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Dramatically simplifies repeated patterns like those in Resource. Now custom endpoints are more easily customized like so:

With a base like so:

```typescript
  protected static endpoint() {
    const init = this.getFetchInit({ method: 'GET' });
    const instanceFetch = this.fetch.bind(this);
    const url = this.url.bind(this);

    return new Endpoint(
      function (params: Readonly<object>) {
        return instanceFetch(this.url(params), this.init);
      },
      {
        ...this.getEndpointExtra(),
        key: function (this: any, params: Readonly<object>) {
          return `${this.init.method} ${this.url(params)}`;
        },
        url,
        init,
      },
    );
  }
```

Now this adds extensibility holes to the endpoint itself. Allowing easy customization of both init as well as url, making defining the CRUD methods very straightforward.

```typescript
  static update<T extends typeof SimpleResource>(this: T) {
    return this.endpointMutate().extend({
      init: this.getFetchInit({ method: 'PUT' }),
      schema: this as SchemaDetail<Readonly<AbstractInstanceType<T>>>,
    });
  }
```

This also has the safety and convenience of introducing types into these patterns. For instance autocomplete will work as well.

Another great use case is exploiting specialization like in delete case:

```typescript
  /** Endpoint to delete an entity (delete) */
  static delete<T extends typeof SimpleResource>(this: T) {
    return this.endpointMutate().extend({
      fetch(params: Readonly<object>) {
        return this.constructor.prototype.fetch
          .call(this, params)
          .then(() => params);
      },
      init: this.getFetchInit({ method: 'DELETE' }),
      schema: new schema.Delete(this),
      bob: 5,
    });
  }
```

Here we can get similar 'super' behavior by using the slightly more verbose `this.constructor.prototype`

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

The key is building a prototype chain based on parents when extending:

```js
    // make a constructor/prototype based off this
    // extend from it and init with options sent
    class E extends this.constructor {}
    Object.assign(E.prototype, this);
    const instance = new E(options.fetch, options);
```

Types were interesting as there were many enforcement areas as well as the desire to infer 'this' correctly.
