### PR TITLE
fix: Support non-JSON payloads (like FormData)

### DIFF
--- a/packages/rest-hooks/src/resource/Resource.ts
+++ b/packages/rest-hooks/src/resource/Resource.ts
@@ -33,7 +33,7 @@ export default abstract class Resource extends SimpleResource {
     };
     if (this.fetchOptionsPlugin) options = this.fetchOptionsPlugin(options);
     if (body) options.body = JSON.stringify(body);
-    if (!(body instanceof FormData)) {
+    if (!options.body || typeof options.body === 'string') {
       options.headers = {
         'Content-Type': 'application/json',
         ...options.headers,

--- a/packages/rest-hooks/src/resource/Resource.ts
+++ b/packages/rest-hooks/src/resource/Resource.ts
@@ -30,13 +30,15 @@ export default abstract class Resource extends SimpleResource {
   ) {
     let options: RequestInit = {
       method: method.toUpperCase(),
-      headers: {
-        'Content-Type': 'application/json',
-        // "Content-Type": "application/x-www-form-urlencoded",  -- maybe use this if typeof body is FormData ?
-      },
     };
     if (this.fetchOptionsPlugin) options = this.fetchOptionsPlugin(options);
     if (body) options.body = JSON.stringify(body);
+    if (!(body instanceof FormData)) {
+      options.headers = {
+        'Content-Type': 'application/json',
+        ...options.headers,
+      };
+    }
     return fetch(url, options)
       .then(response => {
         if (!response.ok) {

--- a/packages/rest-hooks/src/resource/__tests__/resource.ts
+++ b/packages/rest-hooks/src/resource/__tests__/resource.ts
@@ -327,6 +327,32 @@ describe('Resource', () => {
       expect(article).toMatchObject(payload2);
     });
 
+    it('should PUT with multipart form data', async () => {
+      const payload2 = { id: 500, content: 'another' };
+      let lastRequest: any;
+      nock(/.*/)
+        .defaultReplyHeaders({
+          'Access-Control-Allow-Origin': '*',
+        })
+        .put('/article-cooler/500')
+        .reply(function (uri, requestBody) {
+          lastRequest = this.req;
+          return [201, payload2, { 'Content-Type': 'application/json' }];
+        });
+      const newPhoto = new Blob();
+      const body = new FormData();
+      body.append('photo', newPhoto);
+
+      const article = await CoolerArticleResource.fetch(
+        CoolerArticleResource.url({ id: '500' }),
+        { method: 'PUT', body },
+      );
+      expect(lastRequest.headers['content-type']).toContain(
+        'multipart/form-data',
+      );
+      expect(article).toMatchObject(payload2);
+    });
+
     it('should DELETE', async () => {
       const res = await CoolerArticleResource.fetch(
         CoolerArticleResource.url({

--- a/packages/rest/src/Resource.ts
+++ b/packages/rest/src/Resource.ts
@@ -18,14 +18,16 @@ class NetworkError extends Error {
 export default abstract class Resource extends SimpleResource {
   /** Perform network request and resolve with HTTP Response */
   static fetchResponse(input: RequestInfo, init: RequestInit) {
-    const options: RequestInit = {
-      ...init,
-      headers: {
-        'Content-Type': 'application/json',
-        // "Content-Type": "application/x-www-form-urlencoded",  -- maybe use this if typeof body is FormData ?
-        ...init.headers,
-      },
-    };
+    let options: RequestInit = init;
+    if (!(options.body instanceof FormData)) {
+      options = {
+        ...options,
+        headers: {
+          'Content-Type': 'application/json',
+          ...options.headers,
+        },
+      };
+    }
     return fetch(input, options)
       .then(response => {
         if (!response.ok) {

--- a/packages/rest/src/Resource.ts
+++ b/packages/rest/src/Resource.ts
@@ -19,7 +19,7 @@ export default abstract class Resource extends SimpleResource {
   /** Perform network request and resolve with HTTP Response */
   static fetchResponse(input: RequestInfo, init: RequestInit) {
     let options: RequestInit = init;
-    if (!(options.body instanceof FormData)) {
+    if (!options.body || typeof options.body === 'string') {
       options = {
         ...options,
         headers: {

--- a/packages/rest/src/__tests__/resource-endpoint.ts
+++ b/packages/rest/src/__tests__/resource-endpoint.ts
@@ -329,6 +329,32 @@ describe('Resource', () => {
       expect(article).toMatchObject(payload2);
     });
 
+    it('should PUT with multipart form data', async () => {
+      const payload2 = { id: 500, content: 'another' };
+      let lastRequest: any;
+      nock(/.*/)
+        .defaultReplyHeaders({
+          'Access-Control-Allow-Origin': '*',
+        })
+        .put('/article-cooler/500')
+        .reply(function (uri, requestBody) {
+          lastRequest = this.req;
+          return [201, payload2, { 'Content-Type': 'application/json' }];
+        });
+      const newPhoto = new Blob();
+      const body = new FormData();
+      body.append('photo', newPhoto);
+
+      const article = await CoolerArticleResource.fetch(
+        CoolerArticleResource.url({ id: '500' }),
+        { method: 'PUT', body },
+      );
+      expect(lastRequest.headers['content-type']).toContain(
+        'multipart/form-data',
+      );
+      expect(article).toMatchObject(payload2);
+    });
+
     it('should DELETE', async () => {
       const res = await CoolerArticleResource.fetch(
         CoolerArticleResource.url({


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #550  .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
For certain payloads this obviously isn't the correct header.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

- No body, or string body - set default 'Content-Type' header to 'application/json'
- User's init will always override this, which can be specified in many places
- Only for those using `Resource`