### PR TITLE
fix: typeof Resource === typeof SimpleResource

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -76,7 +76,7 @@ export class ArticleResource extends Resource {
     });
   }
 
-  static partialUpdate<T extends typeof SimpleResource>(
+  static partialUpdate<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<RestFetch, T, true> {
     return super.partialUpdate().extend({
@@ -158,7 +158,7 @@ export class TypedArticleResource extends CoolerArticleResource {
     return this.tags.join(', ');
   }
 
-  static update<T extends typeof SimpleResource>(
+  static update<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
     RestFetch<
@@ -172,7 +172,7 @@ export class TypedArticleResource extends CoolerArticleResource {
     return super.update();
   }
 
-  static detail<T extends typeof SimpleResource>(
+  static detail<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
     RestFetch<{ id: number }, undefined, Partial<AbstractInstanceType<T>>>,
@@ -182,7 +182,7 @@ export class TypedArticleResource extends CoolerArticleResource {
     return super.detail();
   }
 
-  static list<T extends typeof SimpleResource>(
+  static list<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
     RestFetch<any, undefined, Partial<AbstractInstanceType<T>>[]>,

--- a/docs/guides/network-transform.md
+++ b/docs/guides/network-transform.md
@@ -142,7 +142,7 @@ abstract class StreamResource extends CamelResource {
     return this.username;
   }
 
-  static detail<T extends typeof SimpleResource>(
+  static detail<T extends typeof Resource>(
     this: T,
   ) {
     const superEndpoint = super.detail() as ReadEndpoint<FetchFunction, T>;

--- a/docs/upgrade/upgrading-to-5.md
+++ b/docs/upgrade/upgrading-to-5.md
@@ -75,7 +75,7 @@ you defined some custom shapes with type: 'delete'
 
 ```typescript
 class MyResource extends Resource {
-  static someOtherDeleteShape<T extends typeof SimpleResource>(
+  static someOtherDeleteShape<T extends typeof Resource>(
     this: T,
   ): DeleteShape<any, Readonly<object>> {
     const options = this.getFetchOptions();
@@ -101,7 +101,7 @@ class MyResource extends Resource {
 ```typescript
 import { schemas } from 'rest-hooks';
 class MyResource extends Resource {
-  static someOtherDeleteShape<T extends typeof SimpleResource>(
+  static someOtherDeleteShape<T extends typeof Resource>(
     this: T,
   ): DeleteShape<any, Readonly<object>> {
     const options = this.getFetchInit();

--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -47,10 +47,7 @@ export default abstract class SimpleResource extends FlatEntity {
    *
    * Default implementation conforms to common REST patterns
    */
-  static url<T extends typeof SimpleResource>(
-    this: T,
-    urlParams: Readonly<Record<string, any>>,
-  ): string {
+  static url(urlParams: Readonly<Record<string, any>>): string {
     if (
       Object.prototype.hasOwnProperty.call(urlParams, 'url') &&
       urlParams.url &&
@@ -104,6 +101,11 @@ export default abstract class SimpleResource extends FlatEntity {
   /** Get the request options for this SimpleResource  */
   static getFetchOptions(): FetchOptions | undefined {
     return;
+  }
+
+  /** Init options for fetch - run at fetch */
+  static getFetchInit(init: Readonly<RequestInit>): RequestInit {
+    return init;
   }
 
   /** Get the request options for this SimpleResource  */

--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -40,10 +40,7 @@ export default abstract class SimpleResource extends Entity {
    *
    * Default implementation conforms to common REST patterns
    */
-  static url<T extends typeof SimpleResource>(
-    this: T,
-    urlParams: Readonly<Record<string, any>>,
-  ): string {
+  static url(urlParams: Readonly<Record<string, any>>): string {
     if (
       Object.prototype.hasOwnProperty.call(urlParams, 'url') &&
       urlParams.url &&

--- a/website/versioned_docs/version-5.0/guides/network-transform.md
+++ b/website/versioned_docs/version-5.0/guides/network-transform.md
@@ -144,7 +144,7 @@ abstract class StreamResource extends CamelResource {
     return this.username;
   }
 
-  static detail<T extends typeof SimpleResource>(
+  static detail<T extends typeof Resource>(
     this: T,
   ) {
     const superEndpoint = super.detail() as ReadEndpoint<FetchFunction, T>;

--- a/website/versioned_docs/version-5.0/upgrade/upgrading-to-5.md
+++ b/website/versioned_docs/version-5.0/upgrade/upgrading-to-5.md
@@ -77,7 +77,7 @@ you defined some custom shapes with type: 'delete'
 
 ```typescript
 class MyResource extends Resource {
-  static someOtherDeleteShape<T extends typeof SimpleResource>(
+  static someOtherDeleteShape<T extends typeof Resource>(
     this: T,
   ): DeleteShape<any, Readonly<object>> {
     const options = this.getFetchOptions();
@@ -103,7 +103,7 @@ class MyResource extends Resource {
 ```typescript
 import { schemas } from 'rest-hooks';
 class MyResource extends Resource {
-  static someOtherDeleteShape<T extends typeof SimpleResource>(
+  static someOtherDeleteShape<T extends typeof Resource>(
     this: T,
   ): DeleteShape<any, Readonly<object>> {
     const options = this.getFetchInit();


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Keeping the class types the same allows simple extensions without knowledge of SimpleResource, which would be another import:

```typescript
static detail<T extends typeof Resource>(this: T) {
    return super.detail().extend({
      schema: { data: this },
    });
  }
```
However, since getFetchInit() was added to legacy Resource this was violated - potentially breaking types.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add default implementation to legacy SimpleResource.
Also removed generics on url() since it no longer uses the class type for its params.
Ensure all test types `extend typeof Resource` to ensure this use-case continues to work.