### PR TITLE
fix: Wait til data is stale for first poll

### DIFF
--- a/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
+++ b/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PollingSubscription should call after period 1`] = `
+exports[`PollingSubscription fresh data should call after period 1`] = `
 Array [
   Object {
     "meta": Object {
@@ -21,7 +21,7 @@ Array [
 ]
 `;
 
-exports[`PollingSubscription should call after period 2`] = `
+exports[`PollingSubscription fresh data should call after period 2`] = `
 Array [
   Object {
     "meta": Object {

--- a/packages/rest-hooks/src/manager/__tests__/pollingSubscription.ts
+++ b/packages/rest-hooks/src/manager/__tests__/pollingSubscription.ts
@@ -1,4 +1,5 @@
 import { PollingArticleResource } from '__tests__/common';
+import { initialState } from '@rest-hooks/core';
 
 import PollingSubscription from '../PollingSubscription';
 import DefaultConnectionListener from '../DefaultConnectionListener';
@@ -78,6 +79,7 @@ describe('PollingSubscription', () => {
       schema: PollingArticleResource,
       fetch,
       frequency: 5000,
+      getState: () => initialState,
     },
     dispatch,
   );
@@ -94,6 +96,7 @@ describe('PollingSubscription', () => {
             key: 'test.com',
             schema: PollingArticleResource,
             fetch,
+            getState: () => initialState,
           },
           dispatch,
         ),
@@ -101,6 +104,7 @@ describe('PollingSubscription', () => {
   });
 
   it('should call immediately', () => {
+    jest.advanceTimersByTime(1);
     expect(dispatch.mock.calls.length).toBe(1);
   });
 
@@ -198,6 +202,7 @@ describe('PollingSubscription', () => {
           schema: PollingArticleResource,
           fetch,
           frequency: 5000,
+          getState: () => initialState,
         },
         dispatch,
       );
@@ -235,10 +240,12 @@ describe('PollingSubscription', () => {
           schema: PollingArticleResource,
           fetch,
           frequency: 5000,
+          getState: () => initialState,
         },
         dispatch,
         listener,
       );
+      jest.advanceTimersByTime(1);
       return { dispatch, fetch, pollingSubscription };
     }
 
@@ -272,6 +279,7 @@ describe('PollingSubscription', () => {
       expect(dispatch.mock.calls.length).toBe(0);
 
       listener.trigger('online');
+      jest.advanceTimersByTime(1);
       expect(dispatch.mock.calls.length).toBe(1);
       jest.advanceTimersByTime(5000);
       expect(dispatch.mock.calls.length).toBe(2);


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Navigating always prompts a fetch when there is a subscription - effectively ignoring TTL policies.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Hold off first polling fetch til after data is stale.