### PR TITLE
enhance: Make type discrimination easier in error types

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -20,9 +20,18 @@ interface Manager {
 
 ```typescript
 interface NetworkError extends Error {
-  status: number | undefined;
+  status: number;
   response?: Response;
 }
+```
+
+### UnknownError
+
+This is a catch-all for errors thrown in fetch functions. It is recommended
+to try to conform to the `NetworkError` interface above
+
+```typescript
+type UnknownError = Error & { status?: unknown; response?: unknown };
 ```
 
 ## @rest-hooks/endpoint

--- a/docs/api/useError.md
+++ b/docs/api/useError.md
@@ -3,15 +3,16 @@ title: useError()
 ---
 
 ```typescript
-interface SyntheticError extends Error {
+export interface SyntheticError extends Error {
   status: number;
-  synthetic: boolean;
+  response?: undefined;
+  synthetic: true;
 }
 
 function useError(
   endpoint: Endpoint,
   params: object | null,
-): NetworkError | Error | SyntheticError | undefined;
+): NetworkError | Unknown | SyntheticError | undefined;
 ```
 
 [NetworkError](./types#networkerror)

--- a/docs/api/useMeta.md
+++ b/docs/api/useMeta.md
@@ -8,14 +8,14 @@ function useMeta(
   params: object | null,
 ): {
     readonly date: number;
-    readonly error?: NetworkError | Error | undefined;
+    readonly error?: NetworkError | UnknownError;
     readonly expiresAt: number;
     readonly prevExpiresAt?: number | undefined;
     readonly invalidated?: boolean | undefined;
 } | null;
 ```
 
-[NetworkError](./types#networkerror)
+[NetworkError](./types#networkerror) [UnknownError](./types#unknownerror)
 
 Retrieves metadata about a request from the cache.
 

--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -1,23 +1,21 @@
 import { ReadShape } from '@rest-hooks/core/endpoint';
-import { NetworkError } from '@rest-hooks/core/types';
+import { NetworkError, UnknownError } from '@rest-hooks/core/types';
 import { Schema } from '@rest-hooks/endpoint';
 
 import useMeta from './useMeta';
 
 export interface SyntheticError extends Error {
   status: number;
-  synthetic: boolean;
-}
-
-export function isSyntheticError(
-  error: SyntheticError | unknown,
-): error is SyntheticError {
-  return error && (error as any).synthetic;
+  response?: undefined;
+  synthetic: true;
 }
 
 type UseErrorReturn<P> = P extends null
   ? undefined
-  : NetworkError | Error | SyntheticError | undefined;
+  :
+      | ((NetworkError | UnknownError) & { synthetic?: undefined | false })
+      | SyntheticError
+      | undefined;
 
 /** Access a resource or error if failed to get it */
 export default function useError<

--- a/packages/core/src/react-integration/hooks/useResource.ts
+++ b/packages/core/src/react-integration/hooks/useResource.ts
@@ -8,7 +8,7 @@ import {
 import { useMemo, useContext } from 'react';
 
 import useRetrieve from './useRetrieve';
-import useError, { isSyntheticError } from './useError';
+import useError from './useError';
 import hasUsableData from './hasUsableData';
 import useMeta from './useMeta';
 
@@ -47,7 +47,7 @@ function useOneResource<
   );
 
   // refetching won't ever save us if the network response is bad.
-  if (isSyntheticError(error)) throw error;
+  if (error && error.synthetic) throw error;
 
   if (
     !hasUsableData(
@@ -118,7 +118,7 @@ function useManyResources<A extends ResourceArgs<any, any>[]>(
     const err = errorValues[i];
     // either the error is synthetic (not from network), or we aren't fetching at all
     // then throw that error
-    if (err && (isSyntheticError(err) || !promises[i])) throw err;
+    if (err && (err.synthetic || !promises[i])) throw err;
   }
 
   const promise = useMemo(() => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,9 +25,11 @@ export type ReceiveTypes = typeof RECEIVE_TYPE;
 export type PK = string;
 
 export interface NetworkError extends Error {
-  status: number | undefined;
+  status: number;
   response?: Response;
 }
+
+export type UnknownError = Error & { status?: unknown; response?: unknown };
 
 export type State<T> = Readonly<{
   entities: {
@@ -38,7 +40,7 @@ export type State<T> = Readonly<{
   meta: {
     readonly [key: string]: {
       readonly date: number;
-      readonly error?: NetworkError | Error;
+      readonly error?: NetworkError | UnknownError;
       readonly expiresAt: number;
       readonly prevExpiresAt?: number;
       readonly invalidated?: boolean;

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -56,7 +56,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "peerDependencies": {
-    "@rest-hooks/core": "^1.0.4",
+    "@rest-hooks/core": "^1.0.5",
     "@types/react": "^16.8.4 || ^17.0.0",
     "react": "^16.8.4 || ^17.0.0"
   },

--- a/website/versioned_docs/version-5.0/api/types.md
+++ b/website/versioned_docs/version-5.0/api/types.md
@@ -22,9 +22,18 @@ interface Manager {
 
 ```typescript
 interface NetworkError extends Error {
-  status: number | undefined;
+  status: number;
   response?: Response;
 }
+```
+
+### UnknownError
+
+This is a catch-all for errors thrown in fetch functions. It is recommended
+to try to conform to the `NetworkError` interface above
+
+```typescript
+type UnknownError = Error & { status?: unknown; response?: unknown };
 ```
 
 ## @rest-hooks/endpoint

--- a/website/versioned_docs/version-5.0/api/useError.md
+++ b/website/versioned_docs/version-5.0/api/useError.md
@@ -5,15 +5,16 @@ original_id: useError
 ---
 
 ```typescript
-interface SyntheticError extends Error {
+export interface SyntheticError extends Error {
   status: number;
-  synthetic: boolean;
+  response?: undefined;
+  synthetic: true;
 }
 
 function useError(
   endpoint: Endpoint,
   params: object | null,
-): NetworkError | Error | SyntheticError | undefined;
+): NetworkError | Unknown | SyntheticError | undefined;
 ```
 
 [NetworkError](./types#networkerror)

--- a/website/versioned_docs/version-5.0/api/useMeta.md
+++ b/website/versioned_docs/version-5.0/api/useMeta.md
@@ -10,14 +10,14 @@ function useMeta(
   params: object | null,
 ): {
     readonly date: number;
-    readonly error?: NetworkError | Error | undefined;
+    readonly error?: NetworkError | UnknownError;
     readonly expiresAt: number;
     readonly prevExpiresAt?: number | undefined;
     readonly invalidated?: boolean | undefined;
 } | null;
 ```
 
-[NetworkError](./types#networkerror)
+[NetworkError](./types#networkerror) [UnknownError](./types#unknownerror)
 
 Retrieves metadata about a request from the cache.
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://github.com/coinbase/rest-hooks/pull/571 improved some of the types, but it made type discrimination harder

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
By keeping key members - but making them unknown in the case of types we don't control (things thrown by users - since there's no type enforcement there) - this allows us to check those members to discriminate.