### PR TITLE
docs: Add warning about abort usage

### DIFF
--- a/docs/guides/abort.md
+++ b/docs/guides/abort.md
@@ -65,3 +65,7 @@ import { useCancelling } from '@rest-hooks/hooks';
 const CancelingUserList = useCancelling(UserList, { query });
 const users = useResource(CancelingUserList, { query });
 ```
+
+> Warning: Be careful when using this with many disjoint components fetching the same
+> arguments (Endpoint/params pair) to useResource(). This solution aborts fetches per-component,
+> which means you might end up canceling a fetch that another component still cares about.


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Abort controller hooked directly to a fetch function can potentially cause race conditions if that fetch is deduped across the app. For now our use case this won't happen so releasing this is still quite useful, but we should warn others if they desire aborting requests sent by many components at once.

1. Many disjoint components useResource() with same parameters, requesting fetch at the same time
1. NetworkManager dedupes, making only one request in flight
1. One component decides it wants to abort that request - but the others are still interested.
1. The fetch is aborted, even though other components still want results
1. Other components will suspend forever.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
