### PR TITLE
feat: Add inferResults()

### DIFF
--- a/packages/experimental/src/entity/Entity.ts
+++ b/packages/experimental/src/entity/Entity.ts
@@ -383,8 +383,7 @@ function indexFromParams<I extends string>(
   indexes?: Readonly<I[]>,
 ) {
   if (!indexes) return undefined;
-  for (const index of indexes) {
-    if (index in params) return index;
-  }
-  return undefined;
+  return indexes.find(index =>
+    Object.prototype.hasOwnProperty.call(params, index),
+  );
 }

--- a/packages/normalizr/src/__tests__/inferResults.ts
+++ b/packages/normalizr/src/__tests__/inferResults.ts
@@ -1,0 +1,171 @@
+import {
+  CoolerArticleResource,
+  UnionResource,
+  IndexedUserResource,
+} from '__tests__/common';
+import { schema as schemas, SimpleRecord } from '@rest-hooks/normalizr';
+
+import buildInferredResults from '../inferResults';
+
+describe('inferResults()', () => {
+  it('should work with Object', () => {
+    const schema = new schemas.Object({
+      data: new schemas.Object({
+        article: CoolerArticleResource,
+      }),
+    });
+    expect(buildInferredResults(schema, [{ id: 5 }], {})).toEqual({
+      data: { article: '5' },
+    });
+  });
+
+  it('should work with SimpleRecord', () => {
+    class Data extends SimpleRecord {
+      readonly article = CoolerArticleResource.fromJS();
+      readonly otherfield = '';
+      static schema = {
+        article: CoolerArticleResource,
+      };
+    }
+    class Message extends SimpleRecord {
+      readonly data = Data.fromJS();
+      static schema = {
+        data: Data,
+      };
+    }
+    const schema = Message;
+    const results = buildInferredResults(schema, [{ id: 5 }], {});
+    expect(results).toEqual({
+      data: { article: '5' },
+    });
+  });
+
+  it('should be undefined with Array', () => {
+    const schema = {
+      data: new schemas.Array(CoolerArticleResource),
+    };
+    expect(buildInferredResults(schema, [{ id: 5 }], {})).toStrictEqual({
+      data: undefined,
+    });
+
+    const schema2 = {
+      data: [CoolerArticleResource],
+    };
+    expect(buildInferredResults(schema2, [{ id: 5 }], {})).toStrictEqual({
+      data: undefined,
+    });
+  });
+
+  it('should be undefined with Values', () => {
+    const schema = {
+      data: new schemas.Values(CoolerArticleResource),
+    };
+    expect(buildInferredResults(schema, [{ id: 5 }], {})).toStrictEqual({
+      data: undefined,
+    });
+  });
+
+  it('should be undefined with Union and type', () => {
+    const schema = UnionResource.detailShape().schema;
+    expect(buildInferredResults(schema, [{ id: 5 }], {})).toBe(undefined);
+  });
+
+  it('should work with Union', () => {
+    const schema = UnionResource.detailShape().schema;
+    expect(buildInferredResults(schema, [{ id: 5, type: 'first' }], {}))
+      .toMatchInlineSnapshot(`
+      Object {
+        "id": 5,
+        "schema": "first",
+      }
+    `);
+  });
+
+  it('should work with primitive defaults', () => {
+    const schema = {
+      pagination: { next: '', previous: '' },
+      data: CoolerArticleResource,
+    };
+    expect(buildInferredResults(schema, [{ id: 5 }], {})).toEqual({
+      pagination: { next: '', previous: '' },
+      data: '5',
+    });
+  });
+
+  it('should work with indexes', () => {
+    const schema = {
+      pagination: { next: '', previous: '' },
+      data: IndexedUserResource,
+    };
+    expect(
+      buildInferredResults(schema, [{ username: 'bob' }], {
+        [IndexedUserResource.key]: {
+          username: {
+            bob: '5',
+          },
+        },
+      }),
+    ).toEqual({
+      pagination: { next: '', previous: '' },
+      data: '5',
+    });
+    expect(
+      buildInferredResults(schema, [{ username: 'bob', mary: 'five' }], {
+        [IndexedUserResource.key]: {
+          username: {
+            bob: '5',
+          },
+        },
+      }),
+    ).toEqual({
+      pagination: { next: '', previous: '' },
+      data: '5',
+    });
+  });
+
+  it('should work with indexes but none set', () => {
+    const schema = {
+      pagination: { next: '', previous: '' },
+      data: IndexedUserResource,
+    };
+    expect(
+      buildInferredResults(schema, [{ username: 'bob' }], {
+        [IndexedUserResource.key]: {
+          username: {
+            charles: '5',
+          },
+        },
+      }),
+    ).toEqual({
+      pagination: { next: '', previous: '' },
+      data: undefined,
+    });
+    expect(
+      buildInferredResults(schema, [{ hover: 'bob' }], {
+        [IndexedUserResource.key]: {
+          username: {
+            charles: '5',
+          },
+        },
+      }),
+    ).toEqual({
+      pagination: { next: '', previous: '' },
+      data: undefined,
+    });
+  });
+
+  it('should work with indexes but no indexes stored', () => {
+    const schema = {
+      pagination: { next: '', previous: '' },
+      data: IndexedUserResource,
+    };
+    expect(buildInferredResults(schema, [{ username: 'bob' }], {})).toEqual({
+      pagination: { next: '', previous: '' },
+      data: undefined,
+    });
+    expect(buildInferredResults(schema, [{ hover: 'bob' }], {})).toEqual({
+      pagination: { next: '', previous: '' },
+      data: undefined,
+    });
+  });
+});

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -329,8 +329,7 @@ function indexFromParams<I extends string>(
   indexes?: Readonly<I[]>,
 ) {
   if (!indexes) return undefined;
-  for (const index of indexes) {
-    if (index in params) return index;
-  }
-  return undefined;
+  return indexes.find(index =>
+    Object.prototype.hasOwnProperty.call(params, index),
+  );
 }

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -239,6 +239,22 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     return id;
   }
 
