### PR TITLE
enhance: Widen RestFetch types to make overriding not break

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -4,6 +4,8 @@ import {
   EndpointExtraOptions,
   FetchFunction,
   Index,
+  SchemaDetail,
+  SchemaList,
 } from '@rest-hooks/endpoint';
 import {
   Resource,
@@ -148,6 +150,46 @@ export class CoolerArticleResource extends ArticleResource {
   static urlRoot = 'http://test.com/article-cooler/';
   get things() {
     return `${this.title} five`;
+  }
+}
+
+export class TypedArticleResource extends CoolerArticleResource {
+  get tagString() {
+    return this.tags.join(', ');
+  }
+
+  static update<T extends typeof SimpleResource>(
+    this: T,
+  ): RestEndpoint<
+    RestFetch<
+      { id: number },
+      Partial<AbstractInstanceType<T>>,
+      Partial<AbstractInstanceType<T>>
+    >,
+    SchemaDetail<AbstractInstanceType<T>>,
+    true
+  > {
+    return super.update();
+  }
+
+  static detail<T extends typeof SimpleResource>(
+    this: T,
+  ): RestEndpoint<
+    RestFetch<{ id: number }, undefined, Partial<AbstractInstanceType<T>>>,
+    SchemaDetail<AbstractInstanceType<T>>,
+    undefined
+  > {
+    return super.detail();
+  }
+
+  static list<T extends typeof SimpleResource>(
+    this: T,
+  ): RestEndpoint<
+    RestFetch<any, undefined, Partial<AbstractInstanceType<T>>[]>,
+    SchemaList<AbstractInstanceType<T>>,
+    undefined
+  > {
+    return super.list();
   }
 }
 

--- a/docs/guides/rest-types.md
+++ b/docs/guides/rest-types.md
@@ -40,13 +40,17 @@ import { Resource, RestEndpoint, RestFetch } from '@rest-hooks/rest';
 class MyResource extends Resource {
   static list<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<RestFetch, T[], undefined> {
+  ): RestEndpoint<RestFetch, SchemaList<AbstractInstanceType<T>>, undefined> {
     return super.list();
   }
 
   static create<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<RestFetch, T, true> {
+  ): RestEndpoint<
+      RestFetch<{}, Partial<AbstractInstanceType<T>>>,
+      SchemaDetail<AbstractInstanceType<T>>,
+      true
+  > {
     return super.create();
   }
 
@@ -57,7 +61,7 @@ class MyResource extends Resource {
     { results: T[]; nextPage: string },
     undefined
   > {
-    return super.list();
+    return super.list().extend({ schema: { results: this[]; nextPage: string } });
   }
 }
 ```
@@ -293,7 +297,6 @@ class User extends Resource {
 
 If we were to explicitly type thing, we could use `RestEndpoint`
 
-
 <!--DOCUSAURUS_CODE_TABS-->
 <!--Schema-->
 
@@ -317,6 +320,7 @@ const { data: user } = useResource(User.detail(), { id: '5' });
 ```
 
 <!--Parameters-->
+
 ```typescript
 // typeof id is string
 const result = useResource(User.detail(), { id });
@@ -328,7 +332,7 @@ import { RestEndpoint, RestFetch, Resource } from '@rest-hooks/rest';
 class User extends Resource {
   static detail<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<RestFetch<{ id: string }>, T, undefined> {
+  ): RestEndpoint<RestFetch<{ id: string }>, SchemaDetail<AbstractInstanceType<T>>, undefined> {
     return super.detail();
   }
 }
@@ -337,6 +341,7 @@ const { data: user } = useResource(User.detail(), { id: '5' });
 ```
 
 <!--Mutate-->
+
 ```typescript
 // works
 const updateUser = useFetcher(User.update());
@@ -359,6 +364,7 @@ const { data: user } = useResource(User.detail(), { id: '5' });
 ```
 
 <!--Payload/Body-->
+
 ```typescript
 const updateUser = useFetcher(User.update());
 
@@ -396,4 +402,3 @@ function arguments as loose as possible (like in hooks). To follow this principa
 - [RestEndpoint](../api/types#restendpoint) for endpoints in [Resource](../api/Resource)s
 - [EndpointInstance](../api/types#endpointinstance) for anything that uses the [Endpoint](../api/Endpoint) class.
 - [EndpointInterface](../api/types#endpointinterface) for any hook arguments
-

--- a/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
+++ b/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
@@ -1,0 +1,127 @@
+import { TypedArticleResource } from '__tests__/new';
+import React from 'react';
+import nock from 'nock';
+
+import {
+  makeRenderRestHook,
+  makeCacheProvider,
+  makeExternalCacheProvider,
+} from '../../../../test';
+import { useResource, useFetcher } from '../hooks';
+import { payload, createPayload, users, nested } from '../test-fixtures';
+
+function onError(e: any) {
+  e.preventDefault();
+}
+beforeEach(() => {
+  if (typeof addEventListener === 'function')
+    addEventListener('error', onError);
+});
+afterEach(() => {
+  if (typeof removeEventListener === 'function')
+    removeEventListener('error', onError);
+});
+
+for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
+  describe('should enforce defined types', () => {
+    let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+    let mynock: nock.Scope;
+
+    beforeEach(() => {
+      nock(/.*/)
+        .persist()
+        .defaultReplyHeaders({
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': 'application/json',
+        })
+        .options(/.*/)
+        .reply(200)
+        .get(`/article-cooler/${payload.id}`)
+        .reply(200, payload)
+        .delete(`/article-cooler/${payload.id}`)
+        .reply(204, '')
+        .delete(`/article/${payload.id}`)
+        .reply(200, {})
+        .get(`/article-cooler/0`)
+        .reply(403, {})
+        .get(`/article-cooler/666`)
+        .reply(200, '')
+        .get(`/article-cooler/`)
+        .reply(200, nested)
+        .post(`/article-cooler/`)
+        .reply(200, createPayload)
+        .get(`/user/`)
+        .reply(200, users)
+        .get(/article-cooler\/.*/)
+        .reply(404, 'not found')
+        .put(`/article-cooler/${payload.id}`)
+        .reply(200, (uri, body) => body)
+        .put(/article-cooler\/[^5].*/)
+        .reply(404, 'not found');
+
+      mynock = nock(/.*/).defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      });
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    beforeEach(() => {
+      renderRestHook = makeRenderRestHook(makeProvider);
+    });
+    afterEach(() => {
+      renderRestHook.cleanup();
+    });
+
+    it('should pass with exact params', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useResource(TypedArticleResource.detail(), {
+          id: payload.id,
+        });
+      });
+      expect(result.current).toBeNull();
+      await waitForNextUpdate();
+      expect(result.current.title).toBe(payload.title);
+    });
+
+    it('should fail with improperly typed param', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        // @ts-expect-error
+        return useResource(TypedArticleResource.detail(), {
+          id: { a: 'five' },
+        });
+      });
+      expect(result.current).toBeNull();
+      await waitForNextUpdate();
+      expect(result.error).toBeDefined();
+      expect((result.error as any).status).toBe(404);
+    });
+
+    it('should work with everything correct', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useFetcher(TypedArticleResource.update());
+      });
+      const a = await result.current({ id: payload.id }, { title: 'hi' });
+    });
+    it('should error on invalid payload', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useFetcher(TypedArticleResource.update());
+      });
+      // @ts-expect-error
+      await result.current({ id: payload.id }, { title2: 'hi' });
+      // @ts-expect-error
+      await result.current({ id: payload.id }, { title: 5 });
+    });
+
+    it('should error on invalid params', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useFetcher(TypedArticleResource.update());
+      });
+      // @ts-expect-error
+      await expect(result.current({ id: 'hi' }, { title: 'hi' })).rejects;
+    });
+  });
+}

--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -6,6 +6,7 @@ import {
   ArticleResourceWithOtherListUrl,
   ListPaginatedArticle,
   CoolerArticleDetail,
+  TypedArticleResource,
   IndexedUserResource,
 } from '__tests__/new';
 import React from 'react';
@@ -74,6 +75,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         .reply(200, createPayload)
         .get(`/user/`)
         .reply(200, users);
+
       mynock = nock(/.*/).defaultReplyHeaders({
         'Access-Control-Allow-Origin': '*',
         'Content-Type': 'application/json',
@@ -108,6 +110,19 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         expect(result.current.title).toBe(payload.title);
         // @ts-expect-error
         expect(result.current.lafsjlfd).toBeUndefined();
+      });
+
+      it('should maintain global referential equality', async () => {
+        const { result, waitForNextUpdate } = renderRestHook(() => {
+          return [
+            useResource(CoolerArticleDetail, payload),
+            useCache(CoolerArticleDetail, payload),
+          ];
+        });
+        expect(result.current).toBeNull();
+        await waitForNextUpdate();
+        expect(result.current[0]?.title).toBe(payload.title);
+        expect(result.current[0]).toBe(result.current[1]);
       });
 
       it('should gracefully abort in useResource()', async () => {
@@ -300,7 +315,8 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
 
     it('useResource() should throw errors on bad network', async () => {
       const { result, waitForNextUpdate } = renderRestHook(() => {
-        return useResource(CoolerArticleResource.detail(), {
+        // @ts-expect-error
+        return useResource(TypedArticleResource.detail(), {
           title: '0',
         });
       });

--- a/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
@@ -11,8 +11,6 @@ import { DispatchContext } from '@rest-hooks/core/react-integration/context';
 import createFetch from '@rest-hooks/core/state/actions/createFetch';
 import { useContext, useCallback } from 'react';
 
-type IfExact<T, Cond, A, B> = Cond extends T ? (T extends Cond ? A : B) : B;
-
 /** Build an imperative dispatcher to issue network requests. */
 export default function useFetchDispatcher(
   throttle = false,

--- a/packages/core/src/react-integration/hooks/useFetcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetcher.ts
@@ -11,7 +11,12 @@ import { useRef, useCallback } from 'react';
 
 import useFetchDispatcher from './useFetchDispatcher';
 
-type IfExact<T, Cond, A, B> = Cond extends T ? (T extends Cond ? A : B) : B;
+type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
+type IfExact<T, Cond, A, B> = IfAny<
+  T,
+  B,
+  Cond extends T ? (T extends Cond ? A : B) : B
+>;
 
 /** Build an imperative dispatcher to issue network requests. */
 export default function useFetcher<

--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -124,12 +124,12 @@ export default abstract class SimpleResource extends Entity {
       const url = this.url.bind(this);
 
       return new Endpoint(
-        function (params: Readonly<object>) {
+        function (params: any) {
           return instanceFetch(this.url(params), this.getFetchInit());
         },
         {
           ...this.getEndpointExtra(),
-          key: function (this: any, params: Readonly<object>) {
+          key: function (this: any, params: any) {
             return `${this.method} ${this.url(params)}`;
           },
           url,
@@ -138,10 +138,7 @@ export default abstract class SimpleResource extends Entity {
             this.fetchInit = self.getFetchInit(this.fetchInit);
             return this;
           },
-          getFetchInit(
-            this: any,
-            body?: RequestInit['body'] | Record<string, any>,
-          ) {
+          getFetchInit(this: any, body?: any) {
             if (isPojo(body)) {
               body = JSON.stringify(body);
             }
@@ -164,11 +161,7 @@ export default abstract class SimpleResource extends Entity {
     const instanceFetch = this.fetch.bind(this);
     return this.memo('#endpointMutate', () =>
       this.endpoint().extend({
-        fetch(
-          this: any,
-          params: Readonly<object>,
-          body?: RequestInit['body'] | Record<string, any>,
-        ) {
+        fetch(this: any, params: any, body?: any) {
           return instanceFetch(this.url(params), this.getFetchInit(body));
         },
         sideEffect: true,

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -2,7 +2,7 @@ import { Schema } from '@rest-hooks/normalizr';
 import { EndpointInstance, FetchFunction } from '@rest-hooks/endpoint';
 
 export type RestFetch<
-  P = object,
+  P = any,
   B = RequestInit['body'] | Record<string, any>,
   R = any
 > = (params: P, body?: B) => Promise<R>;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Ensure override Resource patterns work in all cases.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- RestFetch params: object -> any
  - object no longer widens, so overrides break with `{ id: number }` or the like (even though this matches, due to the directionality)
- useFetcher matches 'any' properly

Also:
- updated tests & docs with all known cases to ensure our recommendations work
