### PR TITLE
enhance: Support TypeScript 3.7

### DIFF
--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -7,18 +7,32 @@
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    ">=4.0": {
+      "*": [
+        "lib/index.d.ts"
+      ]
+    },
+    ">=3.4": {
+      "*": [
+        "ts3.4/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",
     "lib",
+    "ts3.4",
     "LICENSE",
     "README.md"
   ],
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf lib dist *.tsbuildinfo",
+    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build": "yarn run build:lib && yarn run build:bundle",
+    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",
     "prepublishOnly": "yarn run build:bundle",

--- a/packages/endpoint/tsconfig.compile.json
+++ b/packages/endpoint/tsconfig.compile.json
@@ -5,5 +5,5 @@
       "@rest-hooks/endpoint/*": ["packages/endpoint/src/*"]
     }
   },
-  "exclude": ["node_modules", "dist", "lib", "**/__tests__"]
+  "exclude": ["node_modules", "dist", "lib", "lib3.4", "**/__tests__"]
 }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -7,18 +7,32 @@
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    ">=4.0": {
+      "*": [
+        "lib/index.d.ts"
+      ]
+    },
+    ">=3.4": {
+      "*": [
+        "ts3.4/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",
     "lib",
+    "ts3.4",
     "LICENSE",
     "README.md"
   ],
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/hooks' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf lib dist *.tsbuildinfo",
+    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build": "yarn run build:lib && yarn run build:bundle",
+    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",
     "prepublishOnly": "yarn run build:bundle",

--- a/packages/hooks/tsconfig.compile.json
+++ b/packages/hooks/tsconfig.compile.json
@@ -5,5 +5,5 @@
       "@rest-hooks/hooks/*": ["packages/hooks/src/*"]
     }
   },
-  "exclude": ["node_modules", "dist", "lib", "**/__tests__"]
+  "exclude": ["node_modules", "dist", "lib", "ts3.4", "**/__tests__"]
 }

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -7,17 +7,31 @@
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    ">=4.0": {
+      "*": [
+        "lib/index.d.ts"
+      ]
+    },
+    ">=3.4": {
+      "*": [
+        "ts3.4/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",
     "lib",
+    "ts3.4",
     "LICENSE",
     "README.md"
   ],
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf lib dist *.tsbuildinfo",
+    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
+    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "build": "yarn run build:lib && yarn run build:bundle",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",

--- a/packages/img/tsconfig.compile.json
+++ b/packages/img/tsconfig.compile.json
@@ -5,5 +5,5 @@
       "@rest-hooks/img/*": ["packages/img/src/*"]
     }
   },
-  "exclude": ["node_modules", "dist", "lib", "**/__tests__"]
+  "exclude": ["node_modules", "dist", "lib", "ts3.4", "**/__tests__"]
 }

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -7,17 +7,31 @@
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    ">=4.0": {
+      "*": [
+        "lib/index.d.ts"
+      ]
+    },
+    ">=3.4": {
+      "*": [
+        "ts3.4/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",
     "lib",
+    "ts3.4",
     "LICENSE",
     "README.md"
   ],
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf lib dist *.tsbuildinfo",
+    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
+    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "build": "yarn run build:lib && yarn run build:bundle",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",

--- a/packages/legacy/tsconfig.compile.json
+++ b/packages/legacy/tsconfig.compile.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": { "paths": {} },
-  "exclude": ["node_modules", "dist", "lib", "**/__tests__"]
+  "exclude": ["node_modules", "dist", "lib", "ts3.4", "**/__tests__"]
 }

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -7,10 +7,23 @@
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    ">=4.0": {
+      "*": [
+        "lib/index.d.ts"
+      ]
+    },
+    ">=3.4": {
+      "*": [
+        "ts3.4/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",
     "lib",
+    "ts3.4",
     "LICENSE",
     "README.md",
     "./typescript.svg",
@@ -22,7 +35,8 @@
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='rest-hooks' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf lib dist *.tsbuildinfo",
+    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
+    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "build": "yarn run build:lib && yarn run build:bundle",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",

--- a/packages/rest-hooks/tsconfig.compile.json
+++ b/packages/rest-hooks/tsconfig.compile.json
@@ -5,5 +5,5 @@
       "rest-hooks/*": ["packages/rest-hooks/src/*"]
     }
   },
