### PR TITLE
fix: Publish legacy type files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "src",
     "dist",
     "lib",
+    "ts3.4",
     "LICENSE",
     "README.md",
     "./typescript.svg",

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -24,6 +24,7 @@
   "files": [
     "dist/",
     "lib/",
+    "ts3.4",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
Build the new files, define them but missed them in the upload process