### PR TITLE
fix: Explicit extensions for ESM

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -58,6 +58,7 @@ const packages = [
   'use-enhanced-reducer',
   'hooks',
   'img',
+  'test',
 ];
 
 const projects = [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "extends @anansi/browserslist-config"
   ],
   "devDependencies": {
-    "@anansi/babel-preset": "2.1.12",
+    "@anansi/babel-preset": "2.2.0",
     "@anansi/browserslist-config": "1.2.0",
     "@anansi/eslint-plugin": "0.9.24",
     "@babel/cli": "7.13.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -4,7 +4,7 @@
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs",
-  "module": "legacy/index.js",
+  "module": "legacy/browser.js",
   "types": "lib/index.d.ts",
   "exports": {
     ".": [
@@ -35,10 +35,10 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV='modern' ROOT_PATH_PREFIX='@rest-hooks/test' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/test' babel --root-mode upward src --out-dir legacy --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV='modern' RESOLVER_ALIAS='{\"^@rest-hooks/test(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:legacy:lib": "cross-env NODE_ENV=production RESOLVER_ALIAS='{\"^@rest-hooks/test(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir legacy --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf dist *.tsbuildinfo",
+    "build:clean": "rimraf dist lib legacy *.tsbuildinfo",
     "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",

--- a/packages/test/rollup.config.js
+++ b/packages/test/rollup.config.js
@@ -11,15 +11,10 @@ const dependencies = Object.keys(pkg.dependencies)
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
 process.env.NODE_ENV = 'production';
 process.env.BROWSERSLIST_ENV = 'node10';
+process.env.RESOLVER_ALIAS = '{"@rest-hooks/test":"./src"}';
 
 function isExternal(id) {
-  const ret = dependencies.includes(id);
-  if (!ret) {
-    for (const dep of dependencies) {
-      if (id.startsWith(dep)) return true;
-    }
-  }
-  return ret;
+  return dependencies.some(dep => dep === id || id.startsWith(dep));
 }
 
 export default [

--- a/packages/test/src/MockProvider.tsx
+++ b/packages/test/src/MockProvider.tsx
@@ -1,8 +1,7 @@
 import { StateContext, DispatchContext, actionTypes } from '@rest-hooks/core';
 import type { ActionTypes } from '@rest-hooks/core';
 import React from 'react';
-
-import mockState, { Fixture } from './mockState';
+import mockState, { Fixture } from '@rest-hooks/test/mockState';
 
 const mockDispatch = (value: ActionTypes) => {
   if (actionTypes.FETCH_TYPE === value.type) {

--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -6,8 +6,7 @@ import {
 } from '@rest-hooks/core';
 import { useCallback, useContext, useMemo } from 'react';
 import React from 'react';
-
-import { Fixture, actionFromFixture } from './mockState';
+import { Fixture, actionFromFixture } from '@rest-hooks/test/mockState';
 
 type Props = {
   children: React.ReactNode;

--- a/packages/test/src/browser.ts
+++ b/packages/test/src/browser.ts
@@ -1,6 +1,10 @@
-import MockProvider from './MockProvider';
-import mockInitialState from './mockState';
-export { default as MockResolver } from './MockResolver';
-export type { Fixture, SuccessFixture, ErrorFixture } from './mockState';
+import MockProvider from '@rest-hooks/test/MockProvider';
+import mockInitialState from '@rest-hooks/test/mockState';
+export { default as MockResolver } from '@rest-hooks/test/MockResolver';
+export type {
+  Fixture,
+  SuccessFixture,
+  ErrorFixture,
+} from '@rest-hooks/test/mockState';
 
 export { MockProvider, mockInitialState };

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,10 +1,17 @@
-import makeRenderRestHook from './makeRenderRestHook';
-import { makeExternalCacheProvider, makeCacheProvider } from './providers';
-import MockProvider from './MockProvider';
-import mockInitialState from './mockState';
-export * from './managers';
-export { default as MockResolver } from './MockResolver';
-export type { Fixture, SuccessFixture, ErrorFixture } from './mockState';
+import makeRenderRestHook from '@rest-hooks/test/makeRenderRestHook';
+import {
+  makeExternalCacheProvider,
+  makeCacheProvider,
+} from '@rest-hooks/test/providers';
+import MockProvider from '@rest-hooks/test/MockProvider';
+import mockInitialState from '@rest-hooks/test/mockState';
+export * from '@rest-hooks/test/managers';
+export { default as MockResolver } from '@rest-hooks/test/MockResolver';
+export type {
+  Fixture,
+  SuccessFixture,
+  ErrorFixture,
+} from '@rest-hooks/test/mockState';
 
 export {
   makeRenderRestHook,

--- a/packages/test/src/makeRenderRestHook.tsx
+++ b/packages/test/src/makeRenderRestHook.tsx
@@ -1,10 +1,12 @@
 import { State, Manager } from '@rest-hooks/core';
 import { SubscriptionManager } from 'rest-hooks';
 import React from 'react';
-import { renderHook, RenderHookOptions } from '@testing-library/react-hooks';
-
-import { MockNetworkManager, MockPollingSubscription } from './managers';
-import mockInitialState, { Fixture } from './mockState';
+import { renderHook } from '@testing-library/react-hooks';
+import mockInitialState, { Fixture } from '@rest-hooks/test/mockState';
+import {
+  MockNetworkManager,
+  MockPollingSubscription,
+} from '@rest-hooks/test/managers';
 
 export default function makeRenderRestHook(
   makeProvider: (

--- a/packages/test/tsconfig.compile.json
+++ b/packages/test/tsconfig.compile.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig",
-  "compilerOptions": { "paths": {} }
+  "compilerOptions": {
+    "paths": {
+      "@rest-hooks/test/*": ["packages/test/src/*"]
+    }
+  },
+  "exclude": ["node_modules", "dist", "lib", "legacy", "**/__tests__"]
 }

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -53,6 +53,7 @@
     "baseUrl": ".",
     "paths": {
       "@rest-hooks/core/*": ["packages/core/src/*"],
+      "@rest-hooks/test/*": ["packages/test/src/*"],
       "@rest-hooks/*": ["packages/*/src"],
       "rest-hooks": ["packages/rest-hooks/src"],
       "rest-hooks/*": ["packages/rest-hooks/src/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@anansi/babel-preset@2.1.12":
-  version "2.1.12"
-  resolved "https://registry.yarnpkg.com/@anansi/babel-preset/-/babel-preset-2.1.12.tgz#87096c4099513593bf8dffc921da0a2788699d27"
-  integrity sha512-xUXImkJRyukYfd52jkjBIvR9BljDlMDjZL5CSWavhwrvbUN0P3Z5GttPUmhwjcO0wstF1dYug+OnCbMLWSfdgw==
+"@anansi/babel-preset@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@anansi/babel-preset/-/babel-preset-2.2.0.tgz#eae4f0a4bf4224c5c011925d05a636e395852f14"
+  integrity sha512-gS8YgXLWwBhNzmxAwF+Usx0gneq3tS8N6fA5mrZvL1AXOpHFklGtdoGe897gnMfirrGSqSSNgai02cXgXWBdSg==
   dependencies:
     "@babel/plugin-proposal-class-properties" "^7.13.0"
     "@babel/plugin-proposal-class-static-block" "^7.12.13"
@@ -25,6 +25,7 @@
     "@babel/preset-react" "^7.12.13"
     babel-plugin-lodash "^3.3.4"
     babel-plugin-macros "^3.0.1"
+    babel-plugin-module-resolver "^4.1.0"
     babel-plugin-ramda "^2.0.0"
     babel-plugin-react-require "^3.1.3"
     babel-plugin-root-import "^6.6.0"
@@ -3994,6 +3995,17 @@ babel-plugin-macros@^3.0.1:
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
 
+babel-plugin-module-resolver@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz#22a4f32f7441727ec1fbf4967b863e1e3e9f33e2"
+  integrity sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==
+  dependencies:
+    find-babel-config "^1.2.0"
+    glob "^7.1.6"
+    pkg-up "^3.1.0"
+    reselect "^4.0.0"
+    resolve "^1.13.1"
+
 babel-plugin-polyfill-corejs2@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.5.tgz#8fc4779965311393594a1b9ad3adefab3860c8fe"
@@ -6485,6 +6497,14 @@ finalhandler@1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-babel-config@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.2.0.tgz#a9b7b317eb5b9860cda9d54740a8c8337a2283a2"
+  integrity sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-cache-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -8410,7 +8430,7 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
@@ -10688,6 +10708,13 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 plist@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.1.tgz#a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c"
@@ -11490,6 +11517,11 @@ require-package-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
   integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Type module expects explicit file extensions when importing.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Remap all internal imports to relative + add .js extension
- Use package prefix for imports like in other packages (i.e., `@rest-hooks/test`)
