### PR TITLE
fix: Export type correctly in endpoint

### DIFF
--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -17,13 +17,12 @@ export {
   normalize,
   denormalize,
   schema,
-  Schema,
   Entity,
   isEntity,
   SimpleRecord,
   DELETED,
 } from '@rest-hooks/normalizr';
-export type { AbstractInstanceType } from '@rest-hooks/normalizr';
+export type { AbstractInstanceType, Schema } from '@rest-hooks/normalizr';
 export type {
   EndpointExtraOptions,
   FetchFunction,


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #399

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Schema is included in .js built in endpoint because it comes from normalizr and compiler doesn't know to remove it. This causes an error in javascript.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
export Schema marked as `type` so it is not included in js file
