### PR TITLE
docs: Improve legacy browser instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -32,83 +32,12 @@ npm install rest-hooks
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 
-## Legacy browser (IE) support
+## Legacy (IE) browser support
 
-Rest Hooks includes multiple bundles including a commonjs bundle that is compiled with maximum compatibility as well as an ES6 module bundle that is compiled to target modern browsers or react native.
-Tools like webpack or rollup will use the ES6 modules to enable optimizations like tree-shaking. However,
-the Javascript included will not support legacy browsers like Internet Explorer. If your browser target
-includes such browsers (you'll likely see something like `Uncaught TypeError: Class constructor Resource cannot be invoked without 'new'`) you will need to follow the steps below.
+If you see `Uncaught TypeError: Class constructor Resource cannot be invoked without 'new'`,
+follow the instructions to [add legacy browser support to packages](../guides/legacy-browser)
 
-### Transpile Rest Hooks package
-
-> Note: Many out-of-the-box solutions like create react app will already perform this step and no
-> additional work is needed.
-
-Add preset to run only legacy transformations.
-
-<!--DOCUSAURUS_CODE_TABS-->
-<!--yarn-->
-```bash
-yarn add --dev babel-preset-react-app
-```
-<!--npm-->
-```bash
-npm install babel-preset-react-app
-```
-<!--END_DOCUSAURUS_CODE_TABS-->
-
-Add this section to your `webpack.config.js` under the 'rules' section.
-
-This will only run legacy transpilation, and skip all other steps as they are unneeded.
-
-```js
-rules: [
-  // put other js rules here
-  {
-    test: /\.(js|mjs)$/,
-    use: ['babel-loader'],
-    include: [/node_modules/],
-    exclude: /@babel(?:\/|\\{1,2})runtime/,
-    options: {
-      babelrc: false,
-      configFile: false,
-      compact: false,
-      presets: [
-        [
-          require.resolve('babel-preset-react-app/dependencies'),
-          { helpers: true },
-        ],
-      ],
-      cacheDirectory: true,
-    },
-  },
-]
-```
-
-### Polyfills
-
-Use [CRA polyfill](https://github.com/facebook/create-react-app/tree/master/packages/react-app-polyfill)
-or follow instructions below.
-
-<!--DOCUSAURUS_CODE_TABS-->
-<!--yarn-->
-```bash
-yarn add core-js whatwg-fetch
-```
-<!--npm-->
-```bash
-npm install core-js whatwg-fetch
-```
-<!--END_DOCUSAURUS_CODE_TABS-->
-
-#### `index.tsx`
-
-```tsx
-import 'core-js/stable';
-import 'whatwg-fetch';
-// place the above line at top
-```
-
+With most tooling this won't be necessary.
 
 ## Add provider at top-level component
 

--- a/docs/guides/legacy-browser.md
+++ b/docs/guides/legacy-browser.md
@@ -1,0 +1,66 @@
+---
+title: Legacy browser support
+---
+
+Rest Hooks is designed to work out of the box with most tooling.
+
+If you see, `Uncaught TypeError: Class constructor Resource cannot be invoked without 'new'`
+this is most likely due to targeting Internet Explorer support with a custom webpack configuration.
+This will occur even when using a modern browser, so long as your target (typically set with [browserslist](https://www.npmjs.com/package/browserslist))
+includes legacy browsers like Internet Explorer.
+
+In this case, follow the instructions below to ensure compatibility.
+
+### Transpile packages
+
+Adding [webpack-plugin-modern-npm](https://www.npmjs.com/package/webpack-plugin-modern-npm) will ensure compatibility of all installed
+packages with legacy browsers.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--yarn-->
+```bash
+yarn add --dev webpack-plugin-modern-npm
+```
+<!--npm-->
+```bash
+npm install webpack-plugin-modern-npm
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+Then install the plugin by adding to webpack config.
+
+`webpack.config.js`
+
+```js
+const ModernNpmPlugin = require('webpack-plugin-modern-npm');
+
+module.exports = {
+  plugins: [
+    new ModernNpmPlugin()
+  ]
+};
+```
+
+### Polyfills
+
+Use [CRA polyfill](https://github.com/facebook/create-react-app/tree/master/packages/react-app-polyfill)
+or follow instructions below.
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--yarn-->
+```bash
+yarn add core-js whatwg-fetch
+```
+<!--npm-->
+```bash
+npm install core-js whatwg-fetch
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+#### `index.tsx`
+
+```tsx
+import 'core-js/stable';
+import 'whatwg-fetch';
+// place the above line at top
+```

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -172,6 +172,9 @@
       "guides/infinite-scrolling-pagination": {
         "title": "Infinite Scrolling"
       },
+      "guides/legacy-browser": {
+        "title": "Legacy browser support"
+      },
       "guides/loading-state": {
         "title": "Handling loading state"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -74,7 +74,7 @@
       {
         "type": "subcategory",
         "label": "Legacy",
-        "ids": ["guides/class-components", "guides/no-suspense"]
+        "ids": ["guides/class-components", "guides/no-suspense", "guides/legacy-browser"]
       }
     ],
     "API": [


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
High friction due to complex instructions.
- Both hard to follow
- Hard to understand when needed
- Makes the install page look long and complex

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

- Move instructions to distinct page
- Update instructions to use better tooling