### PR TITLE
fix: Endpoint 'type' in loose typescript mode

### DIFF
--- a/packages/endpoint/src/endpoint.d.ts
+++ b/packages/endpoint/src/endpoint.d.ts
@@ -121,8 +121,9 @@ export interface EndpointInstance<
   /** The following is for compatibility with FetchShape */
   /** @deprecated */
   readonly type: M extends undefined
-    ? IfAny<M, any, M extends true ? 'read' | 'mutate' : 'read'>
-    : 'mutate';
+    ? 'read'
+    : IfAny<M, any, IfTypeScriptLooseNull<'read', 'mutate'>>;
+
   /** @deprecated */
   getFetchKey(params: Parameters<F>[0]): string;
   /** @deprecated */
@@ -150,3 +151,4 @@ declare let Endpoint: EndpointConstructor;
 export default Endpoint;
 
 type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
+type IfTypeScriptLooseNull<Y, N> = 1 | undefined extends 1 ? Y : N;


### PR DESCRIPTION
Fixes #569

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Still missed a case in loose world.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`IfTypeScriptLooseNull` detects loose types we can apply specific typing in this case. This makes the types much more readable as we simply write normal types and then cover that case with what we want.

In this case, if we can't detect we want it to be 'read' since that's the looser type. There may be a more elegant way of representing this by types that naturally represent that relationship, while still being terse.

We also exhaustively test the non-loose world to be certain we don't cause regressions there.
