### PR TITLE
internal: Use custom template for release gen

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/react": "^17.0.0",
     "@zerollup/ts-transform-paths": "^1.7.18",
     "babel-jest": "^26.6.3",
-    "conventional-changelog-anansi": "^0.1.2",
+    "conventional-changelog-anansi": "^0.2.0",
     "coveralls": "^3.1.0",
     "core-js": "^3.8.1",
     "cpy-cli": "^3.1.1",
@@ -76,6 +76,9 @@
     "ttypescript": "^1.5.12",
     "typescript": "^4.1.3",
     "whatwg-fetch": "3.0.0"
+  },
+  "resolutions": {
+    "@lerna/conventional-commits": "https://github.com/ntucker/lerna-conventional-commits.git"
   },
   "version": "0.0.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1845,13 +1845,12 @@
     is-ci "^2.0.0"
     npmlog "^4.1.2"
 
-"@lerna/conventional-commits@3.22.0":
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.22.0.tgz#2798f4881ee2ef457bdae027ab7d0bf0af6f1e09"
-  integrity sha512-z4ZZk1e8Mhz7+IS8NxHr64wyklHctCJyWpJKEZZPJiLFJ8yKto/x38O80R10pIzC0rr8Sy/OsjSH4bl0TbbgqA==
+"@lerna/conventional-commits@3.22.0", "@lerna/conventional-commits@https://github.com/ntucker/lerna-conventional-commits.git":
+  version "3.16.4"
+  resolved "https://github.com/ntucker/lerna-conventional-commits.git#7ecf8c762aa9cfd2aeb504683ace8b12d5b3717f"
   dependencies:
-    "@lerna/validation-error" "3.13.0"
-    conventional-changelog-angular "^5.0.3"
+    "@lerna/validation-error" "^3.13"
+    conventional-changelog-angular "^5.0.12"
     conventional-changelog-core "^3.1.6"
     conventional-recommended-bump "^5.0.0"
     fs-extra "^8.1.0"
@@ -2349,7 +2348,7 @@
   resolved "https://registry.yarnpkg.com/@lerna/timer/-/timer-3.13.0.tgz#bcd0904551db16e08364d6c18e5e2160fc870781"
   integrity sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==
 
-"@lerna/validation-error@3.13.0":
+"@lerna/validation-error@3.13.0", "@lerna/validation-error@^3.13":
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/@lerna/validation-error/-/validation-error-3.13.0.tgz#c86b8f07c5ab9539f775bd8a54976e926f3759c3"
   integrity sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==
@@ -4627,13 +4626,13 @@ contains-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
-conventional-changelog-anansi@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-anansi/-/conventional-changelog-anansi-0.1.2.tgz#ee23810fc51a28a790a053497ff63a53921bf509"
-  integrity sha512-KO+OP1cmfkNkhIstkeyh8cTlpcoBOx1FFxqcWeLlS0nac24eRwI+wLcY9uOz7XZlJ5pPUyO7WzMU3L5NWQ7dEw==
+conventional-changelog-anansi@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-anansi/-/conventional-changelog-anansi-0.2.0.tgz#30405f65040486f43df21d11059f7c94133ad08a"
+  integrity sha512-/55PpyZfW2bXcmyM1N8kFdVncXhVIW6qA9+Z7+Gjv2gHBJBBQZbgpto9WQj6JBY8kGolYceh3hkTa5AM+qf1Yg==
   dependencies:
     compare-func "^2.0.0"
-    lodash "^4.17.15"
+    lodash "^4.17.20"
     q "^1.5.1"
 
 conventional-changelog-angular@^5.0.0:
@@ -4644,12 +4643,12 @@ conventional-changelog-angular@^5.0.0:
     compare-func "^1.3.1"
     q "^1.5.1"
 
-conventional-changelog-angular@^5.0.3:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.6.tgz#269540c624553aded809c29a3508fdc2b544c059"
-  integrity sha512-QDEmLa+7qdhVIv8sFZfVxU1VSyVvnXPsxq8Vam49mKUcO1Z8VTLEJk9uI21uiJUsnmm0I4Hrsdc9TgkOQo9WSA==
+conventional-changelog-angular@^5.0.12:
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz#c979b8b921cbfe26402eb3da5bbfda02d865a2b9"
+  integrity sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==
   dependencies:
-    compare-func "^1.3.1"
+    compare-func "^2.0.0"
     q "^1.5.1"
 
 conventional-changelog-conventionalcommits@^4.3.1:
@@ -8557,6 +8556,11 @@ lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-driver@^1.2.7:
   version "1.2.7"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Better organized, easier to read release messages

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- updated packages
- tested here via `yarn lerna version --no-push --no-git-tag-version`

#### Example:

## [1.0.0-rc.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-rc.0...@rest-hooks/core@1.0.0-rc.1) (2021-01-18)


### ⚠ 💥 BREAKING CHANGES

* Remove `normalize`, `denormalize`; use
`normalizr` package for those
* Resources will resolve with any nested
entities from their schemas, rather than the `pk` of those
entities

### 🚀 Features

* Resources can have nested entities ([#469](https://github.com/coinbase/rest-hooks/issues/469)) ([4eeeaae](https://github.com/coinbase/rest-hooks/commit/4eeeaae1026715be4e72a66cd94d81934f2b0ce7))


### 💅 Enhancement

* `endpoint` package only exports definitions ([#473](https://github.com/coinbase/rest-hooks/issues/473)) ([51dcafe](https://github.com/coinbase/rest-hooks/commit/51dcafe98631998a1db1959f2796d7122d96960b))


