### PR TITLE
fix: Generate types that do not refer internally to other packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:bundle": "lerna run build:bundle --stream",
     "build:clean": "lerna run build:clean --stream",
     "build:types": "yarn build:copy:ambient && ttsc --build && lerna run build:legacy-types --stream",
-    "build:copy:ambient": "mkdirp ./packages/normalizr/lib && copyfiles --flat ./packages/normalizr/src/schema.d.ts ./packages/normalizr/lib/ && mkdirp ./packages/endpoint/lib && copyfiles --flat ./packages/endpoint/src/endpoint.d.ts ./packages/endpoint/lib/",
+    "build:copy:ambient": "mkdirp ./packages/normalizr/lib && copyfiles --flat ./packages/normalizr/src/schema.d.ts ./packages/normalizr/lib/ && mkdirp ./packages/endpoint/lib && copyfiles --flat ./packages/endpoint/src/endpoint.d.ts ./packages/endpoint/lib/&& mkdirp ./packages/core/lib && copyfiles --flat ./packages/core/src/state/RIC.d.ts ./packages/core/lib/state",
     "test": "cross-env NODE_ENV=test jest",
     "test:ci": "yarn test -- --ci",
     "test:coverage": "yarn test -- --coverage",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,15 +1,4 @@
-import { DELETED } from '@rest-hooks/endpoint';
-
-import buildInferredResults from './state/selectors/buildInferredResults';
-import RIC from './state/RIC';
-
-const __INTERNAL__ = {
-  buildInferredResults,
-  RIC,
-  DELETED,
-};
-
-export { __INTERNAL__ };
+export * as __INTERNAL__ from './internal';
 export { default as NetworkManager } from './state/NetworkManager';
 export { default as reducer, initialState } from './state/reducer';
 export { useDenormalized } from './state/selectors';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1,0 +1,4 @@
+export { DELETED } from '@rest-hooks/endpoint';
+
+export { default as buildInferredResults } from './state/selectors/buildInferredResults';
+export { default as RIC } from './state/RIC';

--- a/packages/core/src/state/RIC.d.ts
+++ b/packages/core/src/state/RIC.d.ts
@@ -1,2 +1,2 @@
-const RIC: (cb: (...args: any[]) => void, options: any) => void;
+declare const RIC: (cb: (...args: any[]) => void, options: any) => void;
 export default RIC;

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -1,11 +1,3 @@
-import {
-  initialState,
-  StateContext,
-  DispatchContext,
-  hasUsableData,
-  __INTERNAL__ as _INT_,
-} from '@rest-hooks/core';
-
 export {
   useCache,
   useFetcher,
@@ -89,13 +81,4 @@ export {
 } from './manager';
 export type { ConnectionListener, DevToolsConfig } from './manager';
 export { default as useSelectionUnstable } from './react-integration/hooks/useSelection';
-
-const { buildInferredResults, RIC } = _INT_;
-export const __INTERNAL__ = {
-  initialState,
-  StateContext,
-  DispatchContext,
-  RIC,
-  hasUsableData,
-  buildInferredResults,
-};
+export * as __INTERNAL__ from './internal';

--- a/packages/rest-hooks/src/internal.ts
+++ b/packages/rest-hooks/src/internal.ts
@@ -1,0 +1,9 @@
+import { __INTERNAL__ } from '@rest-hooks/core';
+export {
+  initialState,
+  StateContext,
+  DispatchContext,
+  hasUsableData,
+} from '@rest-hooks/core';
+export const buildInferredResults = __INTERNAL__.buildInferredResults;
+export const RIC = __INTERNAL__.RIC;

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -77,6 +77,7 @@
     "node_modules",
     "dist",
     "lib",
+    "ts3.4",
     "coverage"
   ]
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The current structure resulted in the following typescript ambient declaration
```buildInferredResults: typeof import("@rest-hooks/core/lib/state/selectors/buildInferredResults").default;```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Focusing on __INTERNAL__ as module rather than object
- Keep RIC as a module in output

### Testing

Validated output generation no longer reaches into internal file structures