### PR TITLE
enhance: Maintain referential equality globally

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,9 @@
     "./typescript.svg",
     "./rest_hooks_logo_and_text.svg"
   ],
+  "engines": {
+    "node": ">=6.17.1"
+  },
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "./rest_hooks_logo_and_text.svg"
   ],
   "engines": {
-    "node": ">=6.17.1"
+    "node": ">=0.12"
   },
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,11 @@ export {
   useResetter,
   hasUsableData,
 } from './react-integration';
-export { StateContext, DispatchContext } from './react-integration/context';
+export {
+  StateContext,
+  DispatchContext,
+  DenormalizeCacheContext,
+} from './react-integration/context';
 
 export { FlatEntity } from '@rest-hooks/normalizr';
 

--- a/packages/core/src/react-integration/context.ts
+++ b/packages/core/src/react-integration/context.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
-import { ActionTypes } from '@rest-hooks/core/types';
+import type { DenormalizeCache } from '@rest-hooks/normalizr';
+import type { ActionTypes } from '@rest-hooks/core/types';
 import { initialState } from '@rest-hooks/core/state/reducer';
 
 export const StateContext = createContext(initialState);
@@ -18,4 +19,9 @@ export const DispatchContext = createContext((value: ActionTypes) => {
     }
   }
   return Promise.resolve();
+});
+
+export const DenormalizeCacheContext = createContext<DenormalizeCache>({
+  entities: {},
+  results: {},
 });

--- a/packages/core/src/react-integration/hooks/useCache.ts
+++ b/packages/core/src/react-integration/hooks/useCache.ts
@@ -2,7 +2,10 @@ import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
 import { DenormalizeNullable } from '@rest-hooks/endpoint';
 import { useDenormalized } from '@rest-hooks/core/state/selectors';
 import { useContext, useMemo } from 'react';
