### PR TITLE
enhance: Improve error type preciseness

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -16,6 +16,15 @@ interface Manager {
 
 [More](./Manager)
 
+### NetworkError
+
+```typescript
+interface NetworkError extends Error {
+  status: number | undefined;
+  response?: Response;
+}
+```
+
 ## @rest-hooks/endpoint
 
 ### EndpointInterface

--- a/docs/api/useError.md
+++ b/docs/api/useError.md
@@ -3,11 +3,18 @@ title: useError()
 ---
 
 ```typescript
+interface SyntheticError extends Error {
+  status: number;
+  synthetic: boolean;
+}
+
 function useError(
-  endpoint: ReadEndpoint,
+  endpoint: Endpoint,
   params: object | null,
-): Error & { status?: number };
+): NetworkError | Error | SyntheticError | undefined;
 ```
+
+[NetworkError](./types#networkerror)
 
 Provides error information about a request. This builds on [useMeta()](./useMeta),
 but adds some additional logic.

--- a/docs/api/useMeta.md
+++ b/docs/api/useMeta.md
@@ -4,16 +4,18 @@ title: useMeta()
 
 ```typescript
 function useMeta(
-  endpoint: ReadEndpoint,
+  endpoint: Endpoint,
   params: object | null,
 ): {
     readonly date: number;
-    readonly error?: Error | undefined;
+    readonly error?: NetworkError | Error | undefined;
     readonly expiresAt: number;
     readonly prevExpiresAt?: number | undefined;
     readonly invalidated?: boolean | undefined;
 } | null;
 ```
+
+[NetworkError](./types#networkerror)
 
 Retrieves metadata about a request from the cache.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export {
   useResetter,
   hasUsableData,
 } from './react-integration';
+export type { SyntheticError } from './react-integration';
 export {
   StateContext,
   DispatchContext,

--- a/packages/core/src/react-integration/hooks/index.ts
+++ b/packages/core/src/react-integration/hooks/index.ts
@@ -11,6 +11,7 @@ import useResetter from './useResetter';
 import useFetchDispatcher from './useFetchDispatcher';
 import useInvalidateDispatcher from './useInvalidateDispatcher';
 export { default as hasUsableData } from './hasUsableData';
+export type { SyntheticError } from './useError';
 
 export {
   useFetcher,

--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -1,11 +1,23 @@
 import { ReadShape } from '@rest-hooks/core/endpoint';
+import { NetworkError } from '@rest-hooks/core/types';
 import { Schema } from '@rest-hooks/endpoint';
 
 import useMeta from './useMeta';
 
+export interface SyntheticError extends Error {
+  status: number;
+  synthetic: boolean;
+}
+
+export function isSyntheticError(
+  error: SyntheticError | unknown,
+): error is SyntheticError {
+  return error && (error as any).synthetic;
+}
+
 type UseErrorReturn<P> = P extends null
   ? undefined
-  : Error & { status?: number; synthetic?: boolean };
+  : NetworkError | Error | SyntheticError | undefined;
 
 /** Access a resource or error if failed to get it */
 export default function useError<

--- a/packages/core/src/react-integration/hooks/useResource.ts
+++ b/packages/core/src/react-integration/hooks/useResource.ts
@@ -8,7 +8,7 @@ import {
 import { useMemo, useContext } from 'react';
 
 import useRetrieve from './useRetrieve';
-import useError from './useError';
+import useError, { isSyntheticError } from './useError';
 import hasUsableData from './hasUsableData';
 import useMeta from './useMeta';
 
@@ -47,7 +47,7 @@ function useOneResource<
   );
 
   // refetching won't ever save us if the network response is bad.
-  if (error && error.synthetic) throw error;
+  if (isSyntheticError(error)) throw error;
 
   if (
     !hasUsableData(
@@ -118,7 +118,7 @@ function useManyResources<A extends ResourceArgs<any, any>[]>(
     const err = errorValues[i];
     // either the error is synthetic (not from network), or we aren't fetching at all
     // then throw that error
-    if (err && (err.synthetic || !promises[i])) throw err;
+    if (err && (isSyntheticError(err) || !promises[i])) throw err;
   }
 
   const promise = useMemo(() => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -24,6 +24,11 @@ export type ReceiveTypes = typeof RECEIVE_TYPE;
 
 export type PK = string;
 
+export interface NetworkError extends Error {
+  status: number | undefined;
+  response?: Response;
+}
+
 export type State<T> = Readonly<{
   entities: {
     readonly [entityKey: string]: { readonly [pk: string]: T } | undefined;
@@ -33,7 +38,7 @@ export type State<T> = Readonly<{
   meta: {
     readonly [key: string]: {
       readonly date: number;
-      readonly error?: Error;
+      readonly error?: NetworkError | Error;
       readonly expiresAt: number;
       readonly prevExpiresAt?: number;
       readonly invalidated?: boolean;

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -56,7 +56,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "peerDependencies": {
-    "@rest-hooks/core": "^1.0.0-k.6",
+    "@rest-hooks/core": "^1.0.4",
     "@types/react": "^16.8.4 || ^17.0.0",
     "react": "^16.8.4 || ^17.0.0"
   },

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -67,6 +67,7 @@ export type {
   IndexInterface,
   IndexParams,
   ArrayElement,
+  NetworkError,
 } from '@rest-hooks/core';
 
 export { Resource, SimpleResource } from './resource';
@@ -77,7 +78,6 @@ export {
   PromiseifyMiddleware,
   NetworkErrorBoundary,
 } from './react-integration';
-export type { NetworkError } from './react-integration';
 
 export {
   PollingSubscription,

--- a/packages/rest-hooks/src/react-integration/NetworkErrorBoundary.tsx
+++ b/packages/rest-hooks/src/react-integration/NetworkErrorBoundary.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-
-export interface NetworkError extends Error {
-  status: number | undefined;
-  response?: { statusText?: string; body?: any };
-}
+import type { NetworkError } from '@rest-hooks/core';
 
 function isNetworkError(error: NetworkError | unknown): error is NetworkError {
   return Object.prototype.hasOwnProperty.call(error, 'status');

--- a/packages/rest-hooks/src/react-integration/index.ts
+++ b/packages/rest-hooks/src/react-integration/index.ts
@@ -2,5 +2,4 @@ import NetworkErrorBoundary from './NetworkErrorBoundary';
 
 export * from './provider';
 export { default as useSelectionUnstable } from './hooks/useSelection';
-export type { NetworkError } from './NetworkErrorBoundary';
 export { NetworkErrorBoundary };

--- a/website/versioned_docs/version-5.0/api/types.md
+++ b/website/versioned_docs/version-5.0/api/types.md
@@ -18,6 +18,15 @@ interface Manager {
 
 [More](./Manager)
 
+### NetworkError
+
+```typescript
+interface NetworkError extends Error {
+  status: number | undefined;
+  response?: Response;
+}
+```
+
 ## @rest-hooks/endpoint
 
 ### EndpointInterface

--- a/website/versioned_docs/version-5.0/api/useError.md
+++ b/website/versioned_docs/version-5.0/api/useError.md
@@ -5,11 +5,18 @@ original_id: useError
 ---
 
 ```typescript
+interface SyntheticError extends Error {
+  status: number;
+  synthetic: boolean;
+}
+
 function useError(
-  endpoint: ReadEndpoint,
+  endpoint: Endpoint,
   params: object | null,
-): Error & { status?: number };
+): NetworkError | Error | SyntheticError | undefined;
 ```
+
+[NetworkError](./types#networkerror)
 
 Provides error information about a request. This builds on [useMeta()](./useMeta),
 but adds some additional logic.

--- a/website/versioned_docs/version-5.0/api/useMeta.md
+++ b/website/versioned_docs/version-5.0/api/useMeta.md
@@ -6,16 +6,18 @@ original_id: useMeta
 
 ```typescript
 function useMeta(
-  endpoint: ReadEndpoint,
+  endpoint: Endpoint,
   params: object | null,
 ): {
     readonly date: number;
-    readonly error?: Error | undefined;
+    readonly error?: NetworkError | Error | undefined;
     readonly expiresAt: number;
     readonly prevExpiresAt?: number | undefined;
     readonly invalidated?: boolean | undefined;
 } | null;
 ```
+
+[NetworkError](./types#networkerror)
 
 Retrieves metadata about a request from the cache.
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
For those using built in fetch, we can be assured the error might show up as NetworkError. If we expose this in a union at the very least they can test for it

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Establish central NetworkError definition
- Spread through all error code
- Update docs

### Open Questions

Maybe we should have a way of allowing users to customize what their error types are?