### PR TITLE
feat: Add error state to useLoading()

### DIFF
--- a/docs/api/useLoading.md
+++ b/docs/api/useLoading.md
@@ -15,7 +15,7 @@ Helps track loading state of imperative async functions.
 import { useLoading } from '@rest-hooks/hooks';
 
 function Button({ onClick, children, ...props }) {
-  const [clickHandler, loading] = useLoading(onClick);
+  const [clickHandler, loading, error] = useLoading(onClick);
   return (
     <button onClick={clickHandler} {...props}>
       {loading ? 'Loading...' : children}
@@ -48,7 +48,7 @@ function TodoListItem({ todo }) {
     [partialUpdate],
   );
 
-  const [toggleHandler, loading] = useLoading(toggle);
+  const [toggleHandler, loading, error] = useLoading(toggle);
 
   return (
     <div>
@@ -58,6 +58,7 @@ function TodoListItem({ todo }) {
         onChange={toggleHandler}
       />
       {loading ? <Spinner /> : null}
+      {error ? <Error>{error}</Error> : null}
       {todo.title}
     </div>
   );

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -38,7 +38,7 @@ Helps track loading state of imperative async functions.
 
 ```tsx
 function Button({ onClick, children, ...props }) {
-  const [clickHandler, loading] = useLoading(onClick);
+  const [clickHandler, loading, error] = useLoading(onClick);
   return (
     <button onClick={clickHandler} {...props}>
       {loading ? 'Loading...' : children}

--- a/packages/hooks/src/__tests__/useLoading.ts
+++ b/packages/hooks/src/__tests__/useLoading.ts
@@ -101,6 +101,7 @@ describe('useLoading()', () => {
     });
     await waitForNextUpdate();
     expect(result.current[1]).toBe(false);
+    expect(result.current[2]).toBeDefined();
     expect(errcb).toHaveBeenCalledWith(error);
     expect(rejectedError).toBe(error);
     // maintain referential equality
@@ -132,6 +133,8 @@ describe('useLoading()', () => {
     await waitForNextUpdate();
     expect(result.current[1]).toBe(false);
     expect(rejectedError).toBe(error);
+    expect(result.current[2]).toBeDefined();
+    expect(result.current[2]).toBe(error);
     // maintain referential equality
     expect(result.current[0]).toBe(wrappedFunc);
   });

--- a/packages/hooks/src/useLoading.ts
+++ b/packages/hooks/src/useLoading.ts
@@ -15,11 +15,12 @@ import { useEffect, useState, useRef, useCallback } from 'react';
  *   );
  * }
  */
-export default function useLoading<F extends (...args: any) => Promise<any>>(
-  func: F,
-  onError?: (error: Error) => void,
-): [F, boolean] {
+export default function useLoading<
+  F extends (...args: any) => Promise<any>,
+  E extends Error
+>(func: F, onError?: (error: E) => void): [F, boolean, E | undefined] {
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<undefined | E>(undefined);
   const isMountedRef = useRef(true);
   useEffect(
     () => () => {
@@ -35,6 +36,7 @@ export default function useLoading<F extends (...args: any) => Promise<any>>(
         ret = await func(...args);
       } catch (e) {
         if (onError) onError(e);
+        setError(e);
         throw e;
       } finally {
         if (isMountedRef.current) {
@@ -45,5 +47,5 @@ export default function useLoading<F extends (...args: any) => Promise<any>>(
     },
     [onError, func],
   );
-  return [wrappedFunc as any, loading];
+  return [wrappedFunc as any, loading, error];
 }

--- a/website/versioned_docs/version-5.0/api/useLoading.md
+++ b/website/versioned_docs/version-5.0/api/useLoading.md
@@ -17,7 +17,7 @@ Helps track loading state of imperative async functions.
 import { useLoading } from '@rest-hooks/hooks';
 
 function Button({ onClick, children, ...props }) {
-  const [clickHandler, loading] = useLoading(onClick);
+  const [clickHandler, loading, error] = useLoading(onClick);
   return (
     <button onClick={clickHandler} {...props}>
       {loading ? 'Loading...' : children}
@@ -50,7 +50,7 @@ function TodoListItem({ todo }) {
     [partialUpdate],
   );
 
-  const [toggleHandler, loading] = useLoading(toggle);
+  const [toggleHandler, loading, error] = useLoading(toggle);
 
   return (
     <div>
@@ -60,6 +60,7 @@ function TodoListItem({ todo }) {
         onChange={toggleHandler}
       />
       {loading ? <Spinner /> : null}
+      {error ? <Error>{error}</Error> : null}
       {todo.title}
     </div>
   );


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
More convenience

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Adding as third arg makes it back-compat, while still allowing optional partial usage. Loading will almost always be used, but error less often.