### PR TITLE
feat: Rely on mapMiddleware for redux testing

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -80,7 +80,7 @@
     "@types/react": "^16.8.4 || ^17.0.0",
     "react": "^16.8.4 || ^17.0.0",
     "redux": "^4.0.0",
-    "rest-hooks": "^5.0.0-beta.5"
+    "rest-hooks": "^5.0.11"
   },
   "peerDependenciesMeta": {
     "redux": {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Export added in next version of rest hooks. https://github.com/coinbase/rest-hooks/pull/643 added the export, but also to test it we used in the testing lib.

Redux stuff will soon get its own package to make this make a little more sense.
