### PR TITLE
internal: Change dependabot label to more standard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
-      - "packages"
+      - "dependencies"
     allow:
       - dependency-type: "development"
     ignore:


### PR DESCRIPTION
`dependencies` is in standard list for new repos