### PR TITLE
internal: Add lerna options to  cmd

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,15 @@
       "preDistTag": "beta",
       "changelogPreset": "anansi",
       "createRelease": "github",
-      "message": "internal: publish",
+      "message": "internal: publish %s",
+      "ignoreChanges": ["**/__tests__/**", "**/*.md"]
+    },
+    "version": {
+      "conventionalCommits": true,
+      "preid": "beta",
+      "changelogPreset": "anansi",
+      "createRelease": "github",
+      "message": "internal: publish %s",
       "ignoreChanges": ["**/__tests__/**", "**/*.md"]
     }
   }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
To avoid committing directly to master, we need to have a release process that only pushes branches.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
New release process:

1) `git checkout -b release`
2) `lerna version` (this will commit to the current branch and push tags, etc, but not publish)
3) open PR on github for version branch & land PR
4) publish: `yarn clean && yarn build && lerna publish from-git`

Due to this, we are adding the options to lerna version in the config.

### Future work

Automate step 4
