### PR TITLE
internal: Ignore dev env only paths for code coverage

### DIFF
--- a/packages/rest-hooks/src/manager/DevtoolsManager.ts
+++ b/packages/rest-hooks/src/manager/DevtoolsManager.ts
@@ -15,11 +15,13 @@ export default class DevToolsManager implements Manager {
   protected declare devTools: undefined | any;
 
   constructor(config: any = {}) {
+    /* istanbul ignore next */
     this.devTools =
       typeof window !== 'undefined' &&
       (window as any).__REDUX_DEVTOOLS_EXTENSION__ &&
       (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect(config);
 
+    /* istanbul ignore if */
     if (process.env.NODE_ENV === 'development' && this.devTools) {
       this.middleware = <R extends React.Reducer<any, any>>({
         getState,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Dev env checks result in different builds. Current policy is to always test full dev mode.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add instanbul ignore lines