### PR TITLE
feat: Track and use entity resolution time

### DIFF
--- a/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
@@ -13,6 +13,13 @@ Object {
       },
     },
   },
+  "entityMeta": Object {
+    "http://test.com/article-cooler/": Object {
+      "5": Object {
+        "date": 50,
+      },
+    },
+  },
   "indexes": Object {},
   "meta": Object {
     "http://test.com/article-cooler/5": Object {

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -3,6 +3,7 @@
 exports[`reducer should set error in meta for "receive" 1`] = `
 Object {
   "entities": Object {},
+  "entityMeta": Object {},
   "indexes": Object {},
   "meta": Object {
     "http://test.com/article/20": Object {
@@ -26,6 +27,13 @@ Object {
         "id": 20,
         "tags": Array [],
         "title": "hi",
+      },
+    },
+  },
+  "entityMeta": Object {
+    "http://test.com/article/": Object {
+      "20": Object {
+        "date": 5000000000,
       },
     },
   },

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -73,8 +73,70 @@ describe('reducer', () => {
 
       expect(nextEntity.content).toBe(prevEntity.content);
       expect(nextEntity.content).not.toBe(undefined);
+
+      expect(
+        nextState.entityMeta[ArticleResource.key][
+          `${ArticleResource.pk(action.payload)}`
+        ],
+      ).toBeDefined();
+      expect(
+        nextState.entityMeta[ArticleResource.key][
+          `${ArticleResource.pk(action.payload)}`
+        ].date,
+      ).toBe(action.meta.date);
+    });
+
+    it('should have the latest entity date', () => {
+      const localAction = {
+        ...partialResultAction,
+        meta: {
+          ...partialResultAction.meta,
+          date: partialResultAction.meta.date * 2,
+        },
+      };
+      const getMeta = (state: any): { date: number } =>
+        state.entityMeta[ArticleResource.key][
+          `${ArticleResource.pk(action.payload)}`
+        ];
+      const prevMeta = getMeta(newState);
+      expect(prevMeta).toBeDefined();
+      const nextState = reducer(newState, localAction);
+      const nextMeta = getMeta(nextState);
+
+      expect(nextMeta).toBeDefined();
+      expect(nextMeta.date).toBe(localAction.meta.date);
+    });
+
+    it('should use existing entity with older date', () => {
+      const localAction = {
+        ...partialResultAction,
+        meta: {
+          ...partialResultAction.meta,
+          date: partialResultAction.meta.date / 2,
+        },
+      };
+      const getMeta = (state: any): { date: number } =>
+        state.entityMeta[ArticleResource.key][
+          `${ArticleResource.pk(action.payload)}`
+        ];
+      const getEntity = (state: any): ArticleResource =>
+        state.entities[ArticleResource.key][
+          `${ArticleResource.pk(action.payload)}`
+        ];
+      const prevEntity = getEntity(newState);
+      const prevMeta = getMeta(newState);
+      expect(prevMeta).toBeDefined();
+      const nextState = reducer(newState, localAction);
+      const nextMeta = getMeta(nextState);
+      const nextEntity = getEntity(nextState);
+
+      expect(prevEntity).toEqual(nextEntity);
+
+      expect(nextMeta).toBeDefined();
+      expect(nextMeta.date).toBe(action.meta.date);
     });
   });
+
   it('mutate should never change results', () => {
     const id = 20;
     const payload = { id, title: 'hi', content: 'this is the content' };

--- a/packages/core/src/state/merge/mergeDeepCopy.ts
+++ b/packages/core/src/state/merge/mergeDeepCopy.ts
@@ -5,7 +5,12 @@ import isMergeableObject from './isMergeable';
 /**
  * Deep merge two objects or arrays. Uses static merge function if exists.
  */
-export default function mergeDeepCopy<T1, T2>(target: T1, source: T2): T1 & T2 {
+export default function mergeDeepCopy<T1, T2>(
+  target: T1,
+  source: T2,
+  targetMeta?: any,
+  sourceDate?: any,
+): T1 & T2 {
   const sourceIsArray = Array.isArray(source);
   const targetIsArray = Array.isArray(target);
   const sourceAndTargetTypesMatch = sourceIsArray === targetIsArray;
@@ -13,7 +18,12 @@ export default function mergeDeepCopy<T1, T2>(target: T1, source: T2): T1 & T2 {
 
   if (target && Static && isMergeable(Static)) {
     if (isMergeable((target as any).constructor)) {
-      return Static.merge(target, source) as any;
+      // second argument takes priority over first
+      // if either of these is undefined, it resolves to 'false' which
+      // means we fallback to 'newer' (source) takes priority
+      return (targetMeta?.date > sourceDate
+        ? Static.merge(source, target)
+        : Static.merge(target, source)) as any;
     } else {
       return source as any;
     }
@@ -27,6 +37,8 @@ export default function mergeDeepCopy<T1, T2>(target: T1, source: T2): T1 & T2 {
         destination[key] = mergeDeepCopy(
           destination[key],
           (source as any)[key],
+          targetMeta?.[key],
+          sourceDate,
         );
       });
       return destination;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,6 +36,11 @@ export type State<T> = Readonly<{
       readonly invalidated?: boolean;
     };
   };
+  entityMeta: {
+    readonly [entityKey: string]: {
+      readonly [pk: string]: { readonly date: number };
+    };
+  };
   optimistic: ReceiveAction[];
 }>;
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Tracking entity specific resolution time helps improve entity freshness in cases where custom data-specific merging tracking is not provided. There are several cases that will shortly be using the improved tracking of data age at an entity level:

- stale-while-revalidation staleness guarantees when inferring results
- resolving fully normalized persistence caches (@0xcaff )

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Add entityMeta as top level `state` member. This tracks the same shape as entities, but with the data of { date: number }.

```typescript
  entityMeta: {
    readonly [entityKey: string]: {
      readonly [pk: string]: { readonly date: number };
    };
  };
```

This affects merges by potentially changing the order of arguments sent to [SimpleRecord.merge()](https://resthooks.io/docs/next/api/SimpleRecord#static-merget-extends-typeof-simplerecordfirst-instancetypet-second-instancetypet--instancetypet). The second argument is considered 'priority' over the first - as far as the rest hooks cache is considered. User-implemented merge functions can either factor that in to their merge or choose to ignore it.

Previously, the currently processed data was sent as the second 'priority' argument to take precedence over any existing entities. However, now if there is any staleness information, it is used to inform said ordering.

For example, the default merge() copies the 'incoming' replacing 'existing' properties when found.

```typescript
  static merge<T extends typeof SimpleRecord>(
    this: T,
    existing: AbstractInstanceType<T>,
    incoming: AbstractInstanceType<T>,  // this is the priority
  ) {
    const props = Object.assign(
      this.toObjectDefined(existing),
      this.toObjectDefined(incoming),
    );
    return this.fromJS(props);
  }
```

### Alternatives considered

We did consider storing the recency data in the entity itself.

Pros:
- potentially more efficient updates
- simpler data traversal

Cons:
- we infect 'normalizr' code with concerns of the cache implementation
- awkward extra data in what should be an object that most exactly reflects what the user expects.

Another note is that in the future when Entities themselves are not actually stored in state, we could shuffle around where the date information is stored. 