### PR TITLE
fix: When sideEffect type is not known, bias toward 'read'

### DIFF
--- a/packages/endpoint/src/endpoint.d.ts
+++ b/packages/endpoint/src/endpoint.d.ts
@@ -120,7 +120,11 @@ export interface EndpointInstance<
 
   /** The following is for compatibility with FetchShape */
   /** @deprecated */
-  readonly type: M extends true ? 'mutate' : 'read';
+  readonly type: M extends undefined
+    ? M extends true
+      ? 'read' | 'mutate'
+      : 'read'
+    : 'mutate';
   /** @deprecated */
   getFetchKey(params: Parameters<F>[0]): string;
   /** @deprecated */


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #569 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
'mutate' is not allowed in hooks like useResource(), useCache(). 'read' is strictly more permissive. 
This means ambiguous sideEffect types can lead to type matching errors on things that only allow 'read'.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Correctly infer union case of sideEffect to also have union of mutate type.