+  static infer(args, indexes, infer): any {
+    if (!args[0]) return undefined as any;
+    const id = this.pk(args[0], undefined, '');
+    // Was able to infer the entity's primary key from params
+    if (id !== undefined && id !== '') return id as any;
+    // now attempt lookup in indexes
+    const indexName = indexFromParams(args[0], this.indexes);
+    if (indexName && indexes[this.key]) {
+      // 'as Record<string, any>': indexName can only be found if params is a string key'd object
+      return indexes[this.key][indexName][
+        (args[0] as Record<string, any>)[indexName]
+      ] as any;
+    }
+    return undefined as any;
+  }
+
   static denormalize<T extends typeof SimpleRecord>(
     this: T,
     input: Readonly<Partial<AbstractInstanceType<T>>>,
@@ -306,4 +322,15 @@ if (process.env.NODE_ENV !== 'production') {
 
 export function isEntity(schema: Schema): schema is typeof Entity {
   return schema !== null && (schema as any).pk !== undefined;
+}
+
+function indexFromParams<I extends string>(
+  params: Readonly<object>,
+  indexes?: Readonly<I[]>,
+) {
+  if (!indexes) return undefined;
+  for (const index of indexes) {
+    if (index in params) return index;
+  }
+  return undefined;
 }

--- a/packages/normalizr/src/entities/SimpleRecord.ts
+++ b/packages/normalizr/src/entities/SimpleRecord.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { AbstractInstanceType, Schema, NormalizedEntity } from '../types';
-import { normalize } from '../schemas/Object';
+import { normalize, infer } from '../schemas/Object';
 
 const DefinedMembersKey = Symbol('Defined Members');
 const UniqueIdentifierKey = Symbol('unq');
@@ -118,6 +118,15 @@ export default abstract class SimpleRecord {
     ]
   ): NormalizedEntity<T> {
     return normalize(this.schema, ...args) as any;
+  }
+
+  static infer<T extends typeof SimpleRecord>(
+    this: T,
+    args,
+    indexes,
+    recurse,
+  ): NormalizedEntity<T> {
+    return infer(this.schema, args, indexes, recurse);
   }
 
   static denormalize<T extends typeof SimpleRecord>(

--- a/packages/normalizr/src/index.ts
+++ b/packages/normalizr/src/index.ts
@@ -5,6 +5,7 @@ import * as schema from './schema';
 import Entity, { isEntity } from './entities/Entity';
 import SimpleRecord from './entities/SimpleRecord';
 export { default as FlatEntity } from './entities/FlatEntity';
+export { default as inferResults } from './inferResults';
 export { DELETED } from './special';
 
 export type {

--- a/packages/normalizr/src/inferResults.ts
+++ b/packages/normalizr/src/inferResults.ts
@@ -12,15 +12,18 @@ export default function inferResults<S extends Schema>(
   args: any[],
   indexes: NormalizedIndex,
 ): NormalizeNullable<S> {
+  // schema classes
   if (canInfer(schema)) {
     return schema.infer(args, indexes, inferResults);
   }
 
+  // plain case
   if (typeof schema === 'object' && schema) {
     const method = Array.isArray(schema) ? arrayInfer : objectInfer;
     return method(schema, args, indexes, inferResults);
   }
 
+  // fallback for things like null or undefined
   return schema as any;
 }
 

--- a/packages/normalizr/src/inferResults.ts
+++ b/packages/normalizr/src/inferResults.ts
@@ -1,0 +1,29 @@
+import { NormalizedIndex, NormalizeNullable, Schema } from './types';
+import { infer as objectInfer } from './schemas/Object';
+import { infer as arrayInfer } from './schemas/Array';
+import { SchemaSimple } from './schema';
+
+/**
+ * Build the result parameter to denormalize from schema alone.
+ * Tries to compute the entity ids from params.
+ */
+export default function inferResults<S extends Schema>(
+  schema: S,
+  args: any[],
+  indexes: NormalizedIndex,
+): NormalizeNullable<S> {
+  if (canInfer(schema)) {
+    return schema.infer(args, indexes, inferResults);
+  }
+
+  if (typeof schema === 'object' && schema) {
+    const method = Array.isArray(schema) ? arrayInfer : objectInfer;
+    return method(schema, args, indexes, inferResults);
+  }
+
+  return schema as any;
+}
+
+function canInfer(schema: Schema): schema is Pick<SchemaSimple, 'infer'> {
+  return !!schema && typeof (schema as any).infer === 'function';
+}

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -11,6 +11,7 @@ import {
   NormalizedNullableObject,
   UnvisitFunction,
   EntityMap,
+  NormalizedIndex,
 } from './types';
 import { default as Delete } from './schemas/Delete';
 
@@ -54,6 +55,11 @@ export interface SchemaSimple<T = any> {
     input: {} | undefined,
     unvisit: UnvisitFunction,
   ): [T, boolean, boolean];
+  infer(
+    args: any[],
+    indexes: NormalizedIndex,
+    recurse: (...args: any) => any,
+  ): any;
 }
 
 export interface SchemaClass<T = any, N = T | undefined>
@@ -94,6 +100,12 @@ export class Array<S extends Schema = Schema> implements SchemaClass {
   ): [Denormalize<S>[], boolean, boolean];
 
   _denormalizeNullable(): [Denormalize<S>[] | undefined, false, boolean];
+
+  infer(
+    args: any[],
+    indexes: NormalizedIndex,
+    recurse: (...args: any) => any,
+  ): any;
 }
 
 export class Object<O extends Record<string, any> = Record<string, Schema>>
@@ -120,6 +132,12 @@ export class Object<O extends Record<string, any> = Record<string, Schema>>
   ): [DenormalizeObject<O>, boolean, boolean];
 
   _denormalizeNullable(): [DenormalizeNullableObject<O>, false, boolean];
