### PR TITLE
docs: Fix typo

### DIFF
--- a/docs/guides/resource-lifetime.md
+++ b/docs/guides/resource-lifetime.md
@@ -4,7 +4,7 @@ sidebar_label: Custom cache lifetime
 ---
 
 By default the NetworkManager specifies the lifetime of data and errors in the cache.
-If some resources are longer living, or shorter living than other, the can specify their own expiry length values,
+If some resources are longer living, or shorter living than other, you can specify their own expiry length values,
 which will be passed on to all [Endpoint](../api/Endpoint.md) creator functions of [Resource](../api/Resource.md).
 
 ## Examples


### PR DESCRIPTION
This is just a `typo fix` in `docs/guides/resource-lifetime.md` doc file.