### PR TITLE
internal: Dependabot tracking info for normalizr redux example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,13 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "internal: "
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/packages/normalizr/examples/redux"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "internal: "


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Dependabot needs to format commits correctly or CI breaks
