### PR TITLE
enhance: Make hook generics use consistent params

### DIFF
--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -1,4 +1,4 @@
-import { ReadShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
 import { NetworkError, UnknownError } from '@rest-hooks/core/types';
 import { Schema } from '@rest-hooks/endpoint';
 
@@ -18,11 +18,10 @@ type UseErrorReturn<P> = P extends null ? undefined : ErrorTypes | undefined;
 
 /** Access a resource or error if failed to get it */
 export default function useError<
-  Params extends Readonly<object>,
-  S extends Schema
+  Shape extends Pick<ReadShape<any, any>, 'getFetchKey' | 'schema' | 'options'>
 >(
-  fetchShape: Pick<ReadShape<S, Params>, 'getFetchKey' | 'schema' | 'options'>,
-  params: Params | null,
+  fetchShape: Shape,
+  params: ParamsFromShape<Shape> | null,
   cacheReady: boolean,
 ): UseErrorReturn<typeof params> {
   const meta = useMeta(fetchShape, params);

--- a/packages/core/src/react-integration/hooks/useExpiresAt.ts
+++ b/packages/core/src/react-integration/hooks/useExpiresAt.ts
@@ -1,11 +1,13 @@
-import { ReadShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
 
 import useMeta from './useMeta';
 
 /** Returns whether the data at this url is fresh or stale */
-export default function useExpiresAt<Params extends Readonly<object>>(
-  fetchShape: Pick<ReadShape<any, Params>, 'getFetchKey' | 'options'>,
-  params: Params | null,
+export default function useExpiresAt<
+  Shape extends Pick<ReadShape<any, any>, 'getFetchKey' | 'options'>
+>(
+  fetchShape: Shape,
+  params: ParamsFromShape<Shape> | null,
   entitiesExpireAt = 0,
 ): number {
   const meta = useMeta(fetchShape, params);

--- a/packages/core/src/react-integration/hooks/useInvalidateDispatcher.ts
+++ b/packages/core/src/react-integration/hooks/useInvalidateDispatcher.ts
@@ -1,22 +1,22 @@
 import { useContext, useCallback } from 'react';
-import { ReadShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
 import { Schema } from '@rest-hooks/endpoint';
 import { DispatchContext } from '@rest-hooks/core/react-integration/context';
 import { INVALIDATE_TYPE } from '@rest-hooks/core/actionTypes';
 
 /** Invalidate a certain item within the cache */
 export default function useInvalidateDispatcher(): <
-  Params extends Readonly<object>
+  Shape extends ReadShape<any, any>
 >(
-  fetchShape: ReadShape<Schema, Params>,
-  params: Params,
+  fetchShape: Shape,
+  params: ParamsFromShape<Shape>,
 ) => void {
   const dispatch = useContext(DispatchContext);
 
   const invalidateDispatcher = useCallback(
-    <Params extends Readonly<object>>(
-      fetchShape: ReadShape<Schema, Params>,
-      params: Params,
+    <Shape extends ReadShape<any, any>>(
+      fetchShape: Shape,
+      params: ParamsFromShape<Shape>,
     ) => {
       dispatch({
         type: INVALIDATE_TYPE,

--- a/packages/core/src/react-integration/hooks/useInvalidator.ts
+++ b/packages/core/src/react-integration/hooks/useInvalidator.ts
@@ -1,14 +1,13 @@
 import { useCallback, useRef } from 'react';
-import { ReadShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
 import { Schema } from '@rest-hooks/endpoint';
 
 import useInvalidateDispatcher from './useInvalidateDispatcher';
 
 /** Invalidate a certain item within the cache */
-export default function useInvalidator<
-  Params extends Readonly<object>,
-  S extends Schema
->(fetchShape: ReadShape<S, Params>): (params: Params | null) => void {
+export default function useInvalidator<Shape extends ReadShape<any, any>>(
+  fetchShape: Shape,
+): (params: ParamsFromShape<Shape> | null) => void {
   const dispatch = useInvalidateDispatcher();
   const fetchShapeRef = useRef(fetchShape);
   fetchShapeRef.current = fetchShape;

--- a/packages/core/src/react-integration/hooks/useMeta.ts
+++ b/packages/core/src/react-integration/hooks/useMeta.ts
@@ -4,10 +4,9 @@ import { selectMeta } from '@rest-hooks/core/state/selectors';
 import { useContext, useMemo } from 'react';
 
 /** Gets meta for a fetch key. */
-export default function useMeta<Params extends Readonly<object>>(
-  { getFetchKey }: Pick<FetchShape<any, any, Params>, 'getFetchKey'>,
-  params: Params | null,
-) {
+export default function useMeta<
+  Shape extends Pick<FetchShape<any, any>, 'getFetchKey'>
+>({ getFetchKey }: Shape, params: FetchShape<Shape> | null) {
   const state = useContext(StateContext);
   const key = params ? getFetchKey(params) : '';
 

--- a/packages/core/src/react-integration/hooks/useSubscription.ts
+++ b/packages/core/src/react-integration/hooks/useSubscription.ts
@@ -1,14 +1,13 @@
 import { DispatchContext } from '@rest-hooks/core/react-integration/context';
-import { ReadShape } from '@rest-hooks/core/endpoint';
-import { Schema } from '@rest-hooks/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
 import { SUBSCRIBE_TYPE, UNSUBSCRIBE_TYPE } from '@rest-hooks/core/actionTypes';
 import { useContext, useEffect, useRef } from 'react';
 
 /** Keeps a resource fresh by subscribing to updates. */
-export default function useSubscription<
-  Params extends Readonly<object>,
-  S extends Schema
->(fetchShape: ReadShape<S, Params>, params: Params | null) {
+export default function useSubscription<Shape extends ReadShape<any, any>>(
+  fetchShape: Shape,
+  params: ParamsFromShape<Shape> | null,
+) {
   const dispatch = useContext(DispatchContext);
   /*
   we just want the current values when we dispatch, so


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Consistency means less to read and more robustness

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Use the strongly validated pattern from [useCache](https://resthooks.io/docs/api/useCache)