### PR TITLE
feat: Endpoint parameters can be of any length

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -415,6 +415,23 @@ export const GetNoEntities = new Endpoint(
   },
 );
 
+export const Post = new Endpoint(
+  async function ({ userId }: { userId: string }, body: BodyInit) {
+    return await (
+      await fetch(`http://test.com/users/${userId}/simple`, {
+        method: 'POST',
+        body,
+      })
+    ).json();
+  },
+  {
+    key({ userId }: { userId: string }) {
+      return `/users/${userId}/simple`;
+    },
+    schema: { firstThing: '', someItems: [] as { a: number }[] },
+  },
+);
+
 export function makeErrorBoundary(cb: (error: any) => void) {
   return class ErrorInterceptor extends React.Component<any, { error: any }> {
     state = { error: null };

--- a/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
+++ b/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
@@ -102,13 +102,10 @@ describe('useExpiresAt()', () => {
         key: () => 'listtaco',
       },
     );
-    const DetailTaco = new Endpoint(
-      (a: Record<string, unknown>) => Promise.resolve({}),
-      {
-        schema: Tacos,
-        key: ({ id }: { id: any }) => `detailtaco ${id}`,
-      },
-    );
+    const DetailTaco = new Endpoint((a: { id: any }) => Promise.resolve({}), {
+      schema: Tacos,
+      key: ({ id }: { id: any }) => `detailtaco ${id}`,
+    });
     const state = {
       entities: {
         Tacos: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,8 @@ import type {
   UpdateFunction,
   AbstractInstanceType,
   Schema,
+  FetchFunction,
+  EndpointExtraOptions,
 } from '@rest-hooks/endpoint';
 import { Middleware } from '@rest-hooks/use-enhanced-reducer';
 import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
@@ -57,23 +59,9 @@ export type State<T> = Readonly<{
   optimistic: ReceiveAction[];
 }>;
 
-export interface FetchOptions {
-  /** Default data expiry length, will fall back to NetworkManager default if not defined */
-  readonly dataExpiryLength?: number;
-  /** Default error expiry length, will fall back to NetworkManager default if not defined */
-  readonly errorExpiryLength?: number;
-  /** Poll with at least this frequency in miliseconds */
-  readonly pollFrequency?: number;
-  /** Marks cached resources as invalid if they are stale */
-  readonly invalidIfStale?: boolean;
-  /** Enables optimistic updates for this request - uses return value as assumed network response */
-  readonly optimisticUpdate?: (
-    params: Readonly<object>,
-    body: Readonly<object | string> | void,
-  ) => any;
-  /** User-land extra data to send */
-  readonly extra?: any;
-}
+export type FetchOptions<
+  F extends FetchFunction = FetchFunction
+> = EndpointExtraOptions<F>;
 
 export interface ReceiveMeta<S extends Schema | undefined> {
   schema: S;

--- a/packages/endpoint/src-legacy-types/types.d.ts
+++ b/packages/endpoint/src-legacy-types/types.d.ts
@@ -2,7 +2,8 @@ import { schema, Schema } from '@rest-hooks/normalizr';
 
 import { Normalize } from './normal';
 import { EndpointInterface } from './interface';
-export interface EndpointExtraOptions {
+import { ResolveType } from './utility';
+export interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
   /** Default data expiry length, will fall back to NetworkManager default if not defined */
   readonly dataExpiryLength?: number;
   /** Default error expiry length, will fall back to NetworkManager default if not defined */
@@ -12,10 +13,7 @@ export interface EndpointExtraOptions {
   /** Marks cached resources as invalid if they are stale */
   readonly invalidIfStale?: boolean;
   /** Enables optimistic updates for this request - uses return value as assumed network response */
-  readonly optimisticUpdate?: (
-    params: Readonly<object>,
-    body: Readonly<object | string> | void,
-  ) => any;
+  readonly optimisticUpdate?: (...args: Parameters<F>) => ResolveType<F>;
   /** User-land extra data to send */
   readonly extra?: any;
 }

--- a/packages/endpoint/src/endpoint.d.ts
+++ b/packages/endpoint/src/endpoint.d.ts
@@ -6,23 +6,21 @@ import type { EndpointExtraOptions, FetchFunction } from './types';
 import type { ResolveType } from './utility';
 
 export interface EndpointOptions<
-  K extends ((...args: any) => string) | undefined = undefined,
+  F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = undefined,
   M extends true | undefined = undefined
-> extends EndpointExtraOptions {
-  key?: K;
+> extends EndpointExtraOptions<F> {
+  key?: (...args: Parameters<F>) => string;
   sideEffect?: M;
   schema?: S;
   [k: string]: any;
 }
 
 export interface EndpointExtendOptions<
-  K extends ((...args: any) => string) | undefined =
-    | ((...args: any) => string)
-    | undefined,
+  F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
   M extends true | undefined = true | undefined
-> extends EndpointOptions<K, S, M> {
+> extends EndpointOptions<F, S, M> {
   fetch?: FetchFunction;
 }
 
@@ -119,7 +117,7 @@ export interface EndpointInstance<
       Schema | undefined,
       true | undefined
     >,
-    O extends EndpointExtendOptions<EndpointInstance<F>['key']> &
+    O extends EndpointExtendOptions<F> &
       Partial<Omit<E, keyof EndpointInstance<FetchFunction>>>
   >(
     this: E,
@@ -147,7 +145,7 @@ export interface EndpointInstance<
   /** @deprecated */
   getFetchKey(params: Parameters<F>[0]): string;
   /** @deprecated */
-  options?: EndpointExtraOptions;
+  options?: EndpointExtraOptions<F>;
 }
 
 interface EndpointConstructor {
@@ -162,7 +160,7 @@ interface EndpointConstructor {
     E extends Record<string, any> = {}
   >(
     fetchFunction: F,
-    options?: EndpointOptions<EndpointInstance<F>['key'], S, M> & E,
+    options?: EndpointOptions<F, S, M> & E,
   ): EndpointInstance<F, S, M> & E;
   readonly prototype: Function;
 }

--- a/packages/endpoint/src/endpoint.js
+++ b/packages/endpoint/src/endpoint.js
@@ -45,8 +45,8 @@ export default class Endpoint extends Function {
     return self;
   }
 
-  key(params) {
-    return `${this.fetch.name} ${JSON.stringify(params)}`;
+  key(...args) {
+    return `${this.fetch.name} ${JSON.stringify(args)}`;
   }
 
   bind(thisArg, ...args) {

--- a/packages/endpoint/src/interface.ts
+++ b/packages/endpoint/src/interface.ts
@@ -8,7 +8,7 @@ export interface EndpointInterface<
   F extends FetchFunction = FetchFunction,
   S extends Schema | undefined = Schema | undefined,
   M extends true | undefined = true | undefined
-> extends EndpointExtraOptions {
+> extends EndpointExtraOptions<F> {
   (...args: Parameters<F>): InferReturn<F, S>;
   key(...args: Parameters<F>): string;
   readonly sideEffect?: M;

--- a/packages/endpoint/src/types.ts
+++ b/packages/endpoint/src/types.ts
@@ -2,8 +2,9 @@ import { schema, Schema } from '@rest-hooks/normalizr';
 
 import { Normalize } from './normal';
 import { EndpointInterface } from './interface';
+import { ResolveType } from './utility';
 
-export interface EndpointExtraOptions {
+export interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
   /** Default data expiry length, will fall back to NetworkManager default if not defined */
   readonly dataExpiryLength?: number;
   /** Default error expiry length, will fall back to NetworkManager default if not defined */
@@ -13,10 +14,7 @@ export interface EndpointExtraOptions {
   /** Marks cached resources as invalid if they are stale */
   readonly invalidIfStale?: boolean;
   /** Enables optimistic updates for this request - uses return value as assumed network response */
-  readonly optimisticUpdate?: (
-    params: Readonly<object>,
-    body: Readonly<object | string> | void,
-  ) => any;
+  readonly optimisticUpdate?: (...args: Parameters<F>) => ResolveType<F>;
   /** User-land extra data to send */
   readonly extra?: any;
 }

--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -108,7 +108,14 @@ export default abstract class SimpleRecord {
 
   static normalize<T extends typeof SimpleRecord>(
     this: T,
-    ...args: any[]
+    ...args: [
+      input: any,
+      parent: any,
+      key: any,
+      visit: (...args: any) => any,
+      addEntity: (...args: any) => any,
+      visitedEntities: Record<string, any>,
+    ]
   ): NormalizedEntity<T> {
     return normalize(this.schema, ...args) as any;
   }

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -10,10 +10,11 @@ import {
   NormalizeObject,
   NormalizedNullableObject,
   UnvisitFunction,
+  EntityMap,
 } from './types';
 import { default as Delete } from './schemas/Delete';
 
-export { Delete };
+export { Delete, EntityMap };
 
 export type StrategyFunction<T> = (value: any, parent: any, key: string) => T;
 export type SchemaFunction<K = string> = (
@@ -27,7 +28,6 @@ export type SchemaAttributeFunction<S extends Schema> = (
   parent: any,
   key: string,
 ) => S;
-export type EntityMap<T = any> = Record<string, EntityInterface<T>>;
 export type { UnvisitFunction };
 export type UnionResult<Choices extends EntityMap> = {
   id: string;

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -150,3 +150,5 @@ export type NormalizedSchema<E, R> = {
   result: R;
   indexes: NormalizedIndex;
 };
+
+export type EntityMap<T = any> = Record<string, EntityInterface<T>>;

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -5,7 +5,7 @@ export type RestFetch<
   P = any,
   B = RequestInit['body'] | Record<string, any>,
   R = any
-> = (this: RestEndpoint, params: P, body?: B) => Promise<R>;
+> = (this: RestEndpoint, params?: P, body?: B) => Promise<R>;
 
 export type FetchMutate<
   P = any,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Default key takes `JSON.strigify` on full `...params`
  - Previously we were only taking the first arg to 'ignore' the body param. However, this is only valid for mutation endpoints, which aren't usable in declarative cases like useResource() that rely on `key()` in that way.
  - This will change the serialization in results list as it will include body. (only applies to standalone entities - not Resources)

This only changes endpoint definitions - rest hooks itself still need to change to support this (based on variadic types).