### PR TITLE
feat: Add garbage collection action

### DIFF
--- a/packages/core/src/actionTypes.ts
+++ b/packages/core/src/actionTypes.ts
@@ -4,3 +4,4 @@ export const RESET_TYPE = 'rest-hooks/reset' as const;
 export const SUBSCRIBE_TYPE = 'rest-hooks/subscribe' as const;
 export const UNSUBSCRIBE_TYPE = 'rest-hook/unsubscribe' as const;
 export const INVALIDATE_TYPE = 'rest-hooks/invalidate' as const;
+export const GC_TYPE = 'rest-hooks/gc' as const;

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -6,6 +6,7 @@ import {
   INVALIDATE_TYPE,
   RESET_TYPE,
   FETCH_TYPE,
+  GC_TYPE,
 } from '@rest-hooks/core/actionTypes';
 
 import applyUpdatersToResults from './applyUpdatersToResults';
@@ -26,6 +27,17 @@ export default function reducer(
 ): State<unknown> {
   if (!state) state = initialState;
   switch (action.type) {
+    case GC_TYPE:
+      // inline deletes are fine as these should have 0 refcounts
+      action.entities.forEach(([key, pk]) => {
+        delete (state as any).entities[key]?.[pk];
+        delete (state as any).entityMeta[key]?.[pk];
+      });
+      action.results.forEach(fetchKey => {
+        delete (state as any).results[fetchKey];
+        delete (state as any).meta[fetchKey];
+      });
+      return state;
     case FETCH_TYPE: {
       const optimisticResponse = action.meta.optimisticResponse;
       if (optimisticResponse === undefined) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,6 +18,7 @@ import {
   SUBSCRIBE_TYPE,
   UNSUBSCRIBE_TYPE,
   INVALIDATE_TYPE,
+  GC_TYPE,
 } from './actionTypes';
 
 export type { AbstractInstanceType, UpdateFunction };
@@ -152,6 +153,12 @@ export interface InvalidateAction
   };
 }
 
+export interface GCAction {
+  type: typeof GC_TYPE;
+  entities: [string, string][];
+  results: string[];
+}
+
 export type ResponseActions = ReceiveAction;
 
 // put other actions here in union
@@ -161,7 +168,8 @@ export type ActionTypes =
   | SubscribeAction
   | UnsubscribeAction
   | InvalidateAction
-  | ResetAction;
+  | ResetAction
+  | GCAction;
 
 export interface Manager {
   getMiddleware(): Middleware;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Empowers high-performance pluggable GC.

Plan is to follow up with shipping configurable GC Manager based on ref counting and LRU.


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- New action that simply dictates which entities and/or results to remove.
- Assumes issuer properly ref counted so immutability guarantees are not violated since there should be no references.

#### Exports

```ts
export interface GCAction {
      type: typeof GC_TYPE;
      entities: [key: string, pk: string][];
      results: string[];
}
```

`actionTypes.GC_TYPE`