### PR TITLE
fix: Compatibility with TypeScript strict: false

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -9,9 +9,9 @@ import {
 } from '@rest-hooks/endpoint';
 import {
   Resource,
-  SimpleResource,
   RestEndpoint,
   RestFetch,
+  FetchMutate,
 } from '@rest-hooks/rest';
 import React, { createContext, useContext } from 'react';
 
@@ -78,7 +78,7 @@ export class ArticleResource extends Resource {
 
   static partialUpdate<T extends typeof Resource>(
     this: T,
-  ): RestEndpoint<RestFetch, T, true> {
+  ): RestEndpoint<FetchMutate, T, true> {
     return super.partialUpdate().extend({
       optimisticUpdate: (params: any, body: any) => ({
         id: params.id,
@@ -161,7 +161,7 @@ export class TypedArticleResource extends CoolerArticleResource {
   static update<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-    RestFetch<
+    FetchMutate<
       { id: number },
       Partial<AbstractInstanceType<T>>,
       Partial<AbstractInstanceType<T>>
@@ -190,6 +190,18 @@ export class TypedArticleResource extends CoolerArticleResource {
     undefined
   > {
     return super.list();
+  }
+
+  static anyparam<T extends typeof Resource>(
+    this: T,
+  ): RestEndpoint<(a: any) => Promise<any>> {
+    return super.detail() as any;
+  }
+
+  static anybody<T extends typeof Resource>(
+    this: T,
+  ): RestEndpoint<(a: any, b: any) => Promise<any>> {
+    return super.detail() as any;
   }
 }
 

--- a/packages/core/src/endpoint/types.ts
+++ b/packages/core/src/endpoint/types.ts
@@ -53,11 +53,9 @@ export type SchemaFromShape<
 > = F['schema'];
 
 /** Get the Body type for a given Shape */
-export type BodyFromShape<F extends FetchShape<any, any, any>> = F extends {
-  fetch: (p: any, b: infer B) => any;
-}
-  ? B
-  : never;
+export type BodyFromShape<F extends FetchShape<any, any, any>> = Parameters<
+  F['fetch']
+>[1];
 
 export type OptimisticUpdateParams<
   SourceSchema extends Schema | undefined,

--- a/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
+++ b/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
@@ -1,7 +1,6 @@
 import { TypedArticleResource } from '__tests__/new';
 import React from 'react';
 import nock from 'nock';
-import { cleanup } from '@testing-library/react-hooks';
 
 import {
   makeRenderRestHook,
@@ -104,6 +103,27 @@ describe('endpoint types', () => {
         });
         const a = await result.current({ id: payload.id }, { title: 'hi' });
       });
+
+      it('types should strictly enforce with parameters that are any', async () => {
+        const { result } = renderRestHook(() => {
+          return useFetcher(TypedArticleResource.anyparam());
+        });
+        // @ts-expect-error
+        () => result.current({ id: payload.id }, { title: 'hi' });
+        () => result.current({ id: payload.id });
+      });
+
+      it('types should strictly enforce with body that are any', async () => {
+        const { result } = renderRestHook(() => {
+          return useFetcher(TypedArticleResource.anybody());
+        });
+        () => result.current({ id: payload.id }, { title: 'hi' });
+        /* TODO: Re-enable for new fetch dispatcher
+        // @ts-expect-error
+        () => result.current({ id: payload.id });
+        */
+      });
+
       it('should error on invalid payload', async () => {
         const { result } = renderRestHook(() => {
           return useFetcher(TypedArticleResource.update());

--- a/packages/core/src/react-integration/hooks/useFetcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetcher.ts
@@ -1,8 +1,6 @@
 import {
   FetchShape,
   SchemaFromShape,
-  ParamsFromShape,
-  BodyFromShape,
   OptimisticUpdateParams,
   ReturnFromShape,
 } from '@rest-hooks/core/endpoint';
@@ -11,43 +9,22 @@ import { useRef, useCallback } from 'react';
 
 import useFetchDispatcher from './useFetchDispatcher';
 
-type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
-type IfExact<T, Cond, A, B> = IfAny<
-  T,
-  B,
-  Cond extends T ? (T extends Cond ? A : B) : B
->;
-
 /** Build an imperative dispatcher to issue network requests. */
 export default function useFetcher<
   Shape extends FetchShape<Schema, Readonly<object>, any>
 >(
   fetchShape: Shape,
   throttle = false,
-): IfExact<
-  BodyFromShape<Shape>,
-  unknown,
-  <
-    UpdateParams extends OptimisticUpdateParams<
-      SchemaFromShape<Shape>,
-      FetchShape<any, any, any>
-    >[]
-  >(
-    params: ParamsFromShape<Shape>,
-    body?: undefined,
-    updateParams?: UpdateParams | undefined,
-  ) => ReturnFromShape<typeof fetchShape>,
-  <
-    UpdateParams extends OptimisticUpdateParams<
-      SchemaFromShape<Shape>,
-      FetchShape<any, any, any>
-    >[]
-  >(
-    params: ParamsFromShape<Shape>,
-    body: BodyFromShape<Shape>,
-    updateParams?: UpdateParams | undefined,
-  ) => ReturnFromShape<typeof fetchShape>
-> {
+): <
+  UpdateParams extends OptimisticUpdateParams<
+    SchemaFromShape<Shape>,
+    FetchShape<any, any, any>
+  >[]
+>(
+  a: Parameters<Shape['fetch']>[0],
+  b?: Parameters<Shape['fetch']>[1],
+  updateParams?: UpdateParams | undefined,
+) => ReturnFromShape<typeof fetchShape> {
   const dispatchFetcher: any = useFetchDispatcher(throttle);
 
   // we just want the current values when we dispatch, so

--- a/packages/endpoint/src/endpoint.d.ts
+++ b/packages/endpoint/src/endpoint.d.ts
@@ -121,9 +121,7 @@ export interface EndpointInstance<
   /** The following is for compatibility with FetchShape */
   /** @deprecated */
   readonly type: M extends undefined
-    ? M extends true
-      ? 'read' | 'mutate'
-      : 'read'
+    ? IfAny<M, any, M extends true ? 'read' | 'mutate' : 'read'>
     : 'mutate';
   /** @deprecated */
   getFetchKey(params: Parameters<F>[0]): string;
@@ -150,3 +148,5 @@ interface EndpointConstructor {
 declare let Endpoint: EndpointConstructor;
 
 export default Endpoint;
+
+type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;

--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -172,7 +172,7 @@ export default abstract class SimpleResource extends Entity {
     const instanceFetch = this.fetch.bind(this);
     return this.memo('#endpointMutate', () =>
       this.endpoint().extend({
-        fetch(this: RestEndpoint, params: any, body?: any) {
+        fetch(this: RestEndpoint, params: any, body: any) {
           return instanceFetch(this.url(params), this.getFetchInit(body));
         },
         sideEffect: true,
@@ -216,7 +216,7 @@ export default abstract class SimpleResource extends Entity {
   static create<T extends typeof SimpleResource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any, body?: any) => Promise<any>,
+    (this: RestEndpoint, params: any, body: any) => Promise<any>,
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
@@ -233,7 +233,7 @@ export default abstract class SimpleResource extends Entity {
   static update<T extends typeof SimpleResource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any, body?: any) => Promise<any>,
+    (this: RestEndpoint, params: any, body: any) => Promise<any>,
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
@@ -249,7 +249,7 @@ export default abstract class SimpleResource extends Entity {
   static partialUpdate<T extends typeof SimpleResource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any, body?: any) => Promise<any>,
+    (this: RestEndpoint, params: any, body: any) => Promise<any>,
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -3,6 +3,6 @@ import SimpleResource from './SimpleResource';
 
 export { Resource, SimpleResource };
 
-export type { RestEndpoint, RestFetch } from './types';
+export type { RestEndpoint, RestFetch, FetchMutate, FetchGet } from './types';
 
 export * from '@rest-hooks/endpoint';

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -7,6 +7,17 @@ export type RestFetch<
   R = any
 > = (this: RestEndpoint, params: P, body?: B) => Promise<R>;
 
+export type FetchMutate<
+  P = any,
+  B = RequestInit['body'] | Record<string, any>,
+  R = any
+> = (this: RestEndpoint, params: P, body: B) => Promise<R>;
+
+export type FetchGet<P = any, R = any> = (
+  this: RestEndpoint,
+  params: P,
+) => Promise<R>;
+
 /** Endpoint from a Resource
  *
  * Includes additional properties provided by Resource.endpoint()


### PR DESCRIPTION
Fixes #569

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Our previous precise logic worked with typescript 3.7+, but only in strict mode

A user kindly shared: https://github.com/saaymeen/rest-hooks-shape-type-issue

Most problems are derived from the fact that undefined simply does not exist.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Simplify types a bit so it works in both 3.7, as well as strict mode off.

This also means we lose strictness to force body for mutate types. The body param is always optional. However, the new fetch dispatcher design will be able to solve this enforcement and still remain compatible.


### Future work

It would be good to add testing strict = false to test suite. However, this predictably causes some `ts-expect-error` tests to fail, as they should. We'll either need to figure out how to simply disable ts-expect-error or segment the tests by which are valid in strict = false environment.

Due to the complexity of this, to avoid pushing back this fix we're holding this improvement to a later date. This PR was manually tested instead.