### PR TITLE
enhance: Mark Endpoint's back-compat members as 'deprecated'

### DIFF
--- a/packages/endpoint/src/endpoint.d.ts
+++ b/packages/endpoint/src/endpoint.d.ts
@@ -88,6 +88,7 @@ export interface EndpointInstance<
   readonly sideEffect: M;
 
   readonly schema: S extends undefined ? schema.SchemaClass<ResolveType<F>> : S;
+  /** @deprecated */
   readonly _schema: S; // TODO: remove once we don't care about FetchShape compatibility
 
   fetch: F;
@@ -118,8 +119,11 @@ export interface EndpointInstance<
     >;
 
   /** The following is for compatibility with FetchShape */
+  /** @deprecated */
   readonly type: M extends true ? 'mutate' : 'read';
+  /** @deprecated */
   getFetchKey(params: Parameters<F>[0]): string;
+  /** @deprecated */
   options?: EndpointExtraOptions;
 }
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
These annotations will help users realize they shouldn't be using these proprieties when they autocomplete in their IDE.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`/** @deprecated */`