-  "exclude": ["node_modules", "dist", "lib", "**/__tests__"]
+  "exclude": ["node_modules", "dist", "lib", "ts3.4", "**/__tests__"]
 }

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -7,17 +7,31 @@
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    ">=4.0": {
+      "*": [
+        "lib/index.d.ts"
+      ]
+    },
+    ">=3.4": {
+      "*": [
+        "ts3.4/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",
     "lib",
+    "ts3.4",
     "LICENSE",
     "README.md"
   ],
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf lib dist *.tsbuildinfo",
+    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
+    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "build": "yarn run build:lib && yarn run build:bundle",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",

--- a/packages/rest/tsconfig.compile.json
+++ b/packages/rest/tsconfig.compile.json
@@ -5,5 +5,5 @@
       "@rest-hooks/rest/*": ["packages/rest/src/*"]
     }
   },
-  "exclude": ["node_modules", "dist", "lib", "**/__tests__"]
+  "exclude": ["node_modules", "dist", "lib", "ts3.4", "**/__tests__"]
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -6,15 +6,25 @@
   "main": "dist/index.cjs",
   "module": "legacy/browser.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    ">=4.0": {
+      "*": [
+        "lib/index.d.ts"
+      ]
+    },
+    ">=3.4": {
+      "*": [
+        "ts3.4/index.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": [
       {
         "node": {
           "import": "./node.mjs",
-          "require": "./dist/index.cjs",
-          "types": "./lib/index.d.ts"
+          "require": "./dist/index.cjs"
         },
-        "types": "./lib/browser.d.ts",
         "default": "./lib/browser.js"
       },
       "./lib/browser.js"
@@ -29,6 +39,7 @@
     "src",
     "dist",
     "lib",
+    "ts3.4",
     "node.mjs",
     "legacy",
     "LICENSE",
@@ -38,7 +49,8 @@
     "build:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV='modern' RESOLVER_ALIAS='{\"^@rest-hooks/test(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:legacy:lib": "cross-env NODE_ENV=production RESOLVER_ALIAS='{\"^@rest-hooks/test(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir legacy --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf dist lib legacy *.tsbuildinfo",
+    "build:clean": "rimraf lib dist ts3.4 legacy *.tsbuildinfo",
+    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",

--- a/packages/test/tsconfig.compile.json
+++ b/packages/test/tsconfig.compile.json
@@ -5,5 +5,5 @@
       "@rest-hooks/test/*": ["packages/test/src/*"]
     }
   },
-  "exclude": ["node_modules", "dist", "lib", "legacy", "**/__tests__"]
+  "exclude": ["node_modules", "dist", "lib", "ts3.4", "legacy", "**/__tests__"]
 }

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -7,17 +7,31 @@
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",
+  "typesVersions": {
+    ">=4.0": {
+      "*": [
+        "lib/index.d.ts"
+      ]
+    },
+    ">=3.4": {
+      "*": [
+        "ts3.4/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "src",
     "dist",
     "lib",
+    "ts3.4",
     "LICENSE",
     "README.md"
   ],
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
-    "build:clean": "rimraf lib dist *.tsbuildinfo",
+    "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
+    "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "build": "yarn run build:lib && yarn run build:bundle",
     "dev": "yarn run build:lib -w",
     "prepare": "yarn run build:lib",

--- a/packages/use-enhanced-reducer/tsconfig.compile.json
+++ b/packages/use-enhanced-reducer/tsconfig.compile.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": { "paths": {} },
-  "exclude": ["node_modules", "dist", "lib", "**/__tests__"]
+  "exclude": ["node_modules", "dist", "lib", "ts3.4", "**/__tests__"]
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Use use TypeScript >=3.8 import features like `import type`

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Use `typesVersions` with `downlevel-dts` for all remaining packages.