### PR TITLE
pkg: Relax @babel/runtime requirement to ^7.7.2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,7 +66,7 @@
     "@rest-hooks/test": "^3.0.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.0",
+    "@babel/runtime": "^7.7.2",
     "@rest-hooks/endpoint": "^1.0.2",
     "@rest-hooks/normalizr": "^6.0.1",
     "@rest-hooks/use-enhanced-reducer": "^1.0.5",

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -51,7 +51,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.0",
+    "@babel/runtime": "^7.7.2",
     "@rest-hooks/normalizr": "^6.0.1"
   }
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -49,7 +49,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.0"
+    "@babel/runtime": "^7.7.2"
   },
   "peerDependencies": {
     "@rest-hooks/endpoint": "^0.6.1",

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -65,6 +65,6 @@
     "run-p": "^0.0.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.0"
+    "@babel/runtime": "^7.7.2"
   }
 }

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -68,7 +68,7 @@
     "@rest-hooks/test": "^3.0.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.0",
+    "@babel/runtime": "^7.7.2",
     "@rest-hooks/core": "^1.0.2",
     "@rest-hooks/endpoint": "^1.0.2"
   },

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -54,7 +54,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.0"
+    "@babel/runtime": "^7.7.2"
   },
   "peerDependencies": {
     "@rest-hooks/endpoint": "^0.6.1 || ^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,10 +1086,10 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.8.4":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
-  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
+  integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
   dependencies:
     regenerator-runtime "^0.13.4"
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Having multiple @babel/runtimes with nesting creates some interesting issues when building. 

After a more thorough investigation of https://github.com/babel/babel/pull/10853 I have realized that 7.12 is simply the requirement to work with webpack 5, but interop with babel/core will work. This is due to the new package exports directives - which are processed by webpack 5 only.

Thus, users of webpack 5, should ensure they run only babel 7.12+ and also hoist it to ensure a single version. Other users should not care.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
To reduce the chance of non-hoisted runtimes, we relax our requirements to what 4.5.9 was. This should enable no new introduced of non-hoisted runtimes.