+
+  infer(
+    args: any[],
+    indexes: NormalizedIndex,
+    recurse: (...args: any) => any,
+  ): any;
 }
 
 export class Union<Choices extends EntityMap = any> implements SchemaClass {
@@ -156,6 +174,12 @@ export class Union<Choices extends EntityMap = any> implements SchemaClass {
     false,
     boolean,
   ];
+
+  infer(
+    args: any[],
+    indexes: NormalizedIndex,
+    recurse: (...args: any) => any,
+  ): any;
 }
 
 export class Values<Choices extends Schema = any> implements SchemaClass {
@@ -221,4 +245,10 @@ export class Values<Choices extends Schema = any> implements SchemaClass {
     false,
     boolean,
   ];
+
+  infer(
+    args: any[],
+    indexes: NormalizedIndex,
+    recurse: (...args: any) => any,
+  ): any;
 }

--- a/packages/normalizr/src/schemas/Array.js
+++ b/packages/normalizr/src/schemas/Array.js
@@ -56,6 +56,10 @@ export const denormalize = (schema, input, unvisit) => {
   ];
 };
 
+export function infer(schema, args, indexes, recurse) {
+  return undefined;
+}
+
 export default class ArraySchema extends PolymorphicSchema {
   normalize(input, parent, key, visit, addEntity, visitedEntities) {
     const values = getValues(input);
@@ -90,5 +94,9 @@ export default class ArraySchema extends PolymorphicSchema {
       found,
       deleted,
     ];
+  }
+
+  infer(args, indexes, recurse) {
+    return infer(this.schema, args, indexes, recurse);
   }
 }

