### PR TITLE
feat: useFetchDispatcher()

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export { useDenormalized } from './state/selectors';
 export {
   useCache,
   useFetcher,
+  useFetchDispatcher,
   useRetrieve,
   useResource,
   useSubscription,

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useFetchDispatcher.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useFetchDispatcher.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useFetchDispatcher should dispatch an action that fetches a create 1`] = `
+Object {
+  "meta": Object {
+    "createdAt": 1970-01-01T00:00:00.000Z,
+    "key": "POST http://test.com/article-cooler/",
+    "options": Object {
+      "fetchInit": Object {},
+      "getFetchInit": [Function],
+      "method": "POST",
+      "signal": undefined,
+      "url": [Function],
+      "useFetchInit": [Function],
+    },
+    "promise": Promise {},
+    "reject": [Function],
+    "resolve": [Function],
+    "schema": [Function],
+    "throttle": false,
+    "type": "mutate",
+  },
+  "payload": [Function],
+  "type": "rest-hooks/fetch",
+}
+`;

--- a/packages/core/src/react-integration/__tests__/useFetchDispatcher.tsx
+++ b/packages/core/src/react-integration/__tests__/useFetchDispatcher.tsx
@@ -1,0 +1,74 @@
+import { CoolerArticleResource } from '__tests__/new';
+import React, { Suspense } from 'react';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import nock from 'nock';
+
+import { DispatchContext } from '../context';
+import { useFetchDispatcher } from '../hooks';
+
+async function testDispatchFetch(
+  Component: React.FunctionComponent<any>,
+  payloads: any[],
+) {
+  const dispatch = jest.fn();
+  const tree = (
+    <DispatchContext.Provider value={dispatch}>
+      <Suspense fallback={null}>
+        <Component />
+      </Suspense>
+    </DispatchContext.Provider>
+  );
+  render(tree);
+  expect(dispatch).toHaveBeenCalledTimes(payloads.length);
+  let i = 0;
+  for (const call of dispatch.mock.calls) {
+    expect(call[0]).toMatchSnapshot();
+    const action = call[0];
+    const res = await action.payload();
+    expect(res).toEqual(payloads[i]);
+    i++;
+  }
+}
+
+let mynock: nock.Scope;
+
+beforeAll(() => {
+  nock(/.*/)
+    .persist()
+    .defaultReplyHeaders({
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json',
+    })
+    .options(/.*/)
+    .reply(200);
+  mynock = nock(/.*/).defaultReplyHeaders({
+    'Access-Control-Allow-Origin': '*',
+    'Content-Type': 'application/json',
+  });
+});
+
+afterAll(() => {
+  nock.cleanAll();
+});
+
+describe('useFetchDispatcher', () => {
+  const payload = { id: 1, content: 'hi' };
+
+  it('should dispatch an action that fetches a create', async () => {
+    mynock.post(`/article-cooler/`).reply(201, payload);
+
+    function DispatchTester() {
+      const dispatch = useFetchDispatcher();
+      dispatch(CoolerArticleResource.createShape(), {}, { content: 'hi' }).then(
+        v => {
+          v.author;
+          //@ts-expect-error
+          v.jasfdasdf;
+        },
+      );
+      return null;
+    }
+    await testDispatchFetch(DispatchTester, [payload]);
+  });
+});

--- a/packages/core/src/react-integration/hooks/index.ts
+++ b/packages/core/src/react-integration/hooks/index.ts
@@ -7,10 +7,12 @@ import useMeta from './useMeta';
 import useError from './useError';
 import useInvalidator from './useInvalidator';
 import useResetter from './useResetter';
+import useFetchDispatcher from './useFetchDispatcher';
 export { default as hasUsableData } from './hasUsableData';
 
 export {
   useFetcher,
+  useFetchDispatcher,
   useCache,
   useError,
   useRetrieve,

--- a/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
@@ -1,0 +1,58 @@
+import {
+  FetchShape,
+  SchemaFromShape,
+  ParamsFromShape,
+  BodyFromShape,
+  OptimisticUpdateParams,
+  ReturnFromShape,
+} from '@rest-hooks/core/endpoint';
+import { Schema } from '@rest-hooks/normalizr';
+import { DispatchContext } from '@rest-hooks/core/react-integration/context';
+import createFetch from '@rest-hooks/core/state/actions/createFetch';
+import { useContext, useCallback } from 'react';
+
+type IfExact<T, Cond, A, B> = Cond extends T ? (T extends Cond ? A : B) : B;
+
+/** Build an imperative dispatcher to issue network requests. */
+export default function useFetchDispatcher(
+  throttle = false,
+): <
+  Shape extends FetchShape<Schema, Readonly<object>, any>,
+  UpdateParams extends OptimisticUpdateParams<
+    SchemaFromShape<Shape>,
+    FetchShape<any, any, any>
+  >[]
+>(
+  fetchShape: Shape,
+  params: ParamsFromShape<Shape>,
+  body: BodyFromShape<Shape>,
+  updateParams?: UpdateParams | undefined,
+) => ReturnFromShape<typeof fetchShape> {
+  const dispatch = useContext(DispatchContext);
+
+  const fetchDispatcher = useCallback(
+    <Shape extends FetchShape<Schema, Readonly<object>, any>>(
+      fetchShape: Shape,
+      params: ParamsFromShape<Shape>,
+      body: BodyFromShape<Shape>,
+      updateParams?:
+        | OptimisticUpdateParams<
+            SchemaFromShape<Shape>,
+            FetchShape<any, any, any>
+          >[]
+        | undefined,
+    ) => {
+      const action = createFetch(fetchShape, {
+        params,
+        body,
+        throttle,
+        updateParams,
+      });
+      dispatch(action);
+      return action.meta.promise;
+    },
+    [dispatch, throttle],
+  );
+  // any is due to the ternary that we don't want to deal with in our implementation
+  return fetchDispatcher as any;
+}

--- a/packages/core/src/react-integration/hooks/useFetcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetcher.ts
@@ -7,9 +7,9 @@ import {
   ReturnFromShape,
 } from '@rest-hooks/core/endpoint';
 import { Schema } from '@rest-hooks/normalizr';
-import { DispatchContext } from '@rest-hooks/core/react-integration/context';
-import createFetch from '@rest-hooks/core/state/actions/createFetch';
-import { useContext, useRef, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
+
+import useFetchDispatcher from './useFetchDispatcher';
 
 type IfExact<T, Cond, A, B> = Cond extends T ? (T extends Cond ? A : B) : B;
 
@@ -43,7 +43,7 @@ export default function useFetcher<
     updateParams?: UpdateParams | undefined,
   ) => ReturnFromShape<typeof fetchShape>
 > {
-  const dispatch = useContext(DispatchContext);
+  const dispatchFetcher: any = useFetchDispatcher(throttle);
 
   // we just want the current values when we dispatch, so
   // box the shape in a ref to make react-hooks/exhaustive-deps happy
@@ -51,26 +51,8 @@ export default function useFetcher<
   shapeRef.current = fetchShape;
 
   const fetchDispatcher = useCallback(
-    (
-      params: ParamsFromShape<Shape>,
-      body: BodyFromShape<Shape>,
-      updateParams?:
-        | OptimisticUpdateParams<
-            SchemaFromShape<Shape>,
-            FetchShape<any, any, any>
-          >[]
-        | undefined,
-    ) => {
-      const action = createFetch(shapeRef.current, {
-        params,
-        body,
-        throttle,
-        updateParams,
-      });
-      dispatch(action);
-      return action.meta.promise;
-    },
-    [dispatch, throttle],
+    (...args: any) => dispatchFetcher(shapeRef.current, ...args),
+    [dispatchFetcher],
   );
   // any is due to the ternary that we don't want to deal with in our implementation
   return fetchDispatcher as any;

--- a/packages/core/src/react-integration/hooks/useRetrieve.ts
+++ b/packages/core/src/react-integration/hooks/useRetrieve.ts
@@ -1,7 +1,7 @@
 import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
 import { useMemo, useEffect, useContext } from 'react';
 
-import useFetcher from './useFetcher';
+import useFetchDispatcher from './useFetchDispatcher';
 import useExpiresAt from './useExpiresAt';
 import { DispatchContext } from '../context';
 
@@ -11,9 +11,7 @@ export default function useRetrieve<Shape extends ReadShape<any, any>>(
   params: ParamsFromShape<Shape> | null,
   triggerFetch = false,
 ) {
-  const fetch = useFetcher(fetchShape, true) as (
-    params: ParamsFromShape<Shape>,
-  ) => Promise<any>;
+  const dispatchFetch: any = useFetchDispatcher(true);
   const expiresAt = useExpiresAt(fetchShape, params);
 
   // Clears invalidIfStale loop blocking mechanism
@@ -29,12 +27,12 @@ export default function useRetrieve<Shape extends ReadShape<any, any>>(
   return useMemo(() => {
     // null params mean don't do anything
     if ((Date.now() <= expiresAt && !triggerFetch) || !params) return;
-    return fetch(params);
+    return dispatchFetch(fetchShape, params);
     // we need to check against serialized params, since params can change frequently
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     expiresAt,
-    fetch,
+    dispatchFetch,
     params && fetchShape.getFetchKey(params),
     triggerFetch,
   ]);


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Fetching unknown number of items? Never fear, this lets you use one hook with many different fetches!

We'll be using this for our fetch-as-render SSR + concurrent mode routing architecture.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### SSR Concept

This hook is always mounted.
```ts
import { dispatchFetch } from 'rest-hooks';
import { useLocale } from 'i18n';

function useRouteContext() {
  const locale = useLocale();
  const dispatchFetch = useFetchDispatcher();
  return { locale, dispatchFetch };
}
```

Each of these routes resolveData will be run on navigation even stack.
```ts
const routes = [
  {
    path: '/home',
    modulePath: 'Home',
    resolveData: ({ dispatchFetch, locale }) => {
      return dispatchFetch(
        AssetResource.listShape(),
        {
          locale: locale?.currency,
          localeCode: locale?.localeCode
        }
      );
    },
  },
  {
    path: '/careers/:position-id',
    modulePath: 'Careers',
    resolveData: (({ dispatchFetch, params: { positionId })) => {
      return dispatchFetch(PositionResource.detailShape(), { positionId });
    },
  },
]
```

This design allows for multiple, variable number and types of endpoints to fetch without any re-renders.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Should this be the new default, or simply supplement useFetcher()? It doesn't add verbosity really and is more powerful.
