### PR TITLE
enhance: legacy Resource should only warn on validation problems

### DIFF
--- a/__tests__/legacy.ts
+++ b/__tests__/legacy.ts
@@ -1,0 +1,66 @@
+import { Resource } from 'rest-hooks';
+
+export class UserResource extends Resource {
+  readonly id: number | undefined = undefined;
+  readonly username: string = '';
+  readonly email: string = '';
+  readonly isAdmin: boolean = false;
+
+  pk() {
+    return this.id?.toString();
+  }
+
+  static urlRoot = 'http://test.com/user/';
+}
+export class ArticleResource extends Resource {
+  readonly id: number | undefined = undefined;
+  readonly title: string = '';
+  readonly content: string = '';
+  readonly author: number | null = null;
+  readonly tags: string[] = [];
+
+  pk() {
+    return this.id?.toString();
+  }
+
+  static schema = {
+    author: UserResource,
+  };
+
+  static urlRoot = 'http://test.com/article/';
+  static url<T extends typeof Resource>(this: T, urlParams?: any): string {
+    if (urlParams && !urlParams.id) {
+      return `${this.urlRoot}${urlParams.title}`;
+    }
+    return super.url(urlParams);
+  }
+
+  static longLivingRequest<T extends typeof Resource>(this: T) {
+    const single = this.detailShape();
+    return {
+      ...single,
+      options: {
+        ...single.options,
+        dataExpiryLength: 1000 * 60 * 60,
+      },
+    };
+  }
+
+  static neverRetryOnErrorRequest<T extends typeof Resource>(this: T) {
+    const single = this.detailShape();
+    return {
+      ...single,
+      options: {
+        ...single.options,
+        errorExpiryLength: Infinity,
+      },
+    };
+  }
+}
+
+export class CoolerArticleResource extends ArticleResource {
+  static urlRoot = 'http://test.com/article-cooler/';
+  get things() {
+    return `${this.title} five`;
+  }
+}

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource-legacy.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource-legacy.web.tsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useResource() should throw error when response is {} when expecting entity 1`] = `
+Array [
+  Array [
+    "Attempted to initialize CoolerArticleResource with no matching keys found
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: 
+    Missing: id,title,content,author,tags
+  Value: {}",
+  ],
+]
+`;
+
+exports[`useResource() should throw error when response is array when expecting entity 1`] = `
+Array [
+  Array [
+    "Attempted to initialize CoolerArticleResource with no matching keys found
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: 
+    Missing: id,title,content,author,tags
+  Value: {}",
+  ],
+]
+`;
+
+exports[`useResource() should throw error when response is number when expecting entity 1`] = `
+Array [
+  Array [
+    "Attempted to initialize CoolerArticleResource with no matching keys found
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: 
+    Missing: id,title,content,author,tags
+  Value: {}",
+  ],
+]
+`;
+
+exports[`useResource() should throw error when response is string when expecting entity 1`] = `
+Array [
+  Array [
+    "Attempted to initialize CoolerArticleResource with no matching keys found
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: 
+    Missing: id,title,content,author,tags
+  Value: {}",
+  ],
+]
+`;

--- a/packages/core/src/react-integration/__tests__/useResource-legacy.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource-legacy.web.tsx
@@ -1,0 +1,96 @@
+import { CoolerArticleResource, UserResource } from '__tests__/legacy';
+import { ReadShape } from '@rest-hooks/core';
+import React, { Suspense } from 'react';
+import nock from 'nock';
+
+// relative imports to avoid circular dependency in tsconfig references
+
+import { SimpleRecord } from '@rest-hooks/normalizr';
+
+import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { useResource } from '../hooks';
+import { payload, users, nested } from '../test-fixtures';
+
+describe('useResource()', () => {
+  let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+
+  async function testMalformedResponse(
+    payload: any,
+    fetchShape: ReadShape<any> = CoolerArticleResource.detailShape(),
+  ) {
+    nock(/.*/)
+      .persist()
+      .defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': '*',
+        'Content-Type': 'application/json',
+      })
+      .get(`/article-cooler/400`)
+      .reply(200, payload);
+    const warnspy = jest.spyOn(global.console, 'warn');
+
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useResource(fetchShape, {
+        id: 400,
+      });
+    });
+    expect(result.current).toBeUndefined();
+    await waitForNextUpdate();
+    expect(warnspy).toHaveBeenCalled();
+    expect(warnspy.mock.calls).toMatchSnapshot();
+
+    warnspy.mockRestore();
+  }
+
+  beforeAll(() => {
+    nock(/.*/)
+      .persist()
+      .defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Access-Token',
+        'Content-Type': 'application/json',
+      })
+      .options(/.*/)
+      .reply(200)
+      .get(`/article-cooler/${payload.id}`)
+      .reply(200, payload)
+      .get(`/article-time/${payload.id}`)
+      .reply(200, { ...payload, createdAt: '2020-06-07T02:00:15+0000' })
+      .delete(`/article-cooler/${payload.id}`)
+      .reply(204, '')
+      .delete(`/article/${payload.id}`)
+      .reply(200, {})
+      .get(`/article-cooler/0`)
+      .reply(403, {})
+      .get(`/article-cooler/666`)
+      .reply(200, '')
+      .get(`/article-cooler/`)
+      .reply(200, nested)
+      .get(`/user/`)
+      .reply(200, users);
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+  });
+
+  beforeEach(() => {
+    renderRestHook = makeRenderRestHook(makeCacheProvider);
+  });
+
+  it('should throw error when response is array when expecting entity', async () => {
+    await testMalformedResponse([]);
+  });
+
+  it('should throw error when response is {} when expecting entity', async () => {
+    await testMalformedResponse({});
+  });
+
+  it('should throw error when response is number when expecting entity', async () => {
+    await testMalformedResponse(5);
+  });
+
+  it('should throw error when response is string when expecting entity', async () => {
+    await testMalformedResponse('hi');
+  });
+});

--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -32,6 +32,12 @@ export default abstract class SimpleResource extends FlatEntity {
     return this.urlRoot;
   }
 
+  /** Warning level for probable malformed responses
+   *
+   * We only 'warn' here since this is the upgrade path
+   */
+  static automaticValidation = 'warn' as const;
+
   /** URL to find this SimpleResource */
   declare readonly url: string;
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Since `Resource`s in 'rest-hooks' package (vs `@rest-hooks/rest`) are only for legacy, ease upgrade path.

It's still very unlikely to cause problems, but this should make things absolutely easy.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`warn` still so people are aware, but if they were using it before it's likely working correctly.

### Open Questions

In the case of building new Resources off 'rest-hooks' import, it won't bring as many benefits; but more important to get everyone on 5 smoothly.