### PR TITLE
docs: Improve rest-types and network transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ For the small price of 7kb gziped. &nbsp;&nbsp; [🏁Get started now](https://re
 - [x] 💰 Normalized response [configurable](https://resthooks.io/docs/guides/resource-lifetime) caching
 - [x] 💥 Tiny bundle footprint
 - [x] 🛑 Automatic overfetching elimination
-- [x] ✨ Optimistic updates
+- [x] ✨ [Optimistic updates](https://resthooks.io/docs/guides/optimistic-updates)
 - [x] 🧘 [Flexible](https://resthooks.io/docs/api/Endpoint) to fit any API design (one size fits all)
-- [x] 🔧 [Debugging and inspection](https://resthooks.io/docs/next/guides/debugging) via browser extension
+- [x] 🔧 [Debugging and inspection](https://resthooks.io/docs/guides/debugging) via browser extension
 - [x] 🌳 Tree-shakable (only use what you need)
 - [x] 🔁 [Subscriptions](https://resthooks.io/docs/api/useSubscription)
 - [x] ♻️ Optional [redux integration](https://resthooks.io/docs/guides/redux)

--- a/docs/guides/network-transform.md
+++ b/docs/guides/network-transform.md
@@ -5,6 +5,13 @@ title: Transforming data on fetch
 All network requests flow through the `fetch()` method, so any transforms needed can simply
 be done by overriding it with a call to super.
 
+> Note: If you retain control over the API design, generally it's preferred to
+> update the data sent over the network. Keeping the client as `thin` as possible
+> is helpful to both performance and complexity.
+>
+> That said, in many cases you want to consume APIs you don't have control over -
+> be they public APIs, or due to internal organizational structure.
+
 ## Snakes to camels
 
 Commonly APIs are designed with keys using `snake_case`, but many in typescript/javascript

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -72,9 +72,9 @@ For the small price of 7kb gziped. &nbsp;&nbsp; [🏁Get started now](https://re
 - [x] 💰 Normalized response [configurable](https://resthooks.io/docs/guides/resource-lifetime) caching
 - [x] 💥 Tiny bundle footprint
 - [x] 🛑 Automatic overfetching elimination
-- [x] ✨ Optimistic updates
+- [x] ✨ [Optimistic updates](https://resthooks.io/docs/guides/optimistic-updates)
 - [x] 🧘 [Flexible](https://resthooks.io/docs/api/Endpoint) to fit any API design (one size fits all)
-- [x] 🔧 [Debugging and inspection](https://resthooks.io/docs/next/guides/debugging) via browser extension
+- [x] 🔧 [Debugging and inspection](https://resthooks.io/docs/guides/debugging) via browser extension
 - [x] 🌳 Tree-shakable (only use what you need)
 - [x] 🔁 [Subscriptions](https://resthooks.io/docs/api/useSubscription)
 - [x] ♻️ Optional [redux integration](https://resthooks.io/docs/guides/redux)

--- a/packages/rest-hooks/README.md
+++ b/packages/rest-hooks/README.md
@@ -68,9 +68,9 @@ For the small price of 8kb gziped. &nbsp;&nbsp; [🏁Get started now](https://re
 - [x] 💰 Normalized response [configurable](https://resthooks.io/docs/guides/resource-lifetime) caching
 - [x] 💥 Tiny bundle footprint
 - [x] 🛑 Automatic overfetching elimination
-- [x] ✨ Optimistic updates
+- [x] ✨ [Optimistic updates](https://resthooks.io/docs/guides/optimistic-updates)
 - [x] 🧘 [Flexible](https://resthooks.io/docs/api/Endpoint) to fit any API design (one size fits all)
-- [x] 🔧 [Debugging and inspection](https://resthooks.io/docs/next/guides/debugging) via browser extension
+- [x] 🔧 [Debugging and inspection](https://resthooks.io/docs/guides/debugging) via browser extension
 - [x] 🌳 Tree-shakable (only use what you need)
 - [x] 🔁 [Subscriptions](https://resthooks.io/docs/api/useSubscription)
 - [x] ♻️ Optional [redux integration](https://resthooks.io/docs/guides/redux)

--- a/website/versioned_docs/version-5.0.0/guides/network-transform.md
+++ b/website/versioned_docs/version-5.0.0/guides/network-transform.md
@@ -7,6 +7,13 @@ original_id: network-transform
 All network requests flow through the `fetch()` method, so any transforms needed can simply
 be done by overriding it with a call to super.
 
+> Note: If you retain control over the API design, generally it's preferred to
+> update the data sent over the network. Keeping the client as `thin` as possible
+> is helpful to both performance and complexity.
+>
+> That said, in many cases you want to consume APIs you don't have control over -
+> be they public APIs, or due to internal organizational structure.
+
 ## Snakes to camels
 
 Commonly APIs are designed with keys using `snake_case`, but many in typescript/javascript

--- a/website/versioned_docs/version-5.0.0/guides/rest-types.md
+++ b/website/versioned_docs/version-5.0.0/guides/rest-types.md
@@ -259,6 +259,46 @@ console.log(typeof obj);
 
 Now when we call the method defined in `Base` on any descendant, it is typed appropriately!
 
+## A limitation
+
+While generic `this` is powerful in allowing correct typing even for inherited classes, it
+has one annoying bug: `super` calls incorrectly resolve to the constraint, rather than the generic.
+
+```typescript
+class Child extends Base {
+  extra: number = 0;
+
+  static factory<T extends Base>(this: T): T {
+    const obj = super.factory();
+    obj.extra = 2;
+    // @ts-expect-error - typescript says obj is not compatible with T
+    return obj;
+  }
+}
+```
+
+### Workaround
+
+`any` is mostly to be avoided, but since we are careful to type our return
+type correctly in the method, we can be confident the rest of our code will
+still be protected.
+
+```typescript
+class Child extends Base {
+  extra: number = 0;
+
+  static factory<T extends Base>(this: T): T {
+    const obj = super.factory();
+    obj.extra = 2;
+    return obj as any;
+  }
+}
+```
+
+This is only needed if we are setting the type directly from the super call.
+We'll see below we only need to do this when we retain the schema from the super call.
+This is also not necessary if `this.method()` is called as this bug *only* affects `super`
+
 ## As Resource
 
 Applying this to our original example, we get something along the lines of:
@@ -335,7 +375,9 @@ class User extends Resource {
   static detail<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<RestFetch<{ id: string }>, SchemaDetail<AbstractInstanceType<T>>, undefined> {
-    return super.detail();
+    // super.detail() resolves the Schema to be based on `typeof Resource`, rather than `T`
+    // which makes it incompatible with the return type correctly specified.
+    return super.detail() as any;
   }
 }
 
@@ -358,7 +400,9 @@ class User extends Resource {
   static update<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<RestFetch, T, true> {
-    return super.update();
+    // super.update() resolves the Schema to be based on `typeof Resource`, rather than `T`
+    // which makes it incompatible with the return type correctly specified.
+    return super.update() as any;
   }
 }
 
@@ -387,7 +431,9 @@ class User extends Resource {
   static update<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<RestFetch<object, { username: string }>, T, true> {
-    return super.update();
+    // super.update() resolves the Schema to be based on `typeof Resource`, rather than `T`
+    // which makes it incompatible with the return type correctly specified.
+    return super.update() as any;
   }
 }
 


### PR DESCRIPTION
- More links in readmes
- Add details around `super` typescript limitations to rest-type docs
- Add design note in 'network tranform' section