### PR TITLE
feat: Endpoint.update programmable sideeffects

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -249,6 +249,12 @@ export class FutureArticleResource extends CoolerArticleResource {
         return instanceFetch(this.url(), this.getFetchInit(body));
       },
       url: this.listUrl.bind(this),
+      update: (newid: string) => ({
+        [this.list().key({})]: (existing: string[] = []) => [
+          newid,
+          ...existing,
+        ],
+      }),
     });
   }
 

--- a/packages/core/src/state/actions/createReceive.ts
+++ b/packages/core/src/state/actions/createReceive.ts
@@ -15,7 +15,7 @@ interface Options<
   S extends Schema | undefined = any,
 > extends Pick<
     FetchAction<Payload, S>['meta'],
-    'schema' | 'key' | 'type' | 'updaters'
+    'schema' | 'key' | 'type' | 'updaters' | 'update'
   > {
   dataExpiryLength: NonNullable<FetchOptions['dataExpiryLength']>;
 }
@@ -34,7 +34,7 @@ export default function createReceive<
   S extends Schema | undefined = any,
 >(
   data: Payload,
-  { schema, key, updaters, dataExpiryLength }: Options<Payload, S>,
+  { schema, key, updaters, update, dataExpiryLength }: Options<Payload, S>,
 ): ReceiveAction<Payload, S> {
   /* istanbul ignore next */
   if (process.env.NODE_ENV === 'development' && dataExpiryLength < 0) {
@@ -48,6 +48,7 @@ export default function createReceive<
     expiresAt: now + dataExpiryLength,
   };
   meta.updaters = updaters;
+  meta.update = update;
   return {
     type: RECEIVE_TYPE,
     payload: data,

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -71,9 +71,9 @@ export default function reducer(
         results = applyUpdatersToResults(results, result, action.meta.updaters);
         if (action.meta.update) {
           const updaters = action.meta.update(result);
-          Object.keys(updaters).forEach(
-            key => { results[key] = updaters[key](results[key]); },
-          );
+          Object.keys(updaters).forEach(key => {
+            results[key] = updaters[key](results[key]);
+          });
         }
         return {
           entities: mergeDeepCopy(

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -69,6 +69,12 @@ export default function reducer(
           [action.meta.key]: result,
         };
         results = applyUpdatersToResults(results, result, action.meta.updaters);
+        if (action.meta.update) {
+          const updaters = action.meta.update(result);
+          Object.keys(updaters).forEach(
+            key => (results[key] = updaters[key](results[key])),
+          );
+        }
         return {
           entities: mergeDeepCopy(
             state.entities,

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -72,7 +72,7 @@ export default function reducer(
         if (action.meta.update) {
           const updaters = action.meta.update(result);
           Object.keys(updaters).forEach(
-            key => (results[key] = updaters[key](results[key])),
+            key => { results[key] = updaters[key](results[key]); },
           );
         }
         return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,11 +1,4 @@
 import { NormalizedIndex } from '@rest-hooks/normalizr';
-import type {
-  UpdateFunction,
-  AbstractInstanceType,
-  Schema,
-  FetchFunction,
-  EndpointExtraOptions,
-} from '@rest-hooks/endpoint';
 import { Middleware } from '@rest-hooks/use-enhanced-reducer';
 import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
 
@@ -19,6 +12,14 @@ import {
   UNSUBSCRIBE_TYPE,
   INVALIDATE_TYPE,
 } from './actionTypes';
+
+import type {
+  UpdateFunction,
+  AbstractInstanceType,
+  Schema,
+  FetchFunction,
+  EndpointExtraOptions,
+} from '@rest-hooks/endpoint';
 
 export type { AbstractInstanceType, UpdateFunction };
 
@@ -66,6 +67,7 @@ export interface ReceiveMeta<S extends Schema | undefined> {
   schema: S;
   key: string;
   updaters?: Record<string, UpdateFunction<S, any>>;
+  update?: (result: any) => Record<string, (...args: any) => any>;
   date: number;
   expiresAt: number;
 }
@@ -97,6 +99,7 @@ interface FetchMeta<
   schema: S;
   key: string;
   updaters?: Record<string, UpdateFunction<S, any>>;
+  update?: (result: any) => Record<string, (...args: any) => any>;
   options?: FetchOptions;
   throttle: boolean;
   resolve: (value?: any | PromiseLike<any>) => void;

--- a/packages/experimental/src/__tests__/useFetcher.ts
+++ b/packages/experimental/src/__tests__/useFetcher.ts
@@ -1,6 +1,6 @@
 import { FutureArticleResource } from '__tests__/new';
 import nock from 'nock';
-import { useCache } from '@rest-hooks/core';
+import { useCache, useResource } from '@rest-hooks/core';
 
 // relative imports to avoid circular dependency in tsconfig references
 import {
@@ -23,6 +23,29 @@ export const createPayload = {
   content: 'whatever',
   tags: ['a', 'best', 'react'],
 };
+
+export const nested = [
+  {
+    id: 5,
+    title: 'hi ho',
+    content: 'whatever',
+    tags: ['a', 'best', 'react'],
+    author: {
+      id: 23,
+      username: 'bob',
+    },
+  },
+  {
+    id: 3,
+    title: 'the next time',
+    content: 'whatever',
+    author: {
+      id: 23,
+      username: 'charles',
+      email: 'bob@bob.com',
+    },
+  },
+];
 
 for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
   describe(`${makeProvider.name} => <Provider />`, () => {
@@ -50,6 +73,9 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         .reply(403, {})
         .get(`/article-cooler/666`)
         .reply(200, '')
+        .get(`/article-cooler/`)
+        .reply(200, nested)
+
         .post(`/article-cooler/`)
         .reply(200, createPayload);
 
@@ -105,7 +131,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       };
     });
 
-    /*it('should update on create', async () => {
+    it('should update on create', async () => {
       const { result, waitForNextUpdate } = renderRestHook(() => {
         const articles = useResource(FutureArticleResource.list(), {});
         const fetch = useFetcher();
@@ -115,7 +141,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       await result.current.fetch(FutureArticleResource.create(), {
         id: 1,
       });
-      expect(result.current.articles.map(({ id }) => id)).toEqual([5, 3, 1]);
-    });*/
+      expect(result.current.articles.map(({ id }) => id)).toEqual([1, 5, 3]);
+    });
   });
 }

--- a/packages/experimental/src/createFetch.ts
+++ b/packages/experimental/src/createFetch.ts
@@ -1,5 +1,8 @@
-import type { FetchAction } from '@rest-hooks/core';
 import { actionTypes } from '@rest-hooks/core';
+
+import { UpdateFunction } from './types';
+
+import type { FetchAction } from '@rest-hooks/core';
 import type { EndpointInterface } from '@rest-hooks/endpoint';
 
 /** Requesting a fetch to begin
@@ -7,7 +10,9 @@ import type { EndpointInterface } from '@rest-hooks/endpoint';
  * @param endpoint
  * @param options { args, throttle }
  */
-export default function createFetch<E extends EndpointInterface>(
+export default function createFetch<
+  E extends EndpointInterface & { update?: UpdateFunction<E> },
+>(
   endpoint: E,
   { args, throttle }: { args: readonly [...Parameters<E>]; throttle: boolean },
 ): FetchAction {
@@ -32,15 +37,9 @@ export default function createFetch<E extends EndpointInterface>(
         : /* istanbul ignore next */ new Date(),
   };
 
-  /*if (endpoint.update) {
-    meta.updaters = updateParams.reduce(
-      (accumulator: object, [toShape, toParams, updateFn]) => ({
-        [toShape.getFetchKey(toParams)]: updateFn,
-        ...accumulator,
-      }),
-      {},
-    );
-  }*/
+  if (endpoint.update) {
+    meta.update = endpoint.update;
+  }
 
   if (endpoint.optimisticUpdate) {
     meta.optimisticResponse = endpoint.optimisticUpdate(...args);

--- a/packages/experimental/src/types.ts
+++ b/packages/experimental/src/types.ts
@@ -1,0 +1,14 @@
+import { Normalize } from '@rest-hooks/endpoint';
+
+import type { EndpointInterface, ResolveType } from '@rest-hooks/endpoint';
+
+type ResultEntry<E extends EndpointInterface> = E['schema'] extends undefined
+  ? ResolveType<E>
+  : Normalize<E>;
+
+export type UpdateFunction<
+  Source extends EndpointInterface,
+  Updaters extends Record<string, any> = Record<string, any>,
+> = (
+  source: ResultEntry<Source>,
+) => { [K in keyof Updaters]: (result: Updaters[K]) => Updaters[K] };

--- a/packages/experimental/src/useFetcher.ts
+++ b/packages/experimental/src/useFetcher.ts
@@ -3,11 +3,12 @@ import { DispatchContext } from '@rest-hooks/core';
 import { useContext, useCallback } from 'react';
 
 import createFetch from './createFetch';
+import { UpdateFunction } from './types';
 
 /** Build an imperative dispatcher to issue network requests. */
 export default function useFetcher(
   throttle = false,
-): <E extends EndpointInterface>(
+): <E extends EndpointInterface & { update?: UpdateFunction<E> }>(
   endpoint: E,
   ...args: readonly [...Parameters<E>]
 ) => ReturnType<E> {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Iterating toward https://github.com/coinbase/rest-hooks/issues/760

- Define programmable update in endpoint
- Improve function signature

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

We maintain working on raw reducer state, however we introduce improvements on the update method itself being much more straightforward and easy to define correctly.

- two degree function
- map key -> update function

```typescript
const createUser = new Endpoint(postToUserFunction, {
  schema: User,
  update: (newUser: Denormalize<S>)  => {
    const updates = {
      [userList.key()]: (users = []) => [newUser, ...users],
      [userList.key({ sortBy: 'createdAt' })]: (users = [], { sortBy }) => {
        const ret = [createdUser, ...users];
        ret.sortBy(sortBy);
        return ret;
      },
    ];
    if (newUser.isAdmin) {
      updates[userList.key({ admin: true })] = (users = []) => [newUser, ...users];
    }
    return updates;
  },
});
```

### Legacy plan

#### This PR

- Maintain previous updaters in reducer
- add update method to actions
- introduce usage in useFetcher found in experimental

#### Stage 2

- Make previous useFetcher() method transform into new update meta

#### Stage 3

- Stop supporting old update meta by removal from reducer
