### PR TITLE
docs: Added @rest-hooks/rest package to installation guide

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -24,11 +24,11 @@ Install the rest-hooks package into your project using [yarn](https://yarnpkg.co
 <!--DOCUSAURUS_CODE_TABS-->
 <!--yarn-->
 ```bash
-yarn add rest-hooks
+yarn add rest-hooks @rest-hooks/rest
 ```
 <!--npm-->
 ```bash
-npm install rest-hooks
+npm install rest-hooks @rest-hooks/rest
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 

--- a/website/versioned_docs/version-5.0/getting-started/installation.md
+++ b/website/versioned_docs/version-5.0/getting-started/installation.md
@@ -25,11 +25,11 @@ Install the rest-hooks package into your project using [yarn](https://yarnpkg.co
 <!--DOCUSAURUS_CODE_TABS-->
 <!--yarn-->
 ```bash
-yarn add rest-hooks
+yarn add rest-hooks @rest-hooks/rest
 ```
 <!--npm-->
 ```bash
-npm install rest-hooks
+npm install rest-hooks @rest-hooks/rest
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 


### PR DESCRIPTION

### Motivation
Current docs does not mention that you need to install `@rest-hooks/rest` to use the library. 

