### PR TITLE
fix: MockResolver intercepts subscriptions matching fixtures

### DIFF
--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -69,6 +69,11 @@ export default function MockResolver({ children, fixtures }: Props) {
   result: [],
   }`,
         );
+      } else if (action.type === actionTypes.SUBSCRIBE_TYPE) {
+        const { key } = action.meta;
+        if (Object.prototype.hasOwnProperty.call(fetchToReceiveAction, key)) {
+          return Promise.resolve();
+        }
       }
       return dispatch(action);
     },


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Subscriptions cause fetches - which means components using subscriptions that are mocked will still cause a normal fetch

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Since fixtures currently don't support any time-series based changes, simply blocked the mocked subscription dispatches will produce desired results.