### PR TITLE
fix: Only block suspense if errors are synthetic

### DIFF
--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
@@ -133,6 +133,35 @@ Attempted to initialize CoolerArticleResource with substantially different than 
   Value: {}]
 `;
 
+exports[`useResource() should throw error when response is bad (on mount) 1`] = `
+[Error: Entity from "GET http://test.com/article-cooler/4000" not found in cache.
+
+        This is likely due to a malformed response.
+        Try inspecting the network response or fetch() return value.
+
+        Schema: {
+  "name": "Scheme",
+  "schema": {
+    "data": {
+      "name": "CoolerArticleResource",
+      "schema": {
+        "author": {
+          "name": "UserResource",
+          "schema": {},
+          "key": "http://test.com/user/"
+        }
+      },
+      "key": "http://test.com/article-cooler/"
+    },
+    "optional": {
+      "name": "UserResource",
+      "schema": {},
+      "key": "http://test.com/user/"
+    }
+  }
+}]
+`;
+
 exports[`useResource() should throw error when response is expected Resource inside Record 1`] = `
 [Error: Entity from "GET http://test.com/article-cooler/400" not found in cache.
 

--- a/packages/core/src/react-integration/__tests__/useResource.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource.web.tsx
@@ -377,6 +377,65 @@ describe('useResource()', () => {
     expect((result.error as any).status).toBe(403);
   });
 
+  it('should suspend when already has a network error', async () => {
+    const error: any = { message: 'network error', status: 400 };
+    const FS = { ...CoolerArticleResource.detailShape() };
+    FS.options = { ...FS.options, errorExpiryLength: -100 };
+    const { result, waitForNextUpdate } = renderRestHook(
+      () => {
+        return useResource(CoolerArticleResource.detailShape(), {
+          title: '0',
+        });
+      },
+      {
+        results: [
+          {
+            request: FS,
+            params: { title: '0' },
+            result: error,
+            error: true,
+          },
+        ],
+      },
+    );
+    expect(result.current).toBe(null);
+    expect(result.error).toBe(null);
+    await waitForNextUpdate();
+    expect(result.error).toBeDefined();
+    expect((result.error as any).status).toBe(403);
+  });
+
+  it('should suspend when already has a network error (multiarg)', async () => {
+    const error: any = { message: 'network error', status: 400 };
+    const FS = { ...CoolerArticleResource.detailShape() };
+    FS.options = { ...FS.options, errorExpiryLength: -100 };
+    const { result, waitForNextUpdate } = renderRestHook(
+      () => {
+        return useResource([
+          CoolerArticleResource.detailShape(),
+          {
+            title: '0',
+          },
+        ]);
+      },
+      {
+        results: [
+          {
+            request: FS,
+            params: { title: '0' },
+            result: error,
+            error: true,
+          },
+        ],
+      },
+    );
+    expect(result.current).toBe(null);
+    expect(result.error).toBe(null);
+    await waitForNextUpdate();
+    expect(result.error).toBeDefined();
+    expect((result.error as any).status).toBe(403);
+  });
+
   it('should throw error when response is array when expecting entity', async () => {
     await testMalformedResponse([]);
   });

--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -5,7 +5,7 @@ import useMeta from './useMeta';
 
 type UseErrorReturn<P> = P extends null
   ? undefined
-  : Error & { status?: number };
+  : Error & { status?: number; synthetic?: boolean };
 
 /** Access a resource or error if failed to get it */
 export default function useError<
@@ -22,7 +22,7 @@ export default function useError<
     if (!meta) return;
     // this means the response is missing an expected entity
     if (!meta.error && !meta.invalidated) {
-      let error: Error & { status?: number };
+      let error: Error & { status?: number; synthetic?: boolean };
       /* istanbul ignore else */
       if (process.env.NODE_ENV !== 'production') {
         error = new Error(
@@ -41,6 +41,7 @@ export default function useError<
         );
       }
       error.status = 400;
+      error.synthetic = true;
       return error as any;
     } else {
       return meta.error as any;

--- a/packages/core/src/state/actions/createReceiveError.ts
+++ b/packages/core/src/state/actions/createReceiveError.ts
@@ -7,7 +7,7 @@ import {
 import { RECEIVE_TYPE } from '@rest-hooks/core/actionTypes';
 
 interface Options<S extends Schema = any>
-  extends Pick<FetchAction<any, S>['meta'], 'schema' | 'key' | 'type'> {
+  extends Pick<FetchAction<any, S>['meta'], 'schema' | 'key'> {
   errorExpiryLength: NonNullable<FetchOptions['errorExpiryLength']>;
 }
 

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -119,6 +119,7 @@ export default function reducer(
           ...state.meta,
           [action.meta.key]: {
             ...state.meta[action.meta.key],
+            error: undefined,
             expiresAt: 0,
             invalidated: true,
           },

--- a/packages/test/src/mockState.ts
+++ b/packages/test/src/mockState.ts
@@ -4,32 +4,54 @@ import {
   reducer,
   createReceive,
   initialState,
+  createReceiveError,
+  ReceiveAction,
 } from '@rest-hooks/core';
 
-export interface Fixture {
+export interface SuccessFixture {
   request: ReadShape<Schema, object>;
   params: object;
   result: object | string | number;
+  error?: false;
 }
+
+export interface ErrorFixture {
+  request: ReadShape<Schema, object>;
+  params: object;
+  result: Error;
+  error: true;
+}
+
+export type Fixture = SuccessFixture | ErrorFixture;
 
 export default function mockInitialState<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
   Body extends Readonly<object | string> | void = Readonly<object> | undefined
 >(results: Fixture[]) {
-  const mockState = results.reduce((acc, { request, params, result }) => {
-    const { schema, getFetchKey, options } = request;
-    const key = getFetchKey(params);
+  const mockState = results.reduce(
+    (acc, { request, params, result, error }) => {
+      const { schema, getFetchKey, options } = request;
+      const key = getFetchKey(params);
+      let action: ReceiveAction;
+      if (error === true) {
+        action = createReceiveError(result as Error, {
+          schema,
+          key,
+          errorExpiryLength: options?.errorExpiryLength ?? 10000000,
+        });
+      } else {
+        action = createReceive(result, {
+          schema,
+          key,
+          dataExpiryLength: options?.dataExpiryLength ?? 10000000,
+          type: 'read' as const,
+        });
+      }
 
-    return reducer(
-      acc,
-      createReceive(result, {
-        schema,
-        key,
-        dataExpiryLength: options?.dataExpiryLength ?? 10000000,
-        type: 'read' as const,
-      }),
-    );
-  }, initialState);
+      return reducer(acc, action);
+    },
+    initialState,
+  );
   return mockState;
 }


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #408 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In https://github.com/coinbase/rest-hooks/pull/360 we solve an infinite loop problem when the network response was invalid. This required detecting and throwing errors before suspending so it doesn't just keep suspending infinitely.

However, this means that any genuine network errors will now prevent suspending for new content.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
For the one case of response value, we'll mark the error as `synthetic`. Only `synthetic` errors throw before considering suspense.


Also, Fixtures (used in various testing pieces) now support faking errors, by sending error: true.