### PR TITLE
feat: Add <MockResolver />

### DIFF
--- a/docs/api/MockResolver.md
+++ b/docs/api/MockResolver.md
@@ -1,35 +1,41 @@
 ---
-title: <MockProvider />
+title: <MockResolver />
 ---
 
 ```typescript
-function MockProvider({
+function MockResolver({
   children,
   results,
 }: {
-  children: React.ReactChild;
+  children: React.ReactNode;
   results: Fixture[];
 }): JSX.Element;
 ```
 
-\<MockProvider /> is a simple substitute provider to prefill the cache with fixtures so the 'happy path'
-can be tested. This is useful for [storybook](../guides/storybook.md) as well as component testing.
+\<MockResolver /> enables easy loading of fixtures to see what different network responses might look like.
+This is useful for [storybook](../guides/storybook.md) as well as component testing.
 
-> Deprecated: Use [<MockResolver />](./mockResolver) instead as it also supports [imperative fetches](../api/useFetcher) like [create](../api/resource#create-endpoint) and [update](../api/resource#update-endpoint).
-
-> Note: \<MockProvider /> disables dispatches, thus no fetches will occur. To simply initalize the
-> cache, use [mockInitialState()](./mockInitialState) to construct initialState for the normal [\<CacheProvider />](./CacheProvider)
 
 ## Arguments
 
-### results
+### fixtures
 
 ```typescript
-interface Fixture {
-  request: ReadEndpoint;
+export interface SuccessFixture {
+  request: ReadShape<Schema, object>;
   params: object;
   result: object | string | number;
+  error?: false;
 }
+
+export interface ErrorFixture {
+  request: ReadShape<Schema, object>;
+  params: object;
+  result: Error;
+  error: true;
+}
+
+export type Fixture = SuccessFixture | ErrorFixture;
 ```
 
 This prop specifies the fixtures to use data from. Each item represents a fetch defined by the
@@ -45,8 +51,8 @@ Renders the children prop.
 
 ## Example
 
-```typescript
-import { MockProvider } from '@rest-hooks/test';
+```tsx
+import { MockResolver } from '@rest-hooks/test';
 
 import ArticleResource from 'resources/ArticleResource';
 import MyComponentToTest from 'components/MyComponentToTest';
@@ -72,7 +78,9 @@ const results = [
   },
 ];
 
-<MockProvider results={results}>
-  <MyComponentToTest />
-</MockProvider>
+const Template: Story = () => (
+  <MockResolver fixtures={results}><MyComponentToTest /></MockResolver>
+);
+
+export const MyStory = Template.bind({});
 ```

--- a/docs/guides/storybook.md
+++ b/docs/guides/storybook.md
@@ -76,6 +76,16 @@ export default {
         },
       ],
     },
+    {
+      request: ArticleResource.update(),
+      params: { id: 532 },
+      result: {
+        id: 532,
+        content: 'updated "never again"',
+        author: 23,
+        contributors: [5],
+      },
+    },
   ],
   empty: [
     {
@@ -154,7 +164,9 @@ export default {
 };
 
 const Template: Story<{ result: keyof typeof options }> = ({ result }) => (
-  <MockResolver fixtures={options[result]}><ArticleList maxResults={10} /></MockResolver>
+  <MockResolver fixtures={options[result]}>
+    <ArticleList maxResults={10} />
+  </MockResolver>
 );
 
 export const FullArticleList = Template.bind({});
@@ -162,5 +174,4 @@ export const FullArticleList = Template.bind({});
 FullArticleList.args = {
   result: 'full',
 };
-
 ```

