### PR TITLE
internal(fix): Only write to benchmark cache on master

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,13 +19,16 @@ jobs:
         node-version: '14'
     - name: Run benchmark
       run: yarn install && yarn bench | tee output.txt
+
+
+    # PR comments on changes
     - name: Download previous benchmark data
+      if: ${{ github.event_name == 'pull_request' }}
       uses: actions/cache@v2
       with:
         path: ./cache
-        key: ${{ runner.os }}-benchmark
-
-    # PR comments on changes
+        restore-keys:
+          - ${{ runner.os }}-benchmark
     - name: Store benchmark result
       if: ${{ github.event_name == 'pull_request' }}
       uses: rhysd/github-action-benchmark@v1
@@ -43,6 +46,12 @@ jobs:
         save-data-file: false
 
     # master reports to history
+    - name: Download previous benchmark data
+      if: ${{ github.event_name == 'push' }}
+      uses: actions/cache@v2
+      with:
+        path: ./cache
+        key: ${{ runner.os }}-benchmark
     - name: Store benchmark result
       if: ${{ github.event_name == 'push' }}
       uses: rhysd/github-action-benchmark@v1


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Cache action both saves and restores, so PRs are writing nothing to cache.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Use `restore-keys` to read the same cache without saving it for PRs
