### PR TITLE
internal: publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/node": "^7.14.2",
     "@commitlint/cli": "^12.0.0",
     "@commitlint/config-conventional": "^12.0.0",
-    "@rest-hooks/test": "^5.0.0-0",
+    "@rest-hooks/test": "^6.0.0-0",
     "@testing-library/react": "^11.2.3",
     "@testing-library/react-hooks": "^5.0.3",
     "@testing-library/react-native": "^7.1.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.2.1...@rest-hooks/core@1.4.0) (2021-06-02)
+
+
+### 🚀 Features
+
+* Add garbage collection action ([#865](https://github.com/coinbase/rest-hooks/issues/865)) ([aab7ad6](https://github.com/coinbase/rest-hooks/commit/aab7ad6045a08417f53b778a7ea4d2611f6cac06))
+
+
+### 💅 Enhancement
+
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+
 ## [1.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.2.1...@rest-hooks/core@1.3.0) (2021-05-30)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/endpoint": "^1.1.4",
-    "@rest-hooks/normalizr": "^7.0.2",
-    "@rest-hooks/use-enhanced-reducer": "^1.0.7",
+    "@rest-hooks/endpoint": "^1.1.5",
+    "@rest-hooks/normalizr": "^7.0.3",
+    "@rest-hooks/use-enhanced-reducer": "^1.0.8",
     "flux-standard-action": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.3...@rest-hooks/endpoint@1.1.5) (2021-06-02)
+
+
+### 💅 Enhancement
+
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+
 ### [1.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.3...@rest-hooks/endpoint@1.1.4) (2021-05-30)
 
 **Note:** Version bump only for package @rest-hooks/endpoint

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -78,6 +78,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/normalizr": "^7.0.2"
+    "@rest-hooks/normalizr": "^7.0.3"
   }
 }

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.2.1...@rest-hooks/experimental@0.4.0) (2021-06-02)
+
+
+### 🚀 Features
+
+* Export types for Resource ([#889](https://github.com/coinbase/rest-hooks/issues/889)) ([c2766ae](https://github.com/coinbase/rest-hooks/commit/c2766aefa2f1bd736d635c9b5bd51170d9fe104c))
+* Resource.list().paginate() ([#868](https://github.com/coinbase/rest-hooks/issues/868)) ([cecdd7d](https://github.com/coinbase/rest-hooks/commit/cecdd7dd0fc5d4bbffd7f7cf7fa1344be3807697))
+
+
+### 💅 Enhancement
+
+* Cache entity default instances ([#883](https://github.com/coinbase/rest-hooks/issues/883)) ([842f6c8](https://github.com/coinbase/rest-hooks/commit/842f6c8e3dfc27e2946f5adc1bdbef849e8794ab))
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+### 📝 Documentation
+
+* Add paginated() to readme ([#891](https://github.com/coinbase/rest-hooks/issues/891)) ([44b85ed](https://github.com/coinbase/rest-hooks/commit/44b85edc6d3a4273a46a8e0f771ca281af25e254))
+
+
+
 ## [0.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.2.1...@rest-hooks/experimental@0.3.0) (2021-05-30)
 
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.2.0...@rest-hooks/hooks@1.2.1) (2021-06-02)
+
+
+### 💅 Enhancement
+
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+
 ## [1.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.1.3...@rest-hooks/hooks@1.2.0) (2021-05-24)
 
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/img/CHANGELOG.md
+++ b/packages/img/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.2.2...@rest-hooks/img@0.2.3) (2021-06-02)
+
+
+### 💅 Enhancement
+
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+
 ### [0.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.2.1...@rest-hooks/img@0.2.2) (2021-04-24)
 
 

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/img",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.7...@rest-hooks/legacy@2.0.8) (2021-06-02)
+
+
+### 💅 Enhancement
+
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+
 ### [2.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.6...@rest-hooks/legacy@2.0.7) (2021-05-24)
 
 **Note:** Version bump only for package @rest-hooks/legacy

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.0.1...@rest-hooks/normalizr@7.0.3) (2021-06-02)
+
+
+### 💅 Enhancement
+
+* Cache entity default instances ([#883](https://github.com/coinbase/rest-hooks/issues/883)) ([842f6c8](https://github.com/coinbase/rest-hooks/commit/842f6c8e3dfc27e2946f5adc1bdbef849e8794ab))
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+
 ### [7.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.0.1...@rest-hooks/normalizr@7.0.2) (2021-05-30)
 
 **Note:** Version bump only for package @rest-hooks/normalizr

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.1.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.1.1...rest-hooks@5.1.3) (2021-06-02)
+
+
+### 💅 Enhancement
+
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+
 ### [5.1.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.1.1...rest-hooks@5.1.2) (2021-05-30)
 
 **Note:** Version bump only for package rest-hooks

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -87,8 +87,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/core": "^1.3.0",
-    "@rest-hooks/endpoint": "^1.1.4"
+    "@rest-hooks/core": "^1.4.0",
+    "@rest-hooks/endpoint": "^1.1.5"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0",

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.1.2...@rest-hooks/rest@2.1.3) (2021-06-02)
+
+
+### 💅 Enhancement
+
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+
 ### [2.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.1.1...@rest-hooks/rest@2.1.2) (2021-05-24)
 
 

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.1.4...@rest-hooks/test@6.0.0) (2021-06-02)
+
+
+### ⚠ 💥 BREAKING CHANGES
+
+* - requires node 12
+- 'suppressErrorOutput will now work when explicitly called, even if the
+    RHTL_DISABLE_ERROR_FILTERING env variable has been set' (from
+    react-hooks-testing-library)
+
+### 💅 Enhancement
+
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+### 📦 Package
+
+* react-hooks-testing-library v7 ([#866](https://github.com/coinbase/rest-hooks/issues/866)) ([249883b](https://github.com/coinbase/rest-hooks/commit/249883b11624d1adbd440fbbb96f597a81162857))
+
+
+### 🏠 Internal
+
+* Major version bump ([#874](https://github.com/coinbase/rest-hooks/issues/874)) ([37931f3](https://github.com/coinbase/rest-hooks/commit/37931f331a08268fb12f752f26f3281b0cb11adf))
+
+
+
 ## [5.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.1.4...@rest-hooks/test@5.0.0) (2021-05-30)
 
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs",

--- a/packages/use-enhanced-reducer/CHANGELOG.md
+++ b/packages/use-enhanced-reducer/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.7...@rest-hooks/use-enhanced-reducer@1.0.8) (2021-06-02)
+
+
+### 💅 Enhancement
+
+* Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
+
+
+
 ### [1.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.6...@rest-hooks/use-enhanced-reducer@1.0.7) (2021-05-24)
 
 **Note:** Version bump only for package @rest-hooks/use-enhanced-reducer

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
 - @rest-hooks/core@1.4.0
 - @rest-hooks/endpoint@1.1.5
 - @rest-hooks/experimental@0.4.0
 - @rest-hooks/hooks@1.2.1
 - @rest-hooks/img@0.2.3
 - @rest-hooks/legacy@2.0.8
 - @rest-hooks/normalizr@7.0.3
 - rest-hooks@5.1.3
 - @rest-hooks/rest@2.1.3
 - @rest-hooks/test@6.0.0
 - @rest-hooks/use-enhanced-reducer@1.0.8
