### PR TITLE
enhance: Inferred endpoints expiry based on entities

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -21,3 +21,16 @@ export function mockEventHandlers() {
   };
   return triggerEvent;
 }
+
+export function createEntityMeta(
+  entities: Record<string, Record<string, any>>,
+) {
+  const entityMeta: any = {};
+  for (const k in entities) {
+    entityMeta[k] = {};
+    for (const pk in entities[k]) {
+      entityMeta[k][pk] = { date: 0, expiresAt: 0 };
+    }
+  }
+  return entityMeta;
+}

--- a/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
+++ b/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { Entity } from '@rest-hooks/normalizr';
+import { CoolerArticleResource } from '__tests__/new';
+import { renderHook, RenderHookOptions } from '@testing-library/react-hooks';
+
+// relative imports to avoid circular dependency in tsconfig references
+import { Endpoint } from '@rest-hooks/endpoint';
+import { StateContext } from '@rest-hooks/core';
+
+import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { useExpiresAt } from '../hooks';
+import { payload } from '../test-fixtures';
+import { State, useDenormalized } from '../..';
+
+export default class IDEntity extends Entity {
+  readonly id: string | number | undefined = undefined;
+  pk(parent?: any, key?: string): string | undefined {
+    return `${this.id}`;
+  }
+}
+class Ingredients extends IDEntity {
+  readonly name = '';
+}
+class Tacos extends IDEntity {
+  readonly type = '';
+  readonly ingredients: Ingredients[] = [];
+
+  static schema = {
+    ingredients: [Ingredients],
+  };
+}
+
+describe('useExpiresAt()', () => {
+  let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+  beforeEach(() => {
+    renderRestHook = makeRenderRestHook(makeCacheProvider);
+  });
+  afterEach(() => {
+    renderRestHook.cleanup();
+  });
+
+  it('age is minimum of entities', () => {
+    const ListTaco = new Endpoint(
+      (a: Record<string, unknown>) => Promise.resolve({}),
+      {
+        schema: [Tacos],
+        key: () => 'listtaco',
+      },
+    );
+    const state = {
+      entities: {
+        Tacos: {
+          '1': { id: '1', type: 'foo', ingredients: ['1'] },
+          '2': { id: '2', type: 'bar', ingredients: [] },
+        },
+        Ingredients: {
+          '1': { id: '1', name: 'rice' },
+        },
+      },
+      entityMeta: {
+        Tacos: {
+          '1': { date: 0, expiresAt: 1000 },
+          '2': { date: 0, expiresAt: 2000 },
+        },
+        Ingredients: {
+          '1': { date: 0, expiresAt: 500 },
+        },
+      },
+      indexes: {},
+      results: { [ListTaco.key({})]: ['1', '2'] },
+      meta: {},
+      optimistic: [],
+    };
+
+    const wrapper = function ConfiguredCacheProvider({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) {
+      return (
+        <StateContext.Provider value={state}>{children}</StateContext.Provider>
+      );
+    };
+
+    const { result } = renderHook(
+      () => {
+        const [
+          denormalized,
+          ready,
+          deleted,
+          resolvedEntities,
+        ] = useDenormalized(ListTaco, {}, state);
+        return useExpiresAt(ListTaco, {}, resolvedEntities);
+      },
+      { wrapper },
+    );
+    expect(result.current).toBe(500);
+  });
+
+  it('age ignores unused entities', () => {
+    const ListTaco = new Endpoint(
+      (a: Record<string, unknown>) => Promise.resolve({}),
+      {
+        schema: [Tacos],
+        key: () => 'listtaco',
+      },
+    );
+    const DetailTaco = new Endpoint(
+      (a: Record<string, unknown>) => Promise.resolve({}),
+      {
+        schema: Tacos,
+        key: ({ id }: { id: any }) => `detailtaco ${id}`,
+      },
+    );
+    const state = {
+      entities: {
+        Tacos: {
+          1: { id: '1', type: 'foo', ingredients: ['1'] },
+          2: { id: '2', type: 'bar', ingredients: [] },
+          3: { id: '3', type: 'a', ingredients: [] },
+        },
+        Ingredients: {
+          1: { id: '1', name: 'rice' },
+          2: { id: '2', name: 'beans' },
+        },
+      },
+      entityMeta: {
+        Tacos: {
+          1: { date: 0, expiresAt: 1000 },
+          2: { date: 0, expiresAt: 2000 },
+          3: { date: 0, expiresAt: 0 },
+        },
+        Ingredients: {
+          1: { date: 0, expiresAt: 500 },
+          2: { date: 0, expiresAt: 0 },
+        },
+      },
+      indexes: {},
+      results: { [ListTaco.key({})]: ['1', '2'] },
+      meta: {},
+      optimistic: [],
+    };
+
+    const wrapper = function ConfiguredCacheProvider({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) {
+      return (
+        <StateContext.Provider value={state}>{children}</StateContext.Provider>
+      );
+    };
+
+    const { result } = renderHook(
+      () => {
+        const [
+          denormalized,
+          ready,
+          deleted,
+          resolvedEntities,
+        ] = useDenormalized(ListTaco, {}, state);
+        return useExpiresAt(ListTaco, {}, resolvedEntities);
+      },
+      { wrapper },
+    );
+    expect(result.current).toBe(500);
+
+    const { result: result2 } = renderHook(
+      () => {
+        const [
+          denormalized,
+          ready,
+          deleted,
+          resolvedEntities,
+        ] = useDenormalized(DetailTaco, { id: '2' }, state);
+        return useExpiresAt(DetailTaco, { id: '2' }, resolvedEntities);
+      },
+      { wrapper },
+    );
+    expect(result2.current).toBe(2000);
+  });
+});

--- a/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
@@ -254,10 +254,18 @@ describe('useResource()', () => {
   });
   it('should NOT suspend even when result is stale and options.invalidIfStale is false', () => {
     const { entities, result } = normalize(payload, CoolerArticleResource);
+    const entityMeta: any = {};
+    for (const k in entities) {
+      entityMeta[k] = {};
+      for (const pk in entities[k]) {
+        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
+      }
+    }
     const fetchKey = CoolerArticleResource.detail().getFetchKey(payload);
     const state = {
       ...initialState,
       entities,
+      entityMeta,
       results: {
         [fetchKey]: result,
       },
@@ -292,12 +300,20 @@ describe('useResource()', () => {
     const fetchKey = InvalidIfStaleArticleResource.detail().getFetchKey(
       payload,
     );
+    const entityMeta: any = {};
+    for (const k in entities) {
+      entityMeta[k] = {};
+      for (const pk in entities[k]) {
+        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
+      }
+    }
     const state = {
       ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
+      entityMeta,
       meta: {
         [fetchKey]: {
           date: Infinity,
@@ -327,12 +343,20 @@ describe('useResource()', () => {
     const fetchKey = InvalidIfStaleArticleResource.detail().getFetchKey(
       payload,
     );
+    const entityMeta: any = {};
+    for (const k in entities) {
+      entityMeta[k] = {};
+      for (const pk in entities[k]) {
+        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
+      }
+    }
     const state = {
       ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
+      entityMeta,
       meta: {
         [fetchKey]: {
           date: 0,

--- a/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
@@ -8,6 +8,7 @@ import {
   ContextAuthdArticle,
   AuthContext,
 } from '__tests__/new';
+import { createEntityMeta } from '__tests__/utils';
 import { State } from '@rest-hooks/core';
 import { initialState } from '@rest-hooks/core/state/reducer';
 import React, { Suspense } from 'react';
@@ -254,18 +255,11 @@ describe('useResource()', () => {
   });
   it('should NOT suspend even when result is stale and options.invalidIfStale is false', () => {
     const { entities, result } = normalize(payload, CoolerArticleResource);
-    const entityMeta: any = {};
-    for (const k in entities) {
-      entityMeta[k] = {};
-      for (const pk in entities[k]) {
-        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
-      }
-    }
     const fetchKey = CoolerArticleResource.detail().getFetchKey(payload);
     const state = {
       ...initialState,
       entities,
-      entityMeta,
+      entityMeta: createEntityMeta(entities),
       results: {
         [fetchKey]: result,
       },
@@ -300,20 +294,13 @@ describe('useResource()', () => {
     const fetchKey = InvalidIfStaleArticleResource.detail().getFetchKey(
       payload,
     );
-    const entityMeta: any = {};
-    for (const k in entities) {
-      entityMeta[k] = {};
-      for (const pk in entities[k]) {
-        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
-      }
-    }
     const state = {
       ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
-      entityMeta,
+      entityMeta: createEntityMeta(entities),
       meta: {
         [fetchKey]: {
           date: Infinity,
@@ -343,20 +330,13 @@ describe('useResource()', () => {
     const fetchKey = InvalidIfStaleArticleResource.detail().getFetchKey(
       payload,
     );
-    const entityMeta: any = {};
-    for (const k in entities) {
-      entityMeta[k] = {};
-      for (const pk in entities[k]) {
-        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
-      }
-    }
     const state = {
       ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
-      entityMeta,
+      entityMeta: createEntityMeta(entities),
       meta: {
         [fetchKey]: {
           date: 0,

--- a/packages/core/src/react-integration/__tests__/useResource.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource.web.tsx
@@ -6,6 +6,7 @@ import {
   noEntitiesShape,
   ArticleTimedResource,
 } from '__tests__/common';
+import { createEntityMeta } from '__tests__/utils';
 import { State, ReadShape } from '@rest-hooks/core';
 import { initialState } from '@rest-hooks/core/state/reducer';
 import React, { Suspense } from 'react';
@@ -250,17 +251,10 @@ describe('useResource()', () => {
   it('should NOT suspend even when result is stale and options.invalidIfStale is false', () => {
     const { entities, result } = normalize(payload, CoolerArticleResource);
     const fetchKey = CoolerArticleResource.detailShape().getFetchKey(payload);
-    const entityMeta: any = {};
-    for (const k in entities) {
-      entityMeta[k] = {};
-      for (const pk in entities[k]) {
-        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
-      }
-    }
     const state = {
       ...initialState,
       entities,
-      entityMeta,
+      entityMeta: createEntityMeta(entities),
       results: {
         [fetchKey]: result,
       },
@@ -295,20 +289,14 @@ describe('useResource()', () => {
     const fetchKey = InvalidIfStaleArticleResource.detailShape().getFetchKey(
       payload,
     );
-    const entityMeta: any = {};
-    for (const k in entities) {
-      entityMeta[k] = {};
-      for (const pk in entities[k]) {
-        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
-      }
-    }
+
     const state = {
       ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
-      entityMeta,
+      entityMeta: createEntityMeta(entities),
       meta: {
         [fetchKey]: {
           date: Infinity,
@@ -338,20 +326,13 @@ describe('useResource()', () => {
     const fetchKey = InvalidIfStaleArticleResource.detailShape().getFetchKey(
       payload,
     );
-    const entityMeta: any = {};
-    for (const k in entities) {
-      entityMeta[k] = {};
-      for (const pk in entities[k]) {
-        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
-      }
-    }
     const state = {
       ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
-      entityMeta,
+      entityMeta: createEntityMeta(entities),
       meta: {
         [fetchKey]: {
           date: 0,

--- a/packages/core/src/react-integration/__tests__/useResource.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource.web.tsx
@@ -250,9 +250,17 @@ describe('useResource()', () => {
   it('should NOT suspend even when result is stale and options.invalidIfStale is false', () => {
     const { entities, result } = normalize(payload, CoolerArticleResource);
     const fetchKey = CoolerArticleResource.detailShape().getFetchKey(payload);
+    const entityMeta: any = {};
+    for (const k in entities) {
+      entityMeta[k] = {};
+      for (const pk in entities[k]) {
+        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
+      }
+    }
     const state = {
       ...initialState,
       entities,
+      entityMeta,
       results: {
         [fetchKey]: result,
       },
@@ -287,12 +295,20 @@ describe('useResource()', () => {
     const fetchKey = InvalidIfStaleArticleResource.detailShape().getFetchKey(
       payload,
     );
+    const entityMeta: any = {};
+    for (const k in entities) {
+      entityMeta[k] = {};
+      for (const pk in entities[k]) {
+        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
+      }
+    }
     const state = {
       ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
+      entityMeta,
       meta: {
         [fetchKey]: {
           date: Infinity,
@@ -322,12 +338,20 @@ describe('useResource()', () => {
     const fetchKey = InvalidIfStaleArticleResource.detailShape().getFetchKey(
       payload,
     );
+    const entityMeta: any = {};
+    for (const k in entities) {
+      entityMeta[k] = {};
+      for (const pk in entities[k]) {
+        entityMeta[k][pk] = { date: 0, expiresAt: 0 };
+      }
+    }
     const state = {
       ...initialState,
       entities,
       results: {
         [fetchKey]: result,
       },
+      entityMeta,
       meta: {
         [fetchKey]: {
           date: 0,

--- a/packages/core/src/react-integration/hooks/index.ts
+++ b/packages/core/src/react-integration/hooks/index.ts
@@ -5,6 +5,7 @@ import useResource from './useResource';
 import useSubscription from './useSubscription';
 import useMeta from './useMeta';
 import useError from './useError';
+import useExpiresAt from './useExpiresAt';
 import useInvalidator from './useInvalidator';
 import useResetter from './useResetter';
 import useFetchDispatcher from './useFetchDispatcher';
@@ -20,6 +21,7 @@ export {
   useResource,
   useSubscription,
   useMeta,
+  useExpiresAt,
   useInvalidator,
   useInvalidateDispatcher,
   useResetter,

--- a/packages/core/src/react-integration/hooks/useCache.ts
+++ b/packages/core/src/react-integration/hooks/useCache.ts
@@ -23,17 +23,16 @@ export default function useCache<
   fetchShape: Shape,
   params: ParamsFromShape<Shape> | null,
 ): DenormalizeNullable<Shape['schema']> {
-  const expiresAt = useExpiresAt(fetchShape, params);
-
   const state = useContext(StateContext);
   const denormalizeCache = useContext(DenormalizeCacheContext);
 
-  const [denormalized, ready, deleted] = useDenormalized(
+  const [denormalized, ready, deleted, entitiesExpireAt] = useDenormalized(
     fetchShape,
     params,
     state,
     denormalizeCache,
   );
+  const expiresAt = useExpiresAt(fetchShape, params, entitiesExpireAt);
   const error = useError(fetchShape, params, ready);
   const trigger = deleted && !error;
 

--- a/packages/core/src/react-integration/hooks/useExpiresAt.ts
+++ b/packages/core/src/react-integration/hooks/useExpiresAt.ts
@@ -6,11 +6,14 @@ import useMeta from './useMeta';
 export default function useExpiresAt<Params extends Readonly<object>>(
   fetchShape: Pick<ReadShape<any, Params>, 'getFetchKey' | 'options'>,
   params: Params | null,
+  entitiesExpireAt = 0,
 ): number {
   const meta = useMeta(fetchShape, params);
+
   if (!meta) {
-    return 0;
+    return entitiesExpireAt;
   }
+
   // Temporarily prevent infinite loops until invalidIfStale is revised
   if (
     fetchShape.options?.invalidIfStale &&
@@ -19,5 +22,6 @@ export default function useExpiresAt<Params extends Readonly<object>>(
   ) {
     return meta.expiresAt + 2000;
   }
+
   return meta.expiresAt;
 }

--- a/packages/core/src/react-integration/hooks/useResource.ts
+++ b/packages/core/src/react-integration/hooks/useResource.ts
@@ -31,7 +31,7 @@ function useOneResource<
 > {
   const state = useContext(StateContext);
   const denormalizeCache = useContext(DenormalizeCacheContext);
-  const [denormalized, ready, deleted] = useDenormalized(
+  const [denormalized, ready, deleted, entitiesExpireAt] = useDenormalized(
     fetchShape,
     params,
     state,
@@ -39,7 +39,12 @@ function useOneResource<
   );
   const error = useError(fetchShape, params, ready);
 
-  const maybePromise = useRetrieve(fetchShape, params, deleted && !error);
+  const maybePromise = useRetrieve(
+    fetchShape,
+    params,
+    deleted && !error,
+    entitiesExpireAt,
+  );
 
   // refetching won't ever save us if the network response is bad.
   if (error && error.synthetic) throw error;
@@ -93,6 +98,7 @@ function useManyResources<A extends ResourceArgs<any, any>[]>(
         fetchShape,
         params,
         denormalizedValues[i][2] && !errorValues[i],
+        denormalizedValues[i][3],
       ),
     )
     // only wait on promises without results

--- a/packages/core/src/react-integration/hooks/useRetrieve.ts
+++ b/packages/core/src/react-integration/hooks/useRetrieve.ts
@@ -10,9 +10,10 @@ export default function useRetrieve<Shape extends ReadShape<any, any>>(
   fetchShape: Shape,
   params: ParamsFromShape<Shape> | null,
   triggerFetch = false,
+  entitiesExpireAt = 0,
 ) {
   const dispatchFetch: any = useFetchDispatcher(true);
-  const expiresAt = useExpiresAt(fetchShape, params);
+  const expiresAt = useExpiresAt(fetchShape, params, entitiesExpireAt);
 
   // Clears invalidIfStale loop blocking mechanism
   const dispatch = useContext(DispatchContext);

--- a/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
@@ -17,6 +17,7 @@ Object {
     "http://test.com/article-cooler/": Object {
       "5": Object {
         "date": 50,
+        "expiresAt": 55,
       },
     },
   },

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -34,6 +34,7 @@ Object {
     "http://test.com/article/": Object {
       "20": Object {
         "date": 5000000000,
+        "expiresAt": 5000500000,
       },
     },
   },

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -91,10 +91,11 @@ describe('reducer', () => {
         ...partialResultAction,
         meta: {
           ...partialResultAction.meta,
+          expiresAt: partialResultAction.meta.expiresAt * 2,
           date: partialResultAction.meta.date * 2,
         },
       };
-      const getMeta = (state: any): { date: number } =>
+      const getMeta = (state: any): { expiresAt: number } =>
         state.entityMeta[ArticleResource.key][
           `${ArticleResource.pk(action.payload)}`
         ];
@@ -104,7 +105,7 @@ describe('reducer', () => {
       const nextMeta = getMeta(nextState);
 
       expect(nextMeta).toBeDefined();
-      expect(nextMeta.date).toBe(localAction.meta.date);
+      expect(nextMeta.expiresAt).toBe(localAction.meta.expiresAt);
     });
 
     it('should use existing entity with older date', () => {
@@ -113,6 +114,7 @@ describe('reducer', () => {
         meta: {
           ...partialResultAction.meta,
           date: partialResultAction.meta.date / 2,
+          expiresAt: partialResultAction.meta.expiresAt / 2,
         },
       };
       const getMeta = (state: any): { date: number } =>

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -91,11 +91,7 @@ export default function reducer(
               prevExpiresAt: state.meta[action.meta.key]?.expiresAt,
             },
           },
-          entityMeta: updateEntityMeta(
-            state.entityMeta,
-            entities,
-            action.meta.date,
-          ),
+          entityMeta: updateEntityMeta(state.entityMeta, entities, action.meta),
           optimistic: filterOptimistic(state, action),
         };
         // reducer must update the state, so in case of processing errors we simply compute the results inline
@@ -198,13 +194,14 @@ function filterOptimistic(
 function updateEntityMeta(
   entityMeta: State<unknown>['entityMeta'],
   entities: State<unknown>['entities'],
-  date: number, // we may have to update with different times in the future
+  { expiresAt, date }: { expiresAt: number; date: number },
 ): State<unknown>['entityMeta'] {
   const meta: any = { ...entityMeta };
   for (const k in entities) {
     meta[k] = { ...entityMeta[k] };
     for (const pk in entities[k]) {
-      meta[k][pk] = meta[k][pk]?.date >= date ? meta[k][pk] : { date };
+      meta[k][pk] =
+        meta[k][pk]?.expiresAt >= expiresAt ? meta[k][pk] : { expiresAt, date };
     }
   }
   return meta;

--- a/packages/core/src/state/selectors/__tests__/useDenormalized.ts
+++ b/packages/core/src/state/selectors/__tests__/useDenormalized.ts
@@ -6,6 +6,7 @@ import {
   IndexedUserResource,
   photoShape,
 } from '__tests__/common';
+import { createEntityMeta } from '__tests__/utils';
 import { denormalize, normalize, NormalizedIndex } from '@rest-hooks/normalizr';
 import { initialState } from '@rest-hooks/core/state/reducer';
 import { renderHook, act } from '@testing-library/react-hooks';
@@ -81,6 +82,7 @@ describe('useDenormalized()', () => {
           [CoolerArticleResource.detailShape().getFetchKey(params)]: params.id,
         },
       };
+      state.entityMeta = createEntityMeta(state.entities);
       const {
         result: {
           current: [value, found, deleted],
@@ -139,6 +141,7 @@ describe('useDenormalized()', () => {
           },
         },
       };
+      state.entityMeta = createEntityMeta(state.entities);
       const {
         result: {
           current: [value, found, deleted],
@@ -170,6 +173,7 @@ describe('useDenormalized()', () => {
           },
         },
       };
+      state.entityMeta = createEntityMeta(state.entities);
       const {
         result: {
           current: [value, found, deleted],
@@ -219,6 +223,7 @@ describe('useDenormalized()', () => {
             [UserResource.key]: { [`${user.pk()}`]: user },
           },
         };
+        localstate.entityMeta = createEntityMeta(localstate.entities);
 
         const { result, rerender } = renderHook(
           ({ state }) =>
@@ -258,6 +263,7 @@ describe('useDenormalized()', () => {
           )]: params.id,
         },
       };
+      state.entityMeta = createEntityMeta(state.entities);
       const {
         result: {
           current: [value, found],
@@ -319,6 +325,7 @@ describe('useDenormalized()', () => {
           [UserResource.key]: { [`${user.pk()}`]: user },
         },
       };
+      state.entityMeta = createEntityMeta(state.entities);
       const {
         result: {
           current: [value, found],
@@ -670,13 +677,3 @@ describe('useDenormalized()', () => {
     });
   });
 });
-function createEntityMeta(entities: Record<string, Record<string, any>>) {
-  const entityMeta: any = {};
-  for (const k in entities) {
-    entityMeta[k] = {};
-    for (const pk in entities[k]) {
-      entityMeta[k][pk] = { date: 0, expiresAt: 0 };
-    }
-  }
-  return entityMeta;
-}

--- a/packages/core/src/state/selectors/__tests__/useDenormalized.ts
+++ b/packages/core/src/state/selectors/__tests__/useDenormalized.ts
@@ -406,6 +406,7 @@ describe('useDenormalized()', () => {
       const state = {
         ...initialState,
         entities,
+        entityMeta: createEntityMeta(entities),
         results: {
           [CoolerArticleResource.listShape().getFetchKey(params)]: resultState,
         },
@@ -435,6 +436,7 @@ describe('useDenormalized()', () => {
       const state = {
         ...initialState,
         entities,
+        entityMeta: createEntityMeta(entities),
         results: {
           [CoolerArticleResource.listShape().getFetchKey(params)]: resultState,
         },
@@ -466,6 +468,7 @@ describe('useDenormalized()', () => {
       const state = {
         ...initialState,
         entities,
+        entityMeta: createEntityMeta(entities),
         results: {
           [PaginatedArticleResource.listShape().getFetchKey(
             params,
@@ -497,6 +500,7 @@ describe('useDenormalized()', () => {
       const state = {
         ...initialState,
         entities,
+        entityMeta: createEntityMeta(entities),
         results: {
           [PaginatedArticleResource.listShape().getFetchKey(
             params,
@@ -545,17 +549,20 @@ describe('useDenormalized()', () => {
         expect(result.current.ret[0].results).toBe(prevValue.results);
 
         act(() =>
-          result.current.setState((state: any) => ({
-            ...state,
-            entities: {
-              ...state.entities,
-              [PaginatedArticleResource.key]: {
-                1430: 'fake2',
-                ...state.entities[PaginatedArticleResource.key],
-                100000: 'fake',
+          result.current.setState((state: any) => {
+            const ret = {
+              ...state,
+              entities: {
+                ...state.entities,
+                [PaginatedArticleResource.key]: {
+                  1430: 'fake2',
+                  ...state.entities[PaginatedArticleResource.key],
+                  100000: 'fake',
+                },
               },
-            },
-          })),
+            };
+            return { ...ret, entityMeta: createEntityMeta(state.entities) };
+          }),
         );
         expect(result.current.ret[0]).toBe(prevValue);
         expect(result.current.ret[0].results).toBe(prevValue.results);
@@ -604,6 +611,7 @@ describe('useDenormalized()', () => {
       const state = {
         ...initialState,
         entities,
+        entityMeta: createEntityMeta(entities),
       };
       const {
         result: {
@@ -633,7 +641,7 @@ describe('useDenormalized()', () => {
       const { result } = renderHook(() => {
         return useDenormalized(photoShape, { userId }, initialState as any);
       });
-      expect(result.current).toStrictEqual([undefined, false, false]);
+      expect(result.current).toStrictEqual([null, false, false, 0]);
     });
 
     it('should return results as-is for schemas with no entities', () => {
@@ -649,7 +657,7 @@ describe('useDenormalized()', () => {
       const { result } = renderHook(() => {
         return useDenormalized(photoShape, { userId }, state);
       });
-      expect(result.current).toStrictEqual([results, true, false]);
+      expect(result.current).toStrictEqual([results, true, false, 0]);
     });
 
     it('should throw with invalid schemas', () => {
@@ -662,3 +670,13 @@ describe('useDenormalized()', () => {
     });
   });
 });
+function createEntityMeta(entities: Record<string, Record<string, any>>) {
+  const entityMeta: any = {};
+  for (const k in entities) {
+    entityMeta[k] = {};
+    for (const pk in entities[k]) {
+      entityMeta[k][pk] = { date: 0, expiresAt: 0 };
+    }
+  }
+  return entityMeta;
+}

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -24,16 +24,18 @@ import buildInferredResults from './buildInferredResults';
 export default function useDenormalized<
   Shape extends Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>
 >(
-  { schema, getFetchKey, options }: Shape,
+  { schema, getFetchKey }: Shape,
   params: ParamsFromShape<Shape> | null,
   state: State<any>,
   denormalizeCache: DenormalizeCache = { entities: {}, results: {} },
 ): [
-  DenormalizeNullable<Shape['schema']>,
-  typeof params extends null ? false : boolean,
-  boolean,
+  denormalized: DenormalizeNullable<Shape['schema']>,
+  found: typeof params extends null ? false : boolean,
+  deleted: boolean,
+  entitiesExpireAt: number,
 ] {
-  let entities = state.entities;
+  const entities = state.entities;
+  const entityMeta = state.entityMeta;
   const cacheResults = params && state.results[getFetchKey(params)];
   const serializedParams = params && getFetchKey(params);
 
@@ -52,12 +54,14 @@ export default function useDenormalized<
 
   // Compute denormalized value
   return useMemo(() => {
-    if (!needsDenormalization)
-      return [cacheResults, cacheResults !== undefined, false] as [
+    if (!needsDenormalization) {
+      return [results, cacheResults !== undefined, false, 0] as [
         DenormalizeNullable<Shape['schema']>,
         any,
         boolean,
+        number,
       ];
+    }
     // Warn users with bad configurations
     /* istanbul ignore next */
     if (process.env.NODE_ENV !== 'production' && isEntity(schema)) {
@@ -74,31 +78,47 @@ export default function useDenormalized<
       }
     }
 
-    // inferred results are considered stale
-    if (options && options.invalidIfStale && !cacheResults) entities = {};
-
     if (params && !denormalizeCache.results[getFetchKey(params)])
       denormalizeCache.results[getFetchKey(params)] = new WeakListMap();
 
     // second argument is false if any entities are missing
     // eslint-disable-next-line prefer-const
-    return denormalize(
+    const [value, found, deleted, resolvedEntities] = denormalize(
       results,
       schema,
       entities,
       denormalizeCache.entities,
       params ? denormalizeCache.results[getFetchKey(params)] : undefined,
-    ) as [DenormalizeNullable<Shape['schema']>, boolean, boolean];
+    ) as [
+      DenormalizeNullable<Shape['schema']>,
+      boolean,
+      boolean,
+      Record<string, Record<string, any>>,
+    ];
 
+    // oldest entity dictates age
+    let expiresAt = Infinity;
+    if (found) {
+      // using Object.keys ensures we don't hit `toString` type members
+      for (const key of Object.keys(resolvedEntities)) {
+        for (const pk of Object.keys(resolvedEntities[key])) {
+          expiresAt = Math.min(expiresAt, entityMeta?.[key]?.[pk].expiresAt);
+        }
+      }
+    } else {
+      expiresAt = 0;
+    }
+
+    return [value, found, deleted, expiresAt];
     // TODO: would be nice to make this only recompute on the entity types that are in schema
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     entities,
+    entityMeta,
     serializedParams,
     results,
     cacheResults,
     needsDenormalization,
-    options && options.invalidIfStale,
   ]);
 }
 

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -102,7 +102,7 @@ export default function useDenormalized<
       // using Object.keys ensures we don't hit `toString` type members
       Object.keys(resolvedEntities).forEach(key =>
         Object.keys(resolvedEntities[key]).forEach(pk => {
-          expiresAt = Math.min(expiresAt, entityMeta?.[key]?.[pk].expiresAt);
+          expiresAt = Math.min(expiresAt, entityMeta[key][pk].expiresAt);
         }),
       );
     } else {

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -100,11 +100,11 @@ export default function useDenormalized<
     let expiresAt = Infinity;
     if (found) {
       // using Object.keys ensures we don't hit `toString` type members
-      for (const key of Object.keys(resolvedEntities)) {
-        for (const pk of Object.keys(resolvedEntities[key])) {
+      Object.keys(resolvedEntities).forEach(key =>
+        Object.keys(resolvedEntities[key]).forEach(pk => {
           expiresAt = Math.min(expiresAt, entityMeta?.[key]?.[pk].expiresAt);
-        }
-      }
+        }),
+      );
     } else {
       expiresAt = 0;
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,7 +38,10 @@ export type State<T> = Readonly<{
   };
   entityMeta: {
     readonly [entityKey: string]: {
-      readonly [pk: string]: { readonly date: number };
+      readonly [pk: string]: {
+        readonly date: number;
+        readonly expiresAt: number;
+      };
     };
   };
   optimistic: ReceiveAction[];

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -59,7 +59,7 @@
     "@rest-hooks/test": "^2.0.0-k.2"
   },
   "peerDependencies": {
-    "@rest-hooks/core": "^1.0.0-delta.0",
+    "@rest-hooks/core": "^1.0.0-k.6",
     "@types/react": "^16.8.4 || ^17.0.0",
     "react": "^16.8.4 || ^17.0.0"
   },

--- a/packages/legacy/src/index.ts
+++ b/packages/legacy/src/index.ts
@@ -20,7 +20,7 @@ export function useStatefulResource<
   S extends Schema
 >(fetchShape: ReadShape<S, Params>, params: Params | null) {
   const state = useContext(StateContext);
-  const [denormalized, ready, deleted] = useDenormalized(
+  const [denormalized, ready, deleted, entitiesExpireAt] = useDenormalized(
     fetchShape,
     params,
     state,
@@ -31,6 +31,7 @@ export function useStatefulResource<
     fetchShape,
     params,
     deleted && !error,
+    entitiesExpireAt,
   );
 
   if (maybePromise) {

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalize } from '../denormalize';
+import { denormalizeSimple as denormalize } from '../denormalize';
 import { normalize, schema } from '../';
 import Entity from '../entities/Entity';
 import IDEntity from '../entities/IDEntity';

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -2,7 +2,7 @@
 import { fromJS, Record } from 'immutable';
 import { first } from 'lodash';
 
-import { denormalize } from '../../denormalize';
+import { denormalizeSimple as denormalize } from '../../denormalize';
 import { normalize, schema, SimpleRecord, AbstractInstanceType } from '../../';
 import Entity from '../Entity';
 import IDEntity from '../IDEntity';

--- a/packages/normalizr/src/schemas/__tests__/Array.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Array.test.js
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalize } from '../../denormalize';
+import { denormalizeSimple as denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import IDEntity from '../../entities/IDEntity';
 

--- a/packages/normalizr/src/schemas/__tests__/Delete.test.ts
+++ b/packages/normalizr/src/schemas/__tests__/Delete.test.ts
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalize } from '../../denormalize';
+import { denormalizeSimple as denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import IDEntity from '../../entities/IDEntity';
 import { DELETED } from '../../special';

--- a/packages/normalizr/src/schemas/__tests__/Object.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Object.test.js
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalize } from '../../denormalize';
+import { denormalizeSimple as denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import Entity from '../../entities/Entity';
 import IDEntity from '../../entities/IDEntity';

--- a/packages/normalizr/src/schemas/__tests__/Serializable.test.ts
+++ b/packages/normalizr/src/schemas/__tests__/Serializable.test.ts
@@ -1,5 +1,5 @@
 // eslint-env jest
-import { denormalize } from '../../denormalize';
+import { denormalizeSimple as denormalize } from '../../denormalize';
 import { normalize } from '../../';
 import IDEntity from '../../entities/IDEntity';
 

--- a/packages/normalizr/src/schemas/__tests__/Union.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Union.test.js
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalize } from '../../denormalize';
+import { denormalizeSimple as denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import IDEntity from '../../entities/IDEntity';
 

--- a/packages/normalizr/src/schemas/__tests__/Values.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Values.test.js
@@ -1,7 +1,7 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
 
-import { denormalize } from '../../denormalize';
+import { denormalizeSimple as denormalize } from '../../denormalize';
 import { normalize, schema } from '../../';
 import IDEntity from '../../entities/IDEntity';
 import Entity from '../../entities/Entity';


### PR DESCRIPTION
In other words: don't extraneously refetch fresh data.

BREAKING CHANGE: useResource() inferred endpoint will sometimes
not trigger a fetch if entities are fresh enough

Fixes #460 .
Also requested by: @melissafzhang @dgcoffman 
Continuation of: #439

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Allows liberal use of useResource()

- When a detail (inferrable) useResouce() is in a nested component of a list result, will not trigger `N` fetches
- Any other case where manual useCache() tracking was used.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Previously inferred results were set to expiry time of 0, which meant they would try to fetch if they could
- Now this is computed based on the 'oldest' (or soonest to expire) entity of those used.
- If any entities are missing, the full result was not inferred and thus expiry is 0.
- Also went back to previous denormalize() design (from previous commit) that returns the localCache of entities. However, this time we have a slightly cleaner interface to getUnvisit().
- entitiesExpireAt added to several hooks `useRetrieve()`, `useExpiresAt()`. This defaults to 0 so previous behavior is maintained.
- entitiesExpireAt is now returned from `useDenormalized()`