### PR TITLE
enhance: Remove extraneous outdated hack

### DIFF
--- a/packages/core/src/react-integration/hooks/useRetrieve.ts
+++ b/packages/core/src/react-integration/hooks/useRetrieve.ts
@@ -1,9 +1,8 @@
 import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
-import { useMemo, useEffect, useContext } from 'react';
+import { useMemo } from 'react';
 
 import useFetchDispatcher from './useFetchDispatcher';
 import useExpiresAt from './useExpiresAt';
-import { DispatchContext } from '../context';
 
 /** Request a resource if it is not in cache. */
 export default function useRetrieve<Shape extends ReadShape<any, any>>(
@@ -14,16 +13,6 @@ export default function useRetrieve<Shape extends ReadShape<any, any>>(
 ) {
   const dispatchFetch: any = useFetchDispatcher(true);
   const expiresAt = useExpiresAt(fetchShape, params, entitiesExpireAt);
-
-  // Clears invalidIfStale loop blocking mechanism
-  const dispatch = useContext(DispatchContext);
-  useEffect(() => {
-    if (params && fetchShape.options?.invalidIfStale)
-      dispatch({
-        type: 'rest-hook/mounted',
-        payload: fetchShape.getFetchKey(params),
-      }); // set expiry
-  }, [params && fetchShape.getFetchKey(params)]);
 
   return useMemo(() => {
     // null params mean don't do anything

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -108,19 +108,6 @@ export default function reducer(
         return reduceError(state, action, error);
       }
     }
-    case 'rest-hook/mounted': {
-      if (!state.meta || !(action.payload in state.meta)) return state;
-      return {
-        ...state,
-        meta: {
-          ...state.meta,
-          [action.payload]: {
-            ...state.meta[action.payload],
-            prevExpiresAt: undefined,
-          },
-        },
-      };
-    }
     case INVALIDATE_TYPE: {
       const results = { ...state.results };
       delete results[action.meta.key];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -161,8 +161,6 @@ export interface InvalidateAction
   };
 }
 
-export type MountedAction = { type: 'rest-hook/mounted'; payload: string };
-
 export type ResponseActions = ReceiveAction;
 
 // put other actions here in union
@@ -172,8 +170,7 @@ export type ActionTypes =
   | SubscribeAction
   | UnsubscribeAction
   | InvalidateAction
-  | ResetAction
-  | MountedAction;
+  | ResetAction;
 
 export interface Manager {
   getMiddleware(): Middleware;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
A year and a half ago this hack was introduced to allow for measuring rest-hooks with 0 length cache policy for A/B performance testing. This was introduced to prevent infinite loop problems because the code was not as robust back then. Since then, suspense logic was reworked to allow suspending anywhere with useInvalidator, and deletes. The hack has not been needed for some time. However, it remained in place in case there were any dependencies on it.

- The mechanisms were never documented or exposed
- The Coinbase experiment has long since been removed
- I can't imagine any use of building something relying on this - other than to get the same mechanisms that will continue to work without it.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Delete hack