### PR TITLE
feat: New Entity that normalizes to pojos

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,7 @@ const baseConfig = {
     'node_modules',
     'react-integration/hooks/useSelection',
     'packages/test',
+    'packages/experimental',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   moduleNameMapper: {

--- a/packages/experimental/src/entity/Entity.ts
+++ b/packages/experimental/src/entity/Entity.ts
@@ -1,0 +1,356 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { schema } from '@rest-hooks/endpoint';
+import type { AbstractInstanceType, Schema } from '@rest-hooks/endpoint';
+
+import { isImmutable, denormalizeImmutable } from './ImmutableUtils';
+
+/** Represents data that should be deduped by specifying a primary key. */
+export default abstract class Entity {
+  static toJSON() {
+    return {
+      name: this.name,
+      schema: this.schema,
+      key: this.key,
+    };
+  }
+
+  /** Defines nested entities */
+  static schema: { [k: string]: Schema } = {};
+
+  /**
+   * A unique identifier for each Entity
+   *
+   * @param [parent] When normalizing, the object which included the entity
+   * @param [key] When normalizing, the key where this entity was found
+   */
+  abstract pk(parent?: any, key?: string): string | undefined;
+
+  /** Returns the globally unique identifier for the static Entity */
+  static get key(): string {
+    /* istanbul ignore next */
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      (this.name === '' || this.name === 'Entity')
+    )
+      throw new Error(
+        'Entity classes without a name must define `static get key()`',
+      );
+    return this.name;
+  }
+
+  /** Defines indexes to enable lookup by */
+  declare static indexes?: readonly string[];
+
+  /** Control how automatic schema validation is handled
+   *
+   * `undefined`: Defaults - throw error in worst offense
+   * 'warn': only ever warn
+   * 'silent': Don't bother with processing at all
+   *
+   * Note: this only applies to non-nested members.
+   */
+  protected declare static automaticValidation?: 'warn' | 'silent';
+
+  /**
+   * A unique identifier for each Entity
+   *
+   * @param [value] POJO of the entity or subset used
+   * @param [parent] When normalizing, the object which included the entity
+   * @param [key] When normalizing, the key where this entity was found
+   */
+  static pk<T extends typeof Entity>(
+    this: T,
+    value: Partial<AbstractInstanceType<T>>,
+    parent?: any,
+    key?: string,
+  ): string | undefined {
+    return this.prototype.pk.call(value, parent, key) || key;
+  }
+
+  /** Creates new instance copying over defined values of arguments */
+  static merge<T extends typeof Entity>(
+    this: T,
+    existing: Partial<AbstractInstanceType<T>>,
+    incoming: Partial<AbstractInstanceType<T>>,
+  ) {
+    return Object.assign(existing, incoming);
+  }
+
+  /** Factory method to convert from Plain JS Objects.
+   *
+   * @param [props] Plain Object of properties to assign.
+   * @param [parent] When normalizing, the object which included the record
+   * @param [key] When normalizing, the key where this record was found
+   */
+  static fromJS<T extends typeof Entity>(
+    this: T,
+    // TODO: this should only accept members that are not functions
+    props: Partial<AbstractInstanceType<T>> = {},
+  ): AbstractInstanceType<T> {
+    // we type guarded abstract case above, so ok to force typescript to allow constructor call
+    const instance = new (this as any)(props) as AbstractInstanceType<T>;
+    // we can't rely on constructors and override the defaults provided as property assignments
+    // all occur after the constructor
+    Object.assign(instance, props);
+    return instance;
+  }
+
+  /** Do any transformations when first receiving input */
+  static process(input: any, parent: any, key: string | undefined): any {
+    return input;
+  }
+
+  static normalize(
+    input: any,
+    parent: any,
+    key: string | undefined,
+    visit: (...args: any) => any,
+    addEntity: (...args: any) => any,
+    visitedEntities: Record<string, any>,
+  ): any {
+    // pass over already processed entities
+    if (typeof input === 'string') return input;
+    const processedEntity = this.process(input, parent, key);
+    /* istanbul ignore else */
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      this.automaticValidation !== 'silent'
+    ) {
+      const instanceSample = new (this as any)();
+      const keysOfRecord = new Set(Object.keys(instanceSample));
+      const keysOfProps = Object.keys(processedEntity);
+      const [found, missing, unexpected] = [[], [], []] as [
+        string[],
+        string[],
+        string[],
+      ];
+      for (const keyOfProps of keysOfProps) {
+        if (keysOfRecord.has(keyOfProps)) {
+          found.push(keyOfProps);
+        } else {
+          unexpected.push(keyOfProps);
+        }
+      }
+      for (const keyOfRecord of keysOfRecord) {
+        if (!found.includes(keyOfRecord)) {
+          missing.push(keyOfRecord);
+        }
+      }
+
+      // only bother with this if they used *any* defaults
+      if (keysOfRecord.size) {
+        if (Array.isArray(processedEntity) && unexpected.length) {
+          const errorMessage = `Attempted to initialize ${
+            this.name
+          } with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+Missing: ${missing}
+First three members: ${JSON.stringify(processedEntity.slice(0, 3), null, 2)}`;
+          if (this.automaticValidation !== 'warn') {
+            const error = new Error(errorMessage);
+            (error as any).status = 400;
+            throw error;
+          }
+          console.warn(errorMessage);
+        }
+
+        const tooManyUnexpected =
+          // unexpected compared to members in response
+          Math.max(keysOfProps.length / 2, 1) <= unexpected.length &&
+          // unexpected compared to what we specified
+          keysOfRecord.size > Math.max(unexpected.length, 2) &&
+          // as we find more and more be more easily assured it is correct
+          found.length ** 1.5 / 2 <= unexpected.length;
+        const foundNothing = found.length < Math.min(1, keysOfRecord.size / 2);
+        // if we find nothing (we expect at least one member for a pk)
+        // or we find too many unexpected members
+        if (tooManyUnexpected || foundNothing) {
+          let extra = '';
+          let reason = 'substantially different than expected keys';
+          if (foundNothing) {
+            extra += `\n    Missing: ${missing}`;
+            reason = 'no matching keys found';
+          }
+          if (tooManyUnexpected) {
+            extra += `\n    Unexpected keys: ${unexpected}`;
+            reason = 'a large number of unexpected keys found';
+          }
+          const errorMessage = `Attempted to initialize ${
+            this.name
+          } with ${reason}
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: ${found}${extra}
+  Value (processed): ${JSON.stringify(processedEntity, null, 2)}`;
+          if (
+            (found.length >= 4 && tooManyUnexpected) ||
+            this.automaticValidation === 'warn'
+          ) {
+            console.warn(errorMessage);
+          } else {
+            const error = new Error(errorMessage);
+            (error as any).status = 400;
+            throw error;
+          }
+        }
+      }
+    }
+    const id = this.pk(processedEntity, parent, key);
+    if (id === undefined || id === '') {
+      if (process.env.NODE_ENV !== 'production') {
+        const error = new Error(
+          `Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+
+  Entity: ${this.name}
+  Value (processed): ${
+    processedEntity && JSON.stringify(processedEntity, null, 2)
+  }
+  `,
+        );
+        (error as any).status = 400;
+        throw error;
+      } else {
+        // these make the keys get deleted
+        return undefined;
+      }
+    }
+    const entityType = this.key;
+
+    if (!(entityType in visitedEntities)) {
+      visitedEntities[entityType] = {};
+    }
+    if (!(id in visitedEntities[entityType])) {
+      visitedEntities[entityType][id] = [];
+    }
+    if (
+      visitedEntities[entityType][id].some((entity: any) => entity === input)
+    ) {
+      return id;
+    }
+    visitedEntities[entityType][id].push(input);
+
+    Object.keys(this.schema).forEach(key => {
+      if (Object.hasOwnProperty.call(processedEntity, key)) {
+        const schema = this.schema[key];
+        processedEntity[key] = visit(
+          processedEntity[key],
+          processedEntity,
+          key,
+          schema,
+          addEntity,
+          visitedEntities,
+        );
+      } else if (process.env.NODE_ENV !== 'production') {
+        const instanceSample = new (this as any)();
+        if (!Object.hasOwnProperty.call(instanceSample, key)) {
+          const error = new Error(
+            `Schema key is missing in Entity
+
+  Be sure all schema members are also part of the entity
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about nesting schemas: https://resthooks.io/docs/guides/nested-response
+
+  Entity keys: ${Object.keys(instanceSample)}
+  Schema key(missing): ${key}
+  `,
+          );
+          (error as any).status = 400;
+          throw error;
+        }
+      }
+    });
+
+    addEntity(this, processedEntity, id);
+    return id;
+  }
+
+  static denormalize<T extends typeof Entity>(
+    this: T,
+    input: Readonly<Partial<AbstractInstanceType<T>>>,
+    unvisit: schema.UnvisitFunction,
+  ): [AbstractInstanceType<T>, boolean, boolean] {
+    if (isImmutable(input)) {
+      // Need to set this first so that if it is referenced further within the
+      // denormalization the reference will already exist.
+      unvisit.setLocal?.(input);
+      const [denormEntity, found, deleted] = denormalizeImmutable(
+        this.schema,
+        input,
+        unvisit,
+      );
+      return [this.fromJS(denormEntity.toObject()), found, deleted];
+    }
+    const entityCopy: any = this.fromJS(input);
+    // Need to set this first so that if it is referenced further within the
+    // denormalization the reference will already exist.
+    unvisit.setLocal?.(entityCopy);
+
+    // TODO: This creates unneeded memory pressure
+    const instance = new (this as any)();
+    let deleted = false;
+
+    // note: iteration order must be stable
+    Object.keys(this.schema).forEach(key => {
+      const schema = this.schema[key];
+      const nextInput = Object.hasOwnProperty.call(input, key)
+        ? (input as any)[key]
+        : undefined;
+      const [value, , deletedItem] = unvisit(nextInput, schema);
+
+      if (
+        deletedItem &&
+        !(Object.hasOwnProperty.call(input, key) && !instance[key])
+      ) {
+        deleted = true;
+      }
+      if (
+        Object.hasOwnProperty.call(input, key) &&
+        (input as any)[key] !== value
+      ) {
+        this.set(entityCopy, key, value);
+      }
+    });
+
+    return [entityCopy, true, deleted];
+  }
+
+  /** Used by denormalize to set nested members */
+  protected static set(entity: any, key: string, value: any) {
+    entity[key] = value;
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  const superFrom = Entity.fromJS;
+  // for those not using TypeScript this is a good catch to ensure they are defining
+  // the abstract members
+  Entity.fromJS = function fromJS<T extends typeof Entity>(
+    this: T,
+    props: Partial<AbstractInstanceType<T>>,
+  ): AbstractInstanceType<T> {
+    if ((this as any).prototype.pk === undefined)
+      throw new Error('cannot construct on abstract types');
+    return superFrom.call(this, props) as any;
+  };
+}
+
+export function isEntity(schema: Schema): schema is typeof Entity {
+  return schema !== null && (schema as any).pk !== undefined;
+}

--- a/packages/experimental/src/entity/EntityRecord.ts
+++ b/packages/experimental/src/entity/EntityRecord.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import type { AbstractInstanceType } from '@rest-hooks/endpoint';
+
+import Entity from './Entity';
+
+export { isEntity } from './Entity';
+
+const DefinedMembersKey = Symbol('Defined Members');
+const UniqueIdentifierKey = Symbol('unq');
+type Filter<T, U> = T extends U ? T : never;
+interface SimpleResourceMembers<T extends typeof EntityRecord> {
+  [DefinedMembersKey]: Partial<AbstractInstanceType<T>>;
+}
+
+/** Immutable record that keeps track of which members are defined vs defaults. */
+export default abstract class EntityRecord extends Entity {
+  private declare [DefinedMembersKey]: Record<string, any>;
+
+  toString(): string {
+    // we don't make _unq a member so it doesn't play a role in type compatibility
+    return (this as any)[UniqueIdentifierKey];
+  }
+
+  /** Factory method to convert from Plain JS Objects.
+   *
+   * @param [props] Plain Object of properties to assign.
+   * @param [parent] When normalizing, the object which included the record
+   * @param [key] When normalizing, the key where this record was found
+   */
+  static fromJS<T extends typeof Entity>(
+    this: T,
+    // TODO: this should only accept members that are not functions
+    props: Partial<AbstractInstanceType<T>> = {},
+  ): AbstractInstanceType<T> {
+    if (props instanceof EntityRecord) {
+      props = (props.constructor as any).toObjectDefined(props);
+    }
+    const instance: any = super.fromJS(props);
+
+    Object.defineProperty(instance, DefinedMembersKey, {
+      value: props,
+      writable: false,
+    });
+
+    // a 'unique' identifier to make referential equality comparisons easy
+    Object.defineProperty(instance, UniqueIdentifierKey, {
+      value: `${Math.random()}`,
+      writable: false,
+    });
+
+    return instance;
+  }
+
+  /** Creates new instance copying over defined values of arguments */
+  static mergeRecord<T extends typeof Entity>(
+    this: T,
+    existing: AbstractInstanceType<T>,
+    incoming: AbstractInstanceType<T>,
+  ) {
+    const props = Object.assign(
+      (this as any).toObjectDefined(existing),
+      (this as any).toObjectDefined(incoming),
+    );
+    return this.fromJS(props);
+  }
+
+  /** Whether key is non-default */
+  static hasDefined<T extends typeof EntityRecord>(
+    this: T,
+    instance: AbstractInstanceType<T>,
+    key: Filter<keyof AbstractInstanceType<T>, string>,
+  ) {
+    return Object.hasOwnProperty.call(
+      (instance as any as SimpleResourceMembers<T>)[DefinedMembersKey],
+      key,
+    );
+  }
+
+  /** Returns simple object with all the non-default members */
+  static toObjectDefined<T extends typeof EntityRecord>(
+    this: T,
+    instance: AbstractInstanceType<T>,
+  ) {
+    return (instance as any as SimpleResourceMembers<T>)[DefinedMembersKey];
+  }
+
+  /** Returns array of all keys that have values defined in instance */
+  static keysDefined<T extends typeof EntityRecord>(
+    this: T,
+    instance: AbstractInstanceType<T>,
+  ): Filter<keyof AbstractInstanceType<T>, string>[] {
+    return Object.keys(
+      (instance as any as SimpleResourceMembers<T>)[DefinedMembersKey],
+    ) as any;
+  }
+
+  /** Used by denormalize to set nested members */
+  protected static set(entity: any, key: string, value: any) {
+    entity[key] = value;
+    entity[DefinedMembersKey][key] = value;
+  }
+}

--- a/packages/experimental/src/entity/IDEntity.ts
+++ b/packages/experimental/src/entity/IDEntity.ts
@@ -1,0 +1,16 @@
+import Entity from './Entity';
+
+/** Represents data with primary key being from 'id' field. */
+export default class IDEntity extends Entity {
+  readonly id: string | number | undefined = undefined;
+
+  /**
+   * A unique identifier for each Entity
+   *
+   * @param [parent] When normalizing, the object which included the entity
+   * @param [key] When normalizing, the key where this entity was found
+   */
+  pk(parent?: any, key?: string): string | undefined {
+    return `${this.id}`;
+  }
+}

--- a/packages/experimental/src/entity/ImmutableUtils.ts
+++ b/packages/experimental/src/entity/ImmutableUtils.ts
@@ -1,0 +1,58 @@
+/**
+ * Exact copy of the version in normalizr
+ */
+
+/**
+ * Check if an object is immutable by checking if it has a key specific
+ * to the immutable library.
+ *
+ * @param  {any} object
+ * @return {bool}
+ */
+export function isImmutable(object: any) {
+  return !!(
+    object &&
+    typeof object.hasOwnProperty === 'function' &&
+    (Object.hasOwnProperty.call(object, '__ownerID') || // Immutable.Map
+      (object._map && Object.hasOwnProperty.call(object._map, '__ownerID')))
+  ); // Immutable.Record
+}
+
+/**
+ * Denormalize an immutable entity.
+ *
+ * @param  {Schema} schema
+ * @param  {Immutable.Map|Immutable.Record} input
+ * @param  {function} unvisit
+ * @param  {function} getDenormalizedEntity
+ * @return {Immutable.Map|Immutable.Record}
+ */
+export function denormalizeImmutable(schema: any, input: any, unvisit: any) {
+  let found = true;
+  let deleted = false;
+  return [
+    Object.keys(schema).reduce((object, key) => {
+      // Immutable maps cast keys to strings on write so we need to ensure
+      // we're accessing them using string keys.
+      const stringKey = `${key}`;
+
+      const [item, foundItem, deletedItem] = unvisit(
+        object.get(stringKey),
+        schema[stringKey],
+      );
+      if (!foundItem) {
+        found = false;
+      }
+      if (deletedItem) {
+        deleted = true;
+      }
+      if (object.has(stringKey)) {
+        return object.set(stringKey, item);
+      } else {
+        return object;
+      }
+    }, input),
+    found,
+    deleted,
+  ];
+}

--- a/packages/experimental/src/entity/__tests__/NewEntity.test.ts
+++ b/packages/experimental/src/entity/__tests__/NewEntity.test.ts
@@ -1,0 +1,990 @@
+// eslint-env jest
+import { fromJS, Record } from 'immutable';
+import {
+  denormalize,
+  normalize,
+  schema,
+  AbstractInstanceType,
+  DELETED,
+  WeakListMap,
+} from '@rest-hooks/normalizr';
+
+import Entity from '../Entity';
+import IDEntity from '../IDEntity';
+
+const values = <T extends Record<string, any>>(obj: T) =>
+  Object.keys(obj).map(key => obj[key]);
+
+class Tacos extends IDEntity {
+  readonly name: string = '';
+  readonly alias: string | undefined = undefined;
+}
+
+class ArticleEntity extends Entity {
+  readonly id: string = '';
+  readonly title: string = '';
+  readonly author: string = '';
+  readonly content: string = '';
+  pk() {
+    return this.id;
+  }
+}
+
+class WithOptional extends Entity {
+  readonly id: string = '';
+  readonly article: ArticleEntity | null = null;
+  readonly requiredArticle = ArticleEntity.fromJS();
+  readonly nextPage: string = '';
+
+  pk() {
+    return this.id;
+  }
+
+  static schema = {
+    article: ArticleEntity,
+    requiredArticle: ArticleEntity,
+  };
+}
+
+describe(`${Entity.name} normalization`, () => {
+  const originalWarn = console.warn;
+  afterEach(() => {
+    console.warn = originalWarn;
+    consoleOutput = [];
+  });
+  let consoleOutput: string[] = [];
+  const mockedWarn = (output: string) => {
+    consoleOutput.push(output);
+  };
+  beforeEach(() => (console.warn = mockedWarn));
+
+  test('normalizes an entity', () => {
+    class MyEntity extends IDEntity {}
+    expect(normalize({ id: '1' }, MyEntity)).toMatchSnapshot();
+  });
+
+  it('should throw a custom error if data does not include pk', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ secondthing: 'hi' }, schema);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw a custom error if schema key is missing from Entity', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      pk() {
+        return this.name;
+      }
+
+      static schema = {
+        blarb: Date,
+      };
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ name: 'bob', secondthing: 'hi' }, schema);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw a custom error if data loads with no matching props', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({}, schema);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should throw a custom error loads with array', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize(
+        [
+          { name: 'hi', secondthing: 'ho' },
+          { name: 'hi', secondthing: 'ho' },
+          { name: 'hi', secondthing: 'ho' },
+        ],
+        schema,
+      );
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should warn when automaticValidation === "warn"', () => {
+    class MyEntity extends Entity {
+      readonly '0': string = '';
+      readonly secondthing: string = '';
+      static automaticValidation = 'warn' as const;
+      pk() {
+        return this[0];
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize(
+        [
+          { name: 'hi', secondthing: 'ho' },
+          { name: 'hi', secondthing: 'ho' },
+          { name: 'hi', secondthing: 'ho' },
+        ],
+        schema,
+      );
+    }
+    expect(normalizeBad).not.toThrow();
+    expect(consoleOutput.length).toBe(1);
+    expect(consoleOutput).toMatchSnapshot();
+  });
+
+  it('should only warn if at least four members are found with unexpected', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly a: string = '';
+      readonly b: string = '';
+      readonly c: string = '';
+      readonly missinga: string = '';
+      readonly missingb: string = '';
+      readonly missingc: string = '';
+      readonly missingd: string = '';
+      readonly missinge: string = '';
+      readonly missingf: string = '';
+      readonly missingg: string = '';
+      readonly missingh: string = '';
+      readonly missingi: string = '';
+      readonly missingj: string = '';
+      readonly missingk: string = '';
+      readonly missingl: string = '';
+      readonly missingm: string = '';
+      readonly missingn: string = '';
+      readonly missingo: string = '';
+      readonly missingp: string = '';
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+
+    expect(
+      normalize(
+        {
+          name: 'hi',
+          a: 'a',
+          b: 'b',
+          c: 'c',
+          d: 'e',
+          e: 0,
+          f: 0,
+          g: 0,
+          h: 0,
+          i: 0,
+          j: 0,
+          k: 0,
+          l: 0,
+          m: 0,
+          n: 0,
+          o: 0,
+          p: 0,
+        },
+        schema,
+      ),
+    ).toMatchSnapshot();
+    expect(consoleOutput.length).toBe(1);
+    expect(consoleOutput).toMatchSnapshot();
+  });
+
+  it('should allow many unexpected as long as none are missing', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly a: string = '';
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+
+    expect(
+      normalize(
+        {
+          name: 'hi',
+          a: 'a',
+          b: 'b',
+          c: 'c',
+          d: 'e',
+          e: 0,
+          f: 0,
+          g: 0,
+          h: 0,
+          i: 0,
+          j: 0,
+          k: 0,
+          l: 0,
+          m: 0,
+          n: 0,
+          o: 0,
+          p: 0,
+          q: 0,
+          r: 0,
+          s: 0,
+          t: 0,
+          u: 0,
+        },
+        schema,
+      ),
+    ).toMatchSnapshot();
+    expect(consoleOutput.length).toBe(0);
+  });
+
+  it('should not expect getters returned', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      get other() {
+        return this.name + 5;
+      }
+
+      get another() {
+        return 'another';
+      }
+
+      get yetAnother() {
+        return 'another2';
+      }
+
+      pk() {
+        return this.name;
+      }
+    }
+    function normalizeBad() {
+      normalize({ name: 'bob' }, MyEntity);
+    }
+    expect(normalizeBad).not.toThrow();
+    expect(consoleOutput.length).toBe(0);
+  });
+
+  it('should throw if data loads with unexpected prop that is a getter', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+
+      get nonexistantthing() {
+        return this.name + 5;
+      }
+
+      pk() {
+        return this.name;
+      }
+    }
+    function normalizeBad() {
+      normalize({ name: 'hoho', nonexistantthing: 'hi' }, MyEntity);
+    }
+    expect(normalizeBad).toThrow();
+  });
+
+  it('should throw if data loads with unexpected prop that is a method', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+      readonly thirdthing2: number = 0;
+
+      nonexistantthing() {
+        return this.name + 5;
+      }
+
+      nonexistantthing2() {
+        return this.name + 5;
+      }
+
+      nonexistantthing3() {
+        return this.name + 5;
+      }
+
+      nonexistantthing4() {
+        return this.name + 5;
+      }
+
+      pk() {
+        return this.name;
+      }
+    }
+    function normalizeBad() {
+      normalize(
+        {
+          name: 'hoho',
+          nonexistantthing: 'hi',
+          nonexistantthing2: 'hi',
+          nonexistantthing3: 'hi',
+        },
+        MyEntity,
+      );
+    }
+    expect(normalizeBad).toThrow();
+  });
+
+  it('should throw a custom error if data loads with half unexpected props', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ name: 'hoho', nonexistantthing: 'hi' }, schema);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  it('should warn when automaticValidation === "warn"', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+      static automaticValidation = 'warn' as const;
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ name: 'hoho', nonexistantthing: 'hi' }, schema);
+    }
+    expect(normalizeBad).not.toThrow();
+    expect(consoleOutput.length).toBe(1);
+    expect(consoleOutput).toMatchSnapshot();
+  });
+
+  it('should do nothing when automaticValidation === "silent"', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+      static automaticValidation = 'silent' as const;
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize({ name: 'hoho', nonexistantthing: 'hi' }, schema);
+    }
+    expect(normalizeBad).not.toThrow();
+    expect(consoleOutput.length).toBe(0);
+  });
+
+  it('should throw a custom error if data loads with string', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly thirdthing: number = 0;
+      pk() {
+        return this.name;
+      }
+    }
+    const schema = MyEntity;
+    function normalizeBad() {
+      normalize('hibho', schema);
+    }
+    expect(normalizeBad).toThrowErrorMatchingSnapshot();
+  });
+
+  describe('key', () => {
+    test('must be created with a key name', () => {
+      const makeSchema = () =>
+        class extends Entity {
+          readonly id: number = 0;
+          pk() {
+            return `${this.id}`;
+          }
+        };
+      expect(() => makeSchema().key).toThrow();
+    });
+
+    test('key name must be a string', () => {
+      // @ts-expect-error
+      class MyEntity extends IDEntity {
+        static get key() {
+          return 42;
+        }
+      }
+    });
+
+    test('key getter should return key set via `static get key()`', () => {
+      class User extends IDEntity {
+        static get key() {
+          return 'user';
+        }
+      }
+      expect(User.key).toEqual('user');
+    });
+  });
+
+  describe('pk()', () => {
+    test('can use a custom pk() string', () => {
+      class User extends Entity {
+        readonly idStr: string = '';
+        readonly name: string = '';
+
+        pk() {
+          return this.idStr;
+        }
+      }
+      expect(
+        normalize({ idStr: '134351', name: 'Kathy' }, User),
+      ).toMatchSnapshot();
+    });
+
+    test('can normalize entity IDs based on their object key', () => {
+      class User extends Entity {
+        readonly name: string = '';
+        pk(parent?: any, key?: string) {
+          return key;
+        }
+      }
+      const inputSchema = new schema.Values({ users: User }, () => 'users');
+
+      expect(
+        normalize(
+          { '4': { name: 'taco' }, '56': { name: 'burrito' } },
+          inputSchema,
+        ),
+      ).toMatchSnapshot();
+    });
+
+    test("can build the entity's ID from the parent object", () => {
+      class User extends Entity {
+        readonly id: string = '';
+        readonly name: string = '';
+        pk(parent?: any, key?: string) {
+          return `${parent.name}-${key}-${this.id}`;
+        }
+      }
+      const inputSchema = new schema.Object({ user: User });
+
+      expect(
+        normalize(
+          { name: 'tacos', user: { id: '4', name: 'Jimmy' } },
+          inputSchema,
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('mergeStrategy', () => {
+    test('defaults to plain merging', () => {
+      expect(
+        normalize(
+          [
+            { id: '1', name: 'foo' },
+            { id: '1', name: 'bar', alias: 'bar' },
+          ],
+          [Tacos],
+        ),
+      ).toMatchSnapshot();
+    });
+
+    test('can use a custom merging strategy', () => {
+      class MergeTaco extends Tacos {
+        static merge<T extends typeof Entity>(
+          this: T,
+          existing: AbstractInstanceType<T>,
+          incoming: AbstractInstanceType<T>,
+        ) {
+          const props = Object.assign({}, existing, incoming, {
+            name: (existing as MergeTaco).name,
+          });
+          return this.fromJS(props);
+        }
+      }
+
+      expect(
+        normalize(
+          [
+            { id: '1', name: 'foo' },
+            { id: '1', name: 'bar', alias: 'bar' },
+          ],
+          [MergeTaco],
+        ),
+      ).toMatchSnapshot();
+    });
+  });
+});
+
+describe(`${Entity.name} denormalization`, () => {
+  test('denormalizes an entity', () => {
+    const entities = {
+      Tacos: {
+        '1': { id: '1', type: 'foo' },
+      },
+    };
+    expect(denormalize('1', Tacos, entities)).toMatchSnapshot();
+    expect(denormalize('1', Tacos, fromJS(entities))).toMatchSnapshot();
+  });
+
+  class Food extends IDEntity {}
+  class Menu extends IDEntity {
+    readonly food: Food = Food.fromJS();
+
+    static schema = { food: Food };
+  }
+
+  test('denormalizes deep entities', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: '1' },
+        '2': { id: '2' },
+      },
+      Food: {
+        '1': { id: '1' },
+      },
+    };
+
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  test('denormalizes deep entities while maintaining referntial equality', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: '1' },
+        '2': { id: '2' },
+      },
+      Food: {
+        '1': { id: '1' },
+      },
+    };
+    const entityCache = {};
+    const resultCache = new WeakListMap();
+
+    const [first] = denormalize('1', Menu, entities, entityCache, resultCache);
+    const [second] = denormalize('1', Menu, entities, entityCache, resultCache);
+    expect(first).toBe(second);
+    expect(first?.food).toBe(second?.food);
+  });
+
+  test('denormalizes to undefined for missing data', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: '2' },
+      },
+      Food: {
+        '1': { id: '1' },
+      },
+    };
+
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  test('denormalizes to undefined for deleted data', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: '2' },
+        '2': DELETED,
+      },
+      Food: {
+        '1': { id: '1' },
+        '2': DELETED,
+      },
+    };
+
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  test('denormalizes deep entities with records', () => {
+    const Food = Record({ id: null });
+    const MenuR = Record({ id: null, food: null });
+
+    const entities = {
+      Menu: {
+        '1': new MenuR({ id: '1', food: '1' }),
+        '2': new MenuR({ id: '2' }),
+      },
+      Food: {
+        '1': new Food({ id: '1' }),
+      },
+    };
+
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize('2', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  test('can denormalize already partially denormalized data', () => {
+    const entities = {
+      Menu: {
+        '1': { id: '1', food: { id: '1' } },
+      },
+      Food: {
+        '1': { id: '1' },
+      },
+    };
+
+    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
+    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  class User extends IDEntity {
+    readonly role = '';
+    readonly reports: Report[] = [];
+  }
+  class Report extends IDEntity {
+    readonly title: string = '';
+    readonly draftedBy: User = User.fromJS();
+    readonly publishedBy: User = User.fromJS();
+
+    static schema = {
+      draftedBy: User,
+      publishedBy: User,
+    };
+  }
+  User.schema = {
+    reports: [Report],
+  };
+
+  test('denormalizes recursive dependencies', () => {
+    const entities = {
+      Report: {
+        '123': {
+          id: '123',
+          title: 'Weekly report',
+          draftedBy: '456',
+          publishedBy: '456',
+        },
+      },
+      User: {
+        '456': {
+          id: '456',
+          role: 'manager',
+          reports: ['123'],
+        },
+      },
+    };
+
+    expect(denormalize('123', Report, entities)[0]).toMatchSnapshot();
+    expect(denormalize('123', Report, fromJS(entities))[0]).toMatchSnapshot();
+
+    expect(denormalize('456', User, entities)[0]).toMatchSnapshot();
+    expect(denormalize('456', User, fromJS(entities))[0]).toMatchSnapshot();
+  });
+
+  test('denormalizes entities with referential equality', () => {
+    const entities = {
+      Report: {
+        '123': {
+          id: '123',
+          title: 'Weekly report',
+          draftedBy: '456',
+          publishedBy: '456',
+        },
+      },
+      User: {
+        '456': {
+          id: '456',
+          role: 'manager',
+          reports: ['123'],
+        },
+        '457': {
+          id: '457',
+          role: 'servant',
+          reports: ['123'],
+        },
+      },
+    };
+    const entityCache: any = {};
+    const resultCache = new WeakListMap();
+
+    const [denormalizedReport] = denormalize(
+      '123',
+      Report,
+      entities,
+      entityCache,
+      resultCache,
+    );
+
+    expect(denormalizedReport).toBeDefined();
+    // This is just for TypeScript, the above line actually determines this
+    if (!denormalizedReport) throw new Error('expected to be defined');
+    expect(denormalizedReport).toBe(denormalizedReport.draftedBy?.reports[0]);
+    expect(denormalizedReport.publishedBy).toBe(denormalizedReport.draftedBy);
+    expect(denormalizedReport.draftedBy?.reports[0].draftedBy).toBe(
+      denormalizedReport.draftedBy,
+    );
+
+    const [denormalizedReport2] = denormalize(
+      '123',
+      Report,
+      entities,
+      entityCache,
+      resultCache,
+    );
+
+    expect(denormalizedReport2).toBe(denormalizedReport);
+
+    // NOTE: Given how immutable data works, referential equality can't be
+    // maintained with nested denormalization.
+  });
+
+  describe('optional entities', () => {
+    it('should be marked as found even when optional is not there', () => {
+      const [denormalized, found] = denormalize('abc', WithOptional, {
+        [WithOptional.key]: {
+          abc: WithOptional.fromJS({
+            id: 'abc',
+            // this is typed because we're actually sending wrong data to it
+            requiredArticle: '5' as any,
+            nextPage: 'blob',
+          }),
+        },
+        [ArticleEntity.key]: {
+          ['5']: ArticleEntity.fromJS({ id: '5' }),
+        },
+      });
+      expect(found).toBe(true);
+      const response = denormalized;
+      expect(response).toBeDefined();
+      expect(response).toBeInstanceOf(WithOptional);
+      expect(response).toEqual({
+        id: 'abc',
+        article: null,
+        requiredArticle: ArticleEntity.fromJS({ id: '5' }),
+        nextPage: 'blob',
+      });
+    });
+
+    it('should be marked as found when nested entity is missing', () => {
+      const [denormalized, found, deleted] = denormalize('abc', WithOptional, {
+        [WithOptional.key]: {
+          abc: WithOptional.fromJS({
+            id: 'abc',
+            // this is typed because we're actually sending wrong data to it
+            article: '5' as any,
+            nextPage: 'blob',
+          }),
+        },
+        [ArticleEntity.key]: {
+          ['5']: ArticleEntity.fromJS({ id: '5' }),
+        },
+      });
+      expect(found).toBe(true);
+      expect(deleted).toBe(false);
+      const response = denormalized;
+      expect(response).toBeDefined();
+      expect(response).toBeInstanceOf(WithOptional);
+      expect(response).toEqual({
+        id: 'abc',
+        article: ArticleEntity.fromJS({ id: '5' }),
+        requiredArticle: ArticleEntity.fromJS(),
+        nextPage: 'blob',
+      });
+    });
+
+    it('should be marked as deleted when required entity is deleted symbol', () => {
+      const [denormalized, found, deleted] = denormalize('abc', WithOptional, {
+        [WithOptional.key]: {
+          abc: WithOptional.fromJS({
+            id: 'abc',
+            // this is typed because we're actually sending wrong data to it
+            requiredArticle: '5' as any,
+            nextPage: 'blob',
+          }),
+        },
+        [ArticleEntity.key]: {
+          ['5']: DELETED,
+        },
+      });
+      expect(found).toBe(true);
+      expect(deleted).toBe(true);
+      const response = denormalized;
+      expect(response).toBeDefined();
+      expect(response).toBeInstanceOf(WithOptional);
+      expect(response).toEqual({
+        id: 'abc',
+        article: null,
+        requiredArticle: undefined,
+        nextPage: 'blob',
+      });
+    });
+
+    it('should be non-required deleted members should not result in deleted indicator', () => {
+      const [denormalized, found, deleted] = denormalize('abc', WithOptional, {
+        [WithOptional.key]: {
+          abc: WithOptional.fromJS({
+            id: 'abc',
+            // this is typed because we're actually sending wrong data to it
+            article: '5' as any,
+            requiredArticle: '6' as any,
+            nextPage: 'blob',
+          }),
+        },
+        [ArticleEntity.key]: {
+          ['5']: DELETED,
+          ['6']: ArticleEntity.fromJS({ id: '6' }),
+        },
+      });
+      expect(found).toBe(true);
+      expect(deleted).toBe(false);
+      const response = denormalized;
+      expect(response).toBeDefined();
+      expect(response).toBeInstanceOf(WithOptional);
+      expect(response).toEqual({
+        id: 'abc',
+        article: undefined,
+        requiredArticle: ArticleEntity.fromJS({ id: '6' }),
+        nextPage: 'blob',
+      });
+    });
+
+    it('should be both deleted and not found when both are true in different parts of schema', () => {
+      const [denormalized, found, deleted] = denormalize(
+        { data: 'abc' },
+        { data: WithOptional, other: ArticleEntity },
+        {
+          [WithOptional.key]: {
+            abc: WithOptional.fromJS({
+              id: 'abc',
+              // this is typed because we're actually sending wrong data to it
+              article: '6' as any,
+              requiredArticle: '5' as any,
+              nextPage: 'blob',
+            }),
+          },
+          [ArticleEntity.key]: {
+            ['5']: DELETED,
+            ['6']: ArticleEntity.fromJS({ id: '6' }),
+          },
+        },
+      );
+      expect(found).toBe(false);
+      expect(deleted).toBe(true);
+      const response = denormalized;
+      expect(response).toBeDefined();
+      expect(response).toEqual({
+        data: {
+          id: 'abc',
+          article: ArticleEntity.fromJS({ id: '6' }),
+          requiredArticle: undefined,
+          nextPage: 'blob',
+        },
+      });
+    });
+  });
+});
+
+describe('fromJS', () => {
+  test('can use a custom processing strategy', () => {
+    class ProcessTaco extends Tacos {
+      readonly slug: string = '';
+      static process(input: any, parent: any, key: string | undefined): any {
+        return {
+          ...input,
+          slug: `thing-${(input as unknown as ProcessTaco).id}`,
+        };
+      }
+    }
+    const { entities, result } = normalize(
+      { id: '1', name: 'foo' },
+      ProcessTaco,
+    );
+    const [final] = denormalize(result, ProcessTaco, entities);
+    expect(final?.slug).toEqual('thing-1');
+    expect(final).toMatchSnapshot();
+  });
+
+  test('can use information from the parent in the process strategy', () => {
+    class ChildEntity extends IDEntity {
+      readonly content: string = '';
+      readonly parentId: string = '';
+      readonly parentKey: string = '';
+
+      static process(input: any, parent: any, key: string | undefined): any {
+        return {
+          ...input,
+          parentId: parent?.id,
+          parentKey: key,
+        };
+      }
+    }
+    class ParentEntity extends IDEntity {
+      readonly content: string = '';
+      readonly child: ChildEntity = ChildEntity.fromJS({});
+
+      static schema = { child: ChildEntity };
+    }
+
+    const { entities, result } = normalize(
+      {
+        id: '1',
+        content: 'parent',
+        child: { id: '4', content: 'child' },
+      },
+      ParentEntity,
+    );
+    const [final] = denormalize(result, ParentEntity, entities);
+    expect(final?.child?.parentId).toEqual('1');
+    expect(final).toMatchSnapshot();
+  });
+
+  test('is run before and passed to the schema denormalization', () => {
+    class AttachmentsEntity extends IDEntity {}
+    class EntriesEntity extends IDEntity {
+      readonly type: string = '';
+
+      static schema = {
+        data: { attachment: AttachmentsEntity },
+      };
+
+      static process(input: any, parent: any, key: string | undefined): any {
+        return {
+          ...values(input)[0],
+          type: Object.keys(input)[0],
+        };
+      }
+    }
+
+    const { entities, result } = normalize(
+      { message: { id: '123', data: { attachment: { id: '456' } } } },
+      EntriesEntity,
+    );
+    const [final] = denormalize(result, EntriesEntity, entities);
+    expect(final?.type).toEqual('message');
+    expect(final).toMatchSnapshot();
+  });
+});

--- a/packages/experimental/src/entity/__tests__/__snapshots__/NewEntity.test.ts.snap
+++ b/packages/experimental/src/entity/__tests__/__snapshots__/NewEntity.test.ts.snap
@@ -1,0 +1,895 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Entity denormalization can denormalize already partially denormalized data 1`] = `
+Array [
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+  Object {
+    "Food": Object {
+      "[object Object]": Food {
+        "id": "1",
+      },
+    },
+    "Menu": Object {
+      "1": Menu {
+        "food": Food {
+          "id": "1",
+        },
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization can denormalize already partially denormalized data 2`] = `
+Array [
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+  Object {
+    "Food": Object {
+      "Map { \\"id\\": \\"1\\" }": Food {
+        "id": "1",
+      },
+    },
+    "Menu": Object {
+      "1": Menu {
+        "food": Food {
+          "id": "1",
+        },
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes an entity 1`] = `
+Array [
+  Tacos {
+    "alias": undefined,
+    "id": "1",
+    "name": "",
+    "type": "foo",
+  },
+  true,
+  false,
+  Object {
+    "Tacos": Object {
+      "1": Tacos {
+        "alias": undefined,
+        "id": "1",
+        "name": "",
+        "type": "foo",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes an entity 2`] = `
+Array [
+  Tacos {
+    "alias": undefined,
+    "id": "1",
+    "name": "",
+    "type": "foo",
+  },
+  true,
+  false,
+  Object {
+    "Tacos": Object {
+      "1": Tacos {
+        "alias": undefined,
+        "id": "1",
+        "name": "",
+        "type": "foo",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes deep entities 1`] = `
+Array [
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+  Object {
+    "Food": Object {
+      "1": Food {
+        "id": "1",
+      },
+    },
+    "Menu": Object {
+      "1": Menu {
+        "food": Food {
+          "id": "1",
+        },
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes deep entities 2`] = `
+Array [
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+  Object {
+    "Food": Object {
+      "1": Food {
+        "id": "1",
+      },
+    },
+    "Menu": Object {
+      "1": Menu {
+        "food": Food {
+          "id": "1",
+        },
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes deep entities 3`] = `
+Array [
+  Menu {
+    "food": Food {
+      "id": undefined,
+    },
+    "id": "2",
+  },
+  true,
+  false,
+  Object {
+    "Menu": Object {
+      "2": Menu {
+        "food": Food {
+          "id": undefined,
+        },
+        "id": "2",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes deep entities 4`] = `
+Array [
+  Menu {
+    "food": Food {
+      "id": undefined,
+    },
+    "id": "2",
+  },
+  false,
+  false,
+  Object {
+    "Menu": Object {
+      "2": Menu {
+        "food": Food {
+          "id": undefined,
+        },
+        "id": "2",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes deep entities with records 1`] = `
+Array [
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+  Object {
+    "Food": Object {
+      "1": Food {
+        "id": "1",
+      },
+    },
+    "Menu": Object {
+      "1": Menu {
+        "food": Food {
+          "id": "1",
+        },
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes deep entities with records 2`] = `
+Array [
+  Menu {
+    "food": Food {
+      "id": "1",
+    },
+    "id": "1",
+  },
+  true,
+  false,
+  Object {
+    "Food": Object {
+      "1": Food {
+        "id": "1",
+      },
+    },
+    "Menu": Object {
+      "1": Menu {
+        "food": Food {
+          "id": "1",
+        },
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes deep entities with records 3`] = `
+Array [
+  Menu {
+    "food": null,
+    "id": "2",
+  },
+  true,
+  false,
+  Object {
+    "Menu": Object {
+      "2": Menu {
+        "food": null,
+        "id": "2",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes deep entities with records 4`] = `
+Array [
+  Menu {
+    "food": null,
+    "id": "2",
+  },
+  true,
+  false,
+  Object {
+    "Menu": Object {
+      "2": Menu {
+        "food": null,
+        "id": "2",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes recursive dependencies 1`] = `
+Report {
+  "draftedBy": User {
+    "id": "456",
+    "reports": Array [
+      [Circular],
+    ],
+    "role": "manager",
+  },
+  "id": "123",
+  "publishedBy": User {
+    "id": "456",
+    "reports": Array [
+      [Circular],
+    ],
+    "role": "manager",
+  },
+  "title": "Weekly report",
+}
+`;
+
+exports[`Entity denormalization denormalizes recursive dependencies 2`] = `
+Report {
+  "draftedBy": User {
+    "id": "456",
+    "reports": Immutable.List [
+      Immutable.Map {
+        "id": "123",
+        "title": "Weekly report",
+        "draftedBy": "456",
+        "publishedBy": "456",
+      },
+    ],
+    "role": "manager",
+  },
+  "id": "123",
+  "publishedBy": User {
+    "id": "456",
+    "reports": Immutable.List [
+      Immutable.Map {
+        "id": "123",
+        "title": "Weekly report",
+        "draftedBy": "456",
+        "publishedBy": "456",
+      },
+    ],
+    "role": "manager",
+  },
+  "title": "Weekly report",
+}
+`;
+
+exports[`Entity denormalization denormalizes recursive dependencies 3`] = `
+User {
+  "id": "456",
+  "reports": Array [
+    Report {
+      "draftedBy": [Circular],
+      "id": "123",
+      "publishedBy": [Circular],
+      "title": "Weekly report",
+    },
+  ],
+  "role": "manager",
+}
+`;
+
+exports[`Entity denormalization denormalizes recursive dependencies 4`] = `
+User {
+  "id": "456",
+  "reports": Immutable.List [
+    Report {
+      "draftedBy": Immutable.Map {
+        "id": "456",
+        "role": "manager",
+        "reports": Immutable.List [
+          "123",
+        ],
+      },
+      "id": "123",
+      "publishedBy": Immutable.Map {
+        "id": "456",
+        "role": "manager",
+        "reports": Immutable.List [
+          "123",
+        ],
+      },
+      "title": "Weekly report",
+    },
+  ],
+  "role": "manager",
+}
+`;
+
+exports[`Entity denormalization denormalizes to undefined for deleted data 1`] = `
+Array [
+  Menu {
+    "food": undefined,
+    "id": "1",
+  },
+  true,
+  true,
+  Object {
+    "Menu": Object {
+      "1": Menu {
+        "food": undefined,
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes to undefined for deleted data 2`] = `
+Array [
+  Menu {
+    "food": undefined,
+    "id": "1",
+  },
+  true,
+  true,
+  Object {
+    "Menu": Object {
+      "1": Menu {
+        "food": undefined,
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes to undefined for deleted data 3`] = `
+Array [
+  undefined,
+  true,
+  true,
+  Object {},
+]
+`;
+
+exports[`Entity denormalization denormalizes to undefined for deleted data 4`] = `
+Array [
+  undefined,
+  true,
+  true,
+  Object {},
+]
+`;
+
+exports[`Entity denormalization denormalizes to undefined for missing data 1`] = `
+Array [
+  Menu {
+    "food": undefined,
+    "id": "1",
+  },
+  true,
+  false,
+  Object {
+    "Menu": Object {
+      "1": Menu {
+        "food": undefined,
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes to undefined for missing data 2`] = `
+Array [
+  Menu {
+    "food": undefined,
+    "id": "1",
+  },
+  false,
+  false,
+  Object {
+    "Menu": Object {
+      "1": Menu {
+        "food": undefined,
+        "id": "1",
+      },
+    },
+  },
+]
+`;
+
+exports[`Entity denormalization denormalizes to undefined for missing data 3`] = `
+Array [
+  undefined,
+  false,
+  false,
+  Object {},
+]
+`;
+
+exports[`Entity denormalization denormalizes to undefined for missing data 4`] = `
+Array [
+  undefined,
+  false,
+  false,
+  Object {},
+]
+`;
+
+exports[`Entity normalization mergeStrategy can use a custom merging strategy 1`] = `
+Object {
+  "entities": Object {
+    "MergeTaco": Object {
+      "1": MergeTaco {
+        "alias": "bar",
+        "id": "1",
+        "name": "foo",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Array [
+    "1",
+    "1",
+  ],
+}
+`;
+
+exports[`Entity normalization mergeStrategy defaults to plain merging 1`] = `
+Object {
+  "entities": Object {
+    "Tacos": Object {
+      "1": Object {
+        "alias": "bar",
+        "id": "1",
+        "name": "bar",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Array [
+    "1",
+    "1",
+  ],
+}
+`;
+
+exports[`Entity normalization normalizes an entity 1`] = `
+Object {
+  "entities": Object {
+    "MyEntity": Object {
+      "1": Object {
+        "id": "1",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": "1",
+}
+`;
+
+exports[`Entity normalization pk() can build the entity's ID from the parent object 1`] = `
+Object {
+  "entities": Object {
+    "User": Object {
+      "tacos-user-4": Object {
+        "id": "4",
+        "name": "Jimmy",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Object {
+    "name": "tacos",
+    "user": "tacos-user-4",
+  },
+}
+`;
+
+exports[`Entity normalization pk() can normalize entity IDs based on their object key 1`] = `
+Object {
+  "entities": Object {
+    "User": Object {
+      "4": Object {
+        "name": "taco",
+      },
+      "56": Object {
+        "name": "burrito",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": Object {
+    "4": Object {
+      "id": "4",
+      "schema": "users",
+    },
+    "56": Object {
+      "id": "56",
+      "schema": "users",
+    },
+  },
+}
+`;
+
+exports[`Entity normalization pk() can use a custom pk() string 1`] = `
+Object {
+  "entities": Object {
+    "User": Object {
+      "134351": Object {
+        "idStr": "134351",
+        "name": "Kathy",
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": "134351",
+}
+`;
+
+exports[`Entity normalization should allow many unexpected as long as none are missing 1`] = `
+Object {
+  "entities": Object {
+    "MyEntity": Object {
+      "hi": Object {
+        "a": "a",
+        "b": "b",
+        "c": "c",
+        "d": "e",
+        "e": 0,
+        "f": 0,
+        "g": 0,
+        "h": 0,
+        "i": 0,
+        "j": 0,
+        "k": 0,
+        "l": 0,
+        "m": 0,
+        "n": 0,
+        "name": "hi",
+        "o": 0,
+        "p": 0,
+        "q": 0,
+        "r": 0,
+        "s": 0,
+        "t": 0,
+        "u": 0,
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": "hi",
+}
+`;
+
+exports[`Entity normalization should only warn if at least four members are found with unexpected 1`] = `
+Object {
+  "entities": Object {
+    "MyEntity": Object {
+      "hi": Object {
+        "a": "a",
+        "b": "b",
+        "c": "c",
+        "d": "e",
+        "e": 0,
+        "f": 0,
+        "g": 0,
+        "h": 0,
+        "i": 0,
+        "j": 0,
+        "k": 0,
+        "l": 0,
+        "m": 0,
+        "n": 0,
+        "name": "hi",
+        "o": 0,
+        "p": 0,
+      },
+    },
+  },
+  "indexes": Object {},
+  "result": "hi",
+}
+`;
+
+exports[`Entity normalization should only warn if at least four members are found with unexpected 2`] = `
+Array [
+  "Attempted to initialize MyEntity with a large number of unexpected keys found
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: name,a,b,c
+    Unexpected keys: d,e,f,g,h,i,j,k,l,m,n,o,p
+  Value (processed): {
+  \\"name\\": \\"hi\\",
+  \\"a\\": \\"a\\",
+  \\"b\\": \\"b\\",
+  \\"c\\": \\"c\\",
+  \\"d\\": \\"e\\",
+  \\"e\\": 0,
+  \\"f\\": 0,
+  \\"g\\": 0,
+  \\"h\\": 0,
+  \\"i\\": 0,
+  \\"j\\": 0,
+  \\"k\\": 0,
+  \\"l\\": 0,
+  \\"m\\": 0,
+  \\"n\\": 0,
+  \\"o\\": 0,
+  \\"p\\": 0
+}",
+]
+`;
+
+exports[`Entity normalization should throw a custom error if data does not include pk 1`] = `
+"Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+
+  Entity: MyEntity
+  Value (processed): {
+  \\"secondthing\\": \\"hi\\"
+}
+  "
+`;
+
+exports[`Entity normalization should throw a custom error if data loads with half unexpected props 1`] = `
+"Attempted to initialize MyEntity with a large number of unexpected keys found
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: name
+    Unexpected keys: nonexistantthing
+  Value (processed): {
+  \\"name\\": \\"hoho\\",
+  \\"nonexistantthing\\": \\"hi\\"
+}"
+`;
+
+exports[`Entity normalization should throw a custom error if data loads with no matching props 1`] = `
+"Attempted to initialize MyEntity with no matching keys found
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: 
+    Missing: name,secondthing
+  Value (processed): {}"
+`;
+
+exports[`Entity normalization should throw a custom error if data loads with string 1`] = `
+"Unexpected input given to normalize. Expected type to be \\"object\\", found \\"string\\".
+
+          Schema: {
+  \\"name\\": \\"MyEntity\\",
+  \\"schema\\": {},
+  \\"key\\": \\"MyEntity\\"
+}
+          Input: \\"hibho\\""
+`;
+
+exports[`Entity normalization should throw a custom error if schema key is missing from Entity 1`] = `
+"Schema key is missing in Entity
+
+  Be sure all schema members are also part of the entity
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about nesting schemas: https://resthooks.io/docs/guides/nested-response
+
+  Entity keys: name,secondthing
+  Schema key(missing): blarb
+  "
+`;
+
+exports[`Entity normalization should throw a custom error loads with array 1`] = `
+"Attempted to initialize MyEntity with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+Missing: name,secondthing
+First three members: [
+  {
+    \\"name\\": \\"hi\\",
+    \\"secondthing\\": \\"ho\\"
+  },
+  {
+    \\"name\\": \\"hi\\",
+    \\"secondthing\\": \\"ho\\"
+  },
+  {
+    \\"name\\": \\"hi\\",
+    \\"secondthing\\": \\"ho\\"
+  }
+]"
+`;
+
+exports[`Entity normalization should warn when automaticValidation === "warn" 1`] = `
+Array [
+  "Attempted to initialize MyEntity with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+Missing: secondthing
+First three members: [
+  {
+    \\"name\\": \\"hi\\",
+    \\"secondthing\\": \\"ho\\"
+  },
+  {
+    \\"name\\": \\"hi\\",
+    \\"secondthing\\": \\"ho\\"
+  },
+  {
+    \\"name\\": \\"hi\\",
+    \\"secondthing\\": \\"ho\\"
+  }
+]",
+]
+`;
+
+exports[`Entity normalization should warn when automaticValidation === "warn" 2`] = `
+Array [
+  "Attempted to initialize MyEntity with a large number of unexpected keys found
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+  If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+  Expected keys:
+    Found: name
+    Unexpected keys: nonexistantthing
+  Value (processed): {
+  \\"name\\": \\"hoho\\",
+  \\"nonexistantthing\\": \\"hi\\"
+}",
+]
+`;
+
+exports[`fromJS can use a custom processing strategy 1`] = `
+ProcessTaco {
+  "alias": undefined,
+  "id": "1",
+  "name": "foo",
+  "slug": "thing-1",
+}
+`;
+
+exports[`fromJS can use information from the parent in the process strategy 1`] = `
+ParentEntity {
+  "child": ChildEntity {
+    "content": "child",
+    "id": "4",
+    "parentId": "1",
+    "parentKey": "child",
+  },
+  "content": "parent",
+  "id": "1",
+}
+`;
+
+exports[`fromJS is run before and passed to the schema denormalization 1`] = `
+EntriesEntity {
+  "data": Object {
+    "attachment": AttachmentsEntity {
+      "id": "456",
+    },
+  },
+  "id": "123",
+  "type": "message",
+}
+`;

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -1,2 +1,4 @@
 export { default as useFetcher } from './useFetcher';
 export { default as createFetch } from './createFetch';
+export { default as Entity } from './entity/Entity';
+export { default as EntityRecord } from './entity/EntityRecord';


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Simplifies serialization of normalized values
- Improve performance

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

We introduce these new designs into the experimental packages to flesh out before planning migration.

#### Entity
- Normalizes to pojos
  - new: `static process()` (instead of fromJS())
- Does not include Record concepts
  - This can be a performance benefit for those who aren't interested in the helper methods that track which members are defined
  - merge & fromJS are both a lot faster. These operations are performance for every entity in a response.

#### EntityRecord
- Implements the same interface as prior Entity to provide backcompat as well as utility
- Implementation has some overhead but much less than SimpleRecord
- For most this will be 100% backwards compatible as the only distinction is the normalize to pojo, which is uncommon to rely on