### PR TITLE
internal: publish

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.7...@rest-hooks/core@1.0.8) (2021-03-08)
+
+
+### 💅 Enhancement
+
+* Don't use global for rIC def ([#617](https://github.com/coinbase/rest-hooks/issues/617)) ([ed33203](https://github.com/coinbase/rest-hooks/commit/ed33203aa8685953e0d09c831343480e0e2e6051))
+
+
+
 ### [1.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.6...@rest-hooks/core@1.0.7) (2021-03-03)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Dynamic data fetching for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -64,8 +64,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/endpoint": "^1.0.5",
-    "@rest-hooks/normalizr": "^6.0.4",
+    "@rest-hooks/endpoint": "^1.0.6",
+    "@rest-hooks/normalizr": "^6.0.5",
     "@rest-hooks/use-enhanced-reducer": "^1.0.5",
     "flux-standard-action": "^2.1.1"
   },

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.5...@rest-hooks/endpoint@1.0.6) (2021-03-08)
+
+**Note:** Version bump only for package @rest-hooks/endpoint
+
+
+
+
+
 ### [1.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.4...@rest-hooks/endpoint@1.0.5) (2021-03-03)
 
 **Note:** Version bump only for package @rest-hooks/endpoint

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/normalizr": "^6.0.4"
+    "@rest-hooks/normalizr": "^6.0.5"
   }
 }

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.0.1...@rest-hooks/hooks@1.1.0) (2021-03-08)
+
+
+### 🚀 Features
+
+* Add useLoading() hook ([#626](https://github.com/coinbase/rest-hooks/issues/626)) ([caeccd2](https://github.com/coinbase/rest-hooks/commit/caeccd2b5be5806e5ebcdba2493f3f03420eb184))
+
+
+### 📝 Documentation
+
+* Improve @rest-hooks/hooks README ([#627](https://github.com/coinbase/rest-hooks/issues/627)) ([0ccac81](https://github.com/coinbase/rest-hooks/commit/0ccac8154e43962a6636ea837009bdab236299b8))
+
+
+
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.0.0...@rest-hooks/hooks@1.0.1) (2021-02-04)
 
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.4...@rest-hooks/normalizr@6.0.5) (2021-03-08)
+
+
+### 🐛 Bug Fix
+
+* **pkg:** Fix build scripts on windows ([#622](https://github.com/coinbase/rest-hooks/issues/622)) ([c86f00e](https://github.com/coinbase/rest-hooks/commit/c86f00e4529d2bcc53652f40aa17bd7839b9b1c7))
+
+
+
 ### [6.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.3...@rest-hooks/normalizr@6.0.4) (2021-03-03)
 
 

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.0.10](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.9...rest-hooks@5.0.10) (2021-03-08)
+
+### 🐛 Bug Fix
+
+* Add getEndpointExtra(), getFetchInit() to legacy Resource ([#634](https://github.com/coinbase/rest-hooks/issues/634)) ([d6463ce](https://github.com/coinbase/rest-hooks/commit/d6463ce9940e0f96c49c0186bb84be9c54d657a6))
+* DevToolsConfig is type export ([#619](https://github.com/coinbase/rest-hooks/issues/619)) ([b8d9f7e](https://github.com/coinbase/rest-hooks/commit/b8d9f7e488ac5cbbd0c49ff678b689e008f0d34b))
+
+
+
 ### [5.0.9](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.8...rest-hooks@5.0.9) (2021-03-03)
 
 

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "5.0.9",
+  "version": "5.0.10",
   "description": "Dynamic data fetching for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -66,8 +66,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/core": "^1.0.7",
-    "@rest-hooks/endpoint": "^1.0.5"
+    "@rest-hooks/core": "^1.0.8",
+    "@rest-hooks/endpoint": "^1.0.6"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0",

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@1.0.4...@rest-hooks/rest@2.0.0) (2021-03-08)
+
+
+### ⚠ 💥 BREAKING CHANGES
+
+* getFetchInit() -> useFetchInit()
+- getFetchInit() is called during fetch
+- useFetchInit() should be used for hooks
+
+### 🚀 Features
+
+* Add Resource.useFetchInit() ([#635](https://github.com/coinbase/rest-hooks/issues/635)) ([9571870](https://github.com/coinbase/rest-hooks/commit/957187071bc5b654e2f8273b7527f44f27cf0139))
+
+
+
 ### [1.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@1.0.3...@rest-hooks/rest@1.0.4) (2021-02-24)
 
 

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.0.0...@rest-hooks/test@4.0.1) (2021-03-08)
+
+
+### 🐛 Bug Fix
+
+* Explicit extensions for ESM ([#628](https://github.com/coinbase/rest-hooks/issues/628)) ([ece85e4](https://github.com/coinbase/rest-hooks/commit/ece85e4e96f446afcfdacc76e03891848a4c6fd4))
+
+
+
 ## [4.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@3.0.1...@rest-hooks/test@4.0.0) (2021-03-01)
 
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs",


### PR DESCRIPTION
 - @rest-hooks/core: 1.0.7 => 1.0.8
 - @rest-hooks/endpoint: 1.0.5 => 1.0.6
 - @rest-hooks/hooks: 1.0.1 => 1.1.0
 - @rest-hooks/normalizr: 6.0.4 => 6.0.5
 - rest-hooks: 5.0.9 => 5.0.10
 - @rest-hooks/rest: 1.0.4 => 2.0.0
 - @rest-hooks/test: 4.0.0 => 4.0.1