### PR TITLE
fix: Gracefully handle webpack builds

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -4,18 +4,23 @@
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
-  "types": "dist/index.d.ts",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "src",
     "dist",
+    "lib",
     "LICENSE",
     "README.md"
   ],
   "scripts": {
+    "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/test' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf dist *.tsbuildinfo",
-    "build": "yarn run build:bundle",
-    "prepublishOnly": "yarn run build"
+    "build": "yarn run build:lib && yarn run build:bundle",
+    "dev": "yarn run build:lib -w",
+    "prepare": "yarn run build:lib",
+    "prepublishOnly": "yarn run build:bundle"
   },
   "keywords": [
     "test",
@@ -57,6 +62,9 @@
   },
   "peerDependenciesMeta": {
     "redux": {
+      "optional": true
+    },
+    "@types/react": {
       "optional": true
     }
   }

--- a/packages/test/rollup.config.js
+++ b/packages/test/rollup.config.js
@@ -30,7 +30,7 @@ export default [
     plugins: [
       babel({
         exclude: ['node_modules/**', '**/__tests__/**', '**/*.d.ts'],
-        rootMode: "upward",
+        rootMode: 'upward',
         extensions,
         runtimeHelpers: true,
       }),

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": "lib",
     "rootDir": "src"
   },
   "include": ["src"],


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Only having commonjs works fine when importing in node context. However, things like MockResolver are meant to be used with storybook which builds via webpack. This creates two problems
- testing library ends up being pulled in, which isn't build for webpack
- optional redux import only works with actual cjs as bundlers don't run the exception

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
By providing an es6 module version, webpack will pick this up and skip over the modules that are not used - namely the ones that depend on optional redux or testing library

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
There used to be an issue where having non cjs version of test caused loading of both cjs and es6 versions of rest hooks context. I believe this was due to bundling as I could not find a "module" entry since 'test' split into its own package.