### PR TITLE
feat: Add mapMiddleware

### DIFF
--- a/docs/guides/redux.md
+++ b/docs/guides/redux.md
@@ -91,6 +91,8 @@ where in the state tree the rest-hooks information is.
 
 ```typescript
 // ...
+const selector = state => state.restHooks;
+
 const store = createStore(
   // Now we have other reducers
   combineReducers({
@@ -98,12 +100,13 @@ const store = createStore(
     myOtherState: otherReducer,
   }),
   applyMiddleware(
-    manager.getMiddleware(),
-    subscriptionManager.getMiddleware(),
+    ...mapMiddleware(selector)(
+      manager.getMiddleware(),
+      subscriptionManager.getMiddleware(),
+    ),
     PromiseifyMiddleware,
   ),
 );
-const selector = state => state.restHooks;
 // ...
 ```
 
@@ -130,7 +133,7 @@ const store = createStore(
   reducer,
   initialState,
   applyMiddleware(
-    manager.getMiddleware(),
+    networkManager.getMiddleware(),
     subscriptionManager.getMiddleware(),
     // place Rest Hooks built middlewares before PromiseifyMiddleware
     PromiseifyMiddleware,
@@ -156,6 +159,8 @@ where in the state tree the rest-hooks information is.
 
 ```typescript
 // ...
+const selector = state => state.restHooks;
+
 const store = createStore(
   // Now we have other reducers
   combineReducers({
@@ -163,12 +168,13 @@ const store = createStore(
     myOtherState: otherReducer,
   }),
   applyMiddleware(
-    manager.getMiddleware(),
-    subscriptionManager.getMiddleware(),
+    ...mapMiddleware(selector)(
+      manager.getMiddleware(),
+      subscriptionManager.getMiddleware(),
+    ),
     PromiseifyMiddleware,
   ),
 );
-const selector = state => state.restHooks;
 // ...
 ```
 

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -77,6 +77,7 @@ export {
   ExternalCacheProvider,
   PromiseifyMiddleware,
   NetworkErrorBoundary,
+  mapMiddleware,
 } from './react-integration';
 
 export {

--- a/packages/rest-hooks/src/react-integration/provider/index.ts
+++ b/packages/rest-hooks/src/react-integration/provider/index.ts
@@ -22,3 +22,4 @@ if (process.env.NODE_ENV !== 'production')
   CacheProvider.defaultProps.managers.unshift(new DevToolsManager());
 
 export { CacheProvider, ExternalCacheProvider, PromiseifyMiddleware };
+export { default as mapMiddleware } from './mapMiddleware';

--- a/packages/rest-hooks/src/react-integration/provider/mapMiddleware.ts
+++ b/packages/rest-hooks/src/react-integration/provider/mapMiddleware.ts
@@ -1,0 +1,13 @@
+import { Middleware, MiddlewareAPI, State } from '@rest-hooks/core';
+
+const mapMiddleware = <M extends Middleware[]>(
+  selector: (state: any) => State<unknown>,
+) => (...middlewares: Middleware[]): M => {
+  return middlewares.map(
+    middleware => ({ getState, dispatch }: MiddlewareAPI) => {
+      const wrapped = () => selector(getState());
+      return middleware({ getState: wrapped, dispatch });
+    },
+  ) as any;
+};
+export default mapMiddleware;

--- a/website/versioned_docs/version-5.0/guides/redux.md
+++ b/website/versioned_docs/version-5.0/guides/redux.md
@@ -92,6 +92,8 @@ where in the state tree the rest-hooks information is.
 
 ```typescript
 // ...
+const selector = state => state.restHooks;
+
 const store = createStore(
   // Now we have other reducers
   combineReducers({
@@ -99,12 +101,13 @@ const store = createStore(
     myOtherState: otherReducer,
   }),
   applyMiddleware(
-    manager.getMiddleware(),
-    subscriptionManager.getMiddleware(),
+    ...mapMiddleware(selector)(
+      manager.getMiddleware(),
+      subscriptionManager.getMiddleware(),
+    ),
     PromiseifyMiddleware,
   ),
 );
-const selector = state => state.restHooks;
 // ...
 ```
 
@@ -131,7 +134,7 @@ const store = createStore(
   reducer,
   initialState,
   applyMiddleware(
-    manager.getMiddleware(),
+    networkManager.getMiddleware(),
     subscriptionManager.getMiddleware(),
     // place Rest Hooks built middlewares before PromiseifyMiddleware
     PromiseifyMiddleware,
@@ -157,6 +160,8 @@ where in the state tree the rest-hooks information is.
 
 ```typescript
 // ...
+const selector = state => state.restHooks;
+
 const store = createStore(
   // Now we have other reducers
   combineReducers({
@@ -164,12 +169,13 @@ const store = createStore(
     myOtherState: otherReducer,
   }),
   applyMiddleware(
-    manager.getMiddleware(),
-    subscriptionManager.getMiddleware(),
+    ...mapMiddleware(selector)(
+      manager.getMiddleware(),
+      subscriptionManager.getMiddleware(),
+    ),
     PromiseifyMiddleware,
   ),
 );
-const selector = state => state.restHooks;
 // ...
 ```
 


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #638 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Managers should work no matter where rest hooks shows up in a redux tree.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Transform middleware to make getState() return the piece that is rest hooks.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Better name?