### PR TITLE
fix: Delete should only be triggered on finding DELETE symbol

### DIFF
--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
@@ -53,6 +53,30 @@ IndexedUserResource {
 }
 `;
 
+exports[`makeCacheProvider => <Provider /> should passthrough union with unexpected schema attribute 1`] = `
+Array [
+  Array [
+    "Schema attribute \\"another\\" is not expected.
+Expected one of: \\"first\\", \\"second\\"
+
+Value: {
+  \\"id\\": \\"5\\",
+  \\"body\\": \\"hi\\",
+  \\"type\\": \\"another\\"
+}",
+  ],
+  Array [
+    "Schema attribute undefined is not expected.
+Expected one of: \\"first\\", \\"second\\"
+
+Value: {
+  \\"id\\": \\"5\\",
+  \\"body\\": \\"hi\\"
+}",
+  ],
+]
+`;
+
 exports[`makeCacheProvider => <Provider /> should resolve useResource() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
@@ -167,6 +191,30 @@ IndexedUserResource {
   "isAdmin": false,
   "username": "charlie",
 }
+`;
+
+exports[`makeExternal => <Provider /> should passthrough union with unexpected schema attribute 1`] = `
+Array [
+  Array [
+    "Schema attribute \\"another\\" is not expected.
+Expected one of: \\"first\\", \\"second\\"
+
+Value: {
+  \\"id\\": \\"5\\",
+  \\"body\\": \\"hi\\",
+  \\"type\\": \\"another\\"
+}",
+  ],
+  Array [
+    "Schema attribute undefined is not expected.
+Expected one of: \\"first\\", \\"second\\"
+
+Value: {
+  \\"id\\": \\"5\\",
+  \\"body\\": \\"hi\\"
+}",
+  ],
+]
 `;
 
 exports[`makeExternal => <Provider /> should resolve useResource() with SimpleRecords 1`] = `

--- a/packages/normalizr/src/schemas/Polymorphic.js
+++ b/packages/normalizr/src/schemas/Polymorphic.js
@@ -35,6 +35,21 @@ export default class PolymorphicSchema {
   normalizeValue(value, parent, key, visit, addEntity, visitedEntities) {
     const schema = this.inferSchema(value, parent, key);
     if (!schema) {
+      if (process.env.NODE_ENV !== 'production') {
+        const attr = this.getSchemaAttribute(value, parent, key);
+        console.warn(
+          `Schema attribute ${JSON.stringify(
+            attr,
+            undefined,
+            2,
+          )} is not expected.
+Expected one of: ${Object.keys(this.schema)
+            .map(k => `"${k}"`)
+            .join(', ')}
+
+Value: ${JSON.stringify(value, undefined, 2)}`,
+        );
+      }
       return value;
     }
     const normalizedValue = visit(
@@ -61,7 +76,7 @@ export default class PolymorphicSchema {
     }
     const schemaKey = isImmutable(value) ? value.get('schema') : value.schema;
     if (!this.isSingleSchema && !schemaKey) {
-      return [value, true, true];
+      return [value, true, false];
     }
     const id = this.isSingleSchema
       ? undefined

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -971,6 +971,31 @@ Array [
   ],
   Array [
     Object {
+      "id": "789",
+      "name": "fido",
+    },
+    Array [
+      Object {
+        "id": "123",
+        "type": "Cat",
+      },
+      Object {
+        "id": "123",
+        "type": "people",
+      },
+      Object {
+        "id": "789",
+        "name": "fido",
+      },
+      Object {
+        "id": "456",
+        "type": "Cat",
+      },
+    ],
+    undefined,
+  ],
+  Array [
+    Object {
       "id": "456",
       "type": "Cat",
     },

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -102,7 +102,7 @@ Array [
     "id": "1",
   },
   true,
-  true,
+  false,
 ]
 `;
 
@@ -112,7 +112,7 @@ Array [
     "id": "1",
   },
   true,
-  true,
+  false,
 ]
 `;
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Deletes have special behavior and should never trigger when something else is awry.
