### PR TITLE
internal: publish

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.3...@rest-hooks/core@1.0.4) (2021-02-24)
+
+
+### 💅 Enhancement
+
+* Improve error type preciseness ([#571](https://github.com/coinbase/rest-hooks/issues/571)) ([6f760be](https://github.com/coinbase/rest-hooks/commit/6f760be7149f04eb26727730e0ec0d67f2215ed5))
+* legacy Resource should only warn on validation problems ([#540](https://github.com/coinbase/rest-hooks/issues/540)) ([eb83a51](https://github.com/coinbase/rest-hooks/commit/eb83a511d41c0b18ea3f5ecd6696e1013ed8e1c3))
+
+
+
 ### [1.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.2...@rest-hooks/core@1.0.3) (2021-02-04)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Dynamic data fetching for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.1...@rest-hooks/legacy@2.0.2) (2021-02-24)
+
+### 💅 Enhancement
+
+* Improve error type preciseness ([#571](https://github.com/coinbase/rest-hooks/issues/571)) ([6f760be](https://github.com/coinbase/rest-hooks/commit/6f760be7149f04eb26727730e0ec0d67f2215ed5))
+
+
 ### [2.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.0...@rest-hooks/legacy@2.0.1) (2021-01-24)
 
 **Note:** Version bump only for package @rest-hooks/legacy

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.6](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.5...rest-hooks@5.0.6) (2021-02-24)
+
+
+### 💅 Enhancement
+
+* Improve error type preciseness ([#571](https://github.com/coinbase/rest-hooks/issues/571)) ([6f760be](https://github.com/coinbase/rest-hooks/commit/6f760be7149f04eb26727730e0ec0d67f2215ed5))
+
+
+
 ### [5.0.5](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.4...rest-hooks@5.0.5) (2021-02-23)
 
 

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Dynamic data fetching for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/core": "^1.0.3",
+    "@rest-hooks/core": "^1.0.4",
     "@rest-hooks/endpoint": "^1.0.3"
   },
   "peerDependencies": {

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@1.0.3...@rest-hooks/rest@1.0.4) (2021-02-24)
+
+
+### 💅 Enhancement
+
+* Explicitly defined Resource endpoint return types ([#576](https://github.com/coinbase/rest-hooks/issues/576)) ([bc72fa7](https://github.com/coinbase/rest-hooks/commit/bc72fa76a76f769479e6ae3f2e8515a8a9e2e8d2))
+
+
+
 ### [1.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@1.0.2...@rest-hooks/rest@1.0.3) (2021-02-23)
 
 

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
 - @rest-hooks/core: 1.0.3 => 1.0.4
 - @rest-hooks/legacy: 2.0.1 => 2.0.2
 - rest-hooks: 5.0.5 => 5.0.6
 - @rest-hooks/rest: 1.0.3 => 1.0.4