### PR TITLE
fix: Support TypeScript <4

### DIFF
--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -28,10 +28,10 @@ export default function useDenormalized<
   state: State<any>,
   denormalizeCache: DenormalizeCache = { entities: {}, results: {} },
 ): [
-  denormalized: DenormalizeNullable<Shape['schema']>,
-  found: typeof params extends null ? false : boolean,
-  deleted: boolean,
-  entitiesExpireAt: number,
+  DenormalizeNullable<Shape['schema']>,
+  typeof params extends null ? false : boolean,
+  boolean,
+  number,
 ] {
   const entities = state.entities;
   const entityMeta = state.entityMeta;

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -164,23 +164,13 @@ const getEntities = (entities: Record<string, any>) => {
 };
 
 type DenormalizeReturn<S extends Schema> =
+  | [Denormalize<S>, true, false, Record<string, Record<string, any>>]
+  | [DenormalizeNullable<S>, boolean, true, Record<string, Record<string, any>>]
   | [
-      denormalized: Denormalize<S>,
-      found: true,
-      deleted: false,
-      resolvedEntities: Record<string, Record<string, any>>,
-    ]
-  | [
-      denormalized: DenormalizeNullable<S>,
-      found: boolean,
-      deleted: true,
-      resolvedEntities: Record<string, Record<string, any>>,
-    ]
-  | [
-      denormalized: DenormalizeNullable<S>,
-      found: false,
-      deleted: boolean,
-      resolvedEntities: Record<string, Record<string, any>>,
+      DenormalizeNullable<S>,
+      false,
+      boolean,
+      Record<string, Record<string, any>>,
     ];
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Named tuples were introduced in TypeScript 4. They are nice, but TypeScript doesn't have a backwards compatibility compiler, so we cannot use features in exported types that are supported.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Removed named tuple usage in denormalize, useDenormalized. There are still some internal usages but those don't get exported.