### PR TITLE
docs: Update testing guides with latest best practices

### DIFF
--- a/docs/api/makeRenderRestHook.md
+++ b/docs/api/makeRenderRestHook.md
@@ -67,7 +67,9 @@ Hooks to run inside React. Return value will become available in `result`
 #### options.results
 
 Can be used to prime the cache if test expects cache values to already be filled. Takes same
-[array of fixtures as MockProvider](https://resthooks.io/docs/api/MockProvider#results)
+[array of fixtures as MockResolver](../api/MockResolver#fixtures)
+
+This has the same effect as initializing [<CacheProvider />](../api/CacheProvider) with [mockInitialState()](../api/mockInitialState)
 
 #### options.initialProps
 

--- a/docs/api/mockInitialState.md
+++ b/docs/api/mockInitialState.md
@@ -7,7 +7,7 @@ function mockInitialState(results: Fixture[]): State;
 ```
 
 `mockInitialState()` makes it easy to construct prefill the cache with fixtures. It's
-used in [\<MockProvider />](./MockProvider) to process the results prop. However, this
+used in [\<MockResolver />](./MockResolver) to process the results prop. However, this
 can also be useful to send into a normal provider when testing more complete flows
 that need to handle `dispatches` (and thus fetch).
 
@@ -16,11 +16,21 @@ that need to handle `dispatches` (and thus fetch).
 ### results
 
 ```typescript
-interface Fixture {
-  request: ReadEndpoint;
+export interface SuccessFixture {
+  request: ReadShape<Schema, object>;
   params: object;
   result: object | string | number;
+  error?: false;
 }
+
+export interface ErrorFixture {
+  request: ReadShape<Schema, object>;
+  params: object;
+  result: Error;
+  error: true;
+}
+
+export type Fixture = SuccessFixture | ErrorFixture;
 ```
 
 This prop specifies the fixtures to use data from. Each item represents a fetch defined by the

--- a/docs/guides/storybook.md
+++ b/docs/guides/storybook.md
@@ -53,7 +53,7 @@ export default function ArticleList({ maxResults }: { maxResults: number }) {
 We'll test three cases: some interesting results in the list, an empty list, and data not
 existing so loading fallback is shown.
 
-#### `fixtures.ts`
+<details open><summary><b>fixtures.ts</b></summary>
 
 ```typescript
 export default {
@@ -106,6 +106,8 @@ export default {
 };
 ```
 
+</details>
+
 ## Decorators
 
 You'll need to add the appropriate [global decorators](https://storybook.js.org/docs/react/writing-stories/decorators#global-decorators) to establish the correct context.
@@ -133,7 +135,7 @@ export const decorators = [
 
 ## Story
 
-Wrapping our component with <MockResolver /> enables us to declaratively
+Wrapping our component with \<MockResolver /> enables us to declaratively
 control how Rest Hooks' fetches are resolved.
 
 Here we select which fixtures should be used by [storybook controls](https://storybook.js.org/docs/react/essentials/controls).

--- a/docs/guides/unit-testing-components.md
+++ b/docs/guides/unit-testing-components.md
@@ -4,11 +4,11 @@ title: Unit testing components
 
 If you need to add unit tests to your components to check some behavior you might want
 avoid dealing with network fetch cycle as that is probably orthogonal to what your are
-trying to test. Using [\<MockProvider />](../api/MockProvider.md) in our tests allow
+trying to test. Using [\<MockResolver />](../api/MockResolver) in our tests allow
 us to prime the cache with provided fixtures so the components will immediately render
 with said results.
 
-#### `__tests__/fixtures.ts`
+<details open><summary><b>__tests__/fixtures.ts</b></summary>
 
 ```typescript
 export default {
@@ -31,6 +31,16 @@ export default {
         },
       ],
     },
+    {
+      request: ArticleResource.update(),
+      params: { id: 532 },
+      result: {
+        id: 532,
+        content: 'updated "never again"',
+        author: 23,
+        contributors: [5],
+      },
+    },
   ],
   empty: [
     {
@@ -39,16 +49,26 @@ export default {
       result: [],
     },
   ],
+  error: [
+    {
+      request: ArticleResource.list(),
+      params: { maxResults: 10 },
+      result: { message: 'Bad request', status: 400, name: 'Not Found' },
+      error: true,
+    },
+  ],
   loading: [],
 };
 ```
 
-#### `__tests__/ArticleList.tsx`
+</details>
+
+<details open><summary><b>__tests__/ArticleList.tsx</b></summary>
 
 ```tsx
 import { CacheProvider } from 'rest-hooks';
 import { render } from '@testing-library/react';
-import { MockProvider } from '@rest-hooks/test';
+import { MockResolver } from '@rest-hooks/test';
 
 import ArticleList from 'components/ArticleList';
 import results from './fixtures';
@@ -56,37 +76,32 @@ import results from './fixtures';
 describe('<ArticleList />', () => {
   it('renders', () => {
     const tree = (
-      <MockProvider results={results.full}>
+      <CacheProvider initialState={mockInitialState(results.full)}>
         <ArticleList maxResults={10} />
-      </MockProvider>
+      </CacheProvider>
     );
     const { queryByText } = render(tree);
     const content = queryByText(results.full.result[0].content);
     expect(content).toBeDefined();
   });
 
-  it('is stale while revalidates', async () => {
-    nock(/.*/)
-      .defaultReplyHeaders({
-        'Access-Control-Allow-Origin': '*',
-        'Content-Type': 'application/json',
-      })
-      .options(/.*/)
-      .get(`/article/?maxResults=10`).reply(200, results.full[0].result);
-
+  it('suspends then resolves', async () => {
     const tree = (
-      <CacheProvider initialState={mockInitialState(results.full)}>
-        <ArticleList maxResults={10} />
+      <CacheProvider>
+        <MockResolver fixtures={results.full}>
+          <Suspense fallback="loading">
+            <ArticleList maxResults={10} />
+          </Suspense>
+        </MockResolver>
       </CacheProvider>
     );
     const { queryByText, waitForNextUpdate } = render(tree);
-    const content = queryByText(results.full.result[0].content);
-    expect(content).toBeDefined();
+    expect(queryByText('loading')).toBeDefined();
 
     await waitForNextUpdate();
-    // verify we hit the endpoint
-    expect(nock.isDone()).toBeTrue();
     expect(queryByText(results.full.result[0].content)).toBeDefined();
   })
 });
 ```
+
+</details>

--- a/docs/guides/unit-testing-hooks.md
+++ b/docs/guides/unit-testing-hooks.md
@@ -30,11 +30,11 @@ Node doesn't come with fetch out of the box, so we need to be sure to polyfill i
 <!--DOCUSAURUS_CODE_TABS-->
 <!--yarn-->
 ```bash
-yarn add whatwg-fetch
+yarn add --dev whatwg-fetch
 ```
 <!--npm-->
 ```bash
-npm install whatwg-fetch
+npm install --save-dev whatwg-fetch
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -124,6 +124,9 @@
       "api/Values": {
         "title": "Values"
       },
+      "getting-started/endpoint": {
+        "title": "getting-started/endpoint"
+      },
       "getting-started/installation": {
         "title": "Installation"
       },
@@ -894,6 +897,9 @@
       },
       "version-5.0/api/version-5.0-MockResolver": {
         "title": "<MockResolver />"
+      },
+      "version-5.0/api/version-5.0-NetworkErrorBoundary": {
+        "title": "<NetworkErrorBoundary />"
       },
       "version-5.0/api/version-5.0-Object": {
         "title": "Object"

--- a/website/versioned_docs/version-5.0/api/makeRenderRestHook.md
+++ b/website/versioned_docs/version-5.0/api/makeRenderRestHook.md
@@ -69,7 +69,9 @@ Hooks to run inside React. Return value will become available in `result`
 #### options.results
 
 Can be used to prime the cache if test expects cache values to already be filled. Takes same
-[array of fixtures as MockProvider](https://resthooks.io/docs/api/MockProvider#results)
+[array of fixtures as MockResolver](../api/MockResolver#fixtures)
+
+This has the same effect as initializing [<CacheProvider />](../api/CacheProvider) with [mockInitialState()](../api/mockInitialState)
 
 #### options.initialProps
 

--- a/website/versioned_docs/version-5.0/api/mockInitialState.md
+++ b/website/versioned_docs/version-5.0/api/mockInitialState.md
@@ -9,7 +9,7 @@ function mockInitialState(results: Fixture[]): State;
 ```
 
 `mockInitialState()` makes it easy to construct prefill the cache with fixtures. It's
-used in [\<MockProvider />](./MockProvider) to process the results prop. However, this
+used in [\<MockResolver />](./MockResolver) to process the results prop. However, this
 can also be useful to send into a normal provider when testing more complete flows
 that need to handle `dispatches` (and thus fetch).
 
@@ -18,11 +18,21 @@ that need to handle `dispatches` (and thus fetch).
 ### results
 
 ```typescript
-interface Fixture {
-  request: ReadEndpoint;
+export interface SuccessFixture {
+  request: ReadShape<Schema, object>;
   params: object;
   result: object | string | number;
+  error?: false;
 }
+
+export interface ErrorFixture {
+  request: ReadShape<Schema, object>;
+  params: object;
+  result: Error;
+  error: true;
+}
+
+export type Fixture = SuccessFixture | ErrorFixture;
 ```
 
 This prop specifies the fixtures to use data from. Each item represents a fetch defined by the

--- a/website/versioned_docs/version-5.0/getting-started/installation.md
+++ b/website/versioned_docs/version-5.0/getting-started/installation.md
@@ -13,7 +13,7 @@ precisely-typed data to consume.
 Structured data means data composed of [Objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
 ([maps](https://en.wikipedia.org/wiki/Associative_array))
 and [Arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-([lists](https://en.wikipedia.org/wiki/List_(abstract_data_type))), as opposed media
+([lists](https://en.wikipedia.org/wiki/List_(abstract_data_type))), as opposed to media
 like images and videos. This makes it great for API calls regardless of form ([REST-like](https://restfulapi.net/),
 [GraphQL](https://graphql.org/), [gRPC](https://grpc.io/)), serialization ([JSON](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON), [YAML](https://en.wikipedia.org/wiki/YAML)),
 or transport ([HTTP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview), [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API), [local](../guides/mocking-unfinished)).

--- a/website/versioned_docs/version-5.0/guides/storybook.md
+++ b/website/versioned_docs/version-5.0/guides/storybook.md
@@ -55,7 +55,7 @@ export default function ArticleList({ maxResults }: { maxResults: number }) {
 We'll test three cases: some interesting results in the list, an empty list, and data not
 existing so loading fallback is shown.
 
-#### `fixtures.ts`
+<details open><summary><b>fixtures.ts</b></summary>
 
 ```typescript
 export default {
@@ -108,6 +108,8 @@ export default {
 };
 ```
 
+</details>
+
 ## Decorators
 
 You'll need to add the appropriate [global decorators](https://storybook.js.org/docs/react/writing-stories/decorators#global-decorators) to establish the correct context.
@@ -135,7 +137,7 @@ export const decorators = [
 
 ## Story
 
-Wrapping our component with <MockResolver /> enables us to declaratively
+Wrapping our component with \<MockResolver /> enables us to declaratively
 control how Rest Hooks' fetches are resolved.
 
 Here we select which fixtures should be used by [storybook controls](https://storybook.js.org/docs/react/essentials/controls).

--- a/website/versioned_docs/version-5.0/guides/unit-testing-hooks.md
+++ b/website/versioned_docs/version-5.0/guides/unit-testing-hooks.md
@@ -32,11 +32,11 @@ Node doesn't come with fetch out of the box, so we need to be sure to polyfill i
 <!--DOCUSAURUS_CODE_TABS-->
 <!--yarn-->
 ```bash
-yarn add whatwg-fetch
+yarn add --dev whatwg-fetch
 ```
 <!--npm-->
 ```bash
-npm install whatwg-fetch
+npm install --save-dev whatwg-fetch
 ```
 <!--END_DOCUSAURUS_CODE_TABS-->
 


### PR DESCRIPTION
- MockResolver instead of MockProvider everywhere
- Update `Fixture` interface everywhere
- Update unit testing components example