### PR TITLE
enhance: Simplify normalize addEntity function

### DIFF
--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -543,16 +543,5 @@ Array [
     },
     undefined,
   ],
-  Array [
-    Recommendations {
-      "user": "456",
-    },
-    Object {
-      "user": Object {
-        "id": "456",
-      },
-    },
-    undefined,
-  ],
 ]
 `;

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -262,7 +262,7 @@ describe('normalize', () => {
             visitedEntities,
           );
         });
-        addEntity(this, entity, parent, key);
+        addEntity(this, entity, this.pk(entity));
         return {
           uuid: this.pk(entity),
           schema: this.key,

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -236,7 +236,7 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
       }
     });
 
-    addEntity(this, processedEntity, processedEntity, parent, key);
+    addEntity(this, processedEntity, id);
     return id;
   }
 

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -54,9 +54,8 @@ const addEntities =
     existingEntities: Record<string, any>,
     existingIndexes: any,
   ) =>
-  (schema: any, processedEntity: any, value: any, parent: any, key: string) => {
+  (schema: any, processedEntity: any, id: any) => {
     const schemaKey = schema.key;
-    const id = schema.pk(value, parent, key);
     if (!(schemaKey in entities)) {
       entities[schemaKey] = {};
     }

--- a/packages/normalizr/src/schemas/Delete.ts
+++ b/packages/normalizr/src/schemas/Delete.ts
@@ -47,7 +47,7 @@ export default class Delete<E extends EntityInterface & { fromJS: any }>
       (error as any).status = 400;
       throw error;
     }
-    addEntity(this._entity, DELETED, processedEntity, parent, key);
+    addEntity(this._entity, DELETED, id);
     return id;
   }
 


### PR DESCRIPTION
BREAKING CHANGE: normalize arg addEntity is now addEntity(schema,
processed, id)

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- minimize interfaces
- slight performance win

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
The only reason all props are sent are to call pk(), which already happens - so just pass that on instead.

This will only affect those who override the entity normalize method