### PR TITLE
feat: Deprecate Resource in main 'rest-hooks' package

### DIFF
--- a/packages/rest-hooks/src/resource/Resource.ts
+++ b/packages/rest-hooks/src/resource/Resource.ts
@@ -1,7 +1,8 @@
 /* istanbul ignore file */
 
-import type { Method } from './types';
 import SimpleResource from './SimpleResource';
+
+import type { Method } from './types';
 
 class NetworkError extends Error {
   declare status: number;
@@ -18,6 +19,7 @@ class NetworkError extends Error {
  * Represents an entity to be retrieved from a server.
  * Typically 1:1 with a url endpoint.
  */
+/** @deprecated in favor of @rest-hooks/rest */
 export default abstract class Resource extends SimpleResource {
   /** A function to mutate all request options for fetch */
   static fetchOptionsPlugin?: (options: RequestInit) => RequestInit;

--- a/packages/rest-hooks/src/resource/SimpleResource.ts
+++ b/packages/rest-hooks/src/resource/SimpleResource.ts
@@ -1,6 +1,12 @@
 /* istanbul ignore file */
 
 import { FlatEntity } from '@rest-hooks/core';
+
+import { SchemaDetail, Method, SchemaList } from './types';
+import { NotImplementedError } from './errors';
+import paramsToString from './paramsToString';
+import { schemas } from '..';
+
 import type {
   FetchOptions,
   AbstractInstanceType,
@@ -9,16 +15,12 @@ import type {
   DeleteShape,
 } from '@rest-hooks/core';
 
-import { SchemaDetail, Method, SchemaList } from './types';
-import { NotImplementedError } from './errors';
-import paramsToString from './paramsToString';
-import { schemas } from '..';
-
 /** Represents an entity to be retrieved from a server.
  * Typically 1:1 with a url endpoint.
  *
  * This can be a useful organization for many REST-like API patterns.
  */
+/** @deprecated in favor of @rest-hooks/rest */
 export default abstract class SimpleResource extends FlatEntity {
   // typescript todo: require subclasses to implement
   /** Used as base of url construction */


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
To ease migration didn't want to spam editors with deprecation markers til a minor release.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We call this a 'feature' to trigger minor bump.

Use `@rest-hooks/rest` instead!
