### PR TITLE
enhance: Provide name to devtools to make it easier to find

### DIFF
--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -85,7 +85,7 @@ export {
   SubscriptionManager,
   DefaultConnectionListener,
 } from './manager';
-export type { ConnectionListener } from './manager';
+export type { ConnectionListener, DevToolsConfig } from './manager';
 export { default as useSelectionUnstable } from './react-integration/hooks/useSelection';
 
 const { buildInferredResults, RIC } = _INT_;

--- a/packages/rest-hooks/src/manager/DevtoolsManager.ts
+++ b/packages/rest-hooks/src/manager/DevtoolsManager.ts
@@ -6,6 +6,11 @@ import {
   State,
 } from '@rest-hooks/core';
 
+export type DevToolsConfig = {
+  [k: string]: unknown;
+  name: string;
+};
+
 /** Integrates with https://github.com/zalmoxisus/redux-devtools-extension
  *
  * Options: https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md
@@ -14,7 +19,11 @@ export default class DevToolsManager implements Manager {
   protected declare middleware: Middleware;
   protected declare devTools: undefined | any;
 
-  constructor(config: any = {}) {
+  constructor(
+    config: DevToolsConfig = {
+      name: `Rest Hooks: ${globalThis.document?.title}`,
+    },
+  ) {
     /* istanbul ignore next */
     this.devTools =
       typeof window !== 'undefined' &&
@@ -29,7 +38,7 @@ export default class DevToolsManager implements Manager {
       }: MiddlewareAPI<R>) => {
         return (next: Dispatch<R>) => (action: React.ReducerAction<R>) => {
           return next(action).then(() => {
-            this.devTools.send(action, getState(), {}, 'REST_HOOKS');
+            this.devTools.send(action, getState(), undefined, 'REST_HOOKS');
           });
         };
       };

--- a/packages/rest-hooks/src/manager/index.ts
+++ b/packages/rest-hooks/src/manager/index.ts
@@ -2,4 +2,4 @@ export type { default as ConnectionListener } from './ConnectionListener';
 export { default as DefaultConnectionListener } from './DefaultConnectionListener';
 export { default as PollingSubscription } from './PollingSubscription';
 export { default as SubscriptionManager } from './SubscriptionManager';
-export { default as DevToolsManager } from './DevtoolsManager';
+export { default as DevToolsManager, DevToolsConfig } from './DevtoolsManager';


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
When a site has multiple stores, they end up all having the document.title as the name - making it hard to find which one ties to rest hooks.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Explicitly name the redux-devtools integration.

Note: we don't type other options as the redux devtools could change these independently and it is up to the user to use what is provided by that tool.