### PR TITLE
internal: Add test for useStatefulResource() param changes

### DIFF
--- a/packages/legacy/src/__tests__/fixtures.ts
+++ b/packages/legacy/src/__tests__/fixtures.ts
@@ -4,6 +4,12 @@ export const payload = {
   content: 'whatever',
   tags: ['a', 'best', 'react'],
 };
+export const payload2 = {
+  id: 6,
+  title: 'next',
+  content: 'my best content yet',
+  tags: ['b'],
+};
 
 export const createPayload = {
   id: 1,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://github.com/airbytehq/airbyte/pull/1736#discussion_r561338401 mentioned that in previous versions of rest-hooks/legacy (`useStatefulResource()`) the loading prop was sometimes incorrect.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add a new test for when `useStatefulResource()` params change.