### PR TITLE
internal(fix): Fix github action syntax for benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,8 +27,9 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ./cache
-        restore-keys:
-          - ${{ runner.os }}-benchmark
+        key: ${{ runner.os }}-benchmark-pr
+        restore-keys: |
+          ${{ runner.os }}-benchmark
     - name: Store benchmark result
       if: ${{ github.event_name == 'pull_request' }}
       uses: rhysd/github-action-benchmark@v1


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
"The workflow is not valid. .github/workflows/benchmark.yml (Line: 31, Col: 11): A sequence was not expected"

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Stole expected syntax from https://github.com/actions/cache/search?q=restore-keys