### PR TITLE
feat: Resource.list().paginated()

### DIFF
--- a/packages/experimental/src/entity/EntityRecord.ts
+++ b/packages/experimental/src/entity/EntityRecord.ts
@@ -38,7 +38,7 @@ export default abstract class EntityRecord extends Entity {
     const instance: any = super.fromJS(props);
 
     Object.defineProperty(instance, DefinedMembersKey, {
-      value: props,
+      value: { ...props },
       writable: false,
     });
 

--- a/packages/experimental/src/rest/BaseResource.ts
+++ b/packages/experimental/src/rest/BaseResource.ts
@@ -1,11 +1,10 @@
 import { Endpoint } from '@rest-hooks/endpoint';
+import type { EndpointExtraOptions } from '@rest-hooks/endpoint';
+import type { Schema } from '@rest-hooks/normalizr';
 
 import Entity from '../entity/EntityRecord';
 import paramsToString from './paramsToString';
 import { RestEndpoint } from './types';
-
-import type { EndpointExtraOptions } from '@rest-hooks/endpoint';
-import type { Schema } from '@rest-hooks/normalizr';
 
 class NetworkError extends Error {
   declare status: number;

--- a/packages/experimental/src/rest/__tests__/Resource.test.ts
+++ b/packages/experimental/src/rest/__tests__/Resource.test.ts
@@ -1,0 +1,121 @@
+import nock from 'nock';
+import { useResource } from '@rest-hooks/core';
+
+import Resource from '../Resource';
+import useFetcher from '../../useFetcher';
+import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import {
+  payload,
+  createPayload,
+  users,
+  nested,
+  paginatedFirstPage,
+  paginatedSecondPage,
+} from '../test-fixtures';
+
+export class UserResource extends Resource {
+  readonly id: number | undefined = undefined;
+  readonly username: string = '';
+  readonly email: string = '';
+  readonly isAdmin: boolean = false;
+
+  pk() {
+    return this.id?.toString();
+  }
+
+  static urlRoot = 'http://test.com/user/';
+}
+export class PaginatedArticleResource extends Resource {
+  readonly id: number | undefined = undefined;
+  readonly title: string = '';
+  readonly content: string = '';
+  readonly author: number | null = null;
+  readonly tags: string[] = [];
+
+  pk() {
+    return this.id?.toString();
+  }
+
+  static schema = {
+    author: UserResource,
+  };
+
+  static urlRoot = 'http://test.com/article-paginated/';
+
+  static list<T extends typeof Resource>(this: T) {
+    return super.list().extend({
+      schema: {
+        nextPage: '',
+        results: [this],
+      },
+    });
+  }
+
+  static listPage<T extends typeof PaginatedArticleResource>(this: T) {
+    return this.list().paginated(({ cursor, ...rest }) => [rest]);
+  }
+}
+
+describe('Resource', () => {
+  const renderRestHook: ReturnType<typeof makeRenderRestHook> =
+    makeRenderRestHook(makeCacheProvider);
+  let mynock: nock.Scope;
+
+  beforeEach(() => {
+    nock(/.*/)
+      .persist()
+      .defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      })
+      .options(/.*/)
+      .reply(200)
+      .get(`/article-cooler/${payload.id}`)
+      .reply(200, payload)
+      .delete(`/article-cooler/${payload.id}`)
+      .reply(204, '')
+      .delete(`/article/${payload.id}`)
+      .reply(200, {})
+      .get(`/article-cooler/0`)
+      .reply(403, {})
+      .get(`/article-cooler/666`)
+      .reply(200, '')
+      .get(`/article-cooler/`)
+      .reply(200, nested)
+      .post(`/article-cooler/`)
+      .reply(200, createPayload)
+      .get(`/user/`)
+      .reply(200, users);
+    mynock = nock(/.*/).defaultReplyHeaders({
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('should update on get for a paginated resource', async () => {
+    mynock.get(`/article-paginated/`).reply(200, paginatedFirstPage);
+    mynock.get(`/article-paginated/?cursor=2`).reply(200, paginatedSecondPage);
+
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      const fetch = useFetcher();
+      const { results: articles, nextPage } = useResource(
+        PaginatedArticleResource.list(),
+        {},
+      );
+      return { articles, nextPage, fetch };
+    });
+    await waitForNextUpdate();
+    await result.current.fetch(PaginatedArticleResource.listPage(), {
+      cursor: 2,
+    });
+    expect(
+      result.current.articles.map(
+        ({ id }: Partial<PaginatedArticleResource>) => id,
+      ),
+    ).toEqual([5, 3, 7, 8]);
+  });
+});

--- a/packages/experimental/src/rest/getArrayPath.ts
+++ b/packages/experimental/src/rest/getArrayPath.ts
@@ -1,0 +1,19 @@
+import { Schema, schema } from '@rest-hooks/normalizr';
+
+export default function getArrayPath(s: Schema | undefined): string[] | false {
+  if (s === undefined || s instanceof schema.Array || Array.isArray(s)) {
+    return [];
+  }
+  const o: Record<string, Schema> =
+    s instanceof schema.Object ? (s as any).schema : s;
+  for (const k in o) {
+    if (!o[k]) continue;
+    const path = getArrayPath(o[k]);
+    if (path !== false) {
+      // mutation is ok because there is only one path
+      path.unshift(k);
+      return path;
+    }
+  }
+  return false;
+}

--- a/packages/experimental/src/rest/test-fixtures.ts
+++ b/packages/experimental/src/rest/test-fixtures.ts
@@ -1,0 +1,129 @@
+export const payload = {
+  id: 5,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
+export const createPayload = {
+  id: 1,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
+export const articlesPages = {
+  prevPage: '23asdl',
+  nextPage: 's3f3',
+  results: [
+    {
+      id: 23,
+      title: 'the first draft',
+      content: 'the best things in life com efree',
+      tags: ['one', 'two'],
+    },
+    {
+      id: 44,
+      title: 'the second book',
+      content: 'the best things in life com efree',
+      tags: ['hbh', 'wew'],
+    },
+    {
+      id: 2,
+      title: 'the third novel',
+      content: 'the best things in life com efree',
+      tags: ['free', 'honey'],
+    },
+    {
+      id: 643,
+      title: 'a long time ago',
+      content: 'the best things in life com efree',
+    },
+  ],
+};
+
+export const users = [
+  {
+    id: 23,
+    username: 'bob',
+    email: 'bob@bob.com',
+    isAdmin: false,
+  },
+  {
+    id: 7342,
+    username: 'lindsey',
+    email: 'lindsey@bob.com',
+    isAdmin: true,
+  },
+];
+
+export const nested = [
+  {
+    id: 5,
+    title: 'hi ho',
+    content: 'whatever',
+    tags: ['a', 'best', 'react'],
+    author: {
+      id: 23,
+      username: 'bob',
+    },
+  },
+  {
+    id: 3,
+    title: 'the next time',
+    content: 'whatever',
+    author: {
+      id: 23,
+      username: 'charles',
+      email: 'bob@bob.com',
+    },
+  },
+];
+
+const moreNested = [
+  {
+    id: 7,
+    title: 'article 7',
+    content: 'whatever',
+    tags: ['blah'],
+    author: {
+      id: 23,
+      username: 'bob',
+    },
+  },
+  {
+    id: 8,
+    title: 'article 8',
+    content: 'whatever',
+    author: {
+      id: 27,
+      username: 'zac',
+      email: 'zac@bob.com',
+    },
+  },
+];
+
+export const valuesFixture = {
+  first: {
+    id: 1,
+    title: 'first thing',
+    content: 'blah',
+    tags: [],
+  },
+  second: {
+    id: 2,
+    name: 'second thing',
+    content: 'blah',
+    tags: [],
+  },
+};
+
+export const paginatedFirstPage = {
+  nextPage: '2',
+  results: nested,
+};
+
+export const paginatedSecondPage = {
+  nextPage: null,
+  results: moreNested,
+};


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #694 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Pagination is a common scenario, that would benefit from minimal specification.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

By default we rely on finding a list within the schema. The only remaining thing is figuring out how to extract the 'cursor' args to update the main list. Therefore, a function to do just that should be provided by the user like so.

```ts
class NewsResource extends Resource {
  static listPage<T extends typeof NewsResource>(this: T) {
    return this.list().paginated(({ cursor, ...rest }) => [rest]);
  }
}

```


```tsx
import { useResource } from 'rest-hooks';
import NewsResource from 'resources/NewsResource';

function NewsList() {
  const { results, cursor } = useResource(NewsResource.list(), {});
  const curRef = useRef(cursor);
  curRef.current = cursor;
  const fetch = useFetcher();
  const getNextPage = useCallback(
    () => fetch(NewsResource.listPage(), { cursor: curRef.current }),
    []
  );

  return (
    <Pagination onPaginate={getNextPage} nextCursor={cursor}>
      <NewsList data={results} />
    </Pagination>
  );
}
```