### PR TITLE
Fixed code example of extending detail endpoint

### DIFF
--- a/docs/guides/extending-endpoints.md
+++ b/docs/guides/extending-endpoints.md
@@ -136,7 +136,7 @@ import { Resource } from '@rest-hooks/rest';
 
 export default class CommentResource extends Resource {
   static detail<T extends typeof Resource>(this: T) {
-    return super.detail.extend({
+    return super.detail().extend({
       schema: { data: this },
     });
   }

--- a/website/versioned_docs/version-5.0/guides/extending-endpoints.md
+++ b/website/versioned_docs/version-5.0/guides/extending-endpoints.md
@@ -138,7 +138,7 @@ import { Resource } from '@rest-hooks/rest';
 
 export default class CommentResource extends Resource {
   static detail<T extends typeof Resource>(this: T) {
-    return super.detail.extend({
+    return super.detail().extend({
       schema: { data: this },
     });
   }


### PR DESCRIPTION
In custom endpoints docs, the code example is wrong:

```js
export default class CommentResource extends Resource {
  static detail<T extends typeof Resource>(this: T) {
    return super.detail.extend({
      schema: { data: this },
    });
  }
```

Updated **.detail** to **.detail()**

```js
export default class CommentResource extends Resource {
  static detail<T extends typeof Resource>(this: T) {
    return super.detail().extend({
      schema: { data: this },
    });
  }
```