### PR TITLE
fix: Relax DeleteShape def to be back-compat

### DIFF
--- a/__tests__/legacy.ts
+++ b/__tests__/legacy.ts
@@ -1,4 +1,4 @@
-import { Resource } from 'rest-hooks';
+import { MutateShape, Resource, schemas } from 'rest-hooks';
 
 export class UserResource extends Resource {
   readonly id: number | undefined = undefined;
@@ -62,5 +62,11 @@ export class CoolerArticleResource extends ArticleResource {
   static urlRoot = 'http://test.com/article-cooler/';
   get things() {
     return `${this.title} five`;
+  }
+
+  static deleteShape<T extends typeof Resource>(
+    this: T,
+  ): MutateShape<schemas.Delete<T>, Readonly<object>, unknown> {
+    return super.deleteShape() as any;
   }
 }

--- a/packages/core/src/endpoint/shapes.ts
+++ b/packages/core/src/endpoint/shapes.ts
@@ -37,7 +37,7 @@ export interface DeleteShape<
   Response extends object | string | number | boolean | null = any
 > extends FetchShape<S, Params, undefined, Response> {
   readonly type: 'mutate';
-  fetch(params: Params): Promise<Response>;
+  fetch(params: Params, ...args: any): Promise<Response>;
 }
 
 /** For retrieval requests */

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -31,6 +31,7 @@ export type {
   FetchShape,
   ReadShape,
   MutateShape,
+  DeleteShape,
   SetShapeParams,
   ParamsFromShape,
   AbstractInstanceType,

--- a/packages/rest/src/legacy.ts
+++ b/packages/rest/src/legacy.ts
@@ -37,7 +37,7 @@ export interface DeleteShape<
   Response extends object | string | number | boolean | null = any
 > extends FetchShape<S, Params, undefined, Response> {
   readonly type: 'mutate';
-  fetch(params: Params): Promise<Response>;
+  fetch(params: Params, ...args: any): Promise<Response>;
 }
 
 /** For retrieval requests */


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Previously MutateShape definitions were used. We need to make sure those don't cause type errors when still used in overrides.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Flex additional arguments on DeleteShape type