### PR TITLE
fix: schema.Values singleSchema denormalization

### DIFF
--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -144,6 +144,9 @@ function schemaHasEntity(schema: Schema): boolean {
   if (schema && (typeof schema === 'object' || typeof schema === 'function')) {
     const nestedSchema =
       'schema' in schema ? (schema.schema as Record<string, Schema>) : schema;
+    if (typeof nestedSchema === 'function') {
+      return schemaHasEntity(nestedSchema);
+    }
     return Object.values(nestedSchema).reduce(
       (prev, cur) => prev || schemaHasEntity(cur),
       false,

--- a/packages/normalizr/src/schemas/__tests__/Values.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Values.test.js
@@ -15,6 +15,29 @@ class Dog extends IDEntity {
 }
 
 describe(`${schema.Values.name} normalization`, () => {
+  test('normalizes without schemaAttribute', () => {
+    class MyEntity extends IDEntity {
+      name = '';
+    }
+    const valuesSchema = new schema.Values(MyEntity);
+
+    expect(
+      normalize(
+        {
+          first: {
+            id: '1',
+            name: 'first thing',
+          },
+          second: {
+            id: '2',
+            name: 'second thing',
+          },
+        },
+        valuesSchema,
+      ),
+    ).toMatchSnapshot();
+  });
+
   test('normalizes the values of an object with the given schema', () => {
     const valuesSchema = new schema.Values(
       {
@@ -164,6 +187,37 @@ describe(`${schema.Values.name} normalization`, () => {
 });
 
 describe(`${schema.Values.name} denormalization`, () => {
+  test('denormalizes without schemaAttribute', () => {
+    class MyEntity extends IDEntity {
+      name = '';
+    }
+    const valuesSchema = new schema.Values(MyEntity);
+
+    const entities = {
+      MyEntity: {
+        1: {
+          id: '1',
+          name: 'first thing',
+        },
+        2: {
+          id: '2',
+          name: 'second thing',
+        },
+      },
+    };
+
+    expect(
+      denormalize(
+        {
+          first: '1',
+          second: '2',
+        },
+        valuesSchema,
+        entities,
+      ),
+    ).toMatchSnapshot();
+  });
+
   test('denormalizes the values of an object with the given schema', () => {
     const valuesSchema = new schema.Values(
       {

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -102,6 +102,23 @@ Array [
 ]
 `;
 
+exports[`ValuesSchema denormalization denormalizes without schemaAttribute 1`] = `
+Array [
+  Object {
+    "first": MyEntity {
+      "id": "1",
+      "name": "first thing",
+    },
+    "second": MyEntity {
+      "id": "2",
+      "name": "second thing",
+    },
+  },
+  true,
+  false,
+]
+`;
+
 exports[`ValuesSchema denormalization works on complex object 1`] = `
 Object {
   "data": Object {
@@ -259,6 +276,28 @@ Object {
       "id": "1",
       "schema": "cats",
     },
+  },
+}
+`;
+
+exports[`ValuesSchema normalization normalizes without schemaAttribute 1`] = `
+Object {
+  "entities": Object {
+    "MyEntity": Object {
+      "1": MyEntity {
+        "id": "1",
+        "name": "first thing",
+      },
+      "2": MyEntity {
+        "id": "2",
+        "name": "second thing",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Object {
+    "first": "1",
+    "second": "2",
   },
 }
 `;


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #722 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`schemaHasEntity()` assumed schema.schema would always be pojo. This is not true for Polymorphic types.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Use `typeof nestedSchema === 'function'` to check if the nested schema is another schema, rather than pojo - and in this case, simply recurse.

Added tests to both normalizr (validating not a problem there), as well as full integration with `useResource()`. Added for union as well to be comprehensive.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
This is tightly coupled to internal implementations of schemas, rather than public APIs. We should establish a pattern to allow extensibility and reduce breakages.