### PR TITLE
fix: non-JSON payloads on legacy Resource

### DIFF
--- a/packages/rest-hooks/src/resource/Resource.ts
+++ b/packages/rest-hooks/src/resource/Resource.ts
@@ -38,7 +38,7 @@ export default abstract class Resource extends SimpleResource {
       method: method.toUpperCase(),
     };
     options = this.getFetchInit(options);
-    if (body) options.body = JSON.stringify(body);
+    if (body && isPojo(body)) options.body = JSON.stringify(body);
     if (!options.body || typeof options.body === 'string') {
       options.headers = {
         'Content-Type': 'application/json',
@@ -75,4 +75,14 @@ export default abstract class Resource extends SimpleResource {
       });
     });
   }
+}
+
+const proto = Object.prototype;
+const gpo = Object.getPrototypeOf;
+
+function isPojo(obj: unknown): obj is Record<string, any> {
+  if (obj === null || typeof obj !== 'object') {
+    return false;
+  }
+  return gpo(obj) === proto;
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In #552 we made sure to only set the header with the correct payloads. However, legacy Resource still will always JSON encode body even if FormData is sent.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Backport check from @rest-hooks/rest
