### PR TITLE
enhance: Add jsdocs deprecations to deprecated methods

### DIFF
--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -145,6 +145,7 @@ export default abstract class SimpleRecord {
     return [this.fromJS(object) as any, found, deleted];
   }
 
+  /** @deprecated */
   /* istanbul ignore next */
   static asSchema<T extends typeof SimpleRecord>(this: T) {
     /* istanbul ignore next */

--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -94,6 +94,7 @@ export default abstract class SimpleResource extends FlatEntity {
     throw new NotImplementedError();
   }
 
+  /** @deprecated */
   /** Get the request options for this SimpleResource  */
   static getFetchOptions(): FetchOptions | undefined {
     return;

--- a/packages/rest-hooks/src/resource/__tests__/resource.ts
+++ b/packages/rest-hooks/src/resource/__tests__/resource.ts
@@ -4,7 +4,8 @@ import {
   UrlArticleResource,
 } from '__tests__/common';
 import nock from 'nock';
-import { normalize } from '@rest-hooks/normalizr';
+import { normalize, schema, Entity } from '@rest-hooks/normalizr';
+import { AbstractInstanceType } from '@rest-hooks/core';
 
 import Resource from '../Resource';
 import SimpleResource from '../SimpleResource';
@@ -35,6 +36,16 @@ describe('Resource', () => {
 
   afterAll(() => {
     nock.cleanAll();
+  });
+
+  it('should implement schema.EntityInterface', () => {
+    class A extends Resource {
+      readonly id: string = '';
+      pk() {
+        return this.id;
+      }
+    }
+    const a: schema.EntityInterface = A;
   });
 
   it('should init', () => {

--- a/packages/rest/src/__tests__/resource-endpoint.ts
+++ b/packages/rest/src/__tests__/resource-endpoint.ts
@@ -4,7 +4,7 @@ import {
   UrlArticleResource,
 } from '__tests__/new';
 import nock from 'nock';
-import { normalize, Schema } from '@rest-hooks/normalizr';
+import { normalize, schema } from '@rest-hooks/normalizr';
 
 import Resource from '../Resource';
 import SimpleResource from '../SimpleResource';
@@ -36,6 +36,16 @@ describe('Resource', () => {
 
   afterAll(() => {
     nock.cleanAll();
+  });
+
+  it('should implement schema.EntityInterface', () => {
+    class A extends Resource {
+      readonly id: string = '';
+      pk() {
+        return this.id;
+      }
+    }
+    const a: schema.EntityInterface = A;
   });
 
   it('should init', () => {


### PR DESCRIPTION
Integration into VS code came after these were deprecated. This should give nice indications in IDEs that support.
