### PR TITLE
internal: Use github action to enforce commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,12 @@
+name: Lint Commit Messages
+
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2

--- a/package.json
+++ b/package.json
@@ -18,11 +18,6 @@
     "test:coverage": "yarn test -- --coverage",
     "prepare": "yarn run build:types"
   },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
-  },
   "engines": {"node": ">=10.0"},
   "browserslist": [
     "extends @anansi/browserslist-config"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Currently we lint on commit, which is a fairly large amount of friction for contributions. What we really need is to simply enforce conventions for a PR merge.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Adding this GH action. If this works well, will remove the per-commit enforcement
