### PR TITLE
pkg: react-hooks-testing-library major

### DIFF
--- a/docs/api/makeRenderRestHook.md
+++ b/docs/api/makeRenderRestHook.md
@@ -119,7 +119,7 @@ it('should resolve useResource()', async () => {
   const { result, waitForNextUpdate } = renderRestHook(() => {
     return useResource(ArticleResource.detail(), payload);
   });
-  expect(result.current).toBe(null);
+  expect(result.current).toBeUndefined();
   await waitForNextUpdate();
   expect(result.current instanceof ArticleResource).toBe(true);
   expect(result.current.title).toBe(payload.title);

--- a/docs/api/makeRenderRestHook.md
+++ b/docs/api/makeRenderRestHook.md
@@ -111,10 +111,6 @@ beforeEach(() => {
   renderRestHook = makeRenderRestHook(makeCacheProvider);
 });
 
-afterEach(() => {
-  renderRestHook.cleanup();
-});
-
 it('should resolve useResource()', async () => {
   const { result, waitForNextUpdate } = renderRestHook(() => {
     return useResource(ArticleResource.detail(), payload);

--- a/docs/guides/custom-networking.md
+++ b/docs/guides/custom-networking.md
@@ -10,6 +10,9 @@ and is used in the [NetworkManager](../api/NetworkManager).
 `SimpleResource` can be used as an abstract class to implement custom fetch methods
 without including the default.
 
+> Note: If you plan on using [NetworkErrorBoundary](../api/NetworkErrorBoundary) make sure
+> to add a `status` member to errors, as it catches only errors with a `status` member.
+
 ## Fetch (default)
 
 [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)

--- a/docs/guides/redux.md
+++ b/docs/guides/redux.md
@@ -57,14 +57,14 @@ import { initialState } from '@rest-hooks/core';
 import { createStore, applyMiddleware } from 'redux';
 import ReactDOM from 'react-dom';
 
-const manager = new NetworkManager();
+const networkManager = new NetworkManager();
 const subscriptionManager = new SubscriptionManager(PollingSubscription);
 
 const store = createStore(
   reducer,
   initialState,
   applyMiddleware(
-    manager.getMiddleware(),
+    networkManager.getMiddleware(),
     subscriptionManager.getMiddleware(),
     // place Rest Hooks built middlewares before PromiseifyMiddleware
     PromiseifyMiddleware,
@@ -72,6 +72,11 @@ const store = createStore(
   ),
 );
 const selector = state => state;
+
+// managers optionally provide initialization subroutine
+for (const manager of [networkManager, subscriptionManager]) {
+  managers[i].init?.(selector(store.getState()));
+}
 
 ReactDOM.render(
   <ExternalCacheProvider store={store} selector={selector}>

--- a/docs/guides/unit-testing-hooks.md
+++ b/docs/guides/unit-testing-hooks.md
@@ -91,7 +91,7 @@ describe('useResource()', () => {
         title: '0',
       });
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);
@@ -133,7 +133,7 @@ describe('useResource()', () => {
         title: '0',
       });
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);

--- a/docs/guides/unit-testing-hooks.md
+++ b/docs/guides/unit-testing-hooks.md
@@ -82,7 +82,6 @@ describe('useResource()', () => {
 
   afterEach(() => {
     nock.cleanAll();
-    renderRestHook.cleanup();
   });
 
   it('should throw errors on bad network', async () => {
@@ -124,7 +123,6 @@ describe('useResource()', () => {
 
   afterEach(() => {
     nock.cleanAll();
-    renderRestHook.cleanup();
   });
 
   it('should throw errors on bad network', async () => {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@testing-library/react": "^11.2.3",
-    "@testing-library/react-hooks": "^3.4.1",
+    "@testing-library/react-hooks": "^5.0.3",
     "@testing-library/react-native": "^7.1.0",
     "@types/jest": "^26.0.20",
     "@types/lodash": "^4.14.166",

--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
@@ -1,121 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` => <Provider /> Endpoint should gracefully abort in useResource() 1`] = `[AbortError: Aborted]`;
-
-exports[` => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
-Array [
-  PaginatedArticleResource {
-    "author": UserResource {
-      "email": "bob@bob.com",
-      "id": 23,
-      "isAdmin": false,
-      "username": "charles",
-    },
-    "content": "whatever",
-    "id": 5,
-    "tags": Array [
-      "a",
-      "best",
-      "react",
-    ],
-    "title": "hi ho",
-  },
-  PaginatedArticleResource {
-    "author": UserResource {
-      "email": "bob@bob.com",
-      "id": 23,
-      "isAdmin": false,
-      "username": "charles",
-    },
-    "content": "whatever",
-    "id": 3,
-    "tags": Array [],
-    "title": "the next time",
-  },
-]
-`;
-
-exports[` => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 1`] = `
-IndexedUserResource {
-  "email": "bob@bob.com",
-  "id": 23,
-  "isAdmin": false,
-  "username": "bob",
-}
-`;
-
-exports[` => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 2`] = `
-IndexedUserResource {
-  "email": "bob@bob.com",
-  "id": 23,
-  "isAdmin": false,
-  "username": "charlie",
-}
-`;
-
-exports[` => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
-Array [
-  PaginatedArticleResource {
-    "author": UserResource {
-      "email": "bob@bob.com",
-      "id": 23,
-      "isAdmin": false,
-      "username": "charles",
-    },
-    "content": "whatever",
-    "id": 5,
-    "tags": Array [
-      "a",
-      "best",
-      "react",
-    ],
-    "title": "hi ho",
-  },
-  PaginatedArticleResource {
-    "author": UserResource {
-      "email": "bob@bob.com",
-      "id": 23,
-      "isAdmin": false,
-      "username": "charles",
-    },
-    "content": "whatever",
-    "id": 3,
-    "tags": Array [],
-    "title": "the next time",
-  },
-]
-`;
-
-exports[` => <Provider /> useResource() should throw errors on malformed response 1`] = `
-[Error: Error processing GET http://test.com/article-cooler/878
-
-Full Schema: {
-  "name": "CoolerArticleResource",
-  "schema": {
-    "author": {
-      "name": "UserResource",
-      "schema": {},
-      "key": "http://test.com/user/"
-    }
-  },
-  "key": "http://test.com/article-cooler/"
-}
-
-Error:
-Attempted to initialize CoolerArticleResource with an array, but named members were expected
-
-This is likely due to a malformed response.
-Try inspecting the network response or fetch() return value.
-Or use debugging tools: https://resthooks.io/docs/guides/debugging
-Learn more about schemas: https://resthooks.io/docs/api/schema
-If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
-
-Missing: id,title,content,author,tags
-First three members: [
-  1
-]]
-`;
-
 exports[`makeCacheProvider => <Provider /> Endpoint should gracefully abort in useResource() 1`] = `[AbortError: Aborted]`;
 
 exports[`makeCacheProvider => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
@@ -203,6 +87,122 @@ Array [
 `;
 
 exports[`makeCacheProvider => <Provider /> useResource() should throw errors on malformed response 1`] = `
+[Error: Error processing GET http://test.com/article-cooler/878
+
+Full Schema: {
+  "name": "CoolerArticleResource",
+  "schema": {
+    "author": {
+      "name": "UserResource",
+      "schema": {},
+      "key": "http://test.com/user/"
+    }
+  },
+  "key": "http://test.com/article-cooler/"
+}
+
+Error:
+Attempted to initialize CoolerArticleResource with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+Missing: id,title,content,author,tags
+First three members: [
+  1
+]]
+`;
+
+exports[`makeExternal => <Provider /> Endpoint should gracefully abort in useResource() 1`] = `[AbortError: Aborted]`;
+
+exports[`makeExternal => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
+Array [
+  PaginatedArticleResource {
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 5,
+    "tags": Array [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  PaginatedArticleResource {
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 3,
+    "tags": Array [],
+    "title": "the next time",
+  },
+]
+`;
+
+exports[`makeExternal => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 1`] = `
+IndexedUserResource {
+  "email": "bob@bob.com",
+  "id": 23,
+  "isAdmin": false,
+  "username": "bob",
+}
+`;
+
+exports[`makeExternal => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 2`] = `
+IndexedUserResource {
+  "email": "bob@bob.com",
+  "id": 23,
+  "isAdmin": false,
+  "username": "charlie",
+}
+`;
+
+exports[`makeExternal => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
+Array [
+  PaginatedArticleResource {
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 5,
+    "tags": Array [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  PaginatedArticleResource {
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 3,
+    "tags": Array [],
+    "title": "the next time",
+  },
+]
+`;
+
+exports[`makeExternal => <Provider /> useResource() should throw errors on malformed response 1`] = `
 [Error: Error processing GET http://test.com/article-cooler/878
 
 Full Schema: {

--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration.web.tsx.snap
@@ -1,119 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
-Array [
-  PaginatedArticleResource {
-    "author": UserResource {
-      "email": "bob@bob.com",
-      "id": 23,
-      "isAdmin": false,
-      "username": "charles",
-    },
-    "content": "whatever",
-    "id": 5,
-    "tags": Array [
-      "a",
-      "best",
-      "react",
-    ],
-    "title": "hi ho",
-  },
-  PaginatedArticleResource {
-    "author": UserResource {
-      "email": "bob@bob.com",
-      "id": 23,
-      "isAdmin": false,
-      "username": "charles",
-    },
-    "content": "whatever",
-    "id": 3,
-    "tags": Array [],
-    "title": "the next time",
-  },
-]
-`;
-
-exports[` => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 1`] = `
-IndexedUserResource {
-  "email": "bob@bob.com",
-  "id": 23,
-  "isAdmin": false,
-  "username": "bob",
-}
-`;
-
-exports[` => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 2`] = `
-IndexedUserResource {
-  "email": "bob@bob.com",
-  "id": 23,
-  "isAdmin": false,
-  "username": "charlie",
-}
-`;
-
-exports[` => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
-Array [
-  PaginatedArticleResource {
-    "author": UserResource {
-      "email": "bob@bob.com",
-      "id": 23,
-      "isAdmin": false,
-      "username": "charles",
-    },
-    "content": "whatever",
-    "id": 5,
-    "tags": Array [
-      "a",
-      "best",
-      "react",
-    ],
-    "title": "hi ho",
-  },
-  PaginatedArticleResource {
-    "author": UserResource {
-      "email": "bob@bob.com",
-      "id": 23,
-      "isAdmin": false,
-      "username": "charles",
-    },
-    "content": "whatever",
-    "id": 3,
-    "tags": Array [],
-    "title": "the next time",
-  },
-]
-`;
-
-exports[` => <Provider /> useResource() should throw errors on malformed response 1`] = `
-[Error: Error processing GET http://test.com/article-cooler/878
-
-Full Schema: {
-  "name": "CoolerArticleResource",
-  "schema": {
-    "author": {
-      "name": "UserResource",
-      "schema": {},
-      "key": "http://test.com/user/"
-    }
-  },
-  "key": "http://test.com/article-cooler/"
-}
-
-Error:
-Attempted to initialize CoolerArticleResource with an array, but named members were expected
-
-This is likely due to a malformed response.
-Try inspecting the network response or fetch() return value.
-Or use debugging tools: https://resthooks.io/docs/guides/debugging
-Learn more about schemas: https://resthooks.io/docs/api/schema
-If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
-
-Missing: id,title,content,author,tags
-First three members: [
-  1
-]]
-`;
-
 exports[`makeCacheProvider => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
@@ -199,6 +85,120 @@ Array [
 `;
 
 exports[`makeCacheProvider => <Provider /> useResource() should throw errors on malformed response 1`] = `
+[Error: Error processing GET http://test.com/article-cooler/878
+
+Full Schema: {
+  "name": "CoolerArticleResource",
+  "schema": {
+    "author": {
+      "name": "UserResource",
+      "schema": {},
+      "key": "http://test.com/user/"
+    }
+  },
+  "key": "http://test.com/article-cooler/"
+}
+
+Error:
+Attempted to initialize CoolerArticleResource with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+Missing: id,title,content,author,tags
+First three members: [
+  1
+]]
+`;
+
+exports[`makeExternal => <Provider /> Endpoint should resolve useResource() with SimpleRecords 1`] = `
+Array [
+  PaginatedArticleResource {
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 5,
+    "tags": Array [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  PaginatedArticleResource {
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 3,
+    "tags": Array [],
+    "title": "the next time",
+  },
+]
+`;
+
+exports[`makeExternal => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 1`] = `
+IndexedUserResource {
+  "email": "bob@bob.com",
+  "id": 23,
+  "isAdmin": false,
+  "username": "bob",
+}
+`;
+
+exports[`makeExternal => <Provider /> Optimistic Updates indexes should resolve parallel useResource() request 2`] = `
+IndexedUserResource {
+  "email": "bob@bob.com",
+  "id": 23,
+  "isAdmin": false,
+  "username": "charlie",
+}
+`;
+
+exports[`makeExternal => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
+Array [
+  PaginatedArticleResource {
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 5,
+    "tags": Array [
+      "a",
+      "best",
+      "react",
+    ],
+    "title": "hi ho",
+  },
+  PaginatedArticleResource {
+    "author": UserResource {
+      "email": "bob@bob.com",
+      "id": 23,
+      "isAdmin": false,
+      "username": "charles",
+    },
+    "content": "whatever",
+    "id": 3,
+    "tags": Array [],
+    "title": "the next time",
+  },
+]
+`;
+
+exports[`makeExternal => <Provider /> useResource() should throw errors on malformed response 1`] = `
 [Error: Error processing GET http://test.com/article-cooler/878
 
 Full Schema: {

--- a/packages/core/src/react-integration/__tests__/__snapshots__/subscriptions-endpoint.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/subscriptions-endpoint.tsx.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` with subscriptions should console.error() with no frequency specified 1`] = `
+exports[`makeCacheProvider with subscriptions should console.error() with no frequency specified 1`] = `
 Array [
   [Error: frequency needed for polling subscription],
 ]
 `;
 
-exports[`makeCacheProvider with subscriptions should console.error() with no frequency specified 1`] = `
+exports[`makeExternal with subscriptions should console.error() with no frequency specified 1`] = `
 Array [
   [Error: frequency needed for polling subscription],
 ]

--- a/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
+++ b/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
@@ -1,6 +1,7 @@
 import { TypedArticleResource } from '__tests__/new';
 import React from 'react';
 import nock from 'nock';
+import { cleanup } from '@testing-library/react-hooks';
 
 import {
   makeRenderRestHook,
@@ -22,106 +23,105 @@ afterEach(() => {
     removeEventListener('error', onError);
 });
 
-for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
-  describe('should enforce defined types', () => {
-    let renderRestHook: ReturnType<typeof makeRenderRestHook>;
-    let mynock: nock.Scope;
+describe('endpoint types', () => {
+  for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
+    describe(`[${makeProvider.name}] should enforce defined types`, () => {
+      let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+      let mynock: nock.Scope;
 
-    beforeEach(() => {
-      nock(/.*/)
-        .persist()
-        .defaultReplyHeaders({
+      beforeEach(() => {
+        nock(/.*/)
+          .persist()
+          .defaultReplyHeaders({
+            'Access-Control-Allow-Origin': '*',
+            'Content-Type': 'application/json',
+          })
+          .options(/.*/)
+          .reply(200)
+          .get(`/article-cooler/${payload.id}`)
+          .reply(200, payload)
+          .delete(`/article-cooler/${payload.id}`)
+          .reply(204, '')
+          .delete(`/article/${payload.id}`)
+          .reply(200, {})
+          .get(`/article-cooler/0`)
+          .reply(403, {})
+          .get(`/article-cooler/666`)
+          .reply(200, '')
+          .get(`/article-cooler/`)
+          .reply(200, nested)
+          .post(`/article-cooler/`)
+          .reply(200, createPayload)
+          .get(`/user/`)
+          .reply(200, users)
+          .get(/article-cooler\/.*/)
+          .reply(404, 'not found')
+          .put(`/article-cooler/${payload.id}`)
+          .reply(200, (uri, body) => body)
+          .put(/article-cooler\/[^5].*/)
+          .reply(404, 'not found');
+
+        mynock = nock(/.*/).defaultReplyHeaders({
           'Access-Control-Allow-Origin': '*',
           'Content-Type': 'application/json',
-        })
-        .options(/.*/)
-        .reply(200)
-        .get(`/article-cooler/${payload.id}`)
-        .reply(200, payload)
-        .delete(`/article-cooler/${payload.id}`)
-        .reply(204, '')
-        .delete(`/article/${payload.id}`)
-        .reply(200, {})
-        .get(`/article-cooler/0`)
-        .reply(403, {})
-        .get(`/article-cooler/666`)
-        .reply(200, '')
-        .get(`/article-cooler/`)
-        .reply(200, nested)
-        .post(`/article-cooler/`)
-        .reply(200, createPayload)
-        .get(`/user/`)
-        .reply(200, users)
-        .get(/article-cooler\/.*/)
-        .reply(404, 'not found')
-        .put(`/article-cooler/${payload.id}`)
-        .reply(200, (uri, body) => body)
-        .put(/article-cooler\/[^5].*/)
-        .reply(404, 'not found');
-
-      mynock = nock(/.*/).defaultReplyHeaders({
-        'Access-Control-Allow-Origin': '*',
-        'Content-Type': 'application/json',
-      });
-    });
-
-    afterEach(() => {
-      nock.cleanAll();
-    });
-
-    beforeEach(() => {
-      renderRestHook = makeRenderRestHook(makeProvider);
-    });
-    afterEach(() => {
-      renderRestHook.cleanup();
-    });
-
-    it('should pass with exact params', async () => {
-      const { result, waitForNextUpdate } = renderRestHook(() => {
-        return useResource(TypedArticleResource.detail(), {
-          id: payload.id,
         });
       });
-      expect(result.current).toBeNull();
-      await waitForNextUpdate();
-      expect(result.current.title).toBe(payload.title);
-    });
 
-    it('should fail with improperly typed param', async () => {
-      const { result, waitForNextUpdate } = renderRestHook(() => {
+      beforeEach(() => {
+        renderRestHook = makeRenderRestHook(makeProvider);
+      });
+      afterEach(() => {
+        nock.cleanAll();
+        renderRestHook.cleanup();
+      });
+
+      it('should pass with exact params', async () => {
+        const { result, waitForNextUpdate } = renderRestHook(() => {
+          return useResource(TypedArticleResource.detail(), {
+            id: payload.id,
+          });
+        });
+        expect(result.current).toBeUndefined();
+        await waitForNextUpdate();
+        expect(result.current.title).toBe(payload.title);
+      });
+
+      it('should fail with improperly typed param', async () => {
+        const { result, waitForNextUpdate } = renderRestHook(() => {
+          // @ts-expect-error
+          return useResource(TypedArticleResource.detail(), {
+            id: { a: 'five' },
+          });
+        });
+        expect(result.current).toBeUndefined();
+        await waitForNextUpdate();
+        expect(result.error).toBeDefined();
+        expect((result.error as any).status).toBe(404);
+      });
+
+      it('should work with everything correct', async () => {
+        const { result, waitForNextUpdate } = renderRestHook(() => {
+          return useFetcher(TypedArticleResource.update());
+        });
+        const a = await result.current({ id: payload.id }, { title: 'hi' });
+      });
+      it('should error on invalid payload', async () => {
+        const { result, waitForNextUpdate } = renderRestHook(() => {
+          return useFetcher(TypedArticleResource.update());
+        });
         // @ts-expect-error
-        return useResource(TypedArticleResource.detail(), {
-          id: { a: 'five' },
+        await result.current({ id: payload.id }, { title2: 'hi' });
+        // @ts-expect-error
+        await result.current({ id: payload.id }, { title: 5 });
+      });
+
+      it('should error on invalid params', async () => {
+        const { result, waitForNextUpdate } = renderRestHook(() => {
+          return useFetcher(TypedArticleResource.update());
         });
+        // @ts-expect-error
+        await expect(result.current({ id: 'hi' }, { title: 'hi' })).rejects;
       });
-      expect(result.current).toBeNull();
-      await waitForNextUpdate();
-      expect(result.error).toBeDefined();
-      expect((result.error as any).status).toBe(404);
     });
-
-    it('should work with everything correct', async () => {
-      const { result, waitForNextUpdate } = renderRestHook(() => {
-        return useFetcher(TypedArticleResource.update());
-      });
-      const a = await result.current({ id: payload.id }, { title: 'hi' });
-    });
-    it('should error on invalid payload', async () => {
-      const { result, waitForNextUpdate } = renderRestHook(() => {
-        return useFetcher(TypedArticleResource.update());
-      });
-      // @ts-expect-error
-      await result.current({ id: payload.id }, { title2: 'hi' });
-      // @ts-expect-error
-      await result.current({ id: payload.id }, { title: 5 });
-    });
-
-    it('should error on invalid params', async () => {
-      const { result, waitForNextUpdate } = renderRestHook(() => {
-        return useFetcher(TypedArticleResource.update());
-      });
-      // @ts-expect-error
-      await expect(result.current({ id: 'hi' }, { title: 'hi' })).rejects;
-    });
-  });
-}
+  }
+});

--- a/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
+++ b/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
@@ -115,11 +115,15 @@ describe('endpoint types', () => {
       });
 
       it('should error on invalid params', async () => {
+        console.log('last test start');
         const { result, waitForNextUpdate } = renderRestHook(() => {
           return useFetcher(TypedArticleResource.update());
         });
         // @ts-expect-error
         await expect(result.current({ id: 'hi' }, { title: 'hi' })).rejects;
+        console.log('post reject');
+        await waitForNextUpdate();
+        console.log('post update');
       });
     });
   }

--- a/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
+++ b/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
@@ -72,7 +72,6 @@ describe('endpoint types', () => {
       });
       afterEach(() => {
         nock.cleanAll();
-        renderRestHook.cleanup();
       });
 
       it('should pass with exact params', async () => {

--- a/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
+++ b/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
@@ -99,13 +99,13 @@ describe('endpoint types', () => {
       });
 
       it('should work with everything correct', async () => {
-        const { result, waitForNextUpdate } = renderRestHook(() => {
+        const { result } = renderRestHook(() => {
           return useFetcher(TypedArticleResource.update());
         });
         const a = await result.current({ id: payload.id }, { title: 'hi' });
       });
       it('should error on invalid payload', async () => {
-        const { result, waitForNextUpdate } = renderRestHook(() => {
+        const { result } = renderRestHook(() => {
           return useFetcher(TypedArticleResource.update());
         });
         // @ts-expect-error
@@ -115,15 +115,14 @@ describe('endpoint types', () => {
       });
 
       it('should error on invalid params', async () => {
-        console.log('last test start');
         const { result, waitForNextUpdate } = renderRestHook(() => {
           return useFetcher(TypedArticleResource.update());
         });
-        // @ts-expect-error
-        await expect(result.current({ id: 'hi' }, { title: 'hi' })).rejects;
-        console.log('post reject');
-        await waitForNextUpdate();
-        console.log('post update');
+
+        await expect(
+          // @ts-expect-error
+          result.current({ id: 'hi' }, { title: 'hi' }),
+        ).rejects.toEqual(expect.any(Error));
       });
     });
   }

--- a/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
@@ -316,7 +316,6 @@ describe('useRetrieve', () => {
   });
   afterEach(() => {
     nock.cleanAll();
-    renderRestHook.cleanup();
   });
 
   it('should dispatch singles', async () => {

--- a/packages/core/src/react-integration/__tests__/hooks.web.tsx
+++ b/packages/core/src/react-integration/__tests__/hooks.web.tsx
@@ -316,7 +316,6 @@ describe('useRetrieve', () => {
   });
   afterEach(() => {
     nock.cleanAll();
-    renderRestHook.cleanup();
   });
 
   it('should dispatch singles', async () => {

--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -105,7 +105,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         const { result, waitForNextUpdate } = renderRestHook(() => {
           return useResource(CoolerArticleDetail, payload);
         });
-        expect(result.current).toBeNull();
+        expect(result.current).toBeUndefined();
         await waitForNextUpdate();
         expect(result.current.title).toBe(payload.title);
         // @ts-expect-error
@@ -119,7 +119,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
             useCache(CoolerArticleDetail, payload),
           ];
         });
-        expect(result.current).toBeNull();
+        expect(result.current).toBeUndefined();
         await waitForNextUpdate();
         expect(result.current[0]?.title).toBe(payload.title);
         expect(result.current[0]).toBe(result.current[1]);
@@ -137,7 +137,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
             fetch: useFetcher(AbortableArticle),
           };
         });
-        expect(result.current).toBeNull();
+        expect(result.current).toBeUndefined();
         await waitForNextUpdate();
         expect(result.current.data.title).toBe(payload.title);
         // @ts-expect-error
@@ -155,7 +155,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         const { result, waitForNextUpdate } = renderRestHook(() => {
           return useResource(ListPaginatedArticle, {});
         });
-        expect(result.current).toBeNull();
+        expect(result.current).toBeUndefined();
         await waitForNextUpdate();
         expect(result.current).toBeInstanceOf(SimpleRecord);
         expect(result.current.nextPage).toBe('');
@@ -170,7 +170,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       const { result, waitForNextUpdate } = renderRestHook(() => {
         return useResource(CoolerArticleResource.detail(), payload);
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.current instanceof CoolerArticleResource).toBe(true);
       expect(result.current.title).toBe(payload.title);
@@ -182,7 +182,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       const { result, waitForNextUpdate } = renderRestHook(() => {
         return useResource(PaginatedArticleResource.listDefaults(), {});
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.current).toBeInstanceOf(SimpleRecord);
       expect(result.current.nextPage).toBe('');
@@ -218,7 +218,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           throw e;
         }
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       let [data, del] = result.current;
       expect(data).toBeInstanceOf(CoolerArticleResource);
@@ -269,7 +269,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           throw e;
         }
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       let [data, invalidate] = result.current;
       expect(data).toBeInstanceOf(CoolerArticleResource);
@@ -320,7 +320,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           title: '0',
         });
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.error).toBeDefined();
       expect((result.error as any).status).toBe(403);
@@ -335,7 +335,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           },
         ]);
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.error).toBeDefined();
       expect((result.error as any).status).toBe(403);
@@ -349,7 +349,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           id: 878,
         });
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.error).toBeDefined();
       expect((result.error as any).status).toBe(400);
@@ -368,7 +368,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           [UserResource.list(), {}],
         );
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       const [article, users] = result.current;
       expect(article instanceof CoolerArticleResource).toBe(true);
@@ -715,7 +715,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
               fetch: useFetcher(IndexedUserResource.detail()),
             };
           });
-          expect(result.current).toBeNull();
+          expect(result.current).toBeUndefined();
           await waitForNextUpdate();
           const bob = result.current.bob;
           expect(bob).toBeDefined();

--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -89,9 +89,6 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
     beforeEach(() => {
       renderRestHook = makeRenderRestHook(makeProvider);
     });
-    afterEach(() => {
-      renderRestHook.cleanup();
-    });
 
     describe('Endpoint', () => {
       it('should resolve await', async () => {

--- a/packages/core/src/react-integration/__tests__/integration.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration.web.tsx
@@ -103,7 +103,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         const { result, waitForNextUpdate } = renderRestHook(() => {
           return useResource(CoolerArticleDetail, payload);
         });
-        expect(result.current).toBeNull();
+        expect(result.current).toBeUndefined();
         await waitForNextUpdate();
         expect(result.current.title).toBe(payload.title);
         // @ts-expect-error
@@ -116,7 +116,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         const { result, waitForNextUpdate } = renderRestHook(() => {
           return useResource(ListPaginatedArticle, {});
         });
-        expect(result.current).toBeNull();
+        expect(result.current).toBeUndefined();
         await waitForNextUpdate();
         expect(result.current).toBeInstanceOf(SimpleRecord);
         expect(result.current.nextPage).toBe('');
@@ -131,7 +131,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       const { result, waitForNextUpdate } = renderRestHook(() => {
         return useResource(CoolerArticleResource.detailShape(), payload);
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.current instanceof CoolerArticleResource).toBe(true);
       expect(result.current.title).toBe(payload.title);
@@ -143,7 +143,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       const { result, waitForNextUpdate } = renderRestHook(() => {
         return useResource(PaginatedArticleResource.listDefaultsShape(), {});
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.current).toBeInstanceOf(SimpleRecord);
       expect(result.current.nextPage).toBe('');
@@ -179,7 +179,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           throw e;
         }
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       let [data, del] = result.current;
       expect(data).toBeInstanceOf(CoolerArticleResource);
@@ -230,7 +230,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           throw e;
         }
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       let [data, invalidate] = result.current;
       expect(data).toBeInstanceOf(CoolerArticleResource);
@@ -280,7 +280,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           title: '0',
         });
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.error).toBeDefined();
       expect((result.error as any).status).toBe(403);
@@ -295,7 +295,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           },
         ]);
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.error).toBeDefined();
       expect((result.error as any).status).toBe(403);
@@ -309,7 +309,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           id: 878,
         });
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.error).toBeDefined();
       expect((result.error as any).status).toBe(400);
@@ -328,7 +328,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           [UserResource.listShape(), {}],
         );
       });
-      expect(result.current).toBeNull();
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       const [article, users] = result.current;
       expect(article instanceof CoolerArticleResource).toBe(true);
@@ -686,7 +686,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
               fetch: useFetcher(IndexedUserResource.detailShape()),
             };
           });
-          expect(result.current).toBeNull();
+          expect(result.current).toBeUndefined();
           await waitForNextUpdate();
           const bob = result.current.bob;
           expect(bob).toBeDefined();

--- a/packages/core/src/react-integration/__tests__/integration.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration.web.tsx
@@ -87,9 +87,6 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
     beforeEach(() => {
       renderRestHook = makeRenderRestHook(makeProvider);
     });
-    afterEach(() => {
-      renderRestHook.cleanup();
-    });
 
     describe('Endpoint', () => {
       it('should resolve await', async () => {

--- a/packages/core/src/react-integration/__tests__/subscriptions-endpoint.tsx
+++ b/packages/core/src/react-integration/__tests__/subscriptions-endpoint.tsx
@@ -190,7 +190,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
 async function validateSubscription(
   result: {
     readonly current: PollingArticleResource | undefined;
-    readonly error: Error;
+    readonly error?: Error;
   },
   frequency: number,
   waitForNextUpdate: () => Promise<void>,

--- a/packages/core/src/react-integration/__tests__/subscriptions-endpoint.tsx
+++ b/packages/core/src/react-integration/__tests__/subscriptions-endpoint.tsx
@@ -65,8 +65,6 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
     });
     afterEach(() => {
       nock.cleanAll();
-
-      renderRestHook.cleanup();
     });
 
     it('useSubscription() + useCache()', async () => {

--- a/packages/core/src/react-integration/__tests__/subscriptions.tsx
+++ b/packages/core/src/react-integration/__tests__/subscriptions.tsx
@@ -164,7 +164,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
 async function validateSubscription(
   result: {
     readonly current: PollingArticleResource | undefined;
-    readonly error: Error;
+    readonly error?: Error;
   },
   frequency: number,
   waitForNextUpdate: () => Promise<void>,

--- a/packages/core/src/react-integration/__tests__/subscriptions.tsx
+++ b/packages/core/src/react-integration/__tests__/subscriptions.tsx
@@ -58,8 +58,6 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
     });
     afterEach(() => {
       nock.cleanAll();
-
-      renderRestHook.cleanup();
     });
 
     it('useSubscription() + useCache()', async () => {

--- a/packages/core/src/react-integration/__tests__/useCache-endpoint.tsx
+++ b/packages/core/src/react-integration/__tests__/useCache-endpoint.tsx
@@ -16,9 +16,6 @@ describe('useCache()', () => {
   beforeEach(() => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
-  afterEach(() => {
-    renderRestHook.cleanup();
-  });
 
   it('should be null with empty state', () => {
     const { result } = renderRestHook(() => {

--- a/packages/core/src/react-integration/__tests__/useCache.tsx
+++ b/packages/core/src/react-integration/__tests__/useCache.tsx
@@ -16,9 +16,6 @@ describe('useCache()', () => {
   beforeEach(() => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
-  afterEach(() => {
-    renderRestHook.cleanup();
-  });
 
   it('should be null with empty state', () => {
     const { result } = renderRestHook(() => {

--- a/packages/core/src/react-integration/__tests__/useError-endpoint.tsx
+++ b/packages/core/src/react-integration/__tests__/useError-endpoint.tsx
@@ -10,9 +10,6 @@ describe('useError()', () => {
   beforeEach(() => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
-  afterEach(() => {
-    renderRestHook.cleanup();
-  });
 
   it('should return 404 when cache not ready and no error in meta', () => {
     const results = [

--- a/packages/core/src/react-integration/__tests__/useError.tsx
+++ b/packages/core/src/react-integration/__tests__/useError.tsx
@@ -10,9 +10,6 @@ describe('useError()', () => {
   beforeEach(() => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
-  afterEach(() => {
-    renderRestHook.cleanup();
-  });
 
   it('should return 404 when cache not ready and no error in meta', () => {
     const results = [

--- a/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
+++ b/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
@@ -35,9 +35,6 @@ describe('useExpiresAt()', () => {
   beforeEach(() => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
-  afterEach(() => {
-    renderRestHook.cleanup();
-  });
 
   it('age is minimum of entities', () => {
     const ListTaco = new Endpoint(

--- a/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
@@ -92,7 +92,7 @@ describe('useResource()', () => {
         id: 400,
       });
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBeGreaterThan(399);
@@ -365,7 +365,7 @@ describe('useResource()', () => {
         title: '0',
       });
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);
@@ -380,7 +380,7 @@ describe('useResource()', () => {
         },
       ]);
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);
@@ -482,8 +482,8 @@ describe('useResource()', () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(GetNoEntities, { userId });
     });
-    // null means it threw
-    expect(result.current).toBe(null);
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.current).toStrictEqual(response);
   });
@@ -498,8 +498,8 @@ describe('useResource()', () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(GetPhoto, { userId });
     });
-    // null means it threw
-    expect(result.current).toBe(null);
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.current).toStrictEqual(response);
   });
@@ -508,8 +508,8 @@ describe('useResource()', () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(ArticleTimedResource.detail(), payload);
     });
-    // null means it threw
-    expect(result.current).toBe(null);
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.current.createdAt.getDate()).toBe(
       result.current.createdAt.getDate(),
@@ -565,8 +565,8 @@ describe('useResource()', () => {
           initialProps: { authToken: '' },
         },
       );
-      // null means it threw (suspended)
-      expect(result.current).toBe(null);
+      // undefined means it threw (suspended)
+      expect(result.current).toBeUndefined();
       await waitForNextUpdate();
       expect(result.current.data.title).toBe('unauthorized');
       rerender({ authToken: 'thepassword' });

--- a/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
@@ -139,9 +139,6 @@ describe('useResource()', () => {
   beforeEach(() => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
-  afterEach(() => {
-    renderRestHook.cleanup();
-  });
 
   it('should dispatch an action that fetches', async () => {
     await testDispatchFetch(ArticleComponentTester, [payload]);
@@ -362,7 +359,7 @@ describe('useResource()', () => {
   it('should throw errors on bad network', async () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(CoolerArticleResource.detail(), {
-        title: '0',
+        id: '0',
       });
     });
     expect(result.current).toBeUndefined();
@@ -376,7 +373,7 @@ describe('useResource()', () => {
       return useResource([
         CoolerArticleResource.detail(),
         {
-          title: '0',
+          id: '0',
         },
       ]);
     });

--- a/packages/core/src/react-integration/__tests__/useResource.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource.web.tsx
@@ -135,7 +135,11 @@ describe('useResource()', () => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
   afterEach(() => {
-    renderRestHook.cleanup();
+    try {
+      renderRestHook.cleanup();
+    } catch (e) {
+      console.log('error in cleanup');
+    }
   });
 
   it('should dispatch an action that fetches', async () => {
@@ -473,7 +477,7 @@ describe('useResource()', () => {
     const expiredShape = { ...shape };
     expiredShape.options = { ...expiredShape.options, dataExpiryLength: -100 };
 
-    const { result, waitForNextUpdate } = renderRestHook(
+    const { result, rerender } = renderRestHook(
       () => {
         return useResource(shape, {
           id: '4000',
@@ -492,12 +496,14 @@ describe('useResource()', () => {
       },
     );
 
+    const firsterror = result.error;
     expect(result.error).not.toBe(null);
     expect((result.error as any).status).toBe(400);
     expect(result.error).toMatchSnapshot();
-    await waitForNextUpdate();
+    rerender();
     expect(result.error).not.toBe(null);
     expect((result.error as any).status).toBe(400);
+    expect(result.error).not.toBe(firsterror);
   });
 
   it('should throw error when response is array when expecting entity', async () => {

--- a/packages/core/src/react-integration/__tests__/useResource.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource.web.tsx
@@ -88,7 +88,7 @@ describe('useResource()', () => {
         id: 400,
       });
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBeGreaterThan(399);
@@ -361,7 +361,7 @@ describe('useResource()', () => {
         title: '0',
       });
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);
@@ -376,7 +376,7 @@ describe('useResource()', () => {
         },
       ]);
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);
@@ -405,8 +405,8 @@ describe('useResource()', () => {
         ],
       },
     );
-    expect(result.current).toBe(null);
-    expect(result.error).toBe(null);
+    expect(result.current).toBeUndefined();
+    expect(result.error).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);
@@ -438,8 +438,8 @@ describe('useResource()', () => {
         ],
       },
     );
-    expect(result.current).toBe(null);
-    expect(result.error).toBe(null);
+    expect(result.current).toBeUndefined();
+    expect(result.error).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);
@@ -600,8 +600,8 @@ describe('useResource()', () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(noEntitiesShape, { userId });
     });
-    // null means it threw
-    expect(result.current).toBe(null);
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.current).toStrictEqual(response);
   });
@@ -616,8 +616,8 @@ describe('useResource()', () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(photoShape, { userId });
     });
-    // null means it threw
-    expect(result.current).toBe(null);
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.current).toStrictEqual(response);
   });
@@ -626,8 +626,8 @@ describe('useResource()', () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(ArticleTimedResource.detailShape(), payload);
     });
-    // null means it threw
-    expect(result.current).toBe(null);
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.current.createdAt.getDate()).toBe(
       result.current.createdAt.getDate(),

--- a/packages/core/src/react-integration/__tests__/useResource.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource.web.tsx
@@ -78,6 +78,7 @@ describe('useResource()', () => {
       .persist()
       .defaultReplyHeaders({
         'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': '*',
         'Content-Type': 'application/json',
       })
       .get(`/article-cooler/400`)
@@ -105,6 +106,7 @@ describe('useResource()', () => {
       .persist()
       .defaultReplyHeaders({
         'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Access-Token',
         'Content-Type': 'application/json',
       })
       .options(/.*/)
@@ -133,13 +135,6 @@ describe('useResource()', () => {
 
   beforeEach(() => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
-  });
-  afterEach(() => {
-    try {
-      renderRestHook.cleanup();
-    } catch (e) {
-      console.log('error in cleanup');
-    }
   });
 
   it('should dispatch an action that fetches', async () => {
@@ -362,7 +357,7 @@ describe('useResource()', () => {
   it('should throw errors on bad network', async () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(CoolerArticleResource.detailShape(), {
-        title: '0',
+        id: '0',
       });
     });
     expect(result.current).toBeUndefined();
@@ -376,7 +371,7 @@ describe('useResource()', () => {
       return useResource([
         CoolerArticleResource.detailShape(),
         {
-          title: '0',
+          id: '0',
         },
       ]);
     });

--- a/packages/core/src/react-integration/provider/__tests__/provider.tsx
+++ b/packages/core/src/react-integration/provider/__tests__/provider.tsx
@@ -2,6 +2,7 @@ import { CoolerArticleResource } from '__tests__/common';
 import { RECEIVE_TYPE } from '@rest-hooks/core/actionTypes';
 import React, { useContext } from 'react';
 import { act, render } from '@testing-library/react';
+import { NetworkManager } from '@rest-hooks/core';
 
 import { DispatchContext, StateContext } from '../../context';
 import CacheProvider from '../CacheProvider';
@@ -26,19 +27,20 @@ describe('<CacheProvider />', () => {
     rerender(<CacheProvider>{chil}</CacheProvider>);
     expect(curDisp).toBe(dispatch);
     expect(count).toBe(1);
-    const managers: any[] = [];
+    const managers: any[] = [new NetworkManager()];
     rerender(<CacheProvider managers={managers}>{chil}</CacheProvider>);
+    expect(count).toBe(2);
     curDisp = dispatch;
     rerender(<CacheProvider managers={managers}>{chil}</CacheProvider>);
     expect(curDisp).toBe(dispatch);
-    expect(count).toBe(1);
+    expect(count).toBe(2);
     rerender(
       <DispatchContext.Provider value={() => Promise.resolve()}>
         {chil}
       </DispatchContext.Provider>,
     );
     expect(curDisp).not.toBe(dispatch);
-    expect(count).toBe(2);
+    expect(count).toBe(3);
   });
   it('should change state', () => {
     let dispatch: any, state;

--- a/packages/legacy/src/__tests__/useStatefulResource.tsx
+++ b/packages/legacy/src/__tests__/useStatefulResource.tsx
@@ -58,10 +58,6 @@ describe('useStatefulResource()', () => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
 
-  afterEach(() => {
-    renderRestHook.cleanup();
-  });
-
   it('should work on good network', async () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useStatefulResource(CoolerArticleResource.detail(), {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -46,7 +46,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@testing-library/react-hooks": "~3.5.0"
+    "@testing-library/react-hooks": "~5.0.3"
   },
   "peerDependencies": {
     "@rest-hooks/core": "^1.0.0-beta.1",

--- a/packages/test/src/makeRenderRestHook.tsx
+++ b/packages/test/src/makeRenderRestHook.tsx
@@ -43,9 +43,9 @@ export default function makeRenderRestHook(
       wrapper,
     });
   }
+  /** @deprecated */
   renderRestHook.cleanup = () => {
-    manager.cleanup();
-    subManager.cleanup();
+    console.warn('cleanup() now happened automatically on unmount');
   };
   return renderRestHook;
 }

--- a/packages/test/src/providers.tsx
+++ b/packages/test/src/providers.tsx
@@ -19,10 +19,10 @@ let makeExternalCacheProvider: (
 try {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { createStore, applyMiddleware } = require('redux');
-  makeExternalCacheProvider = (
+  makeExternalCacheProvider = function makeExternal(
     managers: Manager[],
     initialState?: DeepPartialWithUnknown<State<any>>,
-  ) => {
+  ) {
     const store = createStore(
       reducer,
       initialState,
@@ -45,10 +45,10 @@ try {
     };
   };
 } catch (e) {
-  makeExternalCacheProvider = (
+  makeExternalCacheProvider = function makeExternal(
     managers: Manager[],
     initialState?: DeepPartialWithUnknown<State<any>>,
-  ): ((props: { children: React.ReactNode }) => JSX.Element) => {
+  ): (props: { children: React.ReactNode }) => JSX.Element {
     throw new Error(
       'Using makeExternalCacheProvider() requires redux to be installed as a peerDependency to rest-hooks',
     );

--- a/packages/test/src/providers.tsx
+++ b/packages/test/src/providers.tsx
@@ -44,7 +44,6 @@ try {
           managers[i].init?.(store.getState());
         }
         return () => {
-          console.log('unmount external');
           for (let i = 0; i < managers.length; ++i) {
             managers[i].cleanup();
           }

--- a/packages/test/src/providers.tsx
+++ b/packages/test/src/providers.tsx
@@ -1,6 +1,6 @@
 import { State, reducer, CacheProvider, Manager } from '@rest-hooks/core';
 import { ExternalCacheProvider, PromiseifyMiddleware } from 'rest-hooks';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 // Extension of the DeepPartial type defined by Redux which handles unknown
 type DeepPartialWithUnknown<T> = {
@@ -37,6 +37,20 @@ try {
     }: {
       children: React.ReactNode;
     }) {
+      // this is not handled in ExternalCacheProvider as it doesn't
+      // own its managers. Since we are owning them here, we should ensure it happens
+      useEffect(() => {
+        for (let i = 0; i < managers.length; ++i) {
+          managers[i].init?.(store.getState());
+        }
+        return () => {
+          console.log('unmount external');
+          for (let i = 0; i < managers.length; ++i) {
+            managers[i].cleanup();
+          }
+        };
+      }, []);
+
       return (
         <ExternalCacheProvider store={store} selector={(s: State<any>) => s}>
           {children}

--- a/packages/use-enhanced-reducer/src/__tests__/middleware.tsx
+++ b/packages/use-enhanced-reducer/src/__tests__/middleware.tsx
@@ -218,6 +218,6 @@ describe('createEnhancedReducerHook', () => {
       useEnhancedReducer(state => state, {}, [dispatchingMiddleware]);
     });
     expect(result.error).toBeDefined();
-    expect(result.error.message).toMatchSnapshot();
+    expect(result.error?.message).toMatchSnapshot();
   });
 });

--- a/website/versioned_docs/version-5.0/guides/redux.md
+++ b/website/versioned_docs/version-5.0/guides/redux.md
@@ -58,14 +58,14 @@ import { initialState } from '@rest-hooks/core';
 import { createStore, applyMiddleware } from 'redux';
 import ReactDOM from 'react-dom';
 
-const manager = new NetworkManager();
+const networkManager = new NetworkManager();
 const subscriptionManager = new SubscriptionManager(PollingSubscription);
 
 const store = createStore(
   reducer,
   initialState,
   applyMiddleware(
-    manager.getMiddleware(),
+    networkManager.getMiddleware(),
     subscriptionManager.getMiddleware(),
     // place Rest Hooks built middlewares before PromiseifyMiddleware
     PromiseifyMiddleware,
@@ -73,6 +73,11 @@ const store = createStore(
   ),
 );
 const selector = state => state;
+
+// managers optionally provide initialization subroutine
+for (const manager of [networkManager, subscriptionManager]) {
+  managers[i].init?.(selector(store.getState()));
+}
 
 ReactDOM.render(
   <ExternalCacheProvider store={store} selector={selector}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,7 +1086,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.4", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -2668,21 +2668,17 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
-"@testing-library/react-hooks@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.1.tgz#1f8ccd21208086ec228d9743fe40b69d0efcd7e5"
-  integrity sha512-LbzvE7oKsVzuW1cxA/aOeNgeVvmHWG2p/WSzalIGyWuqZT3jVcNDT5KPEwy36sUYWde0Qsh32xqIUFXukeywXg==
-  dependencies:
-    "@babel/runtime" "^7.5.4"
-    "@types/testing-library__react-hooks" "^3.3.0"
-
-"@testing-library/react-hooks@~3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.5.0.tgz#8d728f2d56d615935116385f3ff9335e3402e46b"
-  integrity sha512-PpztMzQ+h8hXwd9TtSx6H+D5sKv7sW0sRr0dOW3x9O5yNOHlg5Yi4uCMhYBuGYAHM7XJyceb+u4D3CgT8LotKg==
+"@testing-library/react-hooks@^5.0.3", "@testing-library/react-hooks@~5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.0.3.tgz#dd0d2048817b013b266d35ca45e3ea48a19fd87e"
+  integrity sha512-UrnnRc5II7LMH14xsYNm/WRch/67cBafmrSQcyFh0v+UUmSf1uzfB7zn5jQXSettGwOSxJwdQUN7PgkT0w22Lg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@types/testing-library__react-hooks" "^3.4.0"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    filter-console "^0.1.1"
+    react-error-boundary "^3.1.0"
 
 "@testing-library/react-native@^7.1.0":
   version "7.1.0"
@@ -2889,14 +2885,21 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-test-renderer@*":
-  version "16.9.1"
-  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.1.tgz#9d432c46c515ebe50c45fa92c6fb5acdc22e39c4"
-  integrity sha512-nCXQokZN1jp+QkoDNmDZwoWpKY8HDczqevIDO4Uv9/s9rbGPbSpy8Uaxa5ixHKkcm/Wt0Y9C3wCxZivh4Al+rQ==
+"@types/react-dom@>=16.9.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.0":
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz#9be47b375eeb906fced37049e67284a438d56620"
+  integrity sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
   integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
@@ -2920,20 +2923,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
-
-"@types/testing-library__react-hooks@^3.3.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.0.tgz#be148b7fa7d19cd3349c4ef9d9534486bc582fcc"
-  integrity sha512-QYLZipqt1hpwYsBU63Ssa557v5wWbncqL36No59LI7W3nCMYKrLWTnYGn2griZ6v/3n5nKXNYkTeYpqPHY7Ukg==
-  dependencies:
-    "@types/react-test-renderer" "*"
-
-"@types/testing-library__react-hooks@^3.4.0":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz#b8d7311c6c1f7db3103e94095fe901f8fef6e433"
-  integrity sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
-  dependencies:
-    "@types/react-test-renderer" "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -6199,6 +6188,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-console@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
+  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 finalhandler@1.1.2:
   version "1.1.2"
@@ -10909,6 +10903,13 @@ react-dom@17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.0.tgz#9487443df2f9ba1db90d8ab52351814907ea4af3"
+  integrity sha512-lmPrdi5SLRJR+AeJkqdkGlW/CRkAUvZnETahK58J4xb5wpbfDngasEGu+w0T1iXEhVrYBJZeW+c4V1hILCnMWQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-is@^16.12.0:
   version "16.12.0"


### PR DESCRIPTION
BREAKING CHANGE:
- result.current, result.error is now `undefined` after suspense, rather than `null`
-  interval will now default to 50ms in async utils
-  timeout will now default to 1000ms in async utils
-  suppressErrors has been removed from async utils
- Adjust types so that react renderer exports don't required extra generic parameter
- Importing from renderHook and act from @testing-library/react-hooks will now auto-detect which renderer to used based on the project's dependencies
    - peerDependencies are now optional to support different dependencies being required
    - This means there will be no warning if the dependency is not installed at all, but it will still warn if an incompatible version is installed
    - Auto-detection won't work with bundlers (e.g. Webpack). Please use as specific renderer import instead
(see https://github.com/testing-library/react-hooks-testing-library/releases/tag/v5.0.0)


### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Keep up with the latest

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Upgrade react-hooks-testing-library from 3.2 to 5
Had to change all the checks for suspense to undefined from null.
Deprecated `cleanup()` as it already happens on unmount.
Added cleanup() to externalprovider in tests to reflect behavior of cacheprovider.
Updated redux docs to include calling manager's init


Waiting on https://github.com/testing-library/react-hooks-testing-library/issues/554 to be able to use this version.