### PR TITLE
enhance: Use inferResults() from normalizr

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1,4 +1,6 @@
 export { DELETED } from '@rest-hooks/endpoint';
 
+// TODO: Delete next line for v2
 export { default as buildInferredResults } from './state/selectors/buildInferredResults';
+export { inferResults } from '@rest-hooks/normalizr';
 export { default as RIC } from './state/RIC';

--- a/packages/core/src/react-integration/hooks/useCache.ts
+++ b/packages/core/src/react-integration/hooks/useCache.ts
@@ -11,8 +11,7 @@ import {
   useMeta,
   useError,
 } from '@rest-hooks/core/react-integration/hooks';
-import { denormalize } from '@rest-hooks/normalizr';
-import buildInferredResults from '@rest-hooks/core/state/selectors/buildInferredResults';
+import { denormalize, inferResults } from '@rest-hooks/normalizr';
 
 import useExpiresAt from './useExpiresAt';
 
@@ -59,7 +58,7 @@ export default function useCache<
     expired
   ) {
     return denormalize(
-      buildInferredResults(fetchShape.schema, params, state.indexes),
+      inferResults(fetchShape.schema, [params], state.indexes),
       fetchShape.schema,
       {},
     )[0];

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -6,10 +6,9 @@ import {
   DenormalizeCache,
   WeakListMap,
   denormalize,
+  inferResults,
 } from '@rest-hooks/normalizr';
 import { useMemo } from 'react';
-
-import buildInferredResults from './buildInferredResults';
 
 /**
  * Selects the denormalized form from `state` cache.
@@ -47,7 +46,7 @@ export default function useDenormalized<
 
     // in case we don't even have entities for a model yet, denormalize() will throw
     // entities[entitySchema.key] === undefined
-    return buildInferredResults(schema, params, state.indexes);
+    return inferResults(schema, [params], state.indexes);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cacheResults, state.indexes, serializedParams]);
   // TODO: only update when relevant indexes change
@@ -107,6 +106,7 @@ export default function useDenormalized<
     // in packages/core/src/react-integration/__tests__/useResource.web.tsx
     const ready = !!cacheResults || found;
 
+    // TODO: move this to the .infer() method
     // oldest entity dictates age
     let expiresAt = Infinity;
     if (ready) {

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -76,7 +76,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "peerDependencies": {
-    "@rest-hooks/core": "^1.0.7",
+    "@rest-hooks/core": "^1.5.0",
     "@types/react": "^16.8.4 || ^17.0.0",
     "react": "^16.8.4 || ^17.0.0"
   },

--- a/packages/legacy/src/index.ts
+++ b/packages/legacy/src/index.ts
@@ -18,7 +18,7 @@ import type {
 import { denormalize } from '@rest-hooks/normalizr';
 import { useContext } from 'react';
 
-const { buildInferredResults } = __INTERNAL__;
+const { inferResults } = __INTERNAL__;
 
 type CondNull<P, A, B> = P extends null ? A : B;
 
@@ -71,7 +71,7 @@ export function useStatefulResource<
     ) && !!maybePromise;
   const data = loading
     ? denormalize(
-        buildInferredResults(fetchShape.schema, params, state.indexes),
+        inferResults(fetchShape.schema, [params], state.indexes),
         fetchShape.schema,
         {},
       )[0]

--- a/packages/rest-hooks/src/internal.ts
+++ b/packages/rest-hooks/src/internal.ts
@@ -5,5 +5,7 @@ export {
   DispatchContext,
   hasUsableData,
 } from '@rest-hooks/core';
+// TODO: Delete next line for v6
 export const buildInferredResults = __INTERNAL__.buildInferredResults;
+export const inferResults = __INTERNAL__.inferResults;
 export const RIC = __INTERNAL__.RIC;


### PR DESCRIPTION
Builds on https://github.com/coinbase/rest-hooks/pull/900

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Extracting `buildInferredResults()` into normalizr

- Simplify logic
- Customizable inference behavior including disabling
- Start supporting variable arg length

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add `infer()` to schemas. Somewhat similar to normalize, tho only tries to build results piece - no entity collection.
