### PR TITLE
fix: Actually send optimistic updates to devtool

### DIFF
--- a/packages/rest-hooks/src/manager/DevtoolsManager.ts
+++ b/packages/rest-hooks/src/manager/DevtoolsManager.ts
@@ -42,8 +42,8 @@ export default class DevToolsManager implements Manager {
             const state = getState();
             this.devTools.send(
               action,
-              getState(),
               state.optimistic.reduce(reducer, state),
+              undefined,
               'REST_HOOKS',
             );
           });


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://github.com/coinbase/rest-hooks/pull/603 we put the reporting on the wrong argument of send.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Fix argument order - state is second arg

### Open question
Since this is an external interface with no published types, one wonders how we might introduce more types or tests to catch this. For now I'm not super worried tho.

### Manual testing

Validated by modifying lib code in node_modules in an install