### PR TITLE
enhance: Do not throw on unmount of CacheProvider

### DIFF
--- a/packages/core/src/state/NetworkManager.ts
+++ b/packages/core/src/state/NetworkManager.ts
@@ -13,10 +13,6 @@ import {
 import RIC from './RIC';
 import { createReceive, createReceiveError } from './actions';
 
-class CleanupError extends Error {
-  message = 'Cleaning up Network Manager';
-}
-
 /** Handles all async network dispatches
  *
  * Dedupes concurrent requests by keeping track of all fetches in flight
@@ -79,7 +75,6 @@ export default class NetworkManager implements Manager {
   /** Ensures all promises are completed by rejecting remaining. */
   cleanup() {
     for (const k in this.rejectors) {
-      this.rejectors[k](new CleanupError());
       this.clear(k);
     }
   }
@@ -116,11 +111,6 @@ export default class NetworkManager implements Manager {
           return data;
         })
         .catch(error => {
-          if (error instanceof CleanupError) {
-            // if we don't receive, we need to clear
-            this.clear(key);
-            return;
-          }
           dispatch(
             createReceiveError(error, {
               ...action.meta,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Dangling promises are not a problem as they are cleaned by the GC when they lose references. All references to the promises should be within the tree of CacheProvider - therefore cleanup should remove all promise references.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Remove rejection CleanupError and simply delete everything.