### PR TITLE
enhance: Explicitly defined Resource endpoint return types

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -160,8 +160,8 @@ as [Resource](./resource) expects it
 
 ```typescript
 export type RestFetch<
-  P = object,
+  P = any,
   B = RequestInit['body'] | Record<string, any>,
   R = any
-> = (params: P, body?: B) => Promise<R>;
+> = (this: RestEndpoint, params: P, body?: B) => Promise<R>;
 ```

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -5,7 +5,7 @@ export type RestFetch<
   P = any,
   B = RequestInit['body'] | Record<string, any>,
   R = any
-> = (params: P, body?: B) => Promise<R>;
+> = (this: RestEndpoint, params: P, body?: B) => Promise<R>;
 
 /** Endpoint from a Resource
  *

--- a/website/versioned_docs/version-5.0/api/types.md
+++ b/website/versioned_docs/version-5.0/api/types.md
@@ -162,8 +162,8 @@ as [Resource](./resource) expects it
 
 ```typescript
 export type RestFetch<
-  P = object,
+  P = any,
   B = RequestInit['body'] | Record<string, any>,
   R = any
-> = (params: P, body?: B) => Promise<R>;
+> = (this: RestEndpoint, params: P, body?: B) => Promise<R>;
 ```


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Reduce complexity of return types based on inference
  - This makes the types more readable to user
  - Also can help typescript performance - reducing chance of triggering recursion depth limit (I have theory that https://github.com/coinbase/rest-hooks/issues/569 was caused by this)
- Shows example in code of how to explicitly type return values of endpoints

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add `this` definition to `RestFetch`
