### PR TITLE
feat: Add useLoading() hook

### DIFF
--- a/docs/api/useLoading.md
+++ b/docs/api/useLoading.md
@@ -1,0 +1,63 @@
+---
+title: useLoading()
+---
+
+```typescript
+export default function useLoading<F extends (...args: any) => Promise<any>>(
+  func: F,
+  onError?: (error: Error) => void,
+): [F, boolean];
+```
+
+Tracking promise resolution of a function.
+
+```tsx
+import { useLoading } from '@rest-hooks/hooks';
+
+function Button({ onClick, children, ...props }) {
+  const [clickHandler, loading] = useLoading(onClick);
+  return (
+    <button onClick={clickHandler} {...props}>
+      {loading ? 'Loading...' : children}
+    </button>
+  );
+}
+```
+
+### Todo toggle example
+
+```tsx
+import { useCallback } from 'react';
+import { useFetcher } from 'rest-hooks';
+import { useLoading } from '@rest-hooks/hooks';
+
+import TodoResource from 'resources/TodoResource';
+
+interface Props {
+  todo: TodoResource;
+}
+
+function TodoListItem({ todo }) {
+  const partialUpdate = useFetcher(TodoResource.partialUpdate());
+
+  const toggle = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) =>
+      partialUpdate({ id }, { completed: e.currentTarget.checked }),
+    [partialUpdate],
+  );
+
+  const [toggleHandler, loading] = useLoading(toggle);
+
+  return (
+    <div>
+      <input
+        type="checkbox"
+        checked={todo.completed}
+        onChange={toggleHandler}
+      />
+      {loading ? <Spinner /> : null}
+      {todo.title}
+    </div>
+  );
+}
+```

