### PR TITLE
enhance: Add `static automaticValidation` to Entity

### DIFF
--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
@@ -104,13 +104,14 @@ Full Schema: {
 Error:
 Attempted to initialize CoolerArticleResource with an array, but named members were expected
 
-  This is likely due to a malformed response.
-  Try inspecting the network response or fetch() return value.
-  Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
-  Missing: id,title,content,author,tags
-  First three members: [
+Missing: id,title,content,author,tags
+First three members: [
   1
 ]]
 `;
@@ -219,13 +220,14 @@ Full Schema: {
 Error:
 Attempted to initialize CoolerArticleResource with an array, but named members were expected
 
-  This is likely due to a malformed response.
-  Try inspecting the network response or fetch() return value.
-  Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
-  Missing: id,title,content,author,tags
-  First three members: [
+Missing: id,title,content,author,tags
+First three members: [
   1
 ]]
 `;

--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
@@ -102,13 +102,14 @@ Full Schema: {
 Error:
 Attempted to initialize CoolerArticleResource with an array, but named members were expected
 
-  This is likely due to a malformed response.
-  Try inspecting the network response or fetch() return value.
-  Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
-  Missing: id,title,content,author,tags
-  First three members: [
+Missing: id,title,content,author,tags
+First three members: [
   1
 ]]
 `;
@@ -215,13 +216,14 @@ Full Schema: {
 Error:
 Attempted to initialize CoolerArticleResource with an array, but named members were expected
 
-  This is likely due to a malformed response.
-  Try inspecting the network response or fetch() return value.
-  Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
-  Missing: id,title,content,author,tags
-  First three members: [
+Missing: id,title,content,author,tags
+First three members: [
   1
 ]]
 `;

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
@@ -99,6 +99,7 @@ Attempted to initialize CoolerArticleResource with no matching keys found
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: 
@@ -128,6 +129,7 @@ Attempted to initialize CoolerArticleResource with no matching keys found
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: 
@@ -228,6 +230,7 @@ Attempted to initialize CoolerArticleResource with no matching keys found
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: 
@@ -257,6 +260,7 @@ Attempted to initialize CoolerArticleResource with no matching keys found
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: 

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
@@ -99,6 +99,7 @@ Attempted to initialize CoolerArticleResource with no matching keys found
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: 
@@ -128,6 +129,7 @@ Attempted to initialize CoolerArticleResource with no matching keys found
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: 
@@ -257,6 +259,7 @@ Attempted to initialize CoolerArticleResource with no matching keys found
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: 
@@ -286,6 +289,7 @@ Attempted to initialize CoolerArticleResource with no matching keys found
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: 

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -111,6 +111,31 @@ describe(`${Entity.name} normalization`, () => {
     expect(normalizeBad).toThrowErrorMatchingSnapshot();
   });
 
+  it('should warn when automaticValidation === "warn"', () => {
+    class MyEntity extends Entity {
+      readonly '0': string = '';
+      readonly secondthing: string = '';
+      static automaticValidation = 'warn' as const;
+      pk() {
+        return this[0];
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize(
+        [
+          { name: 'hi', secondthing: 'ho' },
+          { name: 'hi', secondthing: 'ho' },
+          { name: 'hi', secondthing: 'ho' },
+        ],
+        schema,
+      );
+    }
+    expect(normalizeBad).not.toThrow();
+    expect(consoleOutput.length).toBe(1);
+    expect(consoleOutput).toMatchSnapshot();
+  });
+
   it('should only warn if at least four members are found with unexpected', () => {
     class MyEntity extends Entity {
       readonly name: string = '';
@@ -310,6 +335,43 @@ describe(`${Entity.name} normalization`, () => {
       normalize({ name: 'hoho', nonexistantthing: 'hi' }, schema);
     }
     expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should warn when automaticValidation === "warn"', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+      static automaticValidation = 'warn' as const;
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ name: 'hoho', nonexistantthing: 'hi' }, schema);
+    }
+    expect(normalizeBad).not.toThrow();
+    expect(consoleOutput.length).toBe(1);
+    expect(consoleOutput).toMatchSnapshot();
+  });
+
+  it('should do nothing when automaticValidation === "silent"', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+      static automaticValidation = 'silent' as const;
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ name: 'hoho', nonexistantthing: 'hi' }, schema);
+    }
+    expect(normalizeBad).not.toThrow();
+    expect(consoleOutput.length).toBe(0);
   });
 
   it('should throw a custom error if data loads with string', () => {

--- a/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
@@ -602,6 +602,7 @@ Array [
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: name,a,b,c
@@ -650,6 +651,7 @@ exports[`Entity normalization should throw a custom error if data loads with hal
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: name
@@ -667,6 +669,7 @@ exports[`Entity normalization should throw a custom error if data loads with no 
   Try inspecting the network response or fetch() return value.
   Or use debugging tools: https://resthooks.io/docs/guides/debugging
   Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
   Expected keys:
     Found: 
@@ -688,13 +691,14 @@ exports[`Entity normalization should throw a custom error if data loads with str
 exports[`Entity normalization should throw a custom error loads with array 1`] = `
 "Attempted to initialize MyEntity with an array, but named members were expected
 
-  This is likely due to a malformed response.
-  Try inspecting the network response or fetch() return value.
-  Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
 
-  Missing: name,secondthing
-  First three members: [
+Missing: name,secondthing
+First three members: [
   {
     \\"name\\": \\"hi\\",
     \\"secondthing\\": \\"ho\\"
@@ -708,4 +712,52 @@ exports[`Entity normalization should throw a custom error loads with array 1`] =
     \\"secondthing\\": \\"ho\\"
   }
 ]"
+`;
+
+exports[`Entity normalization should warn when automaticValidation === "warn" 1`] = `
+Array [
+  "Attempted to initialize MyEntity with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+Missing: secondthing
+First three members: [
+  {
+    \\"name\\": \\"hi\\",
+    \\"secondthing\\": \\"ho\\"
+  },
+  {
+    \\"name\\": \\"hi\\",
+    \\"secondthing\\": \\"ho\\"
+  },
+  {
+    \\"name\\": \\"hi\\",
+    \\"secondthing\\": \\"ho\\"
+  }
+]",
+]
+`;
+
+exports[`Entity normalization should warn when automaticValidation === "warn" 2`] = `
+Array [
+  "Attempted to initialize MyEntity with a large number of unexpected keys found
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: name
+    Unexpected keys: nonexistantthing
+  Value: {
+  \\"name\\": \\"hoho\\",
+  \\"nonexistantthing\\": \\"hi\\"
+}",
+]
 `;


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #492 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
As good as heuristics might be, until we allow full validation control, this could get annoying sometimes.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add [Entity](https://resthooks.io/docs/api/Entity) member:

`protected declare static automaticValidation?: 'warn' | 'silent';`

#### undefined
Can throw errors

#### warn
Will only ever warn in console

#### silent
Does not do any validation beyond normal PK/nested entities, etc.


> Note: None of this validation occurs in production builds