### PR TITLE
enhance: Improve autoimport handling in vscode

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,11 +9,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -9,11 +9,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -9,11 +9,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -9,11 +9,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -9,11 +9,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -9,11 +9,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -33,11 +33,17 @@
   "typings": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -9,11 +9,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -9,11 +9,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -8,11 +8,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -9,11 +9,17 @@
   "types": "lib/index.d.ts",
   "typesVersions": {
     ">=4.0": {
+      "": [
+        "lib/index.d.ts"
+      ],
       "*": [
         "lib/index.d.ts"
       ]
     },
     ">=3.4": {
+      "": [
+        "ts3.4/index.d.ts"
+      ],
       "*": [
         "ts3.4/index.d.ts"
       ]


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
With TypeScript 4.3, autocomplete imports work even better, which makes this extra important.

For some reason even though the * is recommended by typescript docs, and makes the typescript itself work, it results in 

```ts
import { useResource } from '@rest-hooks/core/*'
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Even though vscode tells me this is not a valid key in the package.json, this makes both auto import and import autocomplete work. Additionally, both lookup and the types still work correctly.