### PR TITLE
fix: Ensure Endpoint doesn't trigger CSP

### DIFF
--- a/packages/endpoint/src/endpoint.js
+++ b/packages/endpoint/src/endpoint.js
@@ -15,11 +15,17 @@ function runCompat(endpoint, options) {
 
 export default class Endpoint extends Function {
   constructor(fetchFunction, options) {
-    super('return arguments.callee.fetch.apply(arguments.callee, arguments)');
-    if (fetchFunction) this.fetch = fetchFunction;
-    Object.assign(this, options);
+    const self = (...args) => self.fetch(...args);
     /** The following is for compatibility with FetchShape */
-    runCompat(this, options);
+    self.getFetchKey = params => self.key(params);
+
+    if (fetchFunction) self.fetch = fetchFunction;
+    Object.assign(self, options);
+    Object.setPrototypeOf(self, new.target.prototype);
+
+    /** The following is for compatibility with FetchShape */
+    runCompat(self, options);
+    return self;
   }
 
   key(params) {
@@ -30,6 +36,7 @@ export default class Endpoint extends Function {
     // make a constructor/prototype based off this
     // extend from it and init with options sent
     class E extends this.constructor {}
+
     Object.assign(E.prototype, this);
     const instance = new E(options.fetch, options);
 
@@ -38,9 +45,4 @@ export default class Endpoint extends Function {
 
     return instance;
   }
-
-  /** The following is for compatibility with FetchShape */
-  getFetchKey = params => {
-    return this.key(params);
-  };
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
[CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) disallows calling Function(), which means in some scenarios the Endpoint class would not work.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Using `Object.setPrototypeOf(self, new.target.prototype);` we can still make instances inherit from Function without using `this` and thus, being forced to call `super()`, which is disallowed.

This does mean we cannot use class assignments, so moved those to constructor. This should work on children though.

A benefit of this method is we no longer have the hacky eval-like string.

### TODO:

This won't work in IE, so we need a detection mechanism to use the old method