### PR TITLE
enhance: Throw error when urlRoot is not defined

### DIFF
--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -28,6 +28,16 @@ export default abstract class SimpleResource extends Entity {
 
   /** Returns the globally unique identifier for this SimpleResource */
   static get key(): string {
+    /* istanbul ignore else */
+    if (process.env.NODE_ENV !== 'production') {
+      if (this.urlRoot === undefined) {
+        throw new Error(`urlRoot is not defined for Resource "${this.name}"
+
+  Resources require a 'static urlRoot' or 'static get key()' defined.
+  (See https://resthooks.io/docs/api/resource#static-urlroot-string)
+`);
+      }
+    }
     return this.urlRoot;
   }
 

--- a/packages/rest/src/__tests__/resource.ts
+++ b/packages/rest/src/__tests__/resource.ts
@@ -57,6 +57,22 @@ describe('Resource', () => {
     expect(() => Resource.fromJS({})).toThrow();
   });
 
+  it('should throw with no urlRoot defined', () => {
+    class NoUrlResource extends Resource {
+      readonly id: string = '';
+      pk() {
+        return this.id;
+      }
+    }
+    expect(() => NoUrlResource.key).toThrowErrorMatchingInlineSnapshot(`
+      "urlRoot is not defined for Resource \\"NoUrlResource\\"
+
+        Resources require a 'static urlRoot' or 'static get key()' defined.
+        (See https://resthooks.io/docs/api/resource#static-urlroot-string)
+      "
+    `);
+  });
+
   it('should work with `url` member', () => {
     expect(() => UrlArticleResource.fromJS({})).not.toThrow();
     expect(() => UrlArticleResource.fromJS({ url: 'five' })).not.toThrow();


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Descriptive aid in development

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
By throwing in key we have the context that it's an improperly defined Resource, so instructions for correction can be more specific.

Since this is a static definition problem we only provide it during development to improve runtime.