### PR TITLE
fix: FixtureManager should dispatch receive async to not break react

### DIFF
--- a/packages/test/src/FixtureManager.ts
+++ b/packages/test/src/FixtureManager.ts
@@ -26,12 +26,15 @@ export default class FixtureManager implements Manager {
       ): Promise<void> => {
         switch (action.type) {
           case actionTypes.FETCH_TYPE: {
-            const { key } = action.meta;
+            const { key, resolve, reject } = action.meta;
 
             if (key in this.mockResults) {
               // All updates must be async or React will complain about re-rendering in same pass
               setTimeout(() => {
-                dispatch(this.mockResults[key] as any);
+                const action: any = this.mockResults[key];
+                dispatch(action);
+                const complete = action.error ? reject : resolve;
+                complete(action.payload);
               }, 0);
               return Promise.resolve();
             }

--- a/packages/test/src/FixtureManager.ts
+++ b/packages/test/src/FixtureManager.ts
@@ -29,7 +29,10 @@ export default class FixtureManager implements Manager {
             const { key } = action.meta;
 
             if (key in this.mockResults) {
-              dispatch(this.mockResults[key] as any);
+              // All updates must be async or React will complain about re-rendering in same pass
+              setTimeout(() => {
+                dispatch(this.mockResults[key] as any);
+              }, 0);
               return Promise.resolve();
             }
             console.warn(

--- a/packages/test/src/FixtureManager.ts
+++ b/packages/test/src/FixtureManager.ts
@@ -32,9 +32,12 @@ export default class FixtureManager implements Manager {
               // All updates must be async or React will complain about re-rendering in same pass
               setTimeout(() => {
                 const action: any = this.mockResults[key];
-                dispatch(action);
-                const complete = action.error ? reject : resolve;
-                complete(action.payload);
+                try {
+                  dispatch(action);
+                } finally {
+                  const complete = action.error ? reject : resolve;
+                  complete(action.payload);
+                }
               }, 0);
               return Promise.resolve();
             }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The fetch comes down the render pass in children components, so the parent was already rendered at that point. We need to schedule another render call async or React complains.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Settimeout with 0

