### PR TITLE
feat: Add FixtureManager to improve testing imperative fetch

### DIFF
--- a/packages/test/src/FixtureManager.ts
+++ b/packages/test/src/FixtureManager.ts
@@ -1,0 +1,67 @@
+import { MiddlewareAPI, Middleware } from '@rest-hooks/use-enhanced-reducer';
+import { NetworkManager, actionTypes, ReceiveAction } from '@rest-hooks/core';
+import type { Dispatch, Manager } from '@rest-hooks/core';
+
+import { Fixture, actionFromFixture } from './mockState';
+
+/** Resolves requests matching provided fixtures
+ *
+ */
+export default class FixtureManager implements Manager {
+  protected mockResults: { [key: string]: ReceiveAction } = {};
+  protected declare middleware: Middleware;
+
+  constructor(fixtures: Fixture[]) {
+    for (const fixture of fixtures) {
+      const { key, action } = actionFromFixture(fixture);
+      this.mockResults[key] = action;
+    }
+
+    this.middleware = <R extends React.Reducer<any, any>>({
+      dispatch,
+      getState,
+    }: MiddlewareAPI<R>) => {
+      return (next: Dispatch<R>) => (
+        action: React.ReducerAction<R>,
+      ): Promise<void> => {
+        switch (action.type) {
+          case actionTypes.FETCH_TYPE: {
+            const { key } = action.meta;
+
+            if (key in this.mockResults) {
+              dispatch(this.mockResults[key] as any);
+              return Promise.resolve();
+            }
+            console.warn(
+              `FixtureManager received a dispatch:
+        ${JSON.stringify(action, undefined, 2)}
+        for which there is no matching fixture.
+
+        If you were expecting to see results, it is likely due to data not being found in fixtures.
+        Double check your params and Endpoint match. For example:
+
+        useResource(ArticleResource.list(), { maxResults: 10 });
+
+        and
+
+        {
+        request: ArticleResource.list(),
+        params: { maxResults: 10 },
+        result: [],
+        }`,
+            );
+            return next(action);
+          }
+          default:
+            return next(action);
+        }
+      };
+    };
+  }
+
+  getMiddleware<T extends NetworkManager>(this: T) {
+    return this.middleware;
+  }
+
+  cleanup() {}
+}

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -3,6 +3,7 @@ import { makeExternalCacheProvider, makeCacheProvider } from './providers';
 import MockProvider from './MockProvider';
 import mockInitialState from './mockState';
 export * from './managers';
+export { default as FixtureManager } from './FixtureManager';
 
 export {
   makeRenderRestHook,

--- a/packages/test/src/mockState.ts
+++ b/packages/test/src/mockState.ts
@@ -24,34 +24,36 @@ export interface ErrorFixture {
 
 export type Fixture = SuccessFixture | ErrorFixture;
 
+export function actionFromFixture(fixture: Fixture) {
+  const { request, params, result, error } = fixture;
+  const { schema, getFetchKey, options } = request;
+  const key = getFetchKey(params);
+  let action: ReceiveAction;
+  if (error === true) {
+    action = createReceiveError(result as Error, {
+      schema,
+      key,
+      errorExpiryLength: options?.errorExpiryLength ?? 10000000,
+    });
+  } else {
+    action = createReceive(result, {
+      schema,
+      key,
+      dataExpiryLength: options?.dataExpiryLength ?? 10000000,
+      type: 'read' as const,
+    });
+  }
+  return { key, action };
+}
+
 export default function mockInitialState<
   S extends Schema,
   Params extends Readonly<object> = Readonly<object>,
   Body extends Readonly<object | string> | void = Readonly<object> | undefined
 >(results: Fixture[]) {
-  const mockState = results.reduce(
-    (acc, { request, params, result, error }) => {
-      const { schema, getFetchKey, options } = request;
-      const key = getFetchKey(params);
-      let action: ReceiveAction;
-      if (error === true) {
-        action = createReceiveError(result as Error, {
-          schema,
-          key,
-          errorExpiryLength: options?.errorExpiryLength ?? 10000000,
-        });
-      } else {
-        action = createReceive(result, {
-          schema,
-          key,
-          dataExpiryLength: options?.dataExpiryLength ?? 10000000,
-          type: 'read' as const,
-        });
-      }
-
-      return reducer(acc, action);
-    },
-    initialState,
-  );
+  const mockState = results.reduce((acc, fixture) => {
+    const { action } = actionFromFixture(fixture);
+    return reducer(acc, action);
+  }, initialState);
   return mockState;
 }


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #415.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In many cases, mocking network itself is inconvenient - which is why MockProvider was created. However, it is incredibly limited in its capability as it cannot handle any updates, thus cannot model imperative pieces.

We wish to have an easy, but universal solution to mocking with fixtures.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
FixtureManager is initialized with fixtures it can handle and automatically dispatches receives in the normal manner when it receives a 'fetch' dispatch.

If it does not find a matching fixture for a given request, it will pass through to other managers. To fallback to normal behavior, simply include those other managers.

### Usage
<!--
(optional) Any open questions or feedback on design desired?
-->
`fixtures.ts`
```typescript
export default {
  full: [
    {
      request: ArticleResource.list(),
      params: { maxResults: 10 },
      result: [
        {
          id: 5,
          content: 'have a merry christmas',
          author: 2,
          contributors: [],
        },
        {
          id: 532,
          content: 'never again',
          author: 23,
          contributors: [5],
        },
      ],
    },
   {
      request: ArticleResource.create(),
      params: { },
      result: {
          id: 51,
          content: 'new item created',
          author: 2,
          contributors: [],
        },
    },
  ],
}
```

`articleStory.tsx`
```typescript
import { select } from '@storybook/addon-knobs';
import { CacheProvider } from '@rest-hooks/core';
import { FixtureManager } from '@rest-hooks/test';
import ArticleList from 'ArticleList';
import options from './fixtures';

const label = 'Data';
const defaultValue = options.full;
const groupId = 'GROUP-ID1';

storiesOf('name', module).add('Name', () => {
  const results = select(label, options, defaultValue, groupId);
  const managers = [new FixtureManager(results)];
  return (
    <CacheProvider managers={managers}>
      <ArticleList maxResults={10} />
    </MockProvider>
  );
});
```

### Future work

This would be a breaking change, but would better consolidate:
- Make MockProvider be a simple proxy to simply use FixtureNetworkManager, so it's one less line to use.
- Make this work with hooks testing as well so people can choose to use this with hook tests rather than mocking with things like 'nock'

### TODO for this PR:

- [ ] Test
- [ ] Update docs