### PR TITLE
internal: publish versions

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.0-k.5 (2021-01-06)
+
+* Expose BodyFromShape from core library ([060dcd3](https://github.com/coinbase/rest-hooks/commit/060dcd3))
+* feat: Track and use entity resolution time ([54203f9](https://github.com/coinbase/rest-hooks/commit/54203f9))
+* pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
+
+
+
+
+
 ## 1.0.0-k.4 (2020-12-08)
 
 * fix: Clear promises on cleanup (#422) ([bcb236e](https://github.com/coinbase/rest-hooks/commit/bcb236e)), closes [#422](https://github.com/coinbase/rest-hooks/issues/422)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "1.0.0-k.4",
+  "version": "1.0.0-k.5",
   "description": "Dynamic data fetching for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -58,12 +58,12 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "devDependencies": {
-    "@rest-hooks/test": "^2.0.0-k.1"
+    "@rest-hooks/test": "^2.0.0-k.2"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "@rest-hooks/endpoint": "^0.7.2",
-    "@rest-hooks/normalizr": "^6.0.0-j.2",
+    "@rest-hooks/endpoint": "^0.7.3",
+    "@rest-hooks/normalizr": "^6.0.0-k.0",
     "@rest-hooks/use-enhanced-reducer": "^1.0.5",
     "flux-standard-action": "^2.1.1"
   },

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## <small>0.7.3 (2021-01-06)</small>
+
+* pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
+
+
+
+
+
 ## <small>0.7.2 (2020-09-08)</small>
 
 * internal: Upgrade build pkgs (#404) ([dc56530](https://github.com/coinbase/rest-hooks/commit/dc56530)), closes [#404](https://github.com/coinbase/rest-hooks/issues/404)

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "@rest-hooks/normalizr": "^6.0.0-j.2"
+    "@rest-hooks/normalizr": "^6.0.0-k.0"
   }
 }

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## <small>0.1.2 (2021-01-06)</small>
+
+* pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
+
+
+
+
+
 ## <small>0.1.1 (2020-08-12)</small>
 
 * enhance: Support React 17 (#397) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f07)), closes [#397](https://github.com/coinbase/rest-hooks/issues/397)

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2.0.0-k.2 (2021-01-06)
+
+**Note:** Version bump only for package @rest-hooks/legacy
+
+
+
+
+
 ## 2.0.0-k.1 (2020-09-08)
 
 **Note:** Version bump only for package @rest-hooks/legacy

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "2.0.0-k.1",
+  "version": "2.0.0-k.2",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -56,7 +56,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "devDependencies": {
-    "@rest-hooks/test": "^2.0.0-k.1"
+    "@rest-hooks/test": "^2.0.0-k.2"
   },
   "peerDependencies": {
     "@rest-hooks/core": "^1.0.0-delta.0",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.0.0-k.0 (2021-01-06)
+
+* pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
+* fix: TypeScript 4 compatibility (#406) ([5d82e24](https://github.com/coinbase/rest-hooks/commit/5d82e24)), closes [#406](https://github.com/coinbase/rest-hooks/issues/406)
+* internal: Upgrade build pkgs (#404) ([dc56530](https://github.com/coinbase/rest-hooks/commit/dc56530)), closes [#404](https://github.com/coinbase/rest-hooks/issues/404)
+
+
+
+
+
 ## 6.0.0-j.2 (2020-08-04)
 
 * fix: Handle entities updated with new indexes (#384) ([2ee3bb6](https://github.com/coinbase/rest-hooks/commit/2ee3bb6)), closes [#384](https://github.com/coinbase/rest-hooks/issues/384)

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "6.0.0-j.2",
+  "version": "6.0.0-k.0",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 5.0.0-k.5 (2021-01-06)
+
+* internal: Ignore dev env only paths for code coverage ([d425dfd](https://github.com/coinbase/rest-hooks/commit/d425dfd))
+* pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
+
+
+
+
+
 ## 5.0.0-k.4 (2020-12-08)
 
 **Note:** Version bump only for package rest-hooks

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "5.0.0-k.4",
+  "version": "5.0.0-k.5",
   "description": "Dynamic data fetching for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -60,12 +60,12 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "devDependencies": {
-    "@rest-hooks/test": "^2.0.0-k.1"
+    "@rest-hooks/test": "^2.0.0-k.2"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "@rest-hooks/core": "^1.0.0-k.4",
-    "@rest-hooks/endpoint": "^0.7.2"
+    "@rest-hooks/core": "^1.0.0-k.5",
+    "@rest-hooks/endpoint": "^0.7.3"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0",

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## <small>0.5.1 (2021-01-06)</small>
+
+* pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
+
+
+
+
+
 ## 0.5.0 (2020-12-08)
 
 * feat: Add RestEndpoint type (#427) ([dc47667](https://github.com/coinbase/rest-hooks/commit/dc47667)), closes [#427](https://github.com/coinbase/rest-hooks/issues/427)

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2.0.0-k.2 (2021-01-06)
+
+* enhance: Remove FixtureManager in favor of MockResolver (#447) ([4aa1617](https://github.com/coinbase/rest-hooks/commit/4aa1617)), closes [#447](https://github.com/coinbase/rest-hooks/issues/447)
+* feat: Add <MockResolver /> (#446) ([614576a](https://github.com/coinbase/rest-hooks/commit/614576a)), closes [#446](https://github.com/coinbase/rest-hooks/issues/446)
+* feat: Add FixtureNetworkManager to provide fixtures for imperative fetch ([0d015dc](https://github.com/coinbase/rest-hooks/commit/0d015dc))
+* fix: FixtureManager should dispatch receive async to not break react (#445) ([e1645cb](https://github.com/coinbase/rest-hooks/commit/e1645cb)), closes [#445](https://github.com/coinbase/rest-hooks/issues/445)
+
+
+
+
+
 ## 2.0.0-k.1 (2020-09-08)
 
 * fix: Only block suspense if errors are synthetic (#410) ([af8ab26](https://github.com/coinbase/rest-hooks/commit/af8ab26)), closes [#410](https://github.com/coinbase/rest-hooks/issues/410)

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "2.0.0-k.1",
+  "version": "2.0.0-k.2",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
 - @rest-hooks/core@1.0.0-k.5
 - @rest-hooks/endpoint@0.7.3
 - @rest-hooks/hooks@0.1.2
 - @rest-hooks/legacy@2.0.0-k.2
 - @rest-hooks/normalizr@6.0.0-k.0
 - rest-hooks@5.0.0-k.5
 - @rest-hooks/rest@0.5.1
 - @rest-hooks/test@2.0.0-k.2
