### PR TITLE
internal(pkg): Hoist @rest-hooks/test inclusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/core": "^7.12.10",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
+    "@rest-hooks/test": "^3.0.0",
     "@testing-library/react": "^11.2.3",
     "@testing-library/react-hooks": "^5.0.3",
     "@testing-library/react-native": "^7.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,9 +62,6 @@
   "bugs": {
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
-  "devDependencies": {
-    "@rest-hooks/test": "^3.0.0"
-  },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@rest-hooks/endpoint": "^1.0.3",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -55,9 +55,6 @@
   "bugs": {
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
-  "devDependencies": {
-    "@rest-hooks/test": "^3.0.0"
-  },
   "peerDependencies": {
     "@rest-hooks/core": "^1.0.0-k.6",
     "@types/react": "^16.8.4 || ^17.0.0",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -64,9 +64,6 @@
   "bugs": {
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
-  "devDependencies": {
-    "@rest-hooks/test": "^3.0.0"
-  },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@rest-hooks/core": "^1.0.3",


### PR DESCRIPTION


### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Eliminate need for version bumps on release in each package

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Hoisting removes the entry in each package.json per package
