### PR TITLE
enhance: Remove dependency on fromJS() from denormalize

### DIFF
--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -274,13 +274,18 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     // note: iteration order must be stable
     Object.keys(this.schema).forEach(key => {
       const schema = this.schema[key];
-      const nextInput = key in input ? input[key] : undefined;
+      const nextInput = Object.hasOwnProperty.call(input, key)
+        ? input[key]
+        : undefined;
       const [value, , deletedItem] = unvisit(nextInput, schema);
 
-      if (deletedItem && !(key in instance && !instance[key])) {
+      if (
+        deletedItem &&
+        !(Object.hasOwnProperty.call(input, key) && !instance[key])
+      ) {
         deleted = true;
       }
-      if (key in input && input[key] !== value) {
+      if (Object.hasOwnProperty.call(input, key) && input[key] !== value) {
         entityCopy[key] = value;
       }
     });

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -242,9 +242,21 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
 
   static denormalize<T extends typeof SimpleRecord>(
     this: T,
-    input: AbstractInstanceType<T>,
+    input: Readonly<Partial<AbstractInstanceType<T>>>,
     unvisit: schema.UnvisitFunction,
   ): [AbstractInstanceType<T>, boolean, boolean] {
+    // TODO: remove immutable case once we stop storing instances in normalized cache
+    const entityCopy: AbstractInstanceType<T> = isImmutable(input)
+      ? (input as any)
+      : this.fromJS(
+          input instanceof SimpleRecord
+            ? this.toObjectDefined(input as any)
+            : input,
+        );
+    // Need to set this first so that if it is referenced further within the
+    // denormalization the reference will already exist.
+    unvisit.setLocal?.(entityCopy);
+
     // TODO: this entire function is redundant with SimpleRecord, however right now we're storing the Entity instance
     // itself in cache. Once we offer full memoization, we will store raw objects and this can be consolidated with SimpleRecord
     if (isImmutable(input)) {
@@ -258,25 +270,22 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     // TODO: This creates unneeded memory pressure
     const instance = new (this as any)();
     let deleted = false;
-    const denormEntity = input;
 
     // note: iteration order must be stable
     Object.keys(this.schema).forEach(key => {
       const schema = this.schema[key];
-      const nextInput = this.hasDefined(input, key as any)
-        ? input[key]
-        : undefined;
+      const nextInput = key in input ? input[key] : undefined;
       const [value, , deletedItem] = unvisit(nextInput, schema);
 
       if (deletedItem && !(key in instance && !instance[key])) {
         deleted = true;
       }
-      if (this.hasDefined(input, key as any) && denormEntity[key] !== value) {
-        denormEntity[key] = value;
+      if (key in input && input[key] !== value) {
+        entityCopy[key] = value;
       }
     });
 
-    return [denormEntity as any, true, deleted];
+    return [entityCopy, true, deleted];
   }
 }
 

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -40,6 +40,7 @@ export interface RecordClass<T = any> extends NestedSchemaClass<T> {
 export interface UnvisitFunction {
   (input: any, schema: any): [any, boolean, boolean];
   og?: UnvisitFunction;
+  setLocal?: (entity: any) => void;
 }
 
 export interface DenormalizeCache {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Reduces interface dependency on denormalize from Entity by making Entity aware of interface requirements for denormalize.

Previously fromJS was called from denormalize when constructing entities, so the local cache could be set. This created a dependency not only on the particular construction method, but also the concept around mutability. Having denormalize mutate a seemingly immutable SimpleRecord is like giving it private access.



### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Instead, we flip the script, providing `setLocal()` callback that requires Entity implementers to call appropriately. Since copying and setting the localcache before is only required to prevent infinite loops in nesting, it seems like this knowledge is already somewhat coupled to the implementation. For instance, there is no need for FlatEntity to use this callback as it does not recurse

### Potential for breaking
Custom denormalize implementations will still work as normal - only not updating cache before nesting. The only case where they could break is where an implementation does nesting. However, this is unlikely to be the case while also not calling super. Also note this has no impact on legacy Resource from `rest-hooks` as that extends from FlatEntity.