### PR TITLE
fix: Allow legacy Resource to use getFetchInit()

### DIFF
--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -119,7 +119,7 @@ export default abstract class SimpleResource extends FlatEntity {
     const getFetchKey = (params: Readonly<object>) => {
       return 'GET ' + this.url(params);
     };
-    const options = this.getFetchOptions();
+    const options = this.getFetchInit();
     return {
       type: 'read',
       schema: this,
@@ -138,7 +138,7 @@ export default abstract class SimpleResource extends FlatEntity {
     const getFetchKey = (params: Readonly<Record<string, string>>) => {
       return 'GET ' + this.listUrl(params);
     };
-    const options = this.getFetchOptions();
+    const options = this.getFetchInit();
     return {
       type: 'read',
       schema: [this],
@@ -158,7 +158,7 @@ export default abstract class SimpleResource extends FlatEntity {
     Readonly<object>,
     Partial<AbstractInstanceType<T>>
   > {
-    const options = this.getFetchOptions();
+    const options = this.getFetchInit();
     return {
       type: 'mutate',
       schema: this,
@@ -183,7 +183,7 @@ export default abstract class SimpleResource extends FlatEntity {
     Readonly<object>,
     Partial<AbstractInstanceType<T>>
   > {
-    const options = this.getFetchOptions();
+    const options = this.getFetchInit();
     return {
       type: 'mutate',
       schema: this,
@@ -208,7 +208,7 @@ export default abstract class SimpleResource extends FlatEntity {
     Readonly<object>,
     Partial<AbstractInstanceType<T>>
   > {
-    const options = this.getFetchOptions();
+    const options = this.getFetchInit();
     return {
       type: 'mutate',
       schema: this,
@@ -229,7 +229,7 @@ export default abstract class SimpleResource extends FlatEntity {
   static deleteShape<T extends typeof SimpleResource>(
     this: T,
   ): MutateShape<schemas.Delete<T>, Readonly<object>, unknown> {
-    const options = this.getFetchOptions();
+    const options = this.getFetchInit();
     return {
       type: 'mutate',
       schema: new schemas.Delete(this),


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
This was provided but never actually used. This eases migration to [@rest-hooks/rest](https://www.npmjs.com/package/@rest-hooks/rest) allowing users to incrementally adopt the new method before switching.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Allows use of `getFetchOptions()` or `getFetchInit()`
