### PR TITLE
enhance: Support 'undefined' as schema

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -362,7 +362,7 @@ export class NestedArticleResource extends OtherArticleResource {
 }
 
 export const GetPhoto = new Endpoint(
-  async function ({ userId }: { userId: string }) {
+  async function ({ userId }: { userId: string }): Promise<ArrayBuffer> {
     const response = await fetch(this.key({ userId }));
     const photoArrayBuffer = await response.arrayBuffer();
     return photoArrayBuffer;
@@ -373,6 +373,17 @@ export const GetPhoto = new Endpoint(
     },
   },
 );
+
+export const GetPhotoUndefined = GetPhoto.extend({
+  key({ userId }: { userId: string }) {
+    return `/users/${userId}/photo2`;
+  },
+});
+// Currently Endpoint sets schema to null for backwards compat
+// However, we explicitly want to test undefined here to support non-backcompat endpoints
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+GetPhotoUndefined.schema = undefined;
 
 export const GetNoEntities = new Endpoint(
   async function ({ userId }: { userId: string }) {

--- a/packages/core/src/endpoint/shapes.ts
+++ b/packages/core/src/endpoint/shapes.ts
@@ -3,7 +3,7 @@ import { Schema } from '@rest-hooks/endpoint';
 
 /** Defines the shape of a network request */
 export interface FetchShape<
-  S extends Schema,
+  S extends Schema | undefined,
   Params extends Readonly<object> = Readonly<object>,
   Body extends Readonly<object | string> | void | unknown =
     | Readonly<object | string>
@@ -19,7 +19,7 @@ export interface FetchShape<
 
 /** To change values on the server */
 export interface MutateShape<
-  S extends Schema,
+  S extends Schema | undefined,
   Params extends Readonly<object> = Readonly<object>,
   Body extends Readonly<object | string> | void | unknown =
     | Readonly<object | string>
@@ -32,7 +32,7 @@ export interface MutateShape<
 
 /** For retrieval requests */
 export interface ReadShape<
-  S extends Schema,
+  S extends Schema | undefined,
   Params extends Readonly<object> = Readonly<object>,
   Response extends object | string | number | boolean | null = any
 > extends FetchShape<S, Params, undefined, Response> {

--- a/packages/core/src/endpoint/types.ts
+++ b/packages/core/src/endpoint/types.ts
@@ -48,7 +48,9 @@ export type ParamsFromShape<S> = S extends {
   : never;
 
 /** Get the Schema type for a given Shape */
-export type SchemaFromShape<F extends FetchShape<any, any, any>> = F['schema'];
+export type SchemaFromShape<
+  F extends FetchShape<Schema | undefined, any, any>
+> = F['schema'];
 
 /** Get the Body type for a given Shape */
 export type BodyFromShape<F extends FetchShape<any, any, any>> = F extends {
@@ -58,7 +60,7 @@ export type BodyFromShape<F extends FetchShape<any, any, any>> = F extends {
   : never;
 
 export type OptimisticUpdateParams<
-  SourceSchema extends Schema,
+  SourceSchema extends Schema | undefined,
   DestShape extends FetchShape<any, any, any>
 > = [
   DestShape,

--- a/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
@@ -3,6 +3,7 @@ import {
   UserResource,
   InvalidIfStaleArticleResource,
   GetPhoto,
+  GetPhotoUndefined,
   GetNoEntities,
   ArticleTimedResource,
   ContextAuthdArticle,
@@ -494,6 +495,24 @@ describe('useResource()', () => {
       .reply(200, response);
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useResource(GetPhoto, { userId });
+    });
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
+    await waitForNextUpdate();
+    expect(result.current).toStrictEqual(response);
+  });
+
+  it('should work with ArrayBuffer endpoint with undefined schema', async () => {
+    const userId = '5';
+    const response = new ArrayBuffer(99);
+    nock(/.*/)
+      .defaultReplyHeaders({
+        'access-control-allow-origin': '*',
+      })
+      .get(`/users/${userId}/photo2`)
+      .reply(200, response);
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useResource(GetPhotoUndefined, { userId });
     });
     // undefined means it threw
     expect(result.current).toBeUndefined();

--- a/packages/core/src/state/actions/createFetch.ts
+++ b/packages/core/src/state/actions/createFetch.ts
@@ -11,7 +11,7 @@ import {
 
 interface Options<
   Shape extends FetchShape<
-    Schema,
+    Schema | undefined,
     Readonly<object>,
     Readonly<object | string> | void
   >
@@ -22,7 +22,7 @@ interface Options<
   updateParams?:
     | OptimisticUpdateParams<
         SchemaFromShape<Shape>,
-        FetchShape<any, any, any>
+        FetchShape<Schema | undefined, any, any>
       >[]
     | undefined;
 }
@@ -34,7 +34,7 @@ interface Options<
  */
 export default function createFetch<
   Shape extends FetchShape<
-    Schema,
+    Schema | undefined,
     Readonly<object>,
     Readonly<object | string> | void
   >

--- a/packages/core/src/state/actions/createReceive.ts
+++ b/packages/core/src/state/actions/createReceive.ts
@@ -12,7 +12,7 @@ interface Options<
     | string
     | number
     | null,
-  S extends Schema = any
+  S extends Schema | undefined = any
 > extends Pick<
     FetchAction<Payload, S>['meta'],
     'schema' | 'key' | 'type' | 'updaters'
@@ -31,7 +31,7 @@ export default function createReceive<
     | string
     | number
     | null,
-  S extends Schema = any
+  S extends Schema | undefined = any
 >(
   data: Payload,
   { schema, key, updaters, dataExpiryLength }: Options<Payload, S>,

--- a/packages/core/src/state/actions/createReceiveError.ts
+++ b/packages/core/src/state/actions/createReceiveError.ts
@@ -6,12 +6,12 @@ import {
 } from '@rest-hooks/core/types';
 import { RECEIVE_TYPE } from '@rest-hooks/core/actionTypes';
 
-interface Options<S extends Schema = any>
+interface Options<S extends Schema | undefined = any>
   extends Pick<FetchAction<any, S>['meta'], 'schema' | 'key'> {
   errorExpiryLength: NonNullable<FetchOptions['errorExpiryLength']>;
 }
 
-export default function createReceiveError<S extends Schema = any>(
+export default function createReceiveError<S extends Schema | undefined = any>(
   error: Error,
   { schema, key, errorExpiryLength }: Options<S>,
 ): ReceiveAction {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -75,7 +75,7 @@ export interface FetchOptions {
   readonly extra?: any;
 }
 
-export interface ReceiveMeta<S extends Schema> {
+export interface ReceiveMeta<S extends Schema | undefined> {
   schema: S;
   key: string;
   updaters?: Record<string, UpdateFunction<S, any>>;
@@ -89,7 +89,7 @@ export type ReceiveAction<
     | string
     | number
     | null,
-  S extends Schema = any
+  S extends Schema | undefined = any
 > = ErrorableFSAWithPayloadAndMeta<
   typeof RECEIVE_TYPE,
   Payload,
@@ -104,7 +104,7 @@ interface FetchMeta<
     | string
     | number
     | null,
-  S extends Schema = any
+  S extends Schema | undefined = any
 > {
   type: FetchShape<any, any>['type'];
   schema: S;
@@ -127,7 +127,7 @@ export interface FetchAction<
     | string
     | number
     | null,
-  S extends Schema = any
+  S extends Schema | undefined = any
 > extends FSAWithPayloadAndMeta<
     typeof FETCH_TYPE,
     () => Promise<Payload>,
@@ -139,7 +139,7 @@ export interface FetchAction<
 export interface SubscribeAction
   extends FSAWithMeta<typeof SUBSCRIBE_TYPE, undefined, any> {
   meta: {
-    schema: Schema;
+    schema: Schema | undefined;
     fetch: () => Promise<any>;
     key: string;
     options: FetchOptions | undefined;

--- a/packages/endpoint/src/types.ts
+++ b/packages/endpoint/src/types.ts
@@ -26,7 +26,7 @@ export type FetchFunction<P = any, B = any, R = any> = (
 ) => Promise<R>;
 
 export type OptimisticUpdateParams<
-  SourceSchema extends Schema,
+  SourceSchema extends Schema | undefined,
   Dest extends EndpointInterface<FetchFunction, Schema, any>
 > = [
   Dest,
@@ -35,7 +35,7 @@ export type OptimisticUpdateParams<
 ];
 
 export type UpdateFunction<
-  SourceSchema extends Schema,
+  SourceSchema extends Schema | undefined,
   DestSchema extends Schema
 > = (
   sourceResults: Normalize<SourceSchema>,

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -20,8 +20,9 @@ describe('normalize', () => {
     });
   });
 
-  test('cannot normalize without a schema', () => {
-    expect(() => normalize({})).toThrow();
+  test('passthrough with undefined schema', () => {
+    const input = {};
+    expect(normalize(input).result).toBe(input);
   });
 
   test('cannot normalize with null input', () => {
@@ -338,8 +339,9 @@ describe('normalize', () => {
 });
 
 describe('denormalize', () => {
-  test('cannot denormalize without a schema', () => {
-    expect(() => denormalize({})).toThrow();
+  test('passthrough with undefined schema', () => {
+    const input = {};
+    expect(denormalize(input)).toStrictEqual([input, true, false]);
   });
 
   test('returns the input if undefined', () => {

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -176,16 +176,16 @@ type DenormalizeReturn<S extends Schema> =
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const denormalize = <S extends Schema>(
   input: any,
-  schema: S,
+  schema: S | undefined,
   entities: any,
   entityCache: DenormalizeCache['entities'] = {},
   resultCache: WeakListMap<object, any> = new WeakListMap(),
 ): DenormalizeReturn<S> => {
-  /* istanbul ignore next */
-  if (process.env.NODE_ENV !== 'production' && schema === undefined) {
-    throw new Error('schema needed');
+  // undefined mean don't do anything
+  if (schema === undefined) {
+    return [input, true, false, {}] as [any, boolean, boolean, any];
   }
-  if (typeof input === 'undefined') {
+  if (input === undefined) {
     return [undefined, false, false, {}] as [any, boolean, boolean, any];
   }
   const resolvedEntities: Record<string, Record<string, any>> = {};
@@ -205,7 +205,7 @@ export const denormalize = <S extends Schema>(
 
 export const denormalizeSimple = <S extends Schema>(
   input: any,
-  schema: S,
+  schema: S | undefined,
   entities: any,
   entityCache: DenormalizeCache['entities'] = {},
   resultCache: WeakListMap<object, any> = new WeakListMap(),

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -284,6 +284,6 @@ if (process.env.NODE_ENV !== 'production') {
   };
 }
 
-export function isEntity(schema: Schema | null): schema is typeof Entity {
+export function isEntity(schema: Schema): schema is typeof Entity {
   return schema !== null && (schema as any).pk !== undefined;
 }

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -123,10 +123,18 @@ export const normalize = <
   R = NormalizeNullable<S>
 >(
   input: any,
-  schema: S,
+  schema?: S,
   existingEntities: Readonly<E> = {} as any,
   existingIndexes: Readonly<NormalizedIndex> = {},
 ): NormalizedSchema<E, R> => {
+  // no schema means we don't process at all
+  if (schema === undefined)
+    return {
+      entities: existingEntities,
+      indexes: existingIndexes,
+      result: input,
+    };
+
   const schemaType = expectedSchemaType(schema);
   if (input === null || typeof input !== schemaType) {
     /* istanbul ignore else */

--- a/packages/rest-hooks/src/manager/PollingSubscription.ts
+++ b/packages/rest-hooks/src/manager/PollingSubscription.ts
@@ -12,7 +12,7 @@ const { FETCH_TYPE } = actionTypes;
  * interval requested.
  */
 export default class PollingSubscription implements Subscription {
-  protected declare readonly schema: Schema;
+  protected declare readonly schema: Schema | undefined;
   protected declare readonly fetch: () => Promise<any>;
   protected declare readonly key: string;
   protected declare frequency: number;

--- a/packages/rest-hooks/src/manager/SubscriptionManager.ts
+++ b/packages/rest-hooks/src/manager/SubscriptionManager.ts
@@ -16,7 +16,7 @@ type Actions = UnsubscribeAction | SubscribeAction;
 
 /** Properties sent to Subscription constructor */
 export interface SubscriptionInit {
-  schema: Schema;
+  schema?: Schema;
   fetch: () => Promise<any>;
   key: string;
   getState: () => State<unknown>;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`undefined` is a sensible symbol to demonstrate lack of processing.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This is the canonical way to represent Endpoint schema's that should just 'pass through' the input. However, for backwards compatibility, we have have been setting schema to `null` if it is undefined.

Fully realizing support to undefined schemas is the first step to properly supported non-backcompat endpoints.

I chose not to convert the hooks FetchShapes as that stage of conversion will occur when they accept Endpoints instead of FetchShapes. Instead, all non-FetchShape places with schema are marked as Schema | undefined.

#### Why not just change Schema to include undefined?

There are many places where we want to only process *actual* schemas. It seems like a better naming convention to defined those as `Schema` and other places with the union. Furthermore, most places where we want to accept | undefined will simply be converted to EndpointInterface, which already includes that symbol.
