### PR TITLE
feat: Add RestEndpoint type

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -1,18 +1,11 @@
-import {
-  AbstractInstanceType,
-  MutateShape,
-  SimpleRecord,
-  schema,
-} from '@rest-hooks/core';
+import { AbstractInstanceType, SimpleRecord, schema } from '@rest-hooks/core';
 import {
   Endpoint,
   EndpointExtraOptions,
-  MutateEndpoint,
   FetchFunction,
-  ReadEndpoint,
   Index,
 } from '@rest-hooks/endpoint';
-import { Resource, SchemaList, SchemaDetail } from '@rest-hooks/rest';
+import { Resource, RestEndpoint } from '@rest-hooks/rest';
 import React, { createContext, useContext } from 'react';
 
 export class UserResource extends Resource {
@@ -76,7 +69,9 @@ export class ArticleResource extends Resource {
     });
   }
 
-  static partialUpdate<T extends typeof Resource>(this: T) {
+  static partialUpdate<T extends typeof Resource>(
+    this: T,
+  ): RestEndpoint<FetchFunction, T, true> {
     return super.partialUpdate().extend({
       optimisticUpdate: (params: any, body: any) => ({
         id: params.id,
@@ -227,7 +222,13 @@ function makePaginatedRecord<T>(entity: T) {
 export class PaginatedArticleResource extends OtherArticleResource {
   static urlRoot = 'http://test.com/article-paginated/';
 
-  static list<T extends typeof Resource>(this: T) {
+  static list<T extends typeof Resource>(
+    this: T,
+  ): RestEndpoint<
+    FetchFunction,
+    { results: T[]; prevPage: string; nextPage: string },
+    undefined
+  > {
     return super.list().extend({
       schema: { results: [this], prevPage: '', nextPage: '' },
     });

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -5,7 +5,7 @@ import {
   FetchFunction,
   Index,
 } from '@rest-hooks/endpoint';
-import { Resource, RestEndpoint } from '@rest-hooks/rest';
+import { Resource, SimpleResource, RestEndpoint } from '@rest-hooks/rest';
 import React, { createContext, useContext } from 'react';
 
 export class UserResource extends Resource {
@@ -69,9 +69,13 @@ export class ArticleResource extends Resource {
     });
   }
 
-  static partialUpdate<T extends typeof Resource>(
+  static partialUpdate<T extends typeof SimpleResource>(
     this: T,
-  ): RestEndpoint<FetchFunction, T, true> {
+  ): RestEndpoint<
+    FetchFunction<object, RequestInit['body'] | Record<string, any>>,
+    T,
+    true
+  > {
     return super.partialUpdate().extend({
       optimisticUpdate: (params: any, body: any) => ({
         id: params.id,

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -5,7 +5,12 @@ import {
   FetchFunction,
   Index,
 } from '@rest-hooks/endpoint';
-import { Resource, SimpleResource, RestEndpoint } from '@rest-hooks/rest';
+import {
+  Resource,
+  SimpleResource,
+  RestEndpoint,
+  RestFetch,
+} from '@rest-hooks/rest';
 import React, { createContext, useContext } from 'react';
 
 export class UserResource extends Resource {
@@ -71,11 +76,7 @@ export class ArticleResource extends Resource {
 
   static partialUpdate<T extends typeof SimpleResource>(
     this: T,
-  ): RestEndpoint<
-    FetchFunction<object, RequestInit['body'] | Record<string, any>>,
-    T,
-    true
-  > {
+  ): RestEndpoint<RestFetch, T, true> {
     return super.partialUpdate().extend({
       optimisticUpdate: (params: any, body: any) => ({
         id: params.id,

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -128,7 +128,7 @@ for easy customization.
 
 ```typescript
 export interface RestEndpoint<
-  F extends FetchFunction = FetchFunction,
+  F extends FetchFunction = RestFetch,
   S extends Schema | undefined = Schema | undefined,
   M extends true | undefined = true | undefined
 > extends EndpointInstance<F, S, M> {
@@ -142,4 +142,17 @@ export interface RestEndpoint<
   method: string;
   signal: AbortSignal | undefined;
 }
+```
+
+### RestFetch
+
+Fetch function for Resources. Unlike [FetchFunction](#fetchfunction), these require the params variable
+as [Resource](./resource) expects it
+
+```typescript
+export type RestFetch<
+  P = object,
+  B = RequestInit['body'] | Record<string, any>,
+  R = any
+> = (params: P, body?: B) => Promise<R>;
 ```

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,0 +1,145 @@
+---
+title: Types
+---
+
+## @rest-hooks/core
+
+### Manager
+
+```typescript
+interface Manager {
+  getMiddleware(): Middleware;
+  cleanup(): void;
+  init?: (state: State<any>) => void;
+}
+```
+
+[More](./Manager)
+
+## @rest-hooks/endpoint
+
+### EndpointInterface
+
+The bare requirements for an endpoint-type. This is useful
+for typing function parameters (like hooks), as it is accepting of any correct
+implementation.
+
+```typescript
+export interface EndpointInterface<
+  F extends FetchFunction = FetchFunction,
+  S extends Schema | undefined = Schema | undefined,
+  M extends true | undefined = true | undefined
+> extends EndpointExtraOptions {
+  (...args: Parameters<F>): InferReturn<F, S>;
+  key(...args: Parameters<F>): string;
+  readonly sideEffect?: M;
+  readonly schema?: S;
+}
+```
+
+e.g.,
+
+```typescript
+function useCache<E extends EndpointInterface>(
+  endpoint: E,
+  params: Parameters<E>[0],
+);
+```
+
+### EndpointInstance
+
+An instance of the [Endpoint](./Endpoint) class.
+
+```typescript
+interface EndpointInstance<
+  F extends FetchFunction = FetchFunction,
+  S extends Schema | undefined = Schema | undefined,
+  M extends true | undefined = true | undefined
+>;
+```
+
+This is useful to specify types explicitly, instead of implicitly in construction.
+Being explicit reduces TypeScript computational overhead when inferring types, which
+is sometimes necessary to avoid tripping the recursion depth limit. This is one of the reasons why
+there is an [eslint rule to explicitly specify return types of methods/functions](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md).
+
+```typescript
+const userDetail: EndpointInstance<FetchFunction<{
+  id: string;
+}>> = new Endpoint(({ id }) => fetch(`/users/${id}`));
+
+class User extends Entity {
+  static detail<T extends User>(
+    this: T,
+  ): EndpointInstance<
+    FetchFunction<{
+      id: string;
+    }>,
+    T,
+    undefined
+  > {
+    return new Endpoint(({ id }) => fetch(`/users/${id}`), { schema: this });
+  }
+
+  /** Expected Body payload is a subset of the properties of User
+  *  Expected Response is all the properties of User
+  */
+  static update<T extends User>(
+    this: T,
+  ): EndpointInstance<
+    FetchFunction<
+      {
+        id: string;
+      },
+      Partial<T>,
+      // return value is plain object - this is an easy way to extract public members from this class' interface
+      Omit<T, never>
+    >,
+    T,
+    true
+  > {
+    return new Endpoint(({ id }) => fetch(`/users/${id}`, { method: 'PUT' }), {
+      schema: this,
+    });
+  }
+}
+```
+
+### FetchFunction
+
+Represents a function that does actual fetch. Convenient type to specify
+only part of the function's type.
+
+```typescript
+export type FetchFunction<P = any, B = any, R = any> = (
+  params?: P,
+  body?: B,
+) => Promise<R>;
+```
+
+Providing a function type that returns a Promise also works.
+
+## @rest-hooks/rest
+
+### RestEndpoint
+
+Is a specialized form of Endpoint that includes additional extension points
+for easy customization.
+
+```typescript
+export interface RestEndpoint<
+  F extends FetchFunction = FetchFunction,
+  S extends Schema | undefined = Schema | undefined,
+  M extends true | undefined = true | undefined
+> extends EndpointInstance<F, S, M> {
+  url: (urlParams: Readonly<Record<string, any>>) => string;
+  fetchInit: RequestInit;
+  useFetchInit: (this: any) => any;
+  getFetchInit: (
+    this: any,
+    body?: RequestInit['body'] | Record<string, any>,
+  ) => any;
+  method: string;
+  signal: AbortSignal | undefined;
+}
+```

--- a/docs/guides/rest-types.md
+++ b/docs/guides/rest-types.md
@@ -20,25 +20,25 @@ Here's an example of each endpoint's return typed followed by usage. For
 a full explanation, continue reading below.
 
 ```typescript
-import { Resource, RestEndpoint, FetchFunction } from '@rest-hooks/rest';
+import { Resource, RestEndpoint, RestFetch } from '@rest-hooks/rest';
 
 class MyResource extends Resource {
   static list<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<FetchFunction, T[], undefined> {
+  ): RestEndpoint<RestFetch, T[], undefined> {
     return super.list();
   }
 
   static create<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<FetchFunction, T, true> {
+  ): RestEndpoint<RestFetch, T, true> {
     return super.create();
   }
 
   static filteredAndPaginatedList<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-    FetchFunction<{ filterA: boolean; sortby: string }>,
+    RestFetch<{ filterA: boolean; sortby: string }>,
     { results: T[]; nextPage: string },
     undefined
   > {
@@ -284,7 +284,7 @@ import { RestEndpoint, Resource } from '@rest-hooks/rest';
 class User extends Resource {
   static detail<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<FetchFunction, { data: T }, undefined> {
+  ): RestEndpoint<RestFetch, { data: T }, undefined> {
     return super.detail().extend({ schema: { data: this } });
   }
 }
@@ -300,7 +300,7 @@ import { RestEndpoint, Resource } from '@rest-hooks/rest';
 class User extends Resource {
   static detail<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<FetchFunction<{ id: string }>, T, undefined> {
+  ): RestEndpoint<RestFetch<{ id: string }>, T, undefined> {
     return super.detail();
   }
 }

--- a/docs/guides/rest-types.md
+++ b/docs/guides/rest-types.md
@@ -1,0 +1,319 @@
+---
+title: Typing REST Endpoints
+---
+
+In REST design, many operations can be performed on a given type of data.
+
+Attaching these operations to the type via static methods allows
+
+- A singular import for both class usage, typing, and endpoints
+- Reducing code duplication by extracting common patterns into base classes
+
+[Resource](../api/Resource) provides one such pattern, which makes getting started
+fast. However, even if the pattern generally matches your API design, there
+are often special operations or one-off cases where additional endpoints must
+be extended or added.
+
+## TL;DR
+
+Here's an example of each endpoint's return typed followed by usage. For
+a full explanation, continue reading below.
+
+```typescript
+import { Resource, RestEndpoint, FetchFunction } from '@rest-hooks/rest';
+
+class MyResource extends Resource {
+  static list<T extends typeof Resource>(
+    this: T,
+  ): RestEndpoint<FetchFunction, T[], undefined> {
+    return super.list();
+  }
+
+  static create<T extends typeof Resource>(
+    this: T,
+  ): RestEndpoint<FetchFunction, T, true> {
+    return super.create();
+  }
+
+  static filteredAndPaginatedList<T extends typeof Resource>(
+    this: T,
+  ): RestEndpoint<
+    FetchFunction<{ filterA: boolean; sortby: string }>,
+    { results: T[]; nextPage: string },
+    undefined
+  > {
+    return super.list();
+  }
+}
+```
+
+```typescript
+import MyResource from 'resources/MyResource';
+import { useResource } from 'rest-hooks';
+
+const items = useResource(MyResource.list(), {});
+const createMy = useFetcher(MyResource.create());
+const { results, nextPage } = useResource(
+  MyResource.filteredAndPaginatedList(),
+  { filterA: true, sortby: 'first' },
+);
+```
+
+## Problem
+
+To reduce code bloat, make development faster, reducing maintenance costs and reduce errors it is recommended
+to share common patterns in parent classes, and only specify what is specific to a given
+resource in that resource's class. Oftentimes this looks like simply its expected members
+and a pk() definition (though if you use a common field for pk() - you can also pull that up).
+
+[Resource](../api/Resource) is an example attempt that is useful for many common REST patterns that
+can be further extended and easily customized like so:
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Bloat -->
+
+```typescript
+class User {
+  readonly id: string = '';
+  readonly username: string = '';
+  readonly createdAt: Date = new Date();
+
+  pk() {
+    return this.id;
+  }
+
+  static schema = {
+    createdAt: Date,
+  };
+
+  static detail() {
+    return new Endpoint(
+      ({ id }: { id: string }) => fetch(`/user/${id}`).then(res => res.json()),
+      { schema: User },
+    );
+  }
+
+  static list() {
+    return new Endpoint(() => fetch(`/user`).then(res => res.json()), {
+      schema: [User],
+    });
+  }
+
+  // ...even more endpoints for this Resource defined below
+}
+
+class Post extends Resource {
+  readonly id: string = '';
+  readonly title: string = '';
+  readonly content: string = '';
+
+  pk() {
+    return this.id;
+  }
+
+  static detail() {
+    return new Endpoint(
+      ({ id }: { id: string }) => fetch(`/post/${id}`).then(res => res.json()),
+      { schema: Post },
+    );
+  }
+
+  static list() {
+    return new Endpoint(() => fetch(`/post`).then(res => res.json()), {
+      schema: [Post],
+    });
+  }
+
+  // ...even more endpoints for this Resource defined below
+}
+```
+
+<!--Gets reduced to-->
+
+```typescript
+class User extends Resource {
+  readonly id: string = '';
+  readonly username: string = '';
+  readonly createdAt: Date = new Date();
+
+  pk() {
+    return this.id;
+  }
+
+  static schema = {
+    createdAt: Date,
+  };
+
+  static urlRoot = '/user';
+}
+
+class Post extends Resource {
+  readonly id: string = '';
+  readonly title: string = '';
+  readonly content: string = '';
+
+  pk() {
+    return this.id;
+  }
+
+  static urlRoot = '/post';
+}
+```
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+Even in this overly simplistic case we're more than halving the lines of code.
+Once the complexities of the real world kick in, this improvement expands.
+
+However, we now have a problem. Before we were explictily specifying the [Endpoint](../api/Endpoint)s'
+expected shape via the [schema](../api/quickstart). Now it if we use the common methods like .detail()
+we lose our typing information.
+
+## Generics, static methods, and this
+
+To explain the solution - generic `this` - let's simplify the example.
+
+Here we'll define a static method that returns the type of the class - `Base`.
+
+```typescript
+class Base {
+  static factory(): Base {
+    const obj = new this();
+    obj.extra = 5;
+    return obj;
+  }
+}
+```
+
+If we inspect the runtime value, it says the type is `Base`.
+
+```typescript
+// type is Base
+const obj = Base.factory();
+// print Base
+console.log(typeof obj);
+```
+
+Now we extend that class
+
+```typescript
+class Child extends Base {
+  another = 5;
+}
+```
+
+And call the same static method
+
+```typescript
+// type is Base
+const obj = Child.factory();
+// print Child
+console.log(typeof obj);
+```
+
+TypeScript will implicitly type `obj` as `Base`, but at runtime, we can see it's really `Child`
+
+## Solution: generics
+
+Generics in TypeScript can be attached to parameters in any function and automatically inferred.
+Since `this` is implicit, TypeScript allows you to explictly bind `this` if you want a method's
+return type based on it:
+
+```typescript
+class Base {
+  static factory<T extends Base>(this: T): T {
+    const obj = new this();
+    obj.extra = 5;
+    return obj;
+  }
+}
+```
+
+```typescript
+// type is Child
+const obj = Child.factory();
+// print Child
+console.log(typeof obj);
+```
+
+Now when we call the method defined in `Base` on any descendant, it is typed appropriately!
+
+## As Resource
+
+Applying this to our original example, we get something along the lines of:
+
+```typescript
+class Resource {
+  static detail<T extends typeof Resource>(this: T) {
+    return new Endpoint(
+      props => fetch(this.url(props)).then(res => res.json()),
+      { schema: this },
+    );
+  }
+
+  static list<T extends typeof Resource>(this: T) {
+    return new Endpoint(
+      props => fetch(this.listUrl(props)).then(res => res.json()),
+      { schema: [this] },
+    );
+  }
+}
+```
+
+## Extending and adding endpoints
+
+This means any time we define our own [custom endpoints](./extending-endpoints) we should
+be sure to include generics so the types are alwalys correct.
+
+For instance, we can change the expected response of the API to have the resource
+inside the 'data' attribute:
+
+```typescript
+class User extends Resource {
+  static detail<T extends typeof Resource>(this: T) {
+    return super.detail().extend({ schema: { data: this } });
+  }
+}
+```
+
+If we were to explicitly type thing, we could use `RestEndpoint`
+
+```typescript
+import { RestEndpoint, Resource } from '@rest-hooks/rest';
+
+class User extends Resource {
+  static detail<T extends typeof Resource>(
+    this: T,
+  ): RestEndpoint<FetchFunction, { data: T }, undefined> {
+    return super.detail().extend({ schema: { data: this } });
+  }
+}
+
+const { data: user } = useResource(User.detail(), { id: '5' });
+```
+
+Or if we simply want to be specific about what arguments are allowed:
+
+```typescript
+import { RestEndpoint, Resource } from '@rest-hooks/rest';
+
+class User extends Resource {
+  static detail<T extends typeof Resource>(
+    this: T,
+  ): RestEndpoint<FetchFunction<{ id: string }>, T, undefined> {
+    return super.detail();
+  }
+}
+
+const { data: user } = useResource(User.detail(), { id: '5' });
+```
+
+## Typing rules of thumb
+
+Generally you want to type return values as specific as possible, but accept
+function arguments as loose as possible (like in hooks). To follow this principal:
+
+- [RestEndpoint](../api/types#restendpoint) for endpoints in [Resource](../api/Resource)s
+- [EndpointInstance](../api/types#endpointinstance) for anything that uses the [Endpoint](../api/Endpoint) class.
+- [EndpointInterface](../api/types#endpointinterface) for any hook arguments
+

--- a/packages/endpoint/src/types.ts
+++ b/packages/endpoint/src/types.ts
@@ -21,7 +21,7 @@ export interface EndpointExtraOptions {
   readonly extra?: any;
 }
 export type FetchFunction<P = any, B = any, R = any> = (
-  params: P,
+  params?: P,
   body?: B,
 ) => Promise<R>;
 

--- a/packages/endpoint/src/types.ts
+++ b/packages/endpoint/src/types.ts
@@ -21,7 +21,7 @@ export interface EndpointExtraOptions {
   readonly extra?: any;
 }
 export type FetchFunction<P = any, B = any, R = any> = (
-  params?: P,
+  params: P,
   body?: B,
 ) => Promise<R>;
 

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -3,4 +3,6 @@ import SimpleResource from './SimpleResource';
 
 export { Resource, SimpleResource };
 
+export type { RestEndpoint } from './types';
+
 export * from '@rest-hooks/endpoint';

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -3,6 +3,6 @@ import SimpleResource from './SimpleResource';
 
 export { Resource, SimpleResource };
 
-export type { RestEndpoint } from './types';
+export type { RestEndpoint, RestFetch } from './types';
 
 export * from '@rest-hooks/endpoint';

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -1,0 +1,22 @@
+import { Schema } from '@rest-hooks/normalizr';
+import { EndpointInstance, FetchFunction } from '@rest-hooks/endpoint';
+
+/** Endpoint from a Resource
+ *
+ * Includes additional properties provided by Resource.endpoint()
+ */
+export interface RestEndpoint<
+  F extends FetchFunction = FetchFunction,
+  S extends Schema | undefined = Schema | undefined,
+  M extends true | undefined = true | undefined
+> extends EndpointInstance<F, S, M> {
+  url: (urlParams: Readonly<Record<string, any>>) => string;
+  fetchInit: RequestInit;
+  useFetchInit: (this: any) => any;
+  getFetchInit: (
+    this: any,
+    body?: RequestInit['body'] | Record<string, any>,
+  ) => any;
+  method: string;
+  signal: AbortSignal | undefined;
+}

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -1,12 +1,18 @@
 import { Schema } from '@rest-hooks/normalizr';
 import { EndpointInstance, FetchFunction } from '@rest-hooks/endpoint';
 
+export type RestFetch<
+  P = object,
+  B = RequestInit['body'] | Record<string, any>,
+  R = any
+> = (params: P, body?: B) => Promise<R>;
+
 /** Endpoint from a Resource
  *
  * Includes additional properties provided by Resource.endpoint()
  */
 export interface RestEndpoint<
-  F extends FetchFunction = FetchFunction,
+  F extends FetchFunction = RestFetch,
   S extends Schema | undefined = Schema | undefined,
   M extends true | undefined = true | undefined
 > extends EndpointInstance<F, S, M> {

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -79,6 +79,9 @@
         "title": "SubscriptionManager<S extends SubscriptionConstructable> implements Manager",
         "sidebar_label": "SubscriptionManager"
       },
+      "api/types": {
+        "title": "Types"
+      },
       "api/Union": {
         "title": "Union"
       },
@@ -210,6 +213,9 @@
       "guides/resource-types": {
         "title": "Defining your Resource types",
         "sidebar_label": "Resource types"
+      },
+      "guides/rest-types": {
+        "title": "Typing REST Endpoints"
       },
       "guides/rpc": {
         "title": "Capturing Mutation Side-Effects"
@@ -842,6 +848,9 @@
       },
       "version-4.5/guides/version-4.5-optimistic-updates": {
         "title": "Optimistic Updates"
+      },
+      "version-4.5/guides/version-4.5-rest-types": {
+        "title": "Typing REST Endpoints"
       },
       "version-4.5/guides/version-4.5-storybook": {
         "title": "Mocking data for Storybook"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -15,6 +15,7 @@
         "ids": [
           "guides/url",
           "guides/extending-endpoints",
+          "guides/rest-types",
           "guides/pagination",
           "guides/auth",
           "guides/network-transform",
@@ -78,6 +79,7 @@
     ],
     "API": [
       "api/README",
+      "api/types",
       {
         "type": "subcategory",
         "label": "Core Hooks",

--- a/website/versioned_docs/version-4.5/guides/rest-types.md
+++ b/website/versioned_docs/version-4.5/guides/rest-types.md
@@ -1,0 +1,60 @@
+---
+title: Typing REST Endpoints
+id: version-4.5-rest-types
+original_id: rest-types
+---
+
+In REST design, many operations can be performed on a given type of data.
+
+Attaching these operations to the type via static methods allows
+
+- A singular import for both class usage, typing, and endpoints
+- Reducing code duplication by extracting common patterns into base classes
+
+[Resource](../api/Resource) provides one such pattern, which makes getting started
+fast. However, even if the pattern generally matches your API design, there
+are often special operations or one-off cases where additional endpoints must
+be extended or added.
+
+## TL;DR
+
+Here's an example of each endpoint's return typed followed by usage. For
+a full explanation, continue reading below.
+
+```typescript
+import { Resource, ReadShape, MutateShape, AbstractInstanceType } from 'rest-hooks';
+
+class MyResource extends Resource {
+  static list<T extends typeof Resource>(
+    this: T,
+  ): ReadShape<AbstractInstanceType<T>[]> {
+    return super.list();
+  }
+
+  static create<T extends typeof Resource>(
+    this: T,
+  ): MutateShape<AbstractInstanceType<T>> {
+    return super.create();
+  }
+
+  static filteredAndPaginatedList<T extends typeof Resource>(
+    this: T,
+  ): MutateShape<
+    { results: AbstractInstanceType<T>[]; nextPage: string }
+  > {
+    return super.list();
+  }
+}
+```
+
+```typescript
+import MyResource from 'resources/MyResource';
+import { useResource } from 'rest-hooks';
+
+const items = useResource(MyResource.list(), {});
+const createMy = useFetcher(MyResource.create());
+const { results, nextPage } = useResource(
+  MyResource.filteredAndPaginatedList(),
+  { filterA: true, sortby: 'first' },
+);
+```

--- a/website/versioned_sidebars/version-4.5-sidebars.json
+++ b/website/versioned_sidebars/version-4.5-sidebars.json
@@ -15,6 +15,7 @@
         "ids": [
           "version-4.5-guides/url",
           "version-4.5-guides/endpoints",
+          "version-4.5-guides/rest-types",
           "version-4.5-guides/pagination",
           "version-4.5-guides/auth",
           "version-4.5-guides/network-transform",


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #423 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Explicitly typing return values is encouraged by common eslint rules and helps TypeScript performance as well as reducing recursion limit hit rate. Let's make it both as easy as possible to do, and clearly explain how to do it.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- We are adding a new convenience type `RestEndpoint` as well as `RestFetch` to make explicit endpoint return types for Resource easier
- Adding thorough documentation about typing Resource endpoints

