### PR TITLE
enhance: Simplify endpoint memoization and provide new extensions

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -13,7 +13,7 @@ import {
   Index,
 } from '@rest-hooks/endpoint';
 import { Resource, SchemaList, SchemaDetail } from '@rest-hooks/rest';
-import React from 'react';
+import React, { createContext, useContext } from 'react';
 
 export class UserResource extends Resource {
   readonly id: number | undefined = undefined;
@@ -91,6 +91,23 @@ export class ArticleResource extends Resource {
       optimisticUpdate: (params: any) => params,
       schema: new schema.Delete(this),
     });
+  }
+}
+
+export const AuthContext = createContext('');
+
+export class ContextAuthdArticle extends ArticleResource {
+  /** Init options for fetch */
+  static getFetchInit(init: RequestInit): RequestInit {
+    /* eslint-disable-next-line */
+    const accessToken = useContext(AuthContext);
+    return {
+      ...init,
+      headers: {
+        ...init.headers,
+        'Access-Token': accessToken,
+      },
+    };
   }
 }
 

--- a/docs/api/Resource.md
+++ b/docs/api/Resource.md
@@ -227,18 +227,41 @@ new endpoints based to match your API.
 A GET request using standard `url()` that receives a detail body.
 Mostly useful with [useResource](../api/useResource.md)
 
