### PR TITLE
fix: Only export AbstractInstanceType in type-world

### DIFF
--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -17,13 +17,13 @@ export {
   normalize,
   denormalize,
   schema,
-  AbstractInstanceType,
   Schema,
   Entity,
   isEntity,
   SimpleRecord,
   DELETED,
 } from '@rest-hooks/normalizr';
+export type { AbstractInstanceType } from '@rest-hooks/normalizr';
 export type {
   EndpointExtraOptions,
   FetchFunction,


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #395.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
.js file tries exporting AbstractInstanceType - which only exists in type-world.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Use export type