### PR TITLE
enhance: Report optimistic state to devtools

### DIFF
--- a/packages/rest-hooks/src/manager/DevtoolsManager.ts
+++ b/packages/rest-hooks/src/manager/DevtoolsManager.ts
@@ -4,6 +4,7 @@ import {
   Dispatch,
   Manager,
   State,
+  reducer,
 } from '@rest-hooks/core';
 
 export type DevToolsConfig = {
@@ -38,7 +39,13 @@ export default class DevToolsManager implements Manager {
       }: MiddlewareAPI<R>) => {
         return (next: Dispatch<R>) => (action: React.ReducerAction<R>) => {
           return next(action).then(() => {
-            this.devTools.send(action, getState(), undefined, 'REST_HOOKS');
+            const state = getState();
+            this.devTools.send(
+              action,
+              getState(),
+              state.optimistic.reduce(reducer, state),
+              'REST_HOOKS',
+            );
           });
         };
       };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Understanding the internal store what really matters is what state is sent to the context.
- Interpreting `state.optimistic` is not very readable or useful. So no loss here

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
DevToolsManager: Apply the same optimistic updates algorithm CacheProvider does before reporting state