### PR TITLE
fix: Rollup name for @rest-hooks/legacy

### DIFF
--- a/packages/legacy/rollup.config.js
+++ b/packages/legacy/rollup.config.js
@@ -8,8 +8,9 @@ import replace from 'rollup-plugin-replace';
 
 import pkg from './package.json';
 
-const dependencies = Object.keys(pkg.peerDependencies)
-  .filter(dep => !['@babel/runtime'].includes(dep));
+const dependencies = Object.keys(pkg.peerDependencies).filter(
+  dep => !['@babel/runtime'].includes(dep),
+);
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
 process.env.NODE_ENV = 'production';
@@ -29,11 +30,11 @@ export default [
   {
     input: 'src/index.ts',
     external: isExternal,
-    output: [{ file: pkg.unpkg, format: 'umd', name: 'restHook' }],
+    output: [{ file: pkg.unpkg, format: 'umd', name: 'restHooksLegacy' }],
     plugins: [
       babel({
         exclude: ['node_modules/**', '**/__tests__/**'],
-        rootMode: "upward",
+        rootMode: 'upward',
         extensions,
         runtimeHelpers: true,
       }),
@@ -53,7 +54,7 @@ export default [
     plugins: [
       babel({
         exclude: ['node_modules/**', '**/__tests__/**', '**/*.d.ts'],
-        rootMode: "upward",
+        rootMode: 'upward',
         extensions,
         runtimeHelpers: true,
       }),


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
unpkg name should be specific to package

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Rollup update. eslint rules also applied here