### PR TITLE
fix: Gracefully handle primitive entity responses

### DIFF
--- a/packages/endpoint/src/endpoint.js
+++ b/packages/endpoint/src/endpoint.js
@@ -17,12 +17,16 @@ let CSP = false;
 try {
   Function();
 } catch (e) {
+  /* istanbul ignore next */
   CSP = true;
 }
 
 export default class Endpoint extends Function {
   constructor(fetchFunction, options) {
     let self;
+    // TODO: Test the fallback?
+    /* istanbul ignore if */
+    /* istanbul ignore next */
     if (CSP) {
       self = (...args) => self.fetch(...args);
       Object.setPrototypeOf(self, new.target.prototype);

--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -211,6 +211,18 @@ Array [
 ]
 `;
 
+exports[`denormalize throws when nested entities are primitives 1`] = `
+"Unexpected primitive found during denormalization
+Found: 4
+Expected entity: class Comment extends _IDEntity.default {
+      constructor(...args) {
+        super(...args);
+        this.comment = '';
+      }
+
+    }"
+`;
+
 exports[`normalize can use fully custom entity classes 1`] = `
 Object {
   "entities": Object {

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -516,6 +516,52 @@ describe('denormalize', () => {
     expect(denormalize('123', Article, entities)).toMatchSnapshot();
   });
 
+  test('throws when nested entities are primitives', () => {
+    class User extends IDEntity {}
+    class Comment extends IDEntity {
+      comment = '';
+      static schema = {
+        user: User,
+      };
+    }
+    class Article extends IDEntity {
+      title = '';
+      body = '';
+      static schema = {
+        author: User,
+        comments: [Comment],
+      };
+    }
+
+    const entities = {
+      Article: {
+        123: {
+          author: '8472',
+          body: 'This article is great.',
+          comments: ['comment-123-4738'],
+          id: '123',
+          title: 'A Great Article',
+        },
+      },
+      Comment: {
+        'comment-123-4738': 4,
+      },
+      User: {
+        10293: {
+          id: '10293',
+          name: 'Jane',
+        },
+        8472: {
+          id: '8472',
+          name: 'Paul',
+        },
+      },
+    };
+    expect(() =>
+      denormalize('123', Article, entities),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
   test('set to undefined if schema key is not in entities', () => {
     class User extends IDEntity {}
     class Comment extends IDEntity {

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -20,7 +20,7 @@ const unvisitEntity = (
   getEntity: (
     entityOrId: Record<string, any> | string,
     schema: typeof Entity,
-  ) => any,
+  ) => EntityInterface | typeof DELETED,
   localCache: Record<string, Record<string, any>>,
   entityCache: DenormalizeCache['entities'],
 ): [
@@ -175,7 +175,7 @@ type DenormalizeReturn<S extends Schema> =
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const denormalize = <S extends Schema>(
-  input: any,
+  input: unknown,
   schema: S,
   entities: any,
   entityCache: DenormalizeCache['entities'] = {},
@@ -228,7 +228,17 @@ function withTrackedEntities(
   const wrappedUnvisit = (input: any, schema: any) => {
     const ret: [any, boolean, boolean] = originalUnvisit(input, schema);
     // pass over undefined in key
-    if (ret[0] && schema && isEntity(schema)) globalKey.push(ret[0]);
+    if (ret[0] && schema && isEntity(schema)) {
+      /* istanbul ignore else */
+      if (typeof ret[0] === 'object') {
+        globalKey.push(ret[0]);
+      } else if (process.env.NODE_ENV !== 'production') {
+        throw new Error(
+          `Unexpected primitive found during denormalization\nFound: ${ret[0]}\nExpected entity: ${schema}`,
+        );
+      }
+    }
+
     return ret;
   };
   wrappedUnvisit.og = unvisit;

--- a/packages/rest-hooks/src/manager/DevtoolsManager.ts
+++ b/packages/rest-hooks/src/manager/DevtoolsManager.ts
@@ -22,6 +22,7 @@ export default class DevToolsManager implements Manager {
       (window as any).__REDUX_DEVTOOLS_EXTENSION__.connect(config);
 
     /* istanbul ignore if */
+    /* istanbul ignore next */
     if (process.env.NODE_ENV === 'development' && this.devTools) {
       this.middleware = <R extends React.Reducer<any, any>>({
         getState,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- We absolutely cannot push things into WeakMap that are not 'object'.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- In dev mode, have useful error message (this indicates something is wrong with response, as entities are only supposed to objects (including arrays))
- In prod, simply ignore all primitives (this won't break anything - as we don't need any primitives to ensure cache consistency)