### PR TITLE
Expose BodyFromShape from core library

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,5 +42,6 @@ export type { FetchShape, ReadShape, MutateShape } from './endpoint/shapes';
 export type {
   SetShapeParams,
   ParamsFromShape,
+  BodyFromShape,
   ReturnFromShape,
 } from './endpoint/types';


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
When extracting the request type from a fetch shape, `get` and `mutate` requests have the requests in either Params or Body of the fetch shape. `ParamsFromShape` was exposed from the package, but `BodyFromShape` wasn't, necessitating the method be copied into the codebase directly until it is exposed.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
One line change to export `BodyFromShape` from `packages/core`.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
What is the appropriate way to update the version of the package?
