### PR TITLE
docs(fix): Update imports for @rest-hooks/core

### DIFF
--- a/docs/guides/redux.md
+++ b/docs/guides/redux.md
@@ -46,14 +46,12 @@ the rest-hooks specific part of the state.
 
 ```tsx
 import {
-  reducer,
-  NetworkManager,
   SubscriptionManager,
   PollingSubscription,
   ExternalCacheProvider,
   PromiseifyMiddleware,
 } from 'rest-hooks';
-import { initialState } from '@rest-hooks/core';
+import { initialState, reducer, NetworkManager } from '@rest-hooks/core';
 import { createStore, applyMiddleware } from 'redux';
 import ReactDOM from 'react-dom';
 
@@ -115,14 +113,12 @@ const selector = state => state.restHooks;
 
 ```tsx
 import {
-  reducer,
-  NetworkManager,
   SubscriptionManager,
   PollingSubscription,
   ExternalCacheProvider,
   PromiseifyMiddleware,
 } from 'rest-hooks';
-import { initialState } from '@rest-hooks/core';
+import { initialState, reducer, NetworkManager } from '@rest-hooks/core';
 import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import ReactDOM from 'react-dom';

--- a/docs/upgrade/upgrading-to-5.md
+++ b/docs/upgrade/upgrading-to-5.md
@@ -154,6 +154,21 @@ Silent removes the check completely.
 
 </details>
 
+### Imports
+
+<details><summary>import { reducer, NetworkManager } from '@rest-hooks/core'</summary>
+
+Many 'advanced' features of rest-hooks are not longer exported by 'rest-hooks' package itself, but require importing from [@rest-hooks/core](https://www.npmjs.com/package/@rest-hooks/core)
+
+- reducer
+- NetworkManager
+- action creators:
+  - createFetch
+  - createReceive
+  - createReceiveError
+
+</details>
+
 ### Managers
 
 These only apply if you have a custom [Manager](../api/Manager)

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -956,6 +956,9 @@
       "version-5.0/api/version-5.0-useInvalidator": {
         "title": "useInvalidator()"
       },
+      "version-5.0/api/version-5.0-useLoading": {
+        "title": "useLoading()"
+      },
       "version-5.0/api/version-5.0-useMeta": {
         "title": "useMeta()"
       },
@@ -1017,6 +1020,9 @@
       },
       "version-5.0/guides/version-5.0-legacy-browser": {
         "title": "Legacy browser support"
+      },
+      "version-5.0/guides/version-5.0-loading-state": {
+        "title": "Handling loading state"
       },
       "version-5.0/guides/version-5.0-mocking-unfinished": {
         "title": "Mocking unfinished endpoints"

--- a/website/versioned_docs/version-5.0/guides/redux.md
+++ b/website/versioned_docs/version-5.0/guides/redux.md
@@ -47,14 +47,12 @@ the rest-hooks specific part of the state.
 
 ```tsx
 import {
-  reducer,
-  NetworkManager,
   SubscriptionManager,
   PollingSubscription,
   ExternalCacheProvider,
   PromiseifyMiddleware,
 } from 'rest-hooks';
-import { initialState } from '@rest-hooks/core';
+import { initialState, reducer, NetworkManager } from '@rest-hooks/core';
 import { createStore, applyMiddleware } from 'redux';
 import ReactDOM from 'react-dom';
 
@@ -116,14 +114,12 @@ const selector = state => state.restHooks;
 
 ```tsx
 import {
-  reducer,
-  NetworkManager,
   SubscriptionManager,
   PollingSubscription,
   ExternalCacheProvider,
   PromiseifyMiddleware,
 } from 'rest-hooks';
-import { initialState } from '@rest-hooks/core';
+import { initialState, reducer, NetworkManager } from '@rest-hooks/core';
 import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import ReactDOM from 'react-dom';

--- a/website/versioned_docs/version-5.0/upgrade/upgrading-to-5.md
+++ b/website/versioned_docs/version-5.0/upgrade/upgrading-to-5.md
@@ -156,6 +156,21 @@ Silent removes the check completely.
 
 </details>
 
+### Imports
+
+<details><summary>import { reducer, NetworkManager } from '@rest-hooks/core'</summary>
+
+Many 'advanced' features of rest-hooks are not longer exported by 'rest-hooks' package itself, but require importing from [@rest-hooks/core](https://www.npmjs.com/package/@rest-hooks/core)
+
+- reducer
+- NetworkManager
+- action creators:
+  - createFetch
+  - createReceive
+  - createReceiveError
+
+</details>
+
 ### Managers
 
 These only apply if you have a custom [Manager](../api/Manager)


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Imports were incorrect.
docs issue from #638

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Add to upgrade guide
- Update import directions