### PR TITLE
enhance: Support endpoint.update in existing useFetcher

### DIFF
--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
@@ -3,6 +3,12 @@
 exports[`useFetcher should dispatch an action that fetches a create 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {},
+      Object {
+        "content": "hi",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
@@ -28,6 +34,14 @@ Object {
 exports[`useFetcher should dispatch an action that fetches a full update 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 1,
+      },
+      Object {
+        "content": "changed",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PUT http://test.com/article-cooler/1",
     "options": Object {
@@ -53,6 +67,14 @@ Object {
 exports[`useFetcher should dispatch an action that fetches a partial update 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 1,
+      },
+      Object {
+        "content": "changed",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PATCH http://test.com/article-cooler/1",
     "optimisticResponse": Object {
@@ -83,6 +105,12 @@ Object {
 exports[`useFetcher should dispatch an action with multiple updaters in the meta if update shapes params are passed in 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {},
+      Object {
+        "content": "hi",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article/",
     "optimisticResponse": Object {
@@ -116,6 +144,12 @@ Object {
 exports[`useFetcher should dispatch an action with updater in the meta if update shapes params are passed in 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {},
+      Object {
+        "content": "hi",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
@@ -144,6 +178,12 @@ Object {
 exports[`useFetcher should refresh get details 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 1,
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/1",
     "options": Object {
@@ -169,6 +209,19 @@ Object {
 exports[`useRetrieve should dispatch singles 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
@@ -194,6 +247,19 @@ Object {
 exports[`useRetrieve should dispatch with fetch shape defined dataExpiryLength 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
@@ -220,6 +286,19 @@ Object {
 exports[`useRetrieve should dispatch with fetch shape defined errorExpiryLength 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
@@ -246,6 +325,19 @@ Object {
 exports[`useRetrieve should dispatch with resource defined dataExpiryLength 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
@@ -3,6 +3,12 @@
 exports[`useFetcher should dispatch an action that fetches a create 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {},
+      Object {
+        "content": "hi",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
@@ -28,6 +34,14 @@ Object {
 exports[`useFetcher should dispatch an action that fetches a full update 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 1,
+      },
+      Object {
+        "content": "changed",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PUT http://test.com/article-cooler/1",
     "options": Object {
@@ -53,6 +67,14 @@ Object {
 exports[`useFetcher should dispatch an action that fetches a partial update 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 1,
+      },
+      Object {
+        "content": "changed",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PATCH http://test.com/article-cooler/1",
     "optimisticResponse": Object {
@@ -77,6 +99,12 @@ Object {
 exports[`useFetcher should dispatch an action with multiple updaters in the meta if update shapes params are passed in 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {},
+      Object {
+        "content": "hi",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article/",
     "optimisticResponse": Object {
@@ -104,6 +132,12 @@ Object {
 exports[`useFetcher should dispatch an action with updater in the meta if update shapes params are passed in 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {},
+      Object {
+        "content": "hi",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
@@ -132,6 +166,12 @@ Object {
 exports[`useFetcher should refresh get details 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 1,
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/1",
     "options": Object {
@@ -157,6 +197,19 @@ Object {
 exports[`useRetrieve should dispatch singles 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
@@ -182,6 +235,19 @@ Object {
 exports[`useRetrieve should dispatch with fetch shape defined dataExpiryLength 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
@@ -208,6 +274,19 @@ Object {
 exports[`useRetrieve should dispatch with fetch shape defined errorExpiryLength 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
@@ -234,6 +313,19 @@ Object {
 exports[`useRetrieve should dispatch with resource defined dataExpiryLength 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useFetchDispatcher.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useFetchDispatcher.tsx.snap
@@ -3,6 +3,12 @@
 exports[`useFetchDispatcher should dispatch an action that fetches a create 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {},
+      Object {
+        "content": "hi",
+      },
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
@@ -3,6 +3,12 @@
 exports[`useResource() should dispatch an action that fetches 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 5,
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
@@ -28,6 +34,12 @@ Object {
 exports[`useResource() should dispatch fetch when sent multiple arguments 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 5,
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
@@ -53,6 +65,10 @@ Object {
 exports[`useResource() should dispatch fetch when sent multiple arguments 2`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {},
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/user/",
     "options": Object {

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
@@ -3,6 +3,12 @@
 exports[`useResource() should dispatch an action that fetches 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 5,
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
@@ -28,6 +34,12 @@ Object {
 exports[`useResource() should dispatch fetch when sent multiple arguments 1`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {
+        "id": 5,
+      },
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
@@ -53,6 +65,10 @@ Object {
 exports[`useResource() should dispatch fetch when sent multiple arguments 2`] = `
 Object {
   "meta": Object {
+    "args": Array [
+      Object {},
+      undefined,
+    ],
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/user/",
     "options": Object {

--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -9,6 +9,7 @@ import {
   TypedArticleResource,
   IndexedUserResource,
   UnionResource,
+  FutureArticleResource,
 } from '__tests__/new';
 import nock from 'nock';
 import { act } from '@testing-library/react-hooks';
@@ -726,6 +727,22 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
             content: 'real response',
           }),
         ]);
+      });
+
+      it('should update on create', async () => {
+        const { result, waitForNextUpdate } = renderRestHook(() => {
+          const articles = useResource(FutureArticleResource.list(), {});
+          const create = useFetcher(FutureArticleResource.create());
+          return { articles, create };
+        });
+
+        await waitForNextUpdate();
+        expect(result.current.articles.map(({ id }) => id)).toEqual([5, 3]);
+
+        await result.current.create({
+          id: 1,
+        });
+        expect(result.current.articles.map(({ id }) => id)).toEqual([1, 5, 3]);
       });
 
       it('should clear only earlier optimistic updates when a promise resolves', async () => {

--- a/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
@@ -12,16 +12,16 @@ import createFetch from '@rest-hooks/core/state/actions/createFetch';
 import { useContext, useCallback } from 'react';
 
 /** Build an imperative dispatcher to issue network requests. */
-export default function useFetchDispatcher(
-  throttle = false,
-): <
+export default function useFetchDispatcher(throttle = false): <
   Shape extends FetchShape<Schema, Readonly<object>, any>,
   UpdateParams extends OptimisticUpdateParams<
     SchemaFromShape<Shape>,
     FetchShape<any, any, any>
   >[],
 >(
-  fetchShape: Shape,
+  fetchShape: Shape & {
+    update?: (...args: any) => Record<string, (...args: any) => any>;
+  },
   params: ParamsFromShape<Shape>,
   body: BodyFromShape<Shape>,
   updateParams?: UpdateParams | undefined,

--- a/packages/core/src/react-integration/hooks/useFetcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetcher.ts
@@ -13,7 +13,9 @@ import useFetchDispatcher from './useFetchDispatcher';
 export default function useFetcher<
   Shape extends FetchShape<Schema, Readonly<object>, any>,
 >(
-  fetchShape: Shape,
+  fetchShape: Shape & {
+    update?: (...args: any) => Record<string, (...args: any) => any>;
+  },
   throttle = false,
 ): <
   UpdateParams extends OptimisticUpdateParams<

--- a/packages/core/src/state/__tests__/networkManager.ts
+++ b/packages/core/src/state/__tests__/networkManager.ts
@@ -117,6 +117,8 @@ describe('NetworkManager', () => {
         payload: data,
         meta: {
           schema: fetchResolveAction.meta.schema,
+          args: fetchResolveAction.meta.args,
+          update: fetchResolveAction.meta.update,
           key: fetchResolveAction.meta.key,
           date: expect.any(Number),
           expiresAt: expect.any(Number),
@@ -139,6 +141,8 @@ describe('NetworkManager', () => {
           updaters: {
             [ArticleResource.listShape().getFetchKey({})]: expect.any(Function),
           },
+          args: fetchReceiveWithUpdatersAction.meta.args,
+          update: fetchReceiveWithUpdatersAction.meta.update,
           schema: fetchReceiveWithUpdatersAction.meta.schema,
           key: fetchReceiveWithUpdatersAction.meta.key,
           date: expect.any(Number),
@@ -162,6 +166,8 @@ describe('NetworkManager', () => {
           updaters: {
             [ArticleResource.listShape().getFetchKey({})]: expect.any(Function),
           },
+          args: fetchRpcWithUpdatersAction.meta.args,
+          update: fetchRpcWithUpdatersAction.meta.update,
           schema: fetchRpcWithUpdatersAction.meta.schema,
           key: fetchRpcWithUpdatersAction.meta.key,
           date: expect.any(Number),
@@ -187,6 +193,8 @@ describe('NetworkManager', () => {
           updaters: {
             [ArticleResource.listShape().getFetchKey({})]: expect.any(Function),
           },
+          args: fetchRpcWithUpdatersAndOptimisticAction.meta.args,
+          update: fetchRpcWithUpdatersAndOptimisticAction.meta.update,
           schema: fetchRpcWithUpdatersAndOptimisticAction.meta.schema,
           key: fetchRpcWithUpdatersAndOptimisticAction.meta.key,
           date: expect.any(Number),

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -454,6 +454,45 @@ describe('reducer', () => {
           },
         );
       });
+
+      it('should account for args', () => {
+        const iniState: any = {
+          ...initialState,
+          entities: {
+            [PaginatedArticle.key]: {
+              '10': PaginatedArticle.fromJS({ id: 10 }),
+            },
+          },
+          results: {
+            [PaginatedArticle.list().key({ admin: true })]: { results: ['10'] },
+          },
+        };
+        const newState = reducer(
+          iniState,
+          createReceive(
+            { results: [{ id: 11 }, { id: 12 }] },
+            {
+              ...endpoint,
+              key: endpoint.key({ cursor: 2, admin: true }),
+              args: [{ cursor: 2, admin: true }],
+              update: (nextpage: { results: string[] }, { admin }) => ({
+                [PaginatedArticle.list().key({ admin })]: (
+                  existing: { results: string[] } = { results: [] },
+                ) => ({
+                  ...existing,
+                  results: [...nextpage.results, ...existing.results],
+                }),
+              }),
+              dataExpiryLength: 600000,
+            },
+          ),
+        );
+        expect(
+          newState.results[PaginatedArticle.list().key({ admin: true })],
+        ).toStrictEqual({
+          results: ['11', '12', '10'],
+        });
+      });
     });
   });
 

--- a/packages/core/src/state/actions/createFetch.ts
+++ b/packages/core/src/state/actions/createFetch.ts
@@ -39,7 +39,9 @@ export default function createFetch<
     Readonly<object | string> | void
   >,
 >(
-  fetchShape: Shape,
+  fetchShape: Shape & {
+    update?: (...args: any) => Record<string, (...args: any) => any>;
+  },
   { params, body, throttle, updateParams }: Options<Shape>,
 ): FetchAction {
   const { schema, type, getFetchKey, options } = fetchShape;
@@ -53,6 +55,7 @@ export default function createFetch<
   const meta: FetchAction['meta'] = {
     schema,
     type,
+    args: [params, body],
     key,
     throttle,
     options,
@@ -73,6 +76,10 @@ export default function createFetch<
       }),
       {},
     );
+  }
+
+  if (fetchShape.update) {
+    meta.update = fetchShape.update;
   }
 
   if (options && options.optimisticUpdate) {

--- a/packages/core/src/state/actions/createReceive.ts
+++ b/packages/core/src/state/actions/createReceive.ts
@@ -15,7 +15,7 @@ interface Options<
   S extends Schema | undefined = any,
 > extends Pick<
     FetchAction<Payload, S>['meta'],
-    'schema' | 'key' | 'type' | 'updaters' | 'update'
+    'schema' | 'key' | 'type' | 'updaters' | 'update' | 'args'
   > {
   dataExpiryLength: NonNullable<FetchOptions['dataExpiryLength']>;
 }
@@ -34,7 +34,14 @@ export default function createReceive<
   S extends Schema | undefined = any,
 >(
   data: Payload,
-  { schema, key, updaters, update, dataExpiryLength }: Options<Payload, S>,
+  {
+    schema,
+    key,
+    args,
+    updaters,
+    update,
+    dataExpiryLength,
+  }: Options<Payload, S>,
 ): ReceiveAction<Payload, S> {
   /* istanbul ignore next */
   if (process.env.NODE_ENV === 'development' && dataExpiryLength < 0) {
@@ -44,6 +51,7 @@ export default function createReceive<
   const meta: ReceiveAction['meta'] = {
     schema,
     key,
+    args,
     date: now,
     expiresAt: now + dataExpiryLength,
   };

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -70,7 +70,10 @@ export default function reducer(
         };
         results = applyUpdatersToResults(results, result, action.meta.updaters);
         if (action.meta.update) {
-          const updaters = action.meta.update(result);
+          const updaters = action.meta.update(
+            result,
+            ...(action.meta.args || []),
+          );
           Object.keys(updaters).forEach(key => {
             results[key] = updaters[key](results[key]);
           });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,13 @@
 import { NormalizedIndex } from '@rest-hooks/normalizr';
 import { Middleware } from '@rest-hooks/use-enhanced-reducer';
 import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
+import type {
+  UpdateFunction,
+  AbstractInstanceType,
+  Schema,
+  FetchFunction,
+  EndpointExtraOptions,
+} from '@rest-hooks/endpoint';
 
 import { ErrorableFSAWithPayloadAndMeta } from './fsa';
 import { FetchShape } from './endpoint';
@@ -12,14 +19,6 @@ import {
   UNSUBSCRIBE_TYPE,
   INVALIDATE_TYPE,
 } from './actionTypes';
-
-import type {
-  UpdateFunction,
-  AbstractInstanceType,
-  Schema,
-  FetchFunction,
-  EndpointExtraOptions,
-} from '@rest-hooks/endpoint';
 
 export type { AbstractInstanceType, UpdateFunction };
 
@@ -66,8 +65,9 @@ export type FetchOptions<F extends FetchFunction = FetchFunction> =
 export interface ReceiveMeta<S extends Schema | undefined> {
   schema: S;
   key: string;
+  args?: readonly any[];
   updaters?: Record<string, UpdateFunction<S, any>>;
-  update?: (result: any) => Record<string, (...args: any) => any>;
+  update?: (result: any, ...args: any) => Record<string, (...args: any) => any>;
   date: number;
   expiresAt: number;
 }
@@ -98,8 +98,9 @@ interface FetchMeta<
   type: FetchShape<any, any>['type'];
   schema: S;
   key: string;
+  args?: readonly any[];
   updaters?: Record<string, UpdateFunction<S, any>>;
-  update?: (result: any) => Record<string, (...args: any) => any>;
+  update?: (result: any, ...args: any) => Record<string, (...args: any) => any>;
   options?: FetchOptions;
   throttle: boolean;
   resolve: (value?: any | PromiseLike<any>) => void;

--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -13,7 +13,13 @@
 
 </div>
 
-## useFetcher()
+## Motivation
+
+Field application of designs help smooth edges of a theoretical design. New designs can be iterated on here, breaking freely without worry of legacy support plans.
+
+## Usage
+
+### useFetcher()
 
 ```tsx
 const fetch = useFetcher();
@@ -25,7 +31,7 @@ return (
 );
 ```
 
-## Endpoint.update
+### Endpoint.update
 
 <details open><summary><b>Simple</b></summary>
 
@@ -65,7 +71,7 @@ const createUser = new Endpoint(postToUserFunction, {
 </details>
 
 
-## Entity, EntityRecord, Resource, BaseResource
+### Entity, EntityRecord, Resource, BaseResource
 
 - Normalizes to pojo
 - Faster

--- a/packages/experimental/src/createFetch.ts
+++ b/packages/experimental/src/createFetch.ts
@@ -1,9 +1,8 @@
 import { actionTypes } from '@rest-hooks/core';
-
-import { UpdateFunction } from './types';
-
 import type { FetchAction } from '@rest-hooks/core';
 import type { EndpointInterface } from '@rest-hooks/endpoint';
+
+import { UpdateFunction } from './types';
 
 /** Requesting a fetch to begin
  *
@@ -25,6 +24,7 @@ export default function createFetch<
   const meta: FetchAction['meta'] = {
     schema: endpoint.schema,
     type: endpoint.sideEffect ? ('mutate' as const) : ('read' as const),
+    args,
     key,
     throttle,
     options: endpoint,
@@ -51,3 +51,17 @@ export default function createFetch<
     meta,
   };
 }
+
+/** Future action shape
+{
+  type: actionTypes.FETCH_TYPE,
+  endpoint,
+  meta: {
+    args,
+    throttle,
+    createdAt,
+    promise,
+    resolve,
+    reject,
+  }
+} */

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -57,6 +57,7 @@ const siteConfig = {
     {
       href: 'https://github.com/Rest-Hooks/todo-example',
       label: '🎮 Demo',
+      external: true,
     },
     //{ page: 'help', label: 'Help' },
     { search: true },


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
No reason to wait for new fetch for new update method since it's optional

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add relevant arguments to action