### PR TITLE
feat: Resources can have nested entities

### DIFF
--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
@@ -5,7 +5,12 @@ exports[` => <Provider /> Endpoint should gracefully abort in useResource() 1`] 
 exports[` => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 5,
     "tags": Array [
@@ -16,7 +21,12 @@ Array [
     "title": "hi ho",
   },
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 3,
     "tags": Array [],
@@ -46,7 +56,12 @@ IndexedUserResource {
 exports[` => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 5,
     "tags": Array [
@@ -57,7 +72,12 @@ Array [
     "title": "hi ho",
   },
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 3,
     "tags": Array [],
@@ -101,7 +121,12 @@ exports[`makeCacheProvider => <Provider /> Endpoint should gracefully abort in u
 exports[`makeCacheProvider => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 5,
     "tags": Array [
@@ -112,7 +137,12 @@ Array [
     "title": "hi ho",
   },
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 3,
     "tags": Array [],
@@ -142,7 +172,12 @@ IndexedUserResource {
 exports[`makeCacheProvider => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 5,
     "tags": Array [
@@ -153,7 +188,12 @@ Array [
     "title": "hi ho",
   },
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 3,
     "tags": Array [],

--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
@@ -3,7 +3,12 @@
 exports[` => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 5,
     "tags": Array [
@@ -14,7 +19,12 @@ Array [
     "title": "hi ho",
   },
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 3,
     "tags": Array [],
@@ -44,7 +54,12 @@ IndexedUserResource {
 exports[` => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 5,
     "tags": Array [
@@ -55,7 +70,12 @@ Array [
     "title": "hi ho",
   },
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 3,
     "tags": Array [],
@@ -97,7 +117,12 @@ Attempted to initialize CoolerArticleResource with substantially different than 
 exports[`makeCacheProvider => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 5,
     "tags": Array [
@@ -108,7 +133,12 @@ Array [
     "title": "hi ho",
   },
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 3,
     "tags": Array [],
@@ -138,7 +168,12 @@ IndexedUserResource {
 exports[`makeCacheProvider => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 5,
     "tags": Array [
@@ -149,7 +184,12 @@ Array [
     "title": "hi ho",
   },
   PaginatedArticleResource {
-    "author": "23",
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
     "content": "whatever",
     "id": 3,
     "tags": Array [],

--- a/packages/core/src/state/selectors/__tests__/useDenormalized.ts
+++ b/packages/core/src/state/selectors/__tests__/useDenormalized.ts
@@ -345,7 +345,12 @@ describe('useDenormalized()', () => {
             "id": 5,
             "tags": Array [],
             "title": "bob",
-            "user": 23,
+            "user": UserResource {
+              "email": "",
+              "id": 23,
+              "isAdmin": false,
+              "username": "anne",
+            },
           }
         `);
       });

--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -1,4 +1,4 @@
-import { FlatEntity, schema } from '@rest-hooks/normalizr';
+import { Entity, schema } from '@rest-hooks/normalizr';
 import type { AbstractInstanceType } from '@rest-hooks/normalizr';
 import { Endpoint } from '@rest-hooks/endpoint';
 import type {
@@ -16,7 +16,7 @@ import paramsToString from './paramsToString';
  *
  * This can be a useful organization for many REST-like API patterns.
  */
-export default abstract class SimpleResource extends FlatEntity {
+export default abstract class SimpleResource extends Entity {
   // typescript todo: require subclasses to implement
   /** Used as base of url construction */
   static readonly urlRoot: string;


### PR DESCRIPTION
(Resource extends from Entity instead of FlatEntity)

BREAKING CHANGE: Resources will resolve with any nested
entities from their schemas, rather than the `pk` of those
entities

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
With referential equality guarantees (#403), fully denormalizing Resources with nested members now makes sense
and is performant.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Using `rest-hooks` package retains the old `Resource` and `SimpleResource` behavior. The new adoption and recommended
method of defining Resources is via `@rest-hooks/rest` package. Eventually the `rest-hooks` version will be removed.