### PR TITLE
enhance: Don't use global for rIC def

### DIFF
--- a/packages/core/src/state/RIC.d.ts
+++ b/packages/core/src/state/RIC.d.ts
@@ -1,0 +1,2 @@
+const RIC: (cb: (...args: any[]) => void, options: any) => void;
+export default RIC;

--- a/packages/core/src/state/RIC.js
+++ b/packages/core/src/state/RIC.js
@@ -1,0 +1,5 @@
+const RIC =
+  typeof requestIdleCallback === 'function'
+    ? requestIdleCallback
+    : cb => setTimeout(cb, 0);
+export default RIC;

--- a/packages/core/src/state/RIC.ts
+++ b/packages/core/src/state/RIC.ts
@@ -1,5 +1,0 @@
-const RIC: (cb: (...args: any[]) => void, options: any) => void =
-  typeof (global as any).requestIdleCallback === 'function'
-    ? (global as any).requestIdleCallback
-    : cb => global.setTimeout(cb, 0);
-export default RIC;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`global` is not max compatibility - so avoid if reasonable

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Don't want to infect a user's global ambient, so we split js and .d.ts to ensure we type internally without polluting scope.