### PR TITLE
internal(fix): Fix bench action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,7 +36,6 @@ jobs:
       with:
         tool: 'benchmarkjs'
         output-file-path: output.txt
-        external-data-json-path: ./cache/benchmark-data.json
         github-token: "${{ secrets.GITHUB_TOKEN }}"
         # Show alert with commit comment on detecting possible performance regression
         alert-threshold: '150%'
@@ -45,6 +44,7 @@ jobs:
         alert-comment-cc-users: '@ntucker'
         # we only want to compare against master, so do not save for PR
         save-data-file: false
+        auto-push: false
 
     # master reports to history
     - name: Download previous benchmark data (main)
@@ -59,7 +59,6 @@ jobs:
       with:
         tool: 'benchmarkjs'
         output-file-path: output.txt
-        external-data-json-path: ./cache/benchmark-data.json
         github-token: "${{ secrets.GITHUB_TOKEN }}"
         gh-pages-branch: 'gh-pages-bench'
         auto-push: true


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Master is broken

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This github action is confused. I believe now `external-data-json-path` is a last resort if the branch option doesn't work. However, if it does, I *think* it still stores information to do bench comparisons. Either case this at least makes master not explode.