### PR TITLE
fix: Inferring schema.Values()

### DIFF
--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -29,6 +29,7 @@ import {
   nested,
   paginatedFirstPage,
   paginatedSecondPage,
+  valuesFixture,
 } from '../test-fixtures';
 
 function onError(e: any) {
@@ -71,6 +72,8 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         .reply(200, '')
         .get(`/article-cooler/`)
         .reply(200, nested)
+        .get(`/article-cooler/values`)
+        .reply(200, valuesFixture)
         .post(`/article-cooler/`)
         .reply(200, createPayload)
         .get(`/user/`)
@@ -180,38 +183,16 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           return this.detail().extend({
             schema: new schema.Values(this),
             url() {
-              return `${urlRoot}/values`;
+              return `${urlRoot}values`;
             },
           });
         }
       }
-      const { result } = renderRestHook(
-        () => {
-          return useResource(ValuesResource.values(), {});
-        },
-        {
-          results: [
-            {
-              request: ValuesResource.values(),
-              params: {},
-              result: {
-                first: {
-                  id: 1,
-                  title: 'first thing',
-                  content: 'blah',
-                  tags: [],
-                },
-                second: {
-                  id: 2,
-                  name: 'second thing',
-                  content: 'blah',
-                  tags: [],
-                },
-              },
-            },
-          ],
-        },
-      );
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        return useResource(ValuesResource.values(), {});
+      });
+      expect(result.current).toBeUndefined();
+      await waitForNextUpdate();
       Object.keys(result.current).forEach(k => {
         expect(result.current[k] instanceof ValuesResource).toBe(true);
         expect(result.current[k].title).toBeDefined();

--- a/packages/core/src/react-integration/test-fixtures.ts
+++ b/packages/core/src/react-integration/test-fixtures.ts
@@ -103,6 +103,21 @@ const moreNested = [
   },
 ];
 
+export const valuesFixture = {
+  first: {
+    id: 1,
+    title: 'first thing',
+    content: 'blah',
+    tags: [],
+  },
+  second: {
+    id: 2,
+    name: 'second thing',
+    content: 'blah',
+    tags: [],
+  },
+};
+
 export const paginatedFirstPage = {
   results: nested,
 };

--- a/packages/core/src/state/selectors/__tests__/buildInferredResults.ts
+++ b/packages/core/src/state/selectors/__tests__/buildInferredResults.ts
@@ -57,12 +57,12 @@ describe('buildInferredResults()', () => {
     });
   });
 
-  it('should be {} with Values', () => {
+  it('should be undefined with Values', () => {
     const schema = {
       data: new schemas.Values(CoolerArticleResource),
     };
     expect(buildInferredResults(schema, { id: 5 }, {})).toStrictEqual({
-      data: {},
+      data: undefined,
     });
   });
 

--- a/packages/core/src/state/selectors/buildInferredResults.ts
+++ b/packages/core/src/state/selectors/buildInferredResults.ts
@@ -45,7 +45,7 @@ export default function buildInferredResults<
     return undefined as any;
   }
   if (schema instanceof schemas.Values) {
-    return {} as any;
+    return undefined as any;
   }
   const o = 'schema' in schema ? (schema as any).schema : schema;
   let resultObject = {} as any;


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes https://github.com/coinbase/rest-hooks/issues/722#issuecomment-816741203

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Values is like array but for mapping types. Thus we need to distinguish when it's truly empty vs we tried to infer.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Make `undefined` like Array in `buildInferredResults()`.

Updated test case to do full networking response for values case