### PR TITLE
internal: publish 5 rc.0

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.0-rc.0 (2021-01-14)
+
+* enhance: Inferred endpoints expiry based on entities (#464) ([975e0d8](https://github.com/coinbase/rest-hooks/commit/975e0d8)), closes [#464](https://github.com/coinbase/rest-hooks/issues/464)
+* enhance: Maintain referential equality globally (#403) ([e1e353d](https://github.com/coinbase/rest-hooks/commit/e1e353d)), closes [#403](https://github.com/coinbase/rest-hooks/issues/403)
+* internal: Fix publish message (#461) ([e1691f5](https://github.com/coinbase/rest-hooks/commit/e1691f5)), closes [#461](https://github.com/coinbase/rest-hooks/issues/461)
+
+
+### BREAKING CHANGE
+
+* Node engine requirement of >=0.12
+* useResource() inferred endpoint will sometimes
+not trigger a fetch if entities are fresh enough
+
+
+
+
 ## 1.0.0-k.5 (2021-01-06)
 
 * Expose BodyFromShape from core library ([060dcd3](https://github.com/coinbase/rest-hooks/commit/060dcd3))

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "1.0.0-k.5",
+  "version": "1.0.0-rc.0",
   "description": "Dynamic data fetching for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -65,8 +65,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "@rest-hooks/endpoint": "^0.7.3",
-    "@rest-hooks/normalizr": "^6.0.0-k.0",
+    "@rest-hooks/endpoint": "^0.7.4",
+    "@rest-hooks/normalizr": "^6.0.0-rc.0",
     "@rest-hooks/use-enhanced-reducer": "^1.0.5",
     "flux-standard-action": "^2.1.1"
   },

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## <small>0.7.4 (2021-01-14)</small>
+
+**Note:** Version bump only for package @rest-hooks/endpoint
+
+
+
+
+
 ## <small>0.7.3 (2021-01-06)</small>
 
 * pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "@rest-hooks/normalizr": "^6.0.0-k.0"
+    "@rest-hooks/normalizr": "^6.0.0-rc.0"
   }
 }

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2.0.0-rc.0 (2021-01-14)
+
+* enhance: Inferred endpoints expiry based on entities (#464) ([975e0d8](https://github.com/coinbase/rest-hooks/commit/975e0d8)), closes [#464](https://github.com/coinbase/rest-hooks/issues/464)
+
+
+### BREAKING CHANGE
+
+* useResource() inferred endpoint will sometimes
+not trigger a fetch if entities are fresh enough
+
+
+
+
 ## 2.0.0-k.2 (2021-01-06)
 
 **Note:** Version bump only for package @rest-hooks/legacy

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "2.0.0-k.2",
+  "version": "2.0.0-rc.0",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 6.0.0-rc.0 (2021-01-14)
+
+* enhance: Inferred endpoints expiry based on entities (#464) ([975e0d8](https://github.com/coinbase/rest-hooks/commit/975e0d8)), closes [#464](https://github.com/coinbase/rest-hooks/issues/464)
+* enhance: Maintain referential equality globally (#403) ([e1e353d](https://github.com/coinbase/rest-hooks/commit/e1e353d)), closes [#403](https://github.com/coinbase/rest-hooks/issues/403)
+* internal: add missing dev dep ([51fc222](https://github.com/coinbase/rest-hooks/commit/51fc222))
+
+
+### BREAKING CHANGE
+
+* Node engine requirement of >=0.12
+* useResource() inferred endpoint will sometimes
+not trigger a fetch if entities are fresh enough
+
+
+
+
 ## 6.0.0-k.0 (2021-01-06)
 
 * pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "6.0.0-k.0",
+  "version": "6.0.0-rc.0",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 5.0.0-rc.0 (2021-01-14)
+
+* enhance: Maintain referential equality globally (#403) ([e1e353d](https://github.com/coinbase/rest-hooks/commit/e1e353d)), closes [#403](https://github.com/coinbase/rest-hooks/issues/403)
+
+
+### BREAKING CHANGE
+
+* Node engine requirement of >=0.12
+
+
+
+
 ## 5.0.0-k.5 (2021-01-06)
 
 * internal: Ignore dev env only paths for code coverage ([d425dfd](https://github.com/coinbase/rest-hooks/commit/d425dfd))

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "5.0.0-k.5",
+  "version": "5.0.0-rc.0",
   "description": "Dynamic data fetching for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -67,8 +67,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",
-    "@rest-hooks/core": "^1.0.0-k.5",
-    "@rest-hooks/endpoint": "^0.7.3"
+    "@rest-hooks/core": "^1.0.0-rc.0",
+    "@rest-hooks/endpoint": "^0.7.4"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0",


### PR DESCRIPTION
 - @rest-hooks/core@1.0.0-rc.0
 - @rest-hooks/endpoint@0.7.4
 - @rest-hooks/legacy@2.0.0-rc.0
 - @rest-hooks/normalizr@6.0.0-rc.0
 - rest-hooks@5.0.0-rc.0

<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->
`yarn lerna version --no-push --preid=rc`