### PR TITLE
enhance: Cache entity default instances

### DIFF
--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -80,8 +80,7 @@ export default abstract class Entity extends SimpleRecord {
       process.env.NODE_ENV !== 'production' &&
       this.automaticValidation !== 'silent'
     ) {
-      const instanceSample = new (this as any)();
-      const keysOfRecord = new Set(Object.keys(instanceSample));
+      const keysOfRecord = new Set(Object.keys(this.defaults));
       const keysOfProps = this.keysDefined(processedEntity);
       const [found, missing, unexpected] = [[], [], []] as [
         string[],
@@ -267,8 +266,6 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
       );
       return [this.fromJS(denormEntity.toObject()), found, deleted];
     }
-    // TODO: This creates unneeded memory pressure
-    const instance = new (this as any)();
     let deleted = false;
 
     // note: iteration order must be stable
@@ -281,7 +278,7 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
 
       if (
         deletedItem &&
-        !(Object.hasOwnProperty.call(input, key) && !instance[key])
+        !(Object.hasOwnProperty.call(input, key) && !this.defaults[key])
       ) {
         deleted = true;
       }

--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -125,8 +125,6 @@ export default abstract class SimpleRecord {
     input: any,
     unvisit: any,
   ): [AbstractInstanceType<T>, boolean, boolean] {
-    // TODO: This creates unneeded memory pressure
-    const instance = new (this as any)();
     const object = { ...input };
     let deleted = false;
     let found = true;
@@ -140,16 +138,24 @@ export default abstract class SimpleRecord {
       }
       // members who default to falsy values are considered 'optional'
       // if falsy value, and default is actually set then it is optional so pass through
-      if (!foundItem && !(key in instance && !instance[key])) {
+      if (!foundItem && !(key in this.defaults && !this.defaults[key])) {
         found = false;
       }
-      if (deletedItem && !(key in instance && !instance[key])) {
+      if (deletedItem && !(key in this.defaults && !this.defaults[key])) {
         deleted = true;
       }
     });
 
     // useDenormalized will memo based on entities, so creating a new object each time is fine
     return [this.fromJS(object) as any, found, deleted];
+  }
+
+  private declare static __defaults: any;
+  /** All instance defaults set */
+  protected static get defaults() {
+    if (!Object.prototype.hasOwnProperty.call(this, '__defaults'))
+      this.__defaults = new (this as any)();
+    return this.__defaults;
   }
 
   /** @deprecated */


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Reduces memory pressure by providing a cached defaults for various algorithms.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```ts
private declare static __defaults: any;
      protected static get defaults() {
        if (!Object.prototype.hasOwnProperty.call(this, '__defaults'))
          this.__defaults = new (this as any)();
        return this.__defaults;
}
```
