### PR TITLE
internal: Major version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/node": "^7.14.2",
     "@commitlint/cli": "^12.0.0",
     "@commitlint/config-conventional": "^12.0.0",
-    "@rest-hooks/test": "^4.0.0",
+    "@rest-hooks/test": "^5.0.0-0",
     "@testing-library/react": "^11.2.3",
     "@testing-library/react-hooks": "^5.0.3",
     "@testing-library/react-native": "^7.1.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "4.1.4",
+  "version": "5.0.0-pre",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs",


### PR DESCRIPTION
BREAKING CHANGE:
- requires node 12
- 'suppressErrorOutput will now work when explicitly called, even if the
RHTL_DISABLE_ERROR_FILTERING env variable has been set' (from
react-hooks-testing-library)


It wasn't picking up on the version change, so trying to trigger it here.