### PR TITLE
docs: More examples for Array and Values

### DIFF
--- a/docs/api/Array.md
+++ b/docs/api/Array.md
@@ -2,7 +2,8 @@
 title: Array
 ---
 
-Creates a schema to normalize an array of schemas. If the input value is an `Object` instead of an `Array`, the normalized result will be an `Array` of the `Object`'s values.
+Creates a schema to normalize an array of schemas. If the input value is an `Object` instead of an `Array`,
+the normalized result will be an `Array` of the `Object`'s values.
 
 _Note: The same behavior can be defined with shorthand syntax: `[ mySchema ]`_
 
@@ -12,11 +13,11 @@ _Note: The same behavior can be defined with shorthand syntax: `[ mySchema ]`_
   _ `value`: The input value of the entity.
   _ `parent`: The parent object of the input array. \* `key`: The key at which the input array appears on the parent object.
 
-#### Instance Methods
+## Instance Methods
 
 - `define(definition)`: When used, the `definition` passed in will be merged with the original definition passed to the `Array` constructor. This method tends to be useful for creating circular references in schema.
 
-#### Usage
+## Usage
 
 To describe a simple array of a singular entity type:
 
@@ -78,11 +79,47 @@ const normalizedData = normalize(data, userListSchema);
 }
 ```
 
+### Dynamic entity types
+
 If your input data is an array of more than one type of entity, it is necessary to define a schema mapping.
 
 _Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created._
 
-For example:
+#### string schemaAttribute
+
+```typescript
+const data = [
+  { id: 1, type: 'admin' },
+  { id: 2, type: 'user' },
+];
+
+class User extends Entity {
+  readonly type = 'user' as const;
+  pk() {
+    return this.id;
+  }
+}
+class Admin extends Entity {
+  readonly type = 'admin' as const;
+  pk() {
+    return this.id;
+  }
+}
+const myArray = new schema.Array(
+  {
+    admin: Admin,
+    user: User,
+  },
+  'type'
+);
+
+const normalizedData = normalize(data, myArray);
+```
+
+#### function schemaAttribute
+
+The return values should match a key in the `definition`. Here we'll show the same behavior as the 'string'
+case, except we'll append an 's'.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--TypeScript-->

--- a/docs/api/Values.md
+++ b/docs/api/Values.md
@@ -2,6 +2,9 @@
 title: Values
 ---
 
+Like [Array](./Array), `Values` are unbounded in size. The definition here describes the types of values to expect,
+with keys being any string.
+
 Describes a map whose values follow the given schema.
 
 - `definition`: **required** A singular schema that this array contains _or_ a mapping of schema to attribute values.
@@ -11,11 +14,11 @@ Describes a map whose values follow the given schema.
   - `parent`: The parent object of the input array.
   - `key`: The key at which the input array appears on the parent object.
 
-#### Instance Methods
+## Instance Methods
 
 - `define(definition)`: When used, the `definition` passed in will be merged with the original definition passed to the `Values` constructor. This method tends to be useful for creating circular references in schema.
 
-#### Usage
+## Usage
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--TypeScript-->
@@ -55,11 +58,45 @@ const normalizedData = normalize(data, valuesSchema);
 }
 ```
 
+### Dynamic entity types
+
 If your input data is an object that has values of more than one type of entity, but their schema is not easily defined by the key, you can use a mapping of schema, much like `schema.Union` and `schema.Array`.
 
 _Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created._
 
-For example:
+#### string schemaAttribute
+
+```typescript
+const data = {
+  '1': { id: 1, type: 'admin' },
+  '2': { id: 2, type: 'user' }
+};
+
+class User extends Entity {
+  readonly id: number = 0;
+  readonly type = 'user' as const;
+  pk() { return `${this.id}`; }
+}
+class Admin extends Entity {
+  readonly id: number = 0;
+  readonly type = 'admin' as const;
+  pk() { return `${this.id}`; }
+}
+const valuesSchema = new schema.Values(
+  {
+    admin: Admin,
+    user: User
+  },
+  'type'
+);
+
+const normalizedData = normalize(data, valuesSchema);
+```
+
+#### function schemaAttribute
+
+The return values should match a key in the `definition`. Here we'll show the same behavior as the 'string'
+case, except we'll append an 's'.
 
 <!--DOCUSAURUS_CODE_TABS-->
 <!--TypeScript-->


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The example shows overly complex function version, when in these simple cases a string usage is better.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Make docs easier to navigate by using standard header levels.
- Add string schemaAttribute example

