### PR TITLE
docs: Minor typos, update 5 docs with master changes

### DIFF
--- a/docs/guides/rest-types.md
+++ b/docs/guides/rest-types.md
@@ -47,9 +47,9 @@ class MyResource extends Resource {
   static create<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-      RestFetch<{}, Partial<AbstractInstanceType<T>>>,
-      SchemaDetail<AbstractInstanceType<T>>,
-      true
+    RestFetch<{}, Partial<AbstractInstanceType<T>>>,
+    SchemaDetail<AbstractInstanceType<T>>,
+    true
   > {
     return super.create();
   }
@@ -61,7 +61,7 @@ class MyResource extends Resource {
     { results: T[]; nextPage: string },
     undefined
   > {
-    return super.list().extend({ schema: { results: this[]; nextPage: string } });
+    return super.list().extend({ schema: { results: [this], nextPage: '' } });
   }
 }
 ```
@@ -295,7 +295,7 @@ class Child extends Base {
 
 This is only needed if we are setting the type directly from the super call.
 We'll see below we only need to do this when we retain the schema from the super call.
-This is also not necessary if `this.method()` is called as this bug *only* affects `super`
+This is also not necessary if `this.method()` is called as this bug _only_ affects `super`
 
 ## As Resource
 
@@ -372,7 +372,11 @@ import { RestEndpoint, RestFetch, Resource } from '@rest-hooks/rest';
 class User extends Resource {
   static detail<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<RestFetch<{ id: string }>, SchemaDetail<AbstractInstanceType<T>>, undefined> {
+  ): RestEndpoint<
+    RestFetch<{ id: string }>,
+    SchemaDetail<AbstractInstanceType<T>>,
+    undefined
+  > {
     // super.detail() resolves the Schema to be based on `typeof Resource`, rather than `T`
     // which makes it incompatible with the return type correctly specified.
     return super.detail() as any;

--- a/website/versioned_docs/version-5.0/api/NetworkErrorBoundary.md
+++ b/website/versioned_docs/version-5.0/api/NetworkErrorBoundary.md
@@ -1,5 +1,7 @@
 ---
 title: <NetworkErrorBoundary />
+id: version-5.0-NetworkErrorBoundary
+original_id: NetworkErrorBoundary
 ---
 
 Displays a fallback component when a network error happens in its subtree.

--- a/website/versioned_docs/version-5.0/api/makeRenderRestHook.md
+++ b/website/versioned_docs/version-5.0/api/makeRenderRestHook.md
@@ -113,15 +113,11 @@ beforeEach(() => {
   renderRestHook = makeRenderRestHook(makeCacheProvider);
 });
 
-afterEach(() => {
-  renderRestHook.cleanup();
-});
-
 it('should resolve useResource()', async () => {
   const { result, waitForNextUpdate } = renderRestHook(() => {
     return useResource(ArticleResource.detail(), payload);
   });
-  expect(result.current).toBe(null);
+  expect(result.current).toBeUndefined();
   await waitForNextUpdate();
   expect(result.current instanceof ArticleResource).toBe(true);
   expect(result.current.title).toBe(payload.title);

--- a/website/versioned_docs/version-5.0/guides/custom-networking.md
+++ b/website/versioned_docs/version-5.0/guides/custom-networking.md
@@ -12,6 +12,9 @@ and is used in the [NetworkManager](../api/NetworkManager).
 `SimpleResource` can be used as an abstract class to implement custom fetch methods
 without including the default.
 
+> Note: If you plan on using [NetworkErrorBoundary](../api/NetworkErrorBoundary) make sure
+> to add a `status` member to errors, as it catches only errors with a `status` member.
+
 ## Fetch (default)
 
 [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)

--- a/website/versioned_docs/version-5.0/guides/rest-types.md
+++ b/website/versioned_docs/version-5.0/guides/rest-types.md
@@ -49,9 +49,9 @@ class MyResource extends Resource {
   static create<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-      RestFetch<{}, Partial<AbstractInstanceType<T>>>,
-      SchemaDetail<AbstractInstanceType<T>>,
-      true
+    RestFetch<{}, Partial<AbstractInstanceType<T>>>,
+    SchemaDetail<AbstractInstanceType<T>>,
+    true
   > {
     return super.create();
   }
@@ -63,7 +63,7 @@ class MyResource extends Resource {
     { results: T[]; nextPage: string },
     undefined
   > {
-    return super.list().extend({ schema: { results: this[]; nextPage: string } });
+    return super.list().extend({ schema: { results: [this], nextPage: '' } });
   }
 }
 ```
@@ -297,7 +297,7 @@ class Child extends Base {
 
 This is only needed if we are setting the type directly from the super call.
 We'll see below we only need to do this when we retain the schema from the super call.
-This is also not necessary if `this.method()` is called as this bug *only* affects `super`
+This is also not necessary if `this.method()` is called as this bug _only_ affects `super`
 
 ## As Resource
 
@@ -374,7 +374,11 @@ import { RestEndpoint, RestFetch, Resource } from '@rest-hooks/rest';
 class User extends Resource {
   static detail<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<RestFetch<{ id: string }>, SchemaDetail<AbstractInstanceType<T>>, undefined> {
+  ): RestEndpoint<
+    RestFetch<{ id: string }>,
+    SchemaDetail<AbstractInstanceType<T>>,
+    undefined
+  > {
     // super.detail() resolves the Schema to be based on `typeof Resource`, rather than `T`
     // which makes it incompatible with the return type correctly specified.
     return super.detail() as any;

--- a/website/versioned_docs/version-5.0/guides/unit-testing-hooks.md
+++ b/website/versioned_docs/version-5.0/guides/unit-testing-hooks.md
@@ -84,7 +84,6 @@ describe('useResource()', () => {
 
   afterEach(() => {
     nock.cleanAll();
-    renderRestHook.cleanup();
   });
 
   it('should throw errors on bad network', async () => {
@@ -93,7 +92,7 @@ describe('useResource()', () => {
         title: '0',
       });
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);
@@ -126,7 +125,6 @@ describe('useResource()', () => {
 
   afterEach(() => {
     nock.cleanAll();
-    renderRestHook.cleanup();
   });
 
   it('should throw errors on bad network', async () => {
@@ -135,7 +133,7 @@ describe('useResource()', () => {
         title: '0',
       });
     });
-    expect(result.current).toBe(null);
+    expect(result.current).toBeUndefined();
     await waitForNextUpdate();
     expect(result.error).toBeDefined();
     expect((result.error as any).status).toBe(403);


### PR DESCRIPTION
- Add small detail to NetworkErrorBoundary 
- Format some docs files
- Typo in rest-types
- Update v5 docs with some master updates that were missed