### PR TITLE
fix: useStatefulResource() return type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ export {
   useResetter,
   hasUsableData,
 } from './react-integration';
-export type { SyntheticError } from './react-integration';
+export type { SyntheticError, ErrorTypes } from './react-integration';
 export {
   StateContext,
   DispatchContext,

--- a/packages/core/src/react-integration/hooks/index.ts
+++ b/packages/core/src/react-integration/hooks/index.ts
@@ -11,7 +11,7 @@ import useResetter from './useResetter';
 import useFetchDispatcher from './useFetchDispatcher';
 import useInvalidateDispatcher from './useInvalidateDispatcher';
 export { default as hasUsableData } from './hasUsableData';
-export type { SyntheticError } from './useError';
+export type { SyntheticError, ErrorTypes } from './useError';
 
 export {
   useFetcher,

--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -10,12 +10,11 @@ export interface SyntheticError extends Error {
   synthetic: true;
 }
 
-type UseErrorReturn<P> = P extends null
-  ? undefined
-  :
-      | ((NetworkError | UnknownError) & { synthetic?: undefined | false })
-      | SyntheticError
-      | undefined;
+export type ErrorTypes =
+  | ((NetworkError | UnknownError) & { synthetic?: undefined | false })
+  | SyntheticError;
+
+type UseErrorReturn<P> = P extends null ? undefined : ErrorTypes | undefined;
 
 /** Access a resource or error if failed to get it */
 export default function useError<

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -56,7 +56,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "peerDependencies": {
-    "@rest-hooks/core": "^1.0.5",
+    "@rest-hooks/core": "^1.0.7",
     "@types/react": "^16.8.4 || ^17.0.0",
     "react": "^16.8.4 || ^17.0.0"
   },

--- a/packages/legacy/src/__tests__/useStatefulResource.tsx
+++ b/packages/legacy/src/__tests__/useStatefulResource.tsx
@@ -1,7 +1,7 @@
 import {
   CoolerArticleResource,
   InvalidIfStaleArticleResource,
-} from '__tests__/common';
+} from '__tests__/new';
 import { makeRenderRestHook, makeCacheProvider } from '@rest-hooks/test';
 import nock from 'nock';
 
@@ -90,7 +90,7 @@ describe('useStatefulResource()', () => {
 
   it('should fetch anew with param changes', async () => {
     const { result, waitForNextUpdate, rerender } = renderRestHook(
-      ({ id }) => {
+      ({ id }: { id: number }) => {
         return useStatefulResource(CoolerArticleResource.detail(), {
           id,
         });
@@ -127,7 +127,7 @@ describe('useStatefulResource()', () => {
     const { result, rerender, waitForNextUpdate } = renderRestHook(
       props => {
         return useStatefulResource(
-          InvalidIfStaleArticleResource.detailShape(),
+          InvalidIfStaleArticleResource.detail(),
           props,
         );
       },

--- a/packages/legacy/src/__tests__/useStatefulResource.tsx
+++ b/packages/legacy/src/__tests__/useStatefulResource.tsx
@@ -1,6 +1,7 @@
 import {
   CoolerArticleResource,
   InvalidIfStaleArticleResource,
+  TypedArticleResource,
 } from '__tests__/new';
 import { makeRenderRestHook, makeCacheProvider } from '@rest-hooks/test';
 import nock from 'nock';
@@ -46,6 +47,10 @@ describe('useStatefulResource()', () => {
       .reply(200, '')
       .get(`/article-cooler/`)
       .reply(200, nested)
+      .get(/article-cooler\/.*/)
+      .reply(404, 'not found')
+      .put(/article-cooler\/[^5].*/)
+      .reply(404, 'not found')
       .get(`/user/`)
       .reply(200, users);
   });
@@ -86,6 +91,40 @@ describe('useStatefulResource()', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeDefined();
     expect((result.current.error as any).status).toBe(403);
+  });
+
+  it('should pass with exact params', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useStatefulResource(TypedArticleResource.detail(), {
+        id: payload.id,
+      });
+    });
+    expect(result.current.data).toBeUndefined();
+    await waitForNextUpdate();
+    // type discrimination forces it to be resolved
+    if (!result.current.loading && !result.current.error) {
+      expect(result.current.data.title).toBe(payload.title);
+      // @ts-expect-error ensure this isn't "any"
+      result.current.data.doesnotexist;
+    }
+  });
+
+  it('should fail with improperly typed param', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useStatefulResource(TypedArticleResource.detail(), {
+        // @ts-expect-error
+        id: { a: 'five' },
+      });
+    });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeDefined();
+    if (result.current.error) {
+      expect(result.current.error.status).toBe(404);
+    }
   });
 
   it('should fetch anew with param changes', async () => {

--- a/packages/legacy/src/index.ts
+++ b/packages/legacy/src/index.ts
@@ -2,23 +2,47 @@ import {
   useRetrieve,
   useError,
   Schema,
-  ReadShape,
   useDenormalized,
   StateContext,
   hasUsableData,
   useMeta,
+  ParamsFromShape,
+  ReadShape,
   __INTERNAL__,
+} from '@rest-hooks/core';
+import type {
+  Denormalize,
+  DenormalizeNullable,
+  ErrorTypes,
 } from '@rest-hooks/core';
 import { denormalize } from '@rest-hooks/normalizr';
 import { useContext } from 'react';
 
 const { buildInferredResults } = __INTERNAL__;
 
+type CondNull<P, A, B> = P extends null ? A : B;
+
+type StatefulReturn<S extends Schema, P> = CondNull<
+  P,
+  {
+    data: DenormalizeNullable<S>;
+    loading: false;
+    error: undefined;
+  },
+  | {
+      data: Denormalize<S>;
+      loading: false;
+      error: undefined;
+    }
+  | { data: DenormalizeNullable<S>; loading: true; error: undefined }
+  | { data: DenormalizeNullable<S>; loading: false; error: ErrorTypes }
+>;
+
 /** Ensure a resource is available; loading and error returned explicitly. */
 export function useStatefulResource<
-  Params extends Readonly<object>,
-  S extends Schema
->(fetchShape: ReadShape<S, Params>, params: Params | null) {
+  Shape extends ReadShape<any, any>,
+  Params extends ParamsFromShape<Shape> | null
+>(fetchShape: Shape, params: Params): StatefulReturn<Shape['schema'], Params> {
   const state = useContext(StateContext);
   const [denormalized, ready, deleted, entitiesExpireAt] = useDenormalized(
     fetchShape,
@@ -57,5 +81,5 @@ export function useStatefulResource<
     data,
     loading,
     error,
-  };
+  } as any;
 }


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #607 .

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Being explicit in our return type gives us a bit more power to control the value.
- Give same powers as useResource() types
  - Enforce acceptable parameters
  - Infer nullability from null parameters
  - Empower type discrimination on return values