### PR TITLE
fix: Exclude browserslist config from published package

### DIFF
--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -50,9 +50,6 @@
     "tsc:ci": "ttsc --project tsconfig.test.json ",
     "typecheck": "yarn run tsc:ci"
   },
-  "browserslist": [
-    "extends @anansi/browserslist-config"
-  ],
   "author": "Nathaniel Tucker",
   "contributors": [
     "Paul Armstrong",


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
This breaks tooling that tries to transpile node_modules as it tries to looking for ` @anansi/browserslist-config` and cannot find it

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Previously, the build configuration for normalizr was separate, but this has changed so it will use the config from the root level package which is not published.