### PR TITLE
fix: Widen Resource.delete() just like other endpoints

### DIFF
--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -225,7 +225,7 @@ export default abstract class SimpleResource extends Entity {
     const endpoint = this.endpointMutate();
     return this.memo('#delete', () =>
       endpoint.extend({
-        fetch(params: Readonly<object>) {
+        fetch(params: any) {
           return endpoint.fetch.call(this, params).then(() => params);
         },
         method: 'DELETE',


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
We widened our params in https://github.com/coinbase/rest-hooks/pull/479 but missed delete because it has a special override