-Uses [url()](#static-urlt-extends-typeof-resourceurlparams-partialabstractinstancetypet--string)
+- Uses [url()](#static-urlt-extends-typeof-resourceurlparams-partialabstractinstancetypet--string)
+- Compatible with all hooks
 
-Compatible with all hooks
+#### Implementation:
+
+```typescript
+static detail<T extends typeof SimpleResource>(this: T) {
+  return this.memo('#detail', () =>
+    this.endpoint().extend({
+      schema: this as SchemaDetail<Readonly<AbstractInstanceType<T>>>,
+    }),
+  );
+}
+```
 
 ### list(): Endpoint
 
 A GET request using `listUrl()` that receives a list of entities.
 Mostly useful with [useResource](../api/useResource.md)
 
-Uses [listUrl()](#static-listurlsearchparams-readonlyrecordstring-string--string)
+- Uses [listUrl()](#static-listurlsearchparams-readonlyrecordstring-string--string)
+- Compatible with all hooks
 
-Compatible with all hooks
+#### Implementation:
+
+```typescript
+static list<T extends typeof SimpleResource>(this: T) {
+  return this.memo('#list', () =>
+    this.endpoint().extend({
+      schema: [this] as SchemaList<Readonly<AbstractInstanceType<T>>>,
+      url: this.listUrl.bind(this),
+    }),
+  );
+}
+```
 
 ### create(): Endpoint
 
@@ -251,6 +274,20 @@ Not compatible with:
 - [useResource()](../api/useResource.md)
 - [useRetrieve()](../api/useRetrieve.md)
 
+
+#### Implementation:
+
+```typescript
+static create<T extends typeof SimpleResource>(this: T) {
+  return this.memo('#create', () =>
+    this.endpointMutate().extend({
+      schema: this as SchemaDetail<Readonly<AbstractInstanceType<T>>>,
+      url: this.listUrl.bind(this),
+    }),
+  );
+}
+```
+
 ### update(): Endpoint
 
 A PUT request sending a payload to a `url()` expecting a detail body response.
@@ -261,6 +298,19 @@ Uses [url()](#static-urlt-extends-typeof-resourceurlparams-partialabstractinstan
 Not compatible with:
 - [useResource()](../api/useResource.md)
 - [useRetrieve()](../api/useRetrieve.md)
+
+#### Implementation:
+
+```typescript
+static update<T extends typeof SimpleResource>(this: T) {
+  return this.memo('#update', () =>
+    this.endpointMutate().extend({
+      method: 'PUT',
+      schema: this as SchemaDetail<Readonly<AbstractInstanceType<T>>>,
+    }),
+  );
+}
+```
 
 ### partialUpdate(): Endpoint
 
@@ -273,6 +323,19 @@ Not compatible with:
 - [useResource()](../api/useResource.md)
 - [useRetrieve()](../api/useRetrieve.md)
 
+#### Implementation:
+
+```typescript
+static partialUpdate<T extends typeof SimpleResource>(this: T) {
+  return this.memo('#partialUpdate', () =>
+    this.endpointMutate().extend({
+      method: 'PATCH',
+      schema: this as SchemaDetail<Readonly<AbstractInstanceType<T>>>,
+    }),
+  );
+}
+```
+
 ### delete(): Endpoint
 
 A DELETE request sent to `url()`
@@ -283,3 +346,20 @@ Uses [url()](#static-urlt-extends-typeof-resourceurlparams-partialabstractinstan
 Not compatible with:
 - [useResource()](../api/useResource.md)
 - [useRetrieve()](../api/useRetrieve.md)
+
+#### Implementation:
+
+```typescript
+static delete<T extends typeof SimpleResource>(this: T) {
+  const endpoint = this.endpointMutate();
+  return this.memo('#delete', () =>
+    endpoint.extend({
+      fetch(params: Readonly<object>) {
+        return endpoint.fetch.call(this, params).then(() => params);
+      },
+      method: 'DELETE',
+      schema: new schema.Delete(this),
+    }),
+  );
+}
+```

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -44,12 +44,12 @@ called from a React Component. (However, this should be fine since the context w
 ```typescript
 class AuthdResource extends Resource {
   static getFetchInit = (init: RequestInit) => {
-    const { session } = useAuthContext();
+    const accessToken = useAuthContext();
     return {
-    ...options,
+    ...init,
       headers: {
-        ...options.headers,
-        'Access-Token': session,
+        ...init.headers,
+        'Access-Token': accessToken,
       },
     }
   };

--- a/docs/guides/extending-endpoints.md
+++ b/docs/guides/extending-endpoints.md
@@ -11,6 +11,9 @@ those types of requests.
 Resource comes with a [small handleful Endpoints](../api/resource#static-network-methods-and-properties)
 for each of the typical [CRUD operations](https://restfulapi.net/http-methods/). This is often not enough.
 
+> A note about TypeScript: When using `super` to override an endpoint, be sure to include the schema.
+> TypeScript will not infer `super` calls correctly in this case.
+
 ## Overriding endpoints
 
 By default the list() assumes an array of entities returned while detail() assumes

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
@@ -9,6 +9,7 @@ Object {
       "init": Object {
         "method": "POST",
       },
+      "method": "POST",
       "type": "mutate",
       "url": [Function],
     },
@@ -31,8 +32,9 @@ Object {
     "key": "PUT http://test.com/article-cooler/1",
     "options": Object {
       "init": Object {
-        "method": "PUT",
+        "method": "POST",
       },
+      "method": "PUT",
       "type": "mutate",
     },
     "promise": Promise {},
@@ -60,6 +62,7 @@ Object {
       "init": Object {
         "method": "PATCH",
       },
+      "method": "PATCH",
       "optimisticUpdate": [Function],
       "type": "mutate",
     },
@@ -116,6 +119,7 @@ Object {
       "init": Object {
         "method": "POST",
       },
+      "method": "POST",
       "type": "mutate",
       "url": [Function],
     },
@@ -143,6 +147,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -167,6 +173,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -189,6 +197,9 @@ Object {
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "dataExpiryLength": 3600000,
+      "init": Object {
+        "method": "GET",
+      },
       "type": "read",
     },
     "promise": Promise {},
@@ -210,6 +221,9 @@ Object {
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "errorExpiryLength": Infinity,
+      "init": Object {
+        "method": "GET",
+      },
       "type": "read",
     },
     "promise": Promise {},
@@ -233,6 +247,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
@@ -9,6 +9,7 @@ Object {
       "init": Object {
         "method": "POST",
       },
+      "method": "POST",
       "type": "mutate",
       "url": [Function],
     },
@@ -31,8 +32,9 @@ Object {
     "key": "PUT http://test.com/article-cooler/1",
     "options": Object {
       "init": Object {
-        "method": "PUT",
+        "method": "POST",
       },
+      "method": "PUT",
       "type": "mutate",
     },
     "promise": Promise {},
@@ -107,6 +109,7 @@ Object {
       "init": Object {
         "method": "POST",
       },
+      "method": "POST",
       "type": "mutate",
       "url": [Function],
     },
@@ -134,6 +137,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -158,6 +163,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -183,6 +190,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -208,6 +217,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -232,6 +243,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
@@ -9,6 +9,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -33,6 +35,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -57,6 +61,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
@@ -9,6 +9,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -33,6 +35,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },
@@ -57,6 +61,8 @@ Object {
       "init": Object {
         "method": "GET",
       },
+      "method": "GET",
+      "runInit": [Function],
       "type": "read",
       "url": [Function],
     },


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Authentication with context requires running some code each time endpoints are called. Do we need to construct the full endpoints then?

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Still memoize endpoints, but provide `runInit()` member that is run everytime the endpoint method is called. Collapsing this into the memoization function also makes the definitions more terse. Also make customizing methods easier, with a method member for endpoints.

Newly added:

- runInit()
- method

Also make memo method a protected member so it can be used to memoize other extensions.

#### Added auth test case using

Useful for #273

```typescript
export const AuthContext = createContext('');

export class ContextAuthdArticle extends ArticleResource {
  /** Init options for fetch */
  static getFetchInit(init: RequestInit): RequestInit {
    /* eslint-disable-next-line */
    const accessToken = useContext(AuthContext);
    return {
      ...init,
      headers: {
        ...init.headers,
        'Access-Token': accessToken,
      },
    };
  }
}
```