### PR TITLE
fix: Clear promises on cleanup

### DIFF
--- a/packages/core/src/state/NetworkManager.ts
+++ b/packages/core/src/state/NetworkManager.ts
@@ -81,6 +81,7 @@ export default class NetworkManager implements Manager {
   cleanup() {
     for (const k in this.rejectors) {
       this.rejectors[k](new CleanupError());
+      this.clear(k);
     }
   }
 
@@ -116,7 +117,11 @@ export default class NetworkManager implements Manager {
           return data;
         })
         .catch(error => {
-          if (error instanceof CleanupError) return;
+          if (error instanceof CleanupError) {
+            // if we don't receive, we need to clear
+            this.clear(key);
+            return;
+          }
           dispatch(
             createReceiveError(error, {
               ...action.meta,

--- a/packages/core/src/state/__tests__/networkManager.ts
+++ b/packages/core/src/state/__tests__/networkManager.ts
@@ -354,6 +354,9 @@ describe('NetworkManager', () => {
 
       expect(dispatch).not.toHaveBeenCalled();
 
+      // promises should be removed
+      expect(Object.keys((manager as any).fetched).length).toBe(0);
+
       manager.cleanup();
     });
   });


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In React Native, when the app is closed, the react tree unmounts. However, the JS runtime still persists. Because of this, module defined NetworkManagers will not be reset, but will have clean called.

Additionally, this race condition also exists with RESETs

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Clean should also prepare NetworkManager to be still used.