--- a/docs/guides/storybook.md
+++ b/docs/guides/storybook.md
@@ -5,8 +5,9 @@ title: Mocking data for Storybook
 [Storybook](https://storybook.js.org/) is a great utility to do isolated development and
 testing, potentially speeding up development time greatly.
 
-[\<MockProvider />](../api/MockProvider.md) enables easy loading of fixtures to test the
-happy path of components. Loading state is bypassed by initializing the cache ahead of time.
+[\<MockResolver />](../api/MockResolver.md) enables easy loading of fixtures to see what
+different network responses might look like. It can be layered, composed, and even used
+for [imperative fetches](../api/useFetcher) like [create](../api/resource#create-endpoint) and [update](../api/resource#update-endpoint).
 
 ## Setup
 
@@ -87,7 +88,7 @@ export default {
     {
       request: ArticleResource.list(),
       params: { maxResults: 10 },
-      result: { message: 'Bad request', status: 400 },
+      result: { message: 'Bad request', status: 400, name: 'Not Found' },
       error: true,
     },
   ],
@@ -95,29 +96,71 @@ export default {
 };
 ```
 
-## Story
+## Decorators
 
-We use a [storybook knob](https://www.npmjs.com/package/@storybook/addon-knobs)
-to make it easy for the user to select between each dataset to compare how it looks.
+You'll need to add the appropriate [global decorators](https://storybook.js.org/docs/react/writing-stories/decorators#global-decorators) to establish the correct context.
 
-#### `ArticleListStory.tsx`
+This should resemble what you have added in [initial setup](../getting-started/installation#add-provider-at-top-level-component)
+
+#### `.storybook/preview.tsx`
 
 ```tsx
-import { select } from '@storybook/addon-knobs';
-import { MockProvider } from '@rest-hooks/test';
+import { Suspense } from 'react';
+import { CacheProvider, NetworkErrorBoundary } from 'rest-hooks';
+
+export const decorators = [
+  Story => (
+    <CacheProvider>
+      <Suspense fallback="loading">
+        <NetworkErrorBoundary>
+          <Story />
+        </NetworkErrorBoundary>
+      </Suspense>
+    </CacheProvider>
+  ),
+];
+```
+
+## Story
+
+Wrapping our component with <MockResolver /> enables us to declaratively
+control how Rest Hooks' fetches are resolved.
+
+Here we select which fixtures should be used by [storybook controls](https://storybook.js.org/docs/react/essentials/controls).
+
+#### `ArticleList.stories.tsx`
+
+```tsx
+import { MockResolver } from '@rest-hooks/test';
+import type { Fixture } from '@rest-hooks/test';
+import { Story } from '@storybook/react/types-6-0';
+
 import ArticleList from 'ArticleList';
 import options from './fixtures';
 
-const label = 'Data';
-const defaultValue = options.full;
-const groupId = 'GROUP-ID1';
+export default {
+  title: 'Pages/ArticleList',
+  component: ArticleList,
+  argTypes: {
+    result: {
+      description: 'Results',
+      defaultValue: 'full',
+      control: {
+        type: 'select',
+        options: Object.keys(options),
+      },
+    },
+  },
+};
 
-storiesOf('name', module).add('Name', () => {
-  const results = select(label, options, defaultValue, groupId);
-  return (
-    <MockProvider results={results}>
-      <ArticleList maxResults={10} />
-    </MockProvider>
-  );
-});
+const Template: Story<{ result: keyof typeof options }> = ({ result }) => (
+  <MockResolver fixtures={options[result]}><ArticleList maxResults={10} /></MockResolver>
+);
+
+export const FullArticleList = Template.bind({});
+
+FullArticleList.args = {
+  result: 'full',
+};
+
 ```

--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -69,10 +69,8 @@ export default function MockResolver({ children, fixtures }: Props) {
   result: [],
   }`,
         );
-        return dispatch(action);
-      } else {
-        return dispatch(action);
       }
+      return dispatch(action);
     },
     [fetchToReceiveAction, dispatch],
   );

--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -1,0 +1,82 @@
+import {
+  DispatchContext,
+  ReceiveAction,
+  actionTypes,
+  ActionTypes,
+} from '@rest-hooks/core';
+import { useCallback, useContext, useMemo } from 'react';
+import React from 'react';
+
+import { Fixture, actionFromFixture } from './mockState';
+
+type Props = {
+  children: React.ReactNode;
+  fixtures: Fixture[];
+};
+
+/** Can be used to mock responses based on fixtures provided.
+ *
+ * <MockResolver fixtures={postFixtures[state]}><MyComponent /></MockResolver>
+ *
+ * Place below <CacheProvider /> and above any components you want to mock.
+ */
+export default function MockResolver({ children, fixtures }: Props) {
+  const actionMap = useMemo(() => {
+    const mockResults: Record<string, ReceiveAction> = {};
+    for (const fixture of fixtures) {
+      const { key, action } = actionFromFixture(fixture);
+      mockResults[key] = action;
+    }
+    return mockResults;
+  }, [fixtures]);
+
+  const dispatch = useContext(DispatchContext);
+  const dispatchIntercept = useCallback(
+    (action: ActionTypes) => {
+      if (action.type === actionTypes.FETCH_TYPE) {
+        const { key, resolve, reject } = action.meta;
+        if (key in actionMap) {
+          // All updates must be async or React will complain about re-rendering in same pass
+          setTimeout(() => {
+            const receiveAction = actionMap[key];
+            try {
+              dispatch(receiveAction);
+            } finally {
+              const complete = receiveAction.error ? reject : resolve;
+              complete(receiveAction.payload);
+            }
+          }, 0);
+          return Promise.resolve();
+        }
+        console.warn(
+          `MockResolver received a dispatch:
+  ${JSON.stringify(action, undefined, 2)}
+  for which there is no matching fixture.
+
+  If you were expecting to see results, it is likely due to data not being found in fixtures.
+  Double check your params and Endpoint match. For example:
+
+  useResource(ArticleResource.list(), { maxResults: 10 });
+
+  and
+
+  {
+  request: ArticleResource.list(),
+  params: { maxResults: 10 },
+  result: [],
+  }`,
+        );
+        return dispatch(action);
+      } else {
+        return dispatch(action);
+      }
+    },
+    [actionMap, dispatch],
+  );
+
+  return (
+    <DispatchContext.Provider value={dispatchIntercept}>
+      {children}
+    </DispatchContext.Provider>
+  );
+}

