### PR TITLE
fix: DevToolsConfig is type export

### DIFF
--- a/packages/rest-hooks/src/manager/index.ts
+++ b/packages/rest-hooks/src/manager/index.ts
@@ -2,4 +2,5 @@ export type { default as ConnectionListener } from './ConnectionListener';
 export { default as DefaultConnectionListener } from './DefaultConnectionListener';
 export { default as PollingSubscription } from './PollingSubscription';
 export { default as SubscriptionManager } from './SubscriptionManager';
-export { default as DevToolsManager, DevToolsConfig } from './DevtoolsManager';
+export { default as DevToolsManager } from './DevtoolsManager';
+export type { DevToolsConfig } from './DevtoolsManager';


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Causes a warning in compilers

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Prefix with `type`