--- a/docs/guides/loading-state.md
+++ b/docs/guides/loading-state.md
@@ -54,51 +54,17 @@ loading state manually you can adapt the [useStatefulResource()](./no-suspense.m
 When performing mutations you'll often want an indicator that the request is still in flight.
 Sometimes form libraries will handling the loading state themselves. However, in the case you're
 making a standalone button or simply using a form library that doesn't track loading state of
-submitters, you can use the following hook.
-
-### Hook
-
-```typescript
-/** Takes an async function and tracks resolution as a boolean.
- *
- */
-function useLoadingFunction<F extends Function>(
-  func: F,
-  onError?: (error: Error) => void,
-): [F, boolean] {
-  const [loading, setLoading] = useState(false);
-  const isMountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      isMountedRef.current = false;
-    },
-    [],
-  );
-  const wrappedClick = useCallback(
-    async (...args: any[]) => {
-      setLoading(true);
-      try {
-        const ret = await func(...args);
-      } catch (e) {
-        if (onError) onError(e);
-        else throw e;
-      }
-      if (isMountedRef.current) setLoading(false);
-      return ret;
-    },
-    [onError, func],
-  );
-  return [wrappedClick, loading];
-}
-```
+submitters, you can use [useLoading()](../api/useLoading) from `@rest-hooks/hooks`.
 
 ### Usage
 
 ```tsx
+import { useLoading } from '@rest-hooks/hooks';
+
 function Button({ onClick, children, ...props }) {
-  const [clicker, loading] = useLoadingFunction(onClick);
+  const [clickHandler, loading] = useLoading(onClick);
   return (
-    <button onClick={clicker} {...props}>
+    <button onClick={clickHandler} {...props}>
       {loading ? 'Loading...' : children}
     </button>
   );

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -10,7 +10,7 @@ Composable hooks for networking data
 
 <div align="center">
 
-**[📖Read The Docs](https://resthooks.io/docs/api/Endpoint)**
+**[📖Read The Docs](https://resthooks.io/docs/api/useDebounce)**
 
 </div>
 
@@ -25,4 +25,17 @@ const data = useResource(useCancelling(MyEndpoint, { filter }), { filter });
 ```typescript
 const debouncedFilter = useDebounce(filter, 200);
 const data = useResource(MyEndpoint, { filter: debouncedFilter });
+```
+
+### useLoading()
+
+```tsx
+function Button({ onClick, children, ...props }) {
+  const [clickHandler, loading] = useLoading(onClick);
+  return (
+    <button onClick={clickHandler} {...props}>
+      {loading ? 'Loading...' : children}
+    </button>
+  );
+}
 ```

--- a/packages/hooks/src/__tests__/useLoading.ts
+++ b/packages/hooks/src/__tests__/useLoading.ts
@@ -1,0 +1,138 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import useLoading from '../useLoading';
+
+describe('useLoading()', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  it('should not update until delay has passed', async () => {
+    function fun(value: string) {
+      return new Promise<string>((resolve, reject) =>
+        setTimeout(() => resolve(value), 1000),
+      );
+    }
+    let resolved = '';
+    let wrongType = 0;
+    const { result, waitForNextUpdate } = renderHook(() => {
+      return useLoading(fun);
+    });
+    const wrappedFunc = result.current[0];
+    expect(result.current[1]).toBe(false);
+    act(() => {
+      wrappedFunc('test string').then(value => {
+        resolved = value;
+        // @ts-expect-error
+        wrongType = value;
+      });
+    });
+    expect(result.current[1]).toBe(true);
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(result.current[1]).toBe(true);
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    await waitForNextUpdate();
+    expect(result.current[1]).toBe(false);
+    expect(resolved).toBe('test string');
+    // maintain referential equality
+    expect(result.current[0]).toBe(wrappedFunc);
+  });
+
+  it('should work when resolution happens after unmount', async () => {
+    function fun(value: string) {
+      return new Promise<string>((resolve, reject) =>
+        setTimeout(() => resolve(value), 1000),
+      );
+    }
+    let resolved = '';
+    let wrongType = 0;
+    const { result, unmount } = renderHook(() => {
+      return useLoading(fun);
+    });
+    const wrappedFunc = result.current[0];
+    expect(result.current[1]).toBe(false);
+    act(() => {
+      wrappedFunc('test string').then(value => {
+        resolved = value;
+        // @ts-expect-error
+        wrongType = value;
+      });
+    });
+    expect(result.current[1]).toBe(true);
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    act(() => {
+      unmount();
+    });
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    // since it's unmounted this won't change
+    expect(result.current[1]).toBe(true);
+  });
+
+  it('should call error callback when rejected', async () => {
+    const errcb = jest.fn();
+    const error = new Error('ack');
+    function fun(value: string) {
+      return new Promise<string>((resolve, reject) =>
+        setTimeout(() => reject(error), 1000),
+      );
+    }
+    let rejectedError: Error | null = null;
+    const { result, waitForNextUpdate } = renderHook(() => {
+      return useLoading(fun, errcb);
+    });
+    const wrappedFunc = result.current[0];
+    expect(result.current[1]).toBe(false);
+    act(() => {
+      wrappedFunc('test string').catch(err => {
+        rejectedError = err;
+      });
+    });
+    expect(result.current[1]).toBe(true);
+    act(() => {
+      jest.advanceTimersByTime(1100);
+    });
+    await waitForNextUpdate();
+    expect(result.current[1]).toBe(false);
+    expect(errcb).toHaveBeenCalledWith(error);
+    expect(rejectedError).toBe(error);
+    // maintain referential equality
+    expect(result.current[0]).toBe(wrappedFunc);
+  });
+
+  it('should stop loading when error thrown', async () => {
+    const error = new Error('ack');
+    function fun(value: string) {
+      return new Promise<string>((resolve, reject) =>
+        setTimeout(() => reject(error), 1000),
+      );
+    }
+    let rejectedError: Error | null = null;
+    const { result, waitForNextUpdate } = renderHook(() => {
+      return useLoading(fun);
+    });
+    const wrappedFunc = result.current[0];
+    expect(result.current[1]).toBe(false);
+    act(() => {
+      wrappedFunc('test string').catch(err => {
+        rejectedError = err;
+      });
+    });
+    expect(result.current[1]).toBe(true);
+    act(() => {
+      jest.advanceTimersByTime(1100);
+    });
+    await waitForNextUpdate();
+    expect(result.current[1]).toBe(false);
+    expect(rejectedError).toBe(error);
+    // maintain referential equality
+    expect(result.current[0]).toBe(wrappedFunc);
+  });
+});

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,2 +1,3 @@
 export { default as useDebounce } from './useDebounce';
 export { default as useCancelling } from './useCancelling';
+export { default as useLoading } from './useLoading';

--- a/packages/hooks/src/useLoading.ts
+++ b/packages/hooks/src/useLoading.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState, useRef, useCallback } from 'react';
+
+/** Takes an async function and tracks resolution as a boolean.
+ *
+ * @param func A function returning a promise
+ * @param onError Callback in case of error (optional)
+ *
+ * Usage:
+ * function Button({ onClick, children, ...props }) {
+ *   const [clickHandler, loading] = useLoading(onClick);
+ *   return (
+ *     <button onClick={clickHandler} {...props}>
+ *       {loading ? 'Loading...' : children}
+ *     </button>
+ *   );
+ * }
+ */
+export default function useLoading<F extends (...args: any) => Promise<any>>(
+  func: F,
+  onError?: (error: Error) => void,
+): [F, boolean] {
+  const [loading, setLoading] = useState(false);
+  const isMountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    [],
+  );
+  const wrappedClick = useCallback(
+    async (...args: any) => {
+      setLoading(true);
+      let ret;
+      try {
+        ret = await func(...args);
+      } catch (e) {
+        if (onError) onError(e);
+        throw e;
+      } finally {
+        if (isMountedRef.current) {
+          setLoading(false);
+        }
+      }
+      return ret;
+    },
+    [onError, func],
+  );
+  return [wrappedClick as any, loading];
+}

--- a/packages/hooks/src/useLoading.ts
+++ b/packages/hooks/src/useLoading.ts
@@ -27,7 +27,7 @@ export default function useLoading<F extends (...args: any) => Promise<any>>(
     },
     [],
   );
-  const wrappedClick = useCallback(
+  const wrappedFunc = useCallback(
     async (...args: any) => {
       setLoading(true);
       let ret;
@@ -45,5 +45,5 @@ export default function useLoading<F extends (...args: any) => Promise<any>>(
     },
     [onError, func],
   );
-  return [wrappedClick as any, loading];
+  return [wrappedFunc as any, loading];
 }

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -106,6 +106,9 @@
       "api/useInvalidator": {
         "title": "useInvalidator()"
       },
+      "api/useLoading": {
+        "title": "useLoading()"
+      },
       "api/useMeta": {
         "title": "useMeta()"
       },
@@ -247,7 +250,10 @@
       "ROADMAP": {
         "title": "ROADMAP"
       },
-      "upgrade/upgrading-test-to-two": {
+      "upgrade/upgrading-test-to-four": {
+        "title": "Upgrading @rest-hooks/test to 4"
+      },
+      "upgrade/upgrading-test-to-three": {
         "title": "Upgrading @rest-hooks/test to 3"
       },
       "upgrade/upgrading-to-5": {
@@ -725,6 +731,12 @@
       "version-4.0/api/version-4.0-SimpleRecord": {
         "title": "SimpleRecord"
       },
+      "version-4.0/api/version-4.0-useresource": {
+        "title": "useResource()"
+      },
+      "version-4.0/api/version-4.0-useRetrieve": {
+        "title": "useRetrieve()"
+      },
       "version-4.0/getting-started/version-4.0-installation": {
         "title": "Installation"
       },
@@ -780,9 +792,6 @@
       },
       "version-4.1/api/version-4.1-useFetcher": {
         "title": "useFetcher()"
-      },
-      "version-4.1/api/version-4.1-useresource": {
-        "title": "useResource()"
       },
       "version-4.1/getting-started/version-4.1-usage": {
         "title": "Usage"
@@ -1059,7 +1068,10 @@
       "version-5.0/guides/version-5.0-url": {
         "title": "URL Patterns"
       },
-      "version-5.0/upgrade/version-5.0-upgrading-test-to-two": {
+      "version-5.0/upgrade/version-5.0-upgrading-test-to-four": {
+        "title": "Upgrading @rest-hooks/test to 4"
+      },
+      "version-5.0/upgrade/version-5.0-upgrading-test-to-three": {
         "title": "Upgrading @rest-hooks/test to 3"
       },
       "version-5.0/upgrade/version-5.0-upgrading-to-5": {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -100,7 +100,8 @@
         "label": "Extra Hooks",
         "ids": [
           "api/useDebounce",
-          "api/useCancelling"
+          "api/useCancelling",
+          "api/useLoading"
         ]
       },
       {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Prefer to have consumable code, vs copy/pasting in docs: https://resthooks.io/docs/guides/loading-state#loading-buttons

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add to hooks package.

```tsx
import { useLoading } from '@rest-hooks/hooks';

function Button({ onClick, children, ...props }) {
  const [clickHandler, loading] = useLoading(onClick);
  return (
    <button onClick={clickHandler} {...props}>
      {loading ? 'Loading...' : children}
    </button>
  );
}
```

