### PR TITLE
enhance: Throw useful error when schema key is missing from Entity

### DIFF
--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -219,6 +219,20 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
           addEntity,
           visitedEntities,
         );
+      } else if (process.env.NODE_ENV !== 'production') {
+        const error = new Error(
+          `Schema key is missing in Entity
+
+  Be sure all schema members are also part of the entity
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about nesting schemas: https://resthooks.io/docs/guides/nested-response
+
+  Entity keys: ${Object.keys(processedEntity)}
+  Schema key(missing): ${key}
+  `,
+        );
+        (error as any).status = 400;
+        throw error;
       }
     });
 

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -74,6 +74,25 @@ describe(`${Entity.name} normalization`, () => {
     expect(normalizeBad).toThrowErrorMatchingSnapshot();
   });
 
+  it('should throw a custom error if schema key is missing from Entity', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      pk() {
+        return this.name;
+      }
+
+      static schema = {
+        blarb: Date,
+      };
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ name: 'bob', secondthing: 'hi' }, schema);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
   it('should throw a custom error if data loads with no matching props', () => {
     class MyEntity extends Entity {
       readonly name: string = '';

--- a/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
@@ -688,6 +688,18 @@ exports[`Entity normalization should throw a custom error if data loads with str
           Input: \\"hibho\\""
 `;
 
+exports[`Entity normalization should throw a custom error if schema key is missing from Entity 1`] = `
+"Schema key is missing in Entity
+
+  Be sure all schema members are also part of the entity
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about nesting schemas: https://resthooks.io/docs/guides/nested-response
+
+  Entity keys: name,secondthing
+  Schema key(missing): blarb
+  "
+`;
+
 exports[`Entity normalization should throw a custom error loads with array 1`] = `
 "Attempted to initialize MyEntity with an array, but named members were expected
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`static schema` keys should map to members of the entity - otherwise they do nothing.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
During development - throw an error in case a schema is missing in response. This should help users with any typos or if they don't understand how `static schema` should work.