### PR TITLE
enhance: Expand matches peerdeps for endpoint

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -57,6 +57,6 @@
     "@babel/runtime": "^7.12.0"
   },
   "peerDependencies": {
-    "@rest-hooks/endpoint": "^0.6.1"
+    "@rest-hooks/endpoint": "^0.6.1 || ^1.0.0"
   }
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Allow matching of v1. Noticed this when using npm instead of yarn and it tried to resolve with v0.6. Realized v1 is breaking from 0.x

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add a union for peerDep of endpoint.
