### PR TITLE
docs: Typo fix + better test example

### DIFF
--- a/docs/api/MockProvider.md
+++ b/docs/api/MockProvider.md
@@ -15,7 +15,7 @@ function MockProvider({
 \<MockProvider /> is a simple substitute provider to prefill the cache with fixtures so the 'happy path'
 can be tested. This is useful for [storybook](../guides/storybook.md) as well as component testing.
 
-> Deprecated: Use [<MockResolver />](./mockResolver) instead as it also supports [imperative fetches](../api/useFetcher) like [create](../api/resource#create-endpoint) and [update](../api/resource#update-endpoint).
+> Deprecated: Use [\<MockResolver />](./mockResolver) instead as it also supports [imperative fetches](../api/useFetcher) like [create](../api/resource#create-endpoint) and [update](../api/resource#update-endpoint).
 
 > Note: \<MockProvider /> disables dispatches, thus no fetches will occur. To simply initalize the
 > cache, use [mockInitialState()](./mockInitialState) to construct initialState for the normal [\<CacheProvider />](./CacheProvider)

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -118,11 +118,19 @@ it('should resolve list', async () => {
       maxResults: 10,
     });
   }, { results: options.full });
-  expect(result.current).toBe(null);
-  await waitForNextUpdate();
   expect(result.current).toBeDefined();
   expect(result.current.length).toBe(2);
   expect(result.current[0]).toBeInstanceOf(ArticleResource);
+});
+
+it('should throw errors on bad network', async () => {
+  const { result, waitForNextUpdate } = renderRestHook(() => {
+    return useResource(ArticleResource.list(), {
+      maxResults: 10,
+    });
+  }, { results: options.error });
+    expect(result.error).toBeDefined();
+    expect((result.error as any).status).toBe(400);
 });
 ```
 

--- a/website/versioned_docs/version-5.0/api/MockProvider.md
+++ b/website/versioned_docs/version-5.0/api/MockProvider.md
@@ -17,7 +17,7 @@ function MockProvider({
 \<MockProvider /> is a simple substitute provider to prefill the cache with fixtures so the 'happy path'
 can be tested. This is useful for [storybook](../guides/storybook.md) as well as component testing.
 
-> Deprecated: Use [<MockResolver />](./mockResolver) instead as it also supports [imperative fetches](../api/useFetcher) like [create](../api/resource#create-endpoint) and [update](../api/resource#update-endpoint).
+> Deprecated: Use [\<MockResolver />](./mockResolver) instead as it also supports [imperative fetches](../api/useFetcher) like [create](../api/resource#create-endpoint) and [update](../api/resource#update-endpoint).
 
 > Note: \<MockProvider /> disables dispatches, thus no fetches will occur. To simply initalize the
 > cache, use [mockInitialState()](./mockInitialState) to construct initialState for the normal [\<CacheProvider />](./CacheProvider)


### PR DESCRIPTION
- Forgot to escape `<`
- Test example: Suspense never occurs when using a fixture