### PR TITLE
enhance: `endpoint` package only exports definitions

### DIFF
--- a/packages/core/src/endpoint/shapes.ts
+++ b/packages/core/src/endpoint/shapes.ts
@@ -1,5 +1,5 @@
 import { FetchOptions } from '@rest-hooks/core/types';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 
 /** Defines the shape of a network request */
 export interface FetchShape<

--- a/packages/core/src/endpoint/types.ts
+++ b/packages/core/src/endpoint/types.ts
@@ -1,5 +1,5 @@
 import { UpdateFunction } from '@rest-hooks/core/types';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 import type { Denormalize } from '@rest-hooks/endpoint';
 
 import { FetchShape } from './shapes';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { DELETED } from '@rest-hooks/normalizr';
+import { DELETED } from '@rest-hooks/endpoint';
 
 import buildInferredResults from './state/selectors/buildInferredResults';
 import RIC from './state/RIC';

--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -1,5 +1,5 @@
 import { ReadShape } from '@rest-hooks/core/endpoint';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 
 import useMeta from './useMeta';
 

--- a/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
@@ -6,7 +6,7 @@ import {
   OptimisticUpdateParams,
   ReturnFromShape,
 } from '@rest-hooks/core/endpoint';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 import { DispatchContext } from '@rest-hooks/core/react-integration/context';
 import createFetch from '@rest-hooks/core/state/actions/createFetch';
 import { useContext, useCallback } from 'react';

--- a/packages/core/src/react-integration/hooks/useFetcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetcher.ts
@@ -6,7 +6,7 @@ import {
   OptimisticUpdateParams,
   ReturnFromShape,
 } from '@rest-hooks/core/endpoint';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 import { useRef, useCallback } from 'react';
 
 import useFetchDispatcher from './useFetchDispatcher';

--- a/packages/core/src/react-integration/hooks/useInvalidateDispatcher.ts
+++ b/packages/core/src/react-integration/hooks/useInvalidateDispatcher.ts
@@ -1,6 +1,6 @@
 import { useContext, useCallback } from 'react';
 import { ReadShape } from '@rest-hooks/core/endpoint';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 import { DispatchContext } from '@rest-hooks/core/react-integration/context';
 import { INVALIDATE_TYPE } from '@rest-hooks/core/actionTypes';
 

--- a/packages/core/src/react-integration/hooks/useInvalidator.ts
+++ b/packages/core/src/react-integration/hooks/useInvalidator.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { ReadShape } from '@rest-hooks/core/endpoint';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 
 import useInvalidateDispatcher from './useInvalidateDispatcher';
 

--- a/packages/core/src/react-integration/hooks/useSubscription.ts
+++ b/packages/core/src/react-integration/hooks/useSubscription.ts
@@ -1,6 +1,6 @@
 import { DispatchContext } from '@rest-hooks/core/react-integration/context';
 import { ReadShape } from '@rest-hooks/core/endpoint';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 import { SUBSCRIBE_TYPE, UNSUBSCRIBE_TYPE } from '@rest-hooks/core/actionTypes';
 import { useContext, useEffect, useRef } from 'react';
 

--- a/packages/core/src/state/actions/createFetch.ts
+++ b/packages/core/src/state/actions/createFetch.ts
@@ -1,6 +1,6 @@
 import { FetchAction } from '@rest-hooks/core/types';
 import { FETCH_TYPE } from '@rest-hooks/core/actionTypes';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 import {
   FetchShape,
   SchemaFromShape,

--- a/packages/core/src/state/actions/createReceive.ts
+++ b/packages/core/src/state/actions/createReceive.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 import {
   FetchAction,
   ReceiveAction,

--- a/packages/core/src/state/actions/createReceiveError.ts
+++ b/packages/core/src/state/actions/createReceiveError.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 import {
   FetchAction,
   ReceiveAction,

--- a/packages/core/src/state/applyUpdatersToResults.ts
+++ b/packages/core/src/state/applyUpdatersToResults.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@rest-hooks/normalizr';
+import type { Schema } from '@rest-hooks/endpoint';
 import { Normalize, UpdateFunction } from '@rest-hooks/endpoint';
 
 type ResultStateFromUpdateFunctions<

--- a/packages/core/src/state/selectors/buildInferredResults.ts
+++ b/packages/core/src/state/selectors/buildInferredResults.ts
@@ -1,9 +1,5 @@
-import {
-  NormalizedIndex,
-  isEntity,
-  Schema,
-  schema as schemas,
-} from '@rest-hooks/normalizr';
+import { isEntity, Schema, schema as schemas } from '@rest-hooks/endpoint';
+import { NormalizedIndex } from '@rest-hooks/normalizr';
 import { NormalizeNullable } from '@rest-hooks/endpoint';
 
 /**

--- a/packages/core/src/state/selectors/getEntityPath.ts
+++ b/packages/core/src/state/selectors/getEntityPath.ts
@@ -1,4 +1,4 @@
-import { isEntity, Schema, schema as schemas } from '@rest-hooks/normalizr';
+import { isEntity, Schema, schema as schemas } from '@rest-hooks/endpoint';
 
 export default function getEntityPath(schema: Schema): string[] | false {
   if (

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -1,12 +1,11 @@
 import { State } from '@rest-hooks/core/types';
 import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
 import { DenormalizeNullable } from '@rest-hooks/endpoint';
+import { isEntity, Schema } from '@rest-hooks/endpoint';
 import {
-  isEntity,
-  Schema,
-  denormalize,
   DenormalizeCache,
   WeakListMap,
+  denormalize,
 } from '@rest-hooks/normalizr';
 import { useMemo } from 'react';
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,9 @@
 import { NormalizedIndex } from '@rest-hooks/normalizr';
-import { UpdateFunction } from '@rest-hooks/endpoint';
-import type { AbstractInstanceType, Schema } from '@rest-hooks/normalizr';
+import type {
+  UpdateFunction,
+  AbstractInstanceType,
+  Schema,
+} from '@rest-hooks/endpoint';
 import { Middleware } from '@rest-hooks/use-enhanced-reducer';
 import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
 

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -14,12 +14,10 @@ export type {
   DenormalizeNullable,
 } from './normal';
 export {
-  normalize,
-  denormalize,
   schema,
+  SimpleRecord,
   Entity,
   isEntity,
-  SimpleRecord,
   DELETED,
 } from '@rest-hooks/normalizr';
 export type { AbstractInstanceType, Schema } from '@rest-hooks/normalizr';


### PR DESCRIPTION
BREAKING CHANGE: Remove `normalize`, `denormalize`; use
`normalizr` package for those

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The goal of endpoints package is to allow people to publish endpoints independent of all implementation details.

Previously, we distinguished this by ignoring the react implementation, however the processing elements like `normalizr` and `denormalize` could change independent of interfaces. For instance, this just happened. However, if we can keep the interfaces non-breaking changes for many years, this means people can use their existing network definitions without worry for a very long time.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Only export the definitions themselves.
- Also change imports in core so normalizr is only used for processing utilities.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Should we perhaps split normalizr package in two so we aren't importing normalizr and only using half of it for this package.