### PR TITLE
enhance: Transform updateParams to 'update' function

### DIFF
--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
@@ -131,10 +131,7 @@ Object {
     "schema": [Function],
     "throttle": false,
     "type": "mutate",
-    "updaters": Object {
-      "GET http://test.com/article/": [Function],
-      "GET http://test.com/article/some-list-url": [Function],
-    },
+    "update": [Function],
   },
   "payload": [Function],
   "type": "rest-hooks/fetch",
@@ -166,9 +163,7 @@ Object {
     "schema": [Function],
     "throttle": false,
     "type": "mutate",
-    "updaters": Object {
-      "GET http://test.com/article-cooler/": [Function],
-    },
+    "update": [Function],
   },
   "payload": [Function],
   "type": "rest-hooks/fetch",

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
@@ -119,10 +119,7 @@ Object {
     "schema": [Function],
     "throttle": false,
     "type": "mutate",
-    "updaters": Object {
-      "GET http://test.com/article/": [Function],
-      "http://test.com/article/some-list-url": [Function],
-    },
+    "update": [Function],
   },
   "payload": [Function],
   "type": "rest-hooks/fetch",
@@ -154,9 +151,7 @@ Object {
     "schema": [Function],
     "throttle": false,
     "type": "mutate",
-    "updaters": Object {
-      "GET http://test.com/article-cooler/": [Function],
-    },
+    "update": [Function],
   },
   "payload": [Function],
   "type": "rest-hooks/fetch",

--- a/packages/core/src/state/__tests__/networkManager.ts
+++ b/packages/core/src/state/__tests__/networkManager.ts
@@ -163,11 +163,9 @@ describe('NetworkManager', () => {
         type: RECEIVE_TYPE,
         payload: data,
         meta: {
-          updaters: {
-            [ArticleResource.listShape().getFetchKey({})]: expect.any(Function),
-          },
+          updaters: undefined,
           args: fetchRpcWithUpdatersAction.meta.args,
-          update: fetchRpcWithUpdatersAction.meta.update,
+          update: expect.any(Function),
           schema: fetchRpcWithUpdatersAction.meta.schema,
           key: fetchRpcWithUpdatersAction.meta.key,
           date: expect.any(Number),
@@ -190,11 +188,9 @@ describe('NetworkManager', () => {
         type: RECEIVE_TYPE,
         payload: data,
         meta: {
-          updaters: {
-            [ArticleResource.listShape().getFetchKey({})]: expect.any(Function),
-          },
+          updaters: undefined,
           args: fetchRpcWithUpdatersAndOptimisticAction.meta.args,
-          update: fetchRpcWithUpdatersAndOptimisticAction.meta.update,
+          update: expect.any(Function),
           schema: fetchRpcWithUpdatersAndOptimisticAction.meta.schema,
           key: fetchRpcWithUpdatersAndOptimisticAction.meta.key,
           date: expect.any(Number),

--- a/packages/core/src/state/actions/createFetch.ts
+++ b/packages/core/src/state/actions/createFetch.ts
@@ -68,18 +68,20 @@ export default function createFetch<
         : /* istanbul ignore next */ new Date(),
   };
 
-  if (updateParams) {
-    meta.updaters = updateParams.reduce(
-      (accumulator: object, [toShape, toParams, updateFn]) => ({
-        [toShape.getFetchKey(toParams)]: updateFn,
-        ...accumulator,
-      }),
-      {},
-    );
-  }
-
   if (fetchShape.update) {
     meta.update = fetchShape.update;
+  }
+
+  // for simplicity we simply override if updateParams are defined - usage together is silly to support as we are migrating
+  if (updateParams) {
+    meta.update = (newresult: any): Record<string, (...args: any) => any> => {
+      const updateMap: any = {};
+      updateParams.forEach(([toShape, toParams, updateFn]) => {
+        updateMap[toShape.getFetchKey(toParams)] = (existing: any) =>
+          updateFn(newresult, existing);
+      });
+      return updateMap;
+    };
   }
 
   if (options && options.optimisticUpdate) {


### PR DESCRIPTION

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
As promised in https://github.com/coinbase/rest-hooks/pull/843 - as part of legacy plan we will only send update functions.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Convert updateParams to update function in core's createFetch().

Will not merge with endpoint.update - instead overrides for simplicity.