--- a/packages/normalizr/src/schemas/Delete.ts
+++ b/packages/normalizr/src/schemas/Delete.ts
@@ -51,6 +51,10 @@ export default class Delete<E extends EntityInterface & { fromJS: any }>
     return id;
   }
 
+  infer(args: any, indexes: any, recurse: any): any {
+    return undefined;
+  }
+
   denormalize(
     id: string,
     unvisit: UnvisitFunction,

--- a/packages/normalizr/src/schemas/Object.js
+++ b/packages/normalizr/src/schemas/Object.js
@@ -54,7 +54,7 @@ export const denormalize = (schema, input, unvisit) => {
 
 export function infer(schema, args, indexes, recurse) {
   let resultObject = {};
-  for (const k in schema) {
+  for (const k of Object.keys(schema)) {
     resultObject[k] = recurse(schema[k], args, indexes);
   }
   return resultObject;

--- a/packages/normalizr/src/schemas/Object.js
+++ b/packages/normalizr/src/schemas/Object.js
@@ -52,6 +52,14 @@ export const denormalize = (schema, input, unvisit) => {
   return [object, found, deleted];
 };
 
+export function infer(schema, args, indexes, recurse) {
+  let resultObject = {};
+  for (const k in schema) {
+    resultObject[k] = recurse(schema[k], args, indexes);
+  }
+  return resultObject;
+}
+
 export default class ObjectSchema {
   constructor(definition) {
     this.define(definition);
@@ -70,5 +78,9 @@ export default class ObjectSchema {
 
   denormalize(...args) {
     return denormalize(this.schema, ...args);
+  }
+
+  infer(args, indexes, recurse) {
+    return infer(this.schema, args, indexes, recurse);
   }
 }

--- a/packages/normalizr/src/schemas/Union.js
+++ b/packages/normalizr/src/schemas/Union.js
@@ -24,4 +24,16 @@ export default class UnionSchema extends PolymorphicSchema {
   denormalize(input, unvisit) {
     return this.denormalizeValue(input, unvisit);
   }
+
+  infer(args, indexes, recurse) {
+    const attr = this.getSchemaAttribute(args[0], undefined, '');
+    const discriminatedSchema = this.schema[attr];
+
+    // Was unable to infer the entity's schema from params
+    if (discriminatedSchema === undefined) return undefined;
+    return {
+      id: recurse(discriminatedSchema, args, indexes),
+      schema: attr,
+    };
+  }
 }

--- a/packages/normalizr/src/schemas/Values.js
+++ b/packages/normalizr/src/schemas/Values.js
@@ -46,4 +46,8 @@ export default class ValuesSchema extends PolymorphicSchema {
       deleted,
     ];
   }
+
+  infer(args, indexes, recurse) {
+    return undefined;
+  }
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Extracting `buildInferredResults()` into normalizr

- Simplify logic
- Customizable inference behavior including disabling
- Start supporting variable arg length

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add `infer()` to schemas. Somewhat similar to normalize, tho only tries to build results piece - no entity collection.

### Next

Utilize this in @rest-hooks/core. We split this up so we can distinctly mark a dependency on this feature in the other package.