--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -41,6 +41,8 @@ export default function MockResolver({ children, fixtures }: Props) {
             const receiveAction = fetchToReceiveAction[key];
             try {
               dispatch(receiveAction);
+              // dispatch goes through user-code that can sometimes fail.
+              // let's ensure we always complete the promise
             } finally {
               const complete = receiveAction.error ? reject : resolve;
               complete(receiveAction.payload);
@@ -48,6 +50,7 @@ export default function MockResolver({ children, fixtures }: Props) {
           }, 0);
           return Promise.resolve();
         }
+        // This is only a warn because sometimes this is intentional
         console.warn(
           `<MockResolver/> received a dispatch:
   ${JSON.stringify(action, undefined, 2)}

--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -35,7 +35,7 @@ export default function MockResolver({ children, fixtures }: Props) {
     (action: ActionTypes) => {
       if (action.type === actionTypes.FETCH_TYPE) {
         const { key, resolve, reject } = action.meta;
-        if (key in fetchToReceiveAction) {
+        if (Object.prototype.hasOwnProperty.call(fetchToReceiveAction, key)) {
           // All updates must be async or React will complain about re-rendering in same pass
           setTimeout(() => {
             const receiveAction = fetchToReceiveAction[key];

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -4,6 +4,8 @@ import MockProvider from './MockProvider';
 import mockInitialState from './mockState';
 export * from './managers';
 export { default as FixtureManager } from './FixtureManager';
+export { default as MockResolver } from './MockResolver';
+export type { Fixture, SuccessFixture, ErrorFixture } from './mockState';
 
 export {
   makeRenderRestHook,

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -48,6 +48,9 @@
       "api/MockProvider": {
         "title": "<MockProvider />"
       },
+      "api/MockResolver": {
+        "title": "<MockResolver />"
+      },
       "api/NetworkErrorBoundary": {
         "title": "<NetworkErrorBoundary />"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -150,11 +150,12 @@
         "type": "subcategory",
         "label": "Testing",
         "ids": [
-          "api/MockProvider",
+          "api/MockResolver",
           "api/makeRenderRestHook",
           "api/makeCacheProvider",
           "api/makeExternalCacheProvider",
-          "api/mockInitialState"
+          "api/mockInitialState",
+          "api/MockProvider"
         ]
       }
     ]


### PR DESCRIPTION
Fixes #415.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Mocking needs to work for imperative endpoints like `update`, not just `read` endpoints as requested in #415.

Initially a new manager was added in #440 (FixtureManager) to solve this problem. However, in practice this became cumbersome for three reasons:

- Full Provider, ErrorBoundary, and Suspense would need to be established in each story.
- Integration with a users' customer managers would need to be re-specified.
- Any changing of fixtures required resetting the entire Provider.

While the first two are only somewhat annoying, the third seemed like a pretty big deal breaker.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Use `dispatch interceptor pattern` via `<MockResolver fixtures={myMockData} />`. 

Since all fetches using rest hooks require an established context, we can bind a new context to intercept dispatches before they
even reach the managers.

This design is greatly beneficial for the following reasons:

- Completely decoupled with the rest of rest-hooks usage (both Provider, as well as components).
- Can be composed in normal React manner to override any other fixtures
- Maintains any manager customizations even in this mock environment.

```tsx
const results = [
  {
    request: ArticleResource.list(),
    params: { maxResults: 10 },
    result: [
      {
        id: 5,
        content: 'have a merry christmas',
        author: 2,
        contributors: [],
      },
      {
        id: 532,
        content: 'never again',
        author: 23,
        contributors: [5],
      },
    ],
  },
];
const Template: Story = () => (
  <MockResolver fixtures={results}><MyComponentToTest /></MockResolver>
);
export const MyStory = Template.bind({});
```

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
- Plan to remove FixtureManager in subsequent PR
- Is there still a use case for MockProvider?
  - It does have the advantage of instantly resolving vs one-tick resolving. This is meaningful in a node-test environment. However, `mockInitialState()` can simply be used in its absence.


### Future work
- Add resolution time mocking to fixture specification (like `nock` does)

### Testing
- Fully tested in `yarn link` storybook environment.
- Automated testing for test package may come later.