### PR TITLE
internal: Dependabot for /website

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,13 @@ updates:
       - dependency-name: "whatwg-fetch"
     commit-message:
       prefix: "internal(pkg): "
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/website/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "internal: "


### PR DESCRIPTION
Keep website yarn.lock up to date. Ensure we have an appropriate prefix even with security updates for /website dir