-import { StateContext } from '@rest-hooks/core/react-integration/context';
+import {
+  DenormalizeCacheContext,
+  StateContext,
+} from '@rest-hooks/core/react-integration/context';
 import {
   hasUsableData,
   useMeta,
@@ -23,10 +26,13 @@ export default function useCache<
   const expiresAt = useExpiresAt(fetchShape, params);
 
   const state = useContext(StateContext);
+  const denormalizeCache = useContext(DenormalizeCacheContext);
+
   const [denormalized, ready, deleted] = useDenormalized(
     fetchShape,
     params,
     state,
+    denormalizeCache,
   );
   const error = useError(fetchShape, params, ready);
   const trigger = deleted && !error;

--- a/packages/core/src/react-integration/hooks/useResource.ts
+++ b/packages/core/src/react-integration/hooks/useResource.ts
@@ -1,10 +1,11 @@
 import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
 import { Denormalize, DenormalizeNullable } from '@rest-hooks/endpoint';
 import { useDenormalized } from '@rest-hooks/core/state/selectors';
-import { StateContext } from '@rest-hooks/core/react-integration/context';
-import { useMemo, useContext, useEffect } from 'react';
-import { subtract } from 'lodash';
-import { resolveConfig } from 'prettier';
+import {
+  DenormalizeCacheContext,
+  StateContext,
+} from '@rest-hooks/core/react-integration/context';
+import { useMemo, useContext } from 'react';
 
 import useRetrieve from './useRetrieve';
 import useError from './useError';
@@ -29,10 +30,12 @@ function useOneResource<
   Denormalize<Shape['schema']>
 > {
   const state = useContext(StateContext);
+  const denormalizeCache = useContext(DenormalizeCacheContext);
   const [denormalized, ready, deleted] = useDenormalized(
     fetchShape,
     params,
     state,
+    denormalizeCache,
   );
   const error = useError(fetchShape, params, ready);
 
@@ -63,13 +66,14 @@ function useManyResources<A extends ResourceArgs<any, any>[]>(
   ...resourceList: A
 ) {
   const state = useContext(StateContext);
+  const denormalizeCache = useContext(DenormalizeCacheContext);
   const denormalizedValues = resourceList.map(
     <
       Shape extends ReadShape<any, any>,
       Params extends ParamsFromShape<Shape> | null
     >([fetchShape, params]: ResourceArgs<Shape, Params>) =>
       // eslint-disable-next-line react-hooks/rules-of-hooks
-      useDenormalized(fetchShape, params, state),
+      useDenormalized(fetchShape, params, state, denormalizeCache),
   );
   const errorValues = resourceList.map(
     <

--- a/packages/core/src/react-integration/provider/CacheProvider.tsx
+++ b/packages/core/src/react-integration/provider/CacheProvider.tsx
@@ -5,8 +5,13 @@ import NetworkManager from '@rest-hooks/core/state/NetworkManager';
 import { State, Manager } from '@rest-hooks/core/types';
 import useEnhancedReducer from '@rest-hooks/use-enhanced-reducer';
 import React, { ReactNode, useEffect, useMemo } from 'react';
+import { useRef } from 'react';
 
-import { StateContext, DispatchContext } from '../context';
+import {
+  StateContext,
+  DispatchContext,
+  DenormalizeCacheContext,
+} from '../context';
 
 interface ProviderProps {
   children: ReactNode;
@@ -20,6 +25,10 @@ export default function CacheProvider({
   managers,
   initialState,
 }: ProviderProps) {
+  const denormalizeCache = useRef({
+    entities: {},
+    results: {},
+  });
   const [state, dispatch] = useEnhancedReducer(
     masterReducer,
     initialState,
@@ -47,7 +56,9 @@ export default function CacheProvider({
   return (
     <DispatchContext.Provider value={dispatch}>
       <StateContext.Provider value={optimisticState}>
-        {children}
+        <DenormalizeCacheContext.Provider value={denormalizeCache.current}>
+          {children}
+        </DenormalizeCacheContext.Provider>
       </StateContext.Provider>
     </DispatchContext.Provider>
   );

--- a/packages/core/src/state/selectors/__tests__/useDenormalized.ts
+++ b/packages/core/src/state/selectors/__tests__/useDenormalized.ts
@@ -6,10 +6,10 @@ import {
   IndexedUserResource,
   photoShape,
 } from '__tests__/common';
-import { normalize, NormalizedIndex } from '@rest-hooks/normalizr';
+import { denormalize, normalize, NormalizedIndex } from '@rest-hooks/normalizr';
 import { initialState } from '@rest-hooks/core/state/reducer';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import useDenormalized from '../useDenormalized';
 
@@ -98,7 +98,8 @@ describe('useDenormalized()', () => {
       });
 
       it('should provide inferred results', () => {
-        expect(value).toBe(article);
+        expect(value).toStrictEqual(article);
+        expect(value).toBeInstanceOf(CoolerArticleResource);
       });
     });
     describe('without entity with defined results', () => {
@@ -155,7 +156,8 @@ describe('useDenormalized()', () => {
       });
 
       it('should provide inferred results', () => {
-        expect(value).toBe(article);
+        expect(value).toStrictEqual(article);
+        expect(value).toBeInstanceOf(CoolerArticleResource);
       });
     });
     describe('no result exists but primary key is used when using nested schema', () => {
@@ -185,7 +187,8 @@ describe('useDenormalized()', () => {
       });
 
       it('should provide inferred results', () => {
-        expect(value.data).toBe(pageArticle);
+        expect(value.data).toStrictEqual(pageArticle);
+        expect(value.data).toBeInstanceOf(PaginatedArticleResource);
       });
     });
 
@@ -236,7 +239,7 @@ describe('useDenormalized()', () => {
         rerender({ state: localstate });
         expect(result.current[1]).toBe(true);
         expect(result.current[2]).toBe(false);
-        expect(result.current[0].data).toBe(user);
+        expect(result.current[0].data).toStrictEqual(user);
       });
     });
 
@@ -268,7 +271,8 @@ describe('useDenormalized()', () => {
       });
 
       it('should provide inferred results', () => {
-        expect(value).toBe(article);
+        expect(value).toStrictEqual(article);
+        expect(value).toBeInstanceOf(CoolerArticleResource);
       });
     });
     it('should throw when results are Array', () => {
@@ -419,7 +423,7 @@ describe('useDenormalized()', () => {
       });
 
       it('should provide inferred results', () => {
-        expect(value).toEqual(articles);
+        expect(value).toStrictEqual(articles);
       });
     });
     describe('missing some ids in entities table', () => {
@@ -500,6 +504,10 @@ describe('useDenormalized()', () => {
         },
       };
       let result: any;
+      const denormalizeCache = {
+        entities: {},
+        results: {},
+      };
 
       beforeEach(() => {
         const v = renderHook(() => {
@@ -509,6 +517,7 @@ describe('useDenormalized()', () => {
               PaginatedArticleResource.listShape(),
               params,
               usedState,
+              denormalizeCache,
             ),
             setState,
           };

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -19,7 +19,6 @@ import buildInferredResults from './buildInferredResults';
  * using params and schema. This increases cache hit rate for many
  * detail shapes.
  *
- *
  * @returns [denormalizedValue, ready]
  */
 export default function useDenormalized<

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -30,7 +30,7 @@
   "typings": "lib/index.d.ts",
   "sideEffects": false,
   "engines": {
-    "node": ">=6.17.1"
+    "node": ">=0.12"
   },
   "scripts": {
     "build": "yarn run build:lib && yarn run build:bundle",

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -29,6 +29,9 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "sideEffects": false,
+  "engines": {
+    "node": ">=6.17.1"
+  },
   "scripts": {
     "build": "yarn run build:lib && yarn run build:bundle",
     "build:bundle": "run-p build:js:*",

--- a/packages/normalizr/src/WeakListMap.ts
+++ b/packages/normalizr/src/WeakListMap.ts
@@ -1,0 +1,65 @@
+/** Link in a chain */
+class Link<K extends object, V> {
+  children = new WeakMap<K, Link<K, V>>();
+  declare value: V | undefined;
+}
+
+class KeySize extends Error {
+  message = 'Keys must include at least one member';
+}
+
+/** Maps from a list of objects (referentially) to any value
+ *
+ * If *any* members of the list get claned up, so does that key/value pair get removed.
+ */
+export default class WeakListMap<K extends object, V> {
+  readonly first = new WeakMap<K, Link<K, V>>();
+
+  delete(key: K[]): boolean {
+    const link = this.traverse(key);
+    delete link?.value;
+    return !!link;
+  }
+
+  get(key: K[]): V | undefined {
+    const link = this.traverse(key);
+    return link?.value;
+  }
+
+  has(key: K[]): boolean {
+    const link = this.traverse(key);
+    if (!link) return false;
+    return Object.prototype.hasOwnProperty.call(link, 'value');
+  }
+
+  set(key: K[], value: V): WeakListMap<K, V> {
+    if (key.length < 1) throw new KeySize();
+    let cur = this.first;
+    let link: Link<K, V>;
+    for (let i = 0; i < key.length; i++) {
+      if (!cur.has(key[i])) {
+        link = new Link<K, V>();
+        cur.set(key[i], link);
+      } else {
+        link = cur.get(key[i]) as Link<K, V>;
+      }
+      cur = link.children;
+      // do on later iteration of loop. this makes typescript happy rather than putting after loop
+      if (i === key.length - 1) {
+        link.value = value;
+      }
+    }
+    return this;
+  }
+
+  protected traverse(key: K[]): Link<K, V> | undefined {
+    let cur = this.first;
+    let link: Link<K, V> | undefined;
+    for (let i = 0; i < key.length; i++) {
+      link = cur.get(key[i]);
+      if (!link) return;
+      cur = link.children;
+    }
+    return link;
+  }
+}

--- a/packages/normalizr/src/__tests__/WeakListMap.test.ts
+++ b/packages/normalizr/src/__tests__/WeakListMap.test.ts
@@ -1,0 +1,88 @@
+import WeakListMap from '../WeakListMap';
+describe('WeakListMap', () => {
+  const a = { hi: '5' };
+  const b = [1, 2, 3];
+  const c = new Date(0);
+
+  it('should construct', () => {
+    const wlm = new WeakListMap();
+  });
+
+  it('should set one item', () => {
+    const wlm = new WeakListMap();
+    wlm.set([a], 'myvalue');
+    expect(wlm).toMatchInlineSnapshot(`
+        WeakListMap {
+          "first": WeakMap {},
+        }
+      `);
+
+    expect(wlm.get([a])).toBe('myvalue');
+
+    expect(wlm.has([a])).toBe(true);
+    expect(wlm.has([a, b])).toBe(false);
+    expect(wlm.has([c, b])).toBe(false);
+    expect(wlm.has([b])).toBe(false);
+    wlm.delete([a]);
+    expect(wlm.has([a])).toBe(false);
+  });
+
+  it('should set multiple on same path', () => {
+    const wlm = new WeakListMap();
+    const attempts = [
+      { key: [a], value: 'first' },
+      { key: [a, b], value: 'second' },
+      { key: [a, b, c], value: 'third' },
+    ];
+
+    for (const attempt of attempts) {
+      wlm.set(attempt.key, attempt.value);
+    }
+    for (const attempt of attempts) {
+      expect(wlm.get(attempt.key)).toBe(attempt.value);
+    }
+
+    expect(wlm.delete(attempts[0].key)).toBe(true);
+
+    expect(wlm.get(attempts[0].key)).toBeUndefined();
+    expect(wlm.has(attempts[0].key)).toBe(false);
+    for (const attempt of attempts.slice(1)) {
+      expect(wlm.get(attempt.key)).toBe(attempt.value);
+    }
+  });
+
+  it('should set multiple on distinct paths', () => {
+    const wlm = new WeakListMap();
+    const attempts = [
+      { key: [a, b], value: 'first' },
+      { key: [b, a], value: 'second' },
+      { key: [c, a], value: 'third' },
+      { key: [a, b, c], value: 'fourth' },
+      { key: [c], value: 'fifth' },
+    ];
+
+    for (const attempt of attempts) {
+      wlm.set(attempt.key, attempt.value);
+    }
+    for (const attempt of attempts) {
+      expect(wlm.get(attempt.key)).toBe(attempt.value);
+      expect(wlm.has(attempt.key)).toBe(true);
+    }
+
+    expect(wlm.get([a])).toBeUndefined();
+    expect(wlm.has([a])).toBe(false);
+  });
+
+  it('considers empty key list invalid', () => {
+    const wlm = new WeakListMap();
+    expect(() => wlm.set([], 'whatever')).toThrowErrorMatchingInlineSnapshot(
+      `"Keys must include at least one member"`,
+    );
+
+    expect(wlm.delete([])).toBe(false);
+
+    expect(wlm.get([])).toBeUndefined();
+
+    expect(wlm.has([])).toBe(false);
+  });
+});

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -615,20 +615,20 @@ describe('denormalize with global cache', () => {
       },
     };
     const result = ['1', '2'];
-    const first = denormalize(
+    const [first] = denormalize(
       result,
       [Tacos],
       entities,
       entityCache,
       resultCache,
-    )[0];
-    const second = denormalize(
+    );
+    const [second] = denormalize(
       result,
       [Tacos],
       entities,
       entityCache,
       resultCache,
-    )[0];
+    );
     expect(first).toBe(second);
 
     const third = denormalize(

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -631,13 +631,13 @@ describe('denormalize with global cache', () => {
     );
     expect(first).toBe(second);
 
-    const third = denormalize(
+    const [third] = denormalize(
       [...result],
       [Tacos],
       entities,
       entityCache,
       resultCache,
-    )[0];
+    );
     expect(first).not.toBe(third);
     expect(first).toEqual(third);
 

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -740,14 +740,14 @@ describe('denormalize with global cache', () => {
       const resultCache = new WeakListMap();
 
       const result = { data: '123' };
-      const first = denormalize(
+      const [first] = denormalize(
         result,
         { data: Article },
         entities,
         entityCache,
         resultCache,
-      )[0];
-      const second = denormalize(
+      );
+      const [second] = denormalize(
         result,
         { data: Article },
         {
@@ -764,7 +764,7 @@ describe('denormalize with global cache', () => {
         },
         entityCache,
         resultCache,
-      )[0];
+      );
       expect(first).not.toBe(second);
       expect(first.data.author).toBe(second.data.author);
       expect(first.data.comments[0]).toBe(second.data.comments[0]);

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -1,18 +1,29 @@
 import { isImmutable } from './schemas/ImmutableUtils';
 import { denormalize as arrayDenormalize } from './schemas/Array';
 import { denormalize as objectDenormalize } from './schemas/Object';
-import { Denormalize, DenormalizeNullable, Schema } from './types';
+import {
+  Denormalize,
+  DenormalizeNullable,
+  Schema,
+  DenormalizeCache,
+  UnvisitFunction,
+} from './types';
 import Entity, { isEntity } from './entities/Entity';
-import FlatEntity from './entities/FlatEntity';
 import { DELETED } from './special';
+import { EntityInterface } from './schema';
+import WeakListMap from './WeakListMap';
 
 const unvisitEntity = (
   id: any,
   schema: any,
-  unvisit: any,
-  getEntity: any,
-  cache: Record<string, any>,
-): [any, boolean, boolean] => {
+  unvisit: UnvisitFunction,
+  getEntity: (
+    entityOrId: Record<string, any> | string,
+    schema: typeof Entity,
+  ) => any,
+  localCache: Record<string, Record<string, any>>,
+  entityCache: DenormalizeCache['entities'],
+): [denormalized: any, found: boolean, deleted: boolean] => {
   const entity = getEntity(id, schema);
   if (entity === DELETED) {
     return [undefined, true, true];
@@ -21,72 +32,131 @@ const unvisitEntity = (
     return [entity, false, false];
   }
 
-  if (!cache[schema.key]) {
-    cache[schema.key] = {};
+  if (!localCache[schema.key]) {
+    localCache[schema.key] = {};
   }
 
   let found = true;
   let deleted = false;
-  if (!cache[schema.key][id]) {
-    // Ensure we don't mutate it non-immutable objects
-    const entityCopy =
-      isImmutable(entity) || entity instanceof FlatEntity
-        ? entity
-        : schema.fromJS(entity);
+  if (!localCache[schema.key][id]) {
+    // make unvisit that tracks entity list here
+    const globalKey: EntityInterface[] = [entity];
+    // every time we nest, we want to unwrap back to the top.
+    // this is due to only needed the next level of nested entities for lookup
+    const originalUnvisit = unvisit.original ? unvisit.original : unvisit;
+    const wrappedUnvisit = (input: any, schema: any) => {
+      const ret: [any, boolean, boolean] = originalUnvisit(input, schema);
+      // pass over undefined in key
+      if (ret[0] && schema && isEntity(schema)) globalKey.push(ret[0]);
+      return ret;
+    };
+    wrappedUnvisit.original = unvisit;
 
+    if (!entityCache[schema.key]) entityCache[schema.key] = {};
+    if (!entityCache[schema.key][id])
+      entityCache[schema.key][id] = new WeakListMap();
+    const globalCacheEntry = entityCache[schema.key][id];
+
+    const entityCopy = isImmutable(entity) ? entity : schema.fromJS(entity);
     // Need to set this first so that if it is referenced further within the
     // denormalization the reference will already exist.
-    cache[schema.key][id] = entityCopy;
-    [cache[schema.key][id], found, deleted] = schema.denormalize(
+    localCache[schema.key][id] = entityCopy;
+    [localCache[schema.key][id], found, deleted] = schema.denormalize(
       entityCopy,
-      unvisit,
+      wrappedUnvisit,
     );
+
+    if (!globalCacheEntry.has(globalKey)) {
+      globalCacheEntry.set(globalKey, localCache[schema.key][id]);
+    } else {
+      // localCache is only used before this point for recursive relationships
+      // since recursive relationships must all referentially change if *any* do, we either
+      // get the correct one here, or will never find the same version in the cache
+      localCache[schema.key][id] = globalCacheEntry.get(globalKey);
+    }
   }
 
-  return [cache[schema.key][id], found, deleted];
+  return [localCache[schema.key][id], found, deleted];
 };
 
-const getUnvisit = (entities: Record<string, any>) => {
-  const cache = {};
+const getUnvisit = (
+  entities: Record<string, Record<string, any>>,
+  entityCache: DenormalizeCache['entities'],
+  resultCache: WeakListMap<object, any>,
+) => {
+  const localCache = {};
   const getEntity = getEntities(entities);
 
-  return [
-    function unvisit(input: any, schema: any): [any, boolean, boolean] {
-      if (!schema) return [input, true, false];
+  function unvisit(
+    input: any,
+    schema: any,
+  ): [denormalized: any, found: boolean, deleted: boolean] {
+    if (!schema) return [input, true, false];
 
-      if (!schema.denormalize || typeof schema.denormalize !== 'function') {
-        if (typeof schema === 'function') {
-          if (input instanceof schema) return [input, true, false];
-          return [new schema(input), true, false];
-        } else if (typeof schema === 'object') {
-          const method = Array.isArray(schema)
-            ? arrayDenormalize
-            : objectDenormalize;
-          return method(schema, input, unvisit);
-        }
+    if (!schema.denormalize || typeof schema.denormalize !== 'function') {
+      if (typeof schema === 'function') {
+        if (input instanceof schema) return [input, true, false];
+        return [new schema(input), true, false];
+      } else if (typeof schema === 'object') {
+        const method = Array.isArray(schema)
+          ? arrayDenormalize
+          : objectDenormalize;
+        return method(schema, input, wrappedUnvisit);
       }
+    }
 
-      // null is considered intentional, thus always 'found' as true
-      if (input === null) {
-        return [input, true, false];
-      }
-
-      if (isEntity(schema)) {
-        // unvisitEntity just can't handle undefined
-        if (input === undefined) {
-          return [input, false, false];
-        }
-        return unvisitEntity(input, schema, unvisit, getEntity, cache);
-      }
-
-      if (typeof schema.denormalize === 'function') {
-        return schema.denormalize(input, unvisit);
-      }
-
+    // null is considered intentional, thus always 'found' as true
+    if (input === null) {
       return [input, true, false];
-    },
-    cache,
-  ] as const;
+    }
+
+    if (isEntity(schema)) {
+      // unvisitEntity just can't handle undefined
+      if (input === undefined) {
+        return [input, false, false];
+      }
+      return unvisitEntity(
+        input,
+        schema,
+        wrappedUnvisit,
+        getEntity,
+        localCache,
+        entityCache,
+      );
+    }
+
+    if (typeof schema.denormalize === 'function') {
+      return schema.denormalize(input, wrappedUnvisit);
+    }
+
+    return [input, true, false];
+  }
+
+  // make unvisit that tracks entity list here
+  const globalKey: EntityInterface[] = [];
+  const wrappedUnvisit = (input: any, schema: any) => {
+    const ret: [any, boolean, boolean] = unvisit(input, schema);
+    // pass over undefined in key
+    if (ret[0] && schema && isEntity(schema)) globalKey.push(ret[0]);
+    return ret;
+  };
+  wrappedUnvisit.original = unvisit;
+
+  return (
+    input: any,
+    schema: any,
+  ): [denormalized: any, found: boolean, deleted: boolean] => {
+    globalKey.push(input);
+    const ret = unvisit(input, schema);
+    if (typeof input !== 'object') return ret;
+
+    if (!resultCache.has(globalKey)) {
+      resultCache.set(globalKey, ret[0]);
+      return ret;
+    } else {
+      return [resultCache.get(globalKey), ret[1], ret[2]];
+    }
+  };
 };
 
 const getEntities = (entities: Record<string, any>) => {
@@ -112,36 +182,19 @@ export const denormalize = <S extends Schema>(
   input: any,
   schema: S,
   entities: any,
-):
-  | [Denormalize<S>, true, false, Record<string, Record<string, any>>]
-  | [
-      DenormalizeNullable<S>,
-      false,
-      boolean,
-      Record<string, Record<string, any>>,
-    ]
-  | [
-      DenormalizeNullable<S>,
-      boolean,
-      true,
-      Record<string, Record<string, any>>,
-    ] => {
-  /* istanbul ignore next */
-  if (process.env.NODE_ENV !== 'production' && schema === undefined)
-    throw new Error('schema needed');
-  if (typeof input !== 'undefined') {
-    const [unvisit, cache] = getUnvisit(entities);
-    return [...unvisit(input, schema), cache] as any;
-  }
-  return [undefined, false, false, {}] as any;
-};
-
-export const denormalizeSimple = <S extends Schema>(
-  input: any,
-  schema: S,
-  entities: any,
+  entityCache: DenormalizeCache['entities'] = {},
+  resultCache: WeakListMap<object, any> = new WeakListMap(),
 ):
   | [Denormalize<S>, true, false]
   | [DenormalizeNullable<S>, boolean, true]
-  | [DenormalizeNullable<S>, false, boolean] =>
-  denormalize(input, schema, entities).slice(0, 3) as any;
+  | [DenormalizeNullable<S>, false, boolean] => {
+  /* istanbul ignore next */
+  if (process.env.NODE_ENV !== 'production' && schema === undefined) {
+    throw new Error('schema needed');
+  }
+  if (typeof input === 'undefined') {
+    return [undefined, false, false] as [any, boolean, boolean];
+  }
+  const unvisit = getUnvisit(entities, entityCache, resultCache);
+  return unvisit(input, schema) as [any, boolean, boolean];
+};

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -43,7 +43,7 @@ const unvisitEntity = (
     const globalKey: EntityInterface[] = [entity];
     // every time we nest, we want to unwrap back to the top.
     // this is due to only needed the next level of nested entities for lookup
-    const originalUnvisit = unvisit.original ? unvisit.original : unvisit;
+    const originalUnvisit = unvisit.original || unvisit;
     const wrappedUnvisit = (input: any, schema: any) => {
       const ret: [any, boolean, boolean] = originalUnvisit(input, schema);
       // pass over undefined in key

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -23,7 +23,11 @@ const unvisitEntity = (
   ) => any,
   localCache: Record<string, Record<string, any>>,
   entityCache: DenormalizeCache['entities'],
-): [denormalized: any, found: boolean, deleted: boolean] => {
+): [
+  denormalized: EntityInterface | undefined,
+  found: boolean,
+  deleted: boolean,
+] => {
   const entity = getEntity(id, schema);
   if (entity === DELETED) {
     return [undefined, true, true];

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -36,7 +36,7 @@ const unvisitEntity = (
     return [entity, false, false];
   }
 
-  if (!localCache[schema.key]) {
+  if (localCache[schema.key] === undefined) {
     localCache[schema.key] = {};
   }
 

--- a/packages/normalizr/src/entities/FlatEntity.ts
+++ b/packages/normalizr/src/entities/FlatEntity.ts
@@ -3,6 +3,7 @@ import * as schema from '../schema';
 import { AbstractInstanceType } from '../types';
 import { SimpleRecord } from '..';
 
+/** @deprecated */
 export default abstract class FlatEntity extends Entity {
   static denormalize<T extends typeof SimpleRecord>(
     this: T,

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -460,13 +460,7 @@ describe(`${Entity.name} denormalization`, () => {
     const resultCache = new WeakListMap();
 
     const [first] = denormalize('1', Menu, entities, entityCache, resultCache);
-    const [second] = denormalize(
-      '1',
-      Menu,
-      entities,
-      entityCache,
-      resultCache,
-    );
+    const [second] = denormalize('1', Menu, entities, entityCache, resultCache);
     expect(first).toBe(second);
     expect(first?.food).toBe(second?.food);
   });

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -459,14 +459,14 @@ describe(`${Entity.name} denormalization`, () => {
     const entityCache = {};
     const resultCache = new WeakListMap();
 
-    const first = denormalize('1', Menu, entities, entityCache, resultCache)[0];
-    const second = denormalize(
+    const [first] = denormalize('1', Menu, entities, entityCache, resultCache);
+    const [second] = denormalize(
       '1',
       Menu,
       entities,
       entityCache,
       resultCache,
-    )[0];
+    );
     expect(first).toBe(second);
     expect(first?.food).toBe(second?.food);
   });

--- a/packages/normalizr/src/index.ts
+++ b/packages/normalizr/src/index.ts
@@ -1,5 +1,6 @@
 import { denormalize } from './denormalize';
 import { normalize } from './normalize';
+import WeakListMap from './WeakListMap';
 import * as schema from './schema';
 import Entity, { isEntity } from './entities/Entity';
 import SimpleRecord from './entities/SimpleRecord';
@@ -17,6 +18,15 @@ export type {
   Denormalize,
   DenormalizeNullable,
   DenormalizeReturnType,
+  DenormalizeCache,
 } from './types';
 
-export { denormalize, schema, normalize, SimpleRecord, Entity, isEntity };
+export {
+  denormalize,
+  schema,
+  normalize,
+  SimpleRecord,
+  Entity,
+  isEntity,
+  WeakListMap,
+};

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -9,6 +9,7 @@ import {
   DenormalizeNullableObject,
   NormalizeObject,
   NormalizedNullableObject,
+  UnvisitFunction,
 } from './types';
 import { default as Delete } from './schemas/Delete';
 
@@ -27,10 +28,7 @@ export type SchemaAttributeFunction<S extends Schema> = (
   key: string,
 ) => S;
 export type EntityMap<T = any> = Record<string, EntityInterface<T>>;
-export type UnvisitFunction = (
-  input: any,
-  schema: any,
-) => [any, boolean, boolean];
+export type { UnvisitFunction };
 export type UnionResult<Choices extends EntityMap> = {
   id: string;
   schema: keyof Choices;

--- a/packages/normalizr/src/schemas/__tests__/Array.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Array.test.js
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalizeSimple as denormalize } from '../../denormalize';
+import { denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import IDEntity from '../../entities/IDEntity';
 

--- a/packages/normalizr/src/schemas/__tests__/Delete.test.ts
+++ b/packages/normalizr/src/schemas/__tests__/Delete.test.ts
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalizeSimple as denormalize } from '../../denormalize';
+import { denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import IDEntity from '../../entities/IDEntity';
 import { DELETED } from '../../special';

--- a/packages/normalizr/src/schemas/__tests__/Object.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Object.test.js
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalizeSimple as denormalize } from '../../denormalize';
+import { denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import Entity from '../../entities/Entity';
 import IDEntity from '../../entities/IDEntity';

--- a/packages/normalizr/src/schemas/__tests__/Serializable.test.ts
+++ b/packages/normalizr/src/schemas/__tests__/Serializable.test.ts
@@ -1,5 +1,5 @@
 // eslint-env jest
-import { denormalizeSimple as denormalize } from '../../denormalize';
+import { denormalize } from '../../denormalize';
 import { normalize } from '../../';
 import IDEntity from '../../entities/IDEntity';
 

--- a/packages/normalizr/src/schemas/__tests__/Union.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Union.test.js
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalizeSimple as denormalize } from '../../denormalize';
+import { denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import IDEntity from '../../entities/IDEntity';
 

--- a/packages/normalizr/src/schemas/__tests__/Values.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Values.test.js
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalizeSimple as denormalize } from '../../denormalize';
+import { denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import IDEntity from '../../entities/IDEntity';
 import Entity from '../../entities/Entity';

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -1,4 +1,5 @@
 import type { default as schema, EntityInterface } from './schema';
+import WeakListMap from './WeakListMap';
 
 export type AbstractInstanceType<T> = T extends { prototype: infer U }
   ? U
@@ -34,6 +35,22 @@ interface NestedSchemaClass<T = any> {
 
 export interface RecordClass<T = any> extends NestedSchemaClass<T> {
   fromJS: (...args: any) => AbstractInstanceType<T>;
+}
+
+export interface UnvisitFunction {
+  (input: any, schema: any): [any, boolean, boolean];
+  original?: UnvisitFunction;
+}
+
+export interface DenormalizeCache {
+  entities: {
+    [key: string]: {
+      [pk: string]: WeakListMap<object, EntityInterface>;
+    };
+  };
+  results: {
+    [key: string]: WeakListMap<object, any>;
+  };
 }
 
 export type DenormalizeNullableNestedSchema<

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -39,7 +39,7 @@ export interface RecordClass<T = any> extends NestedSchemaClass<T> {
 
 export interface UnvisitFunction {
   (input: any, schema: any): [any, boolean, boolean];
-  original?: UnvisitFunction;
+  og?: UnvisitFunction;
 }
 
 export interface DenormalizeCache {

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -17,7 +17,7 @@
     "./rest_hooks_logo_and_text.svg"
   ],
   "engines": {
-    "node": ">=6.17.1"
+    "node": ">=0.12"
   },
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='rest-hooks' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -16,6 +16,9 @@
     "./typescript.svg",
     "./rest_hooks_logo_and_text.svg"
   ],
+  "engines": {
+    "node": ">=6.17.1"
+  },
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='rest-hooks' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
#### SSR

To make SSR easy, the cache itself should be easily serializable/deserializable. Currently the cache stores instances of Entities, which means any deserialization construct would have to deal with knowing how to load the Entity classes. While this may be achievable, this amount of complexity while maintaining codesplitting seems undesirable.

#### Entities nested in entities

Since the flat entities are stored as results of fromJS() (normalized form) - they simply contain ids to their nested counterparts. This makes the typing somewhat odd, but more importantly means that denormalizing them on the fly violates referential equality expectations of any entity. In the past this hasn’t been a huge deal because we mostly don’t use nested entities in retail.

#### Update Performance

Referential guarantees are currently provided by a useDenormalized() hook. Using useMemo() ensures concurrent mode compatibility - but it also means all caches are distinct. This has several downsides.
- requiring recomputation even for repeated denormalizations
- no referential equality guarantees cross-component (though this is unlikely to cause problems, and hasn’t yet, it would be safer to provide global guarantees.)
- This ties the pub/sub system to React itself, limiting our ability to use things like recoil or context selector systems that can improve performance needed for react native, and potentially web with faster updates

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Denormalize function will take in an extra optional argument that is a denormalization cache. This will be used to short-circuit computations if the pieces exist. This also means useDenormalized() will be simplified - possibly removed later.

The denormalized cache will be provided via context, but maintain referential equality due to its mutable nature.

#### Design constraints

Since concurrent mode compatibility is necessary, extra care is needed when creating a cache that is global. Unlike component-level caches which only need the last value, global caches need to be able to provide answers to questions from disjoint state trees.

Hence, we need a mechanism to look up based on the current state tree, which cache result might exist. Furthermore, once React has discarded a tree, and thus the state representation - these cache answers should be released to be collected from the GC.

This makes [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) an ideal supplementary data structure. However, there is an additional challenge to provide a list of keys that will be outlined below.

#### Cache data structure
```ts
const denormalizedCacheInstance = {
  entities: {
    [key]: {
      [pk]: WeakListMap([og, ...nestedEntities]
               -> { author: { id: 1, name: 'bob' }, content: 'hi' } (fromJS() result)
            )
    }
  }
  results: {
    [key]: WeakListMap([og, ...entities] -> EntireDenormalizedResponse)
  }
}
```
This structure mirrors the state cache itself, with the values of entities, and results being supplemented with a WeakMap.


#### WeakListMap

Mapping a list of referential objects to a value is not actually provided by the WeakMap interface. WeakMap can only map a singular object. To create the necessary data structure, we pull from lisps’ [`cons` data construct](http://www.lispworks.com/documentation/HyperSpec/Body/f_cons.htm). We can recursively apply a WeakMap to each entry in the list to achieve the appropriate mapping. This also resembles the [Trie](https://en.wikipedia.org/wiki/Trie) data structure.

This structure
```ts
WM([og, entitya, entityb] -> denorm(og, entitya, entityb))
```

Is represented by
```ts
WM(og -> WM(entitya -> WM(entityb -> denorm(og, entitya, entityb)))
```

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->

### Future work
- [ ] Store pojos, not Entity instances
