### PR TITLE
enhance: 'module' entrypoint targets 2019 browsers

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,6 +10,13 @@ module.exports = function (api) {
         },
       ],
     ],
+    assumptions: {
+      noDocumentAll: true,
+      noClassCalls: true,
+      constantReexports: true,
+      objectRestNoSymbols: true,
+      pureGetters: true,
+    },
     // allows us to load .babelrc in addition to this
     babelrcRoots: ['packages/*', '__tests__'],
   };

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "extends @anansi/browserslist-config"
   ],
   "devDependencies": {
-    "@anansi/babel-preset": "2.6.3",
-    "@anansi/browserslist-config": "1.2.0",
+    "@anansi/babel-preset": "2.6.4",
+    "@anansi/browserslist-config": "1.3.0",
     "@anansi/eslint-plugin": "0.11.11",
     "@anansi/jest-preset": "^0.2.2",
     "@babel/cli": "7.14.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "node": ">=0.12"
   },
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV=2019 ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib ts3.4 dist *.tsbuildinfo",
     "build:legacy-types": "yarn run downlevel-dts lib ts3.4 && copyfiles --up 1 ./src-legacy-types/**/*.d.ts ./ts3.4/",

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production  BROWSERSLIST_ENV=2019 ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build": "yarn run build:lib && yarn run build:bundle",

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV=2019 babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build:legacy-types": "yarn run downlevel-dts lib ts3.4",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/hooks' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production  BROWSERSLIST_ENV=2019 ROOT_PATH_PREFIX='@rest-hooks/hooks' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build": "yarn run build:lib && yarn run build:bundle",

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production  BROWSERSLIST_ENV=2019 babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build:legacy-types": "yarn run downlevel-dts lib ts3.4",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production  BROWSERSLIST_ENV=2019 babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build:legacy-types": "yarn run downlevel-dts lib ts3.4",

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -58,7 +58,7 @@
     "build:bundle": "run-p build:js:*",
     "build:js:development": "cross-env BROWSERSLIST_ENV=legacy NODE_ENV=development rollup -c",
     "build:js:production": "cross-env BROWSERSLIST_ENV=legacy NODE_ENV=production rollup -c",
-    "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/normalizr' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/__benchmarks__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production  BROWSERSLIST_ENV=2019 ROOT_PATH_PREFIX='@rest-hooks/normalizr' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/__benchmarks__/**' --ignore '**/*.d.ts'",
     "build:clean": "rimraf dist lib ts3.4 *.tsbuildinfo",
     "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "lint": "yarn lint:cmd --fix",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -39,7 +39,7 @@
     "node": ">=0.12"
   },
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='rest-hooks' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production  BROWSERSLIST_ENV=2019 ROOT_PATH_PREFIX='rest-hooks' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build:legacy-types": "yarn run downlevel-dts lib ts3.4",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production  BROWSERSLIST_ENV=2019 ROOT_PATH_PREFIX='@rest-hooks/core' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build:legacy-types": "yarn run downlevel-dts lib ts3.4",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -52,7 +52,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV='modern' RESOLVER_ALIAS='{\"^@rest-hooks/test(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production  BROWSERSLIST_ENV=2019 BROWSERSLIST_ENV='modern' RESOLVER_ALIAS='{\"^@rest-hooks/test(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:legacy:lib": "cross-env NODE_ENV=production RESOLVER_ALIAS='{\"^@rest-hooks/test(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir legacy --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist ts3.4 legacy *.tsbuildinfo",

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -34,7 +34,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production  BROWSERSLIST_ENV=2019 babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:bundle": "rollup -c",
     "build:clean": "rimraf lib dist ts3.4 *.tsbuildinfo",
     "build:legacy-types": "yarn run downlevel-dts lib ts3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@anansi/babel-preset@2.6.3":
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/@anansi/babel-preset/-/babel-preset-2.6.3.tgz#d2f2a804415f9f4ef09376a4896d341d0279743f"
-  integrity sha512-9CAJeqSbarrERzZPjYEHBE/eolvhUxrR4d8rkvcMtxzWG3H1HFTWZmydP+bVnbDEvD+QKT+q0a0Z2l+RjbXrxQ==
+"@anansi/babel-preset@2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@anansi/babel-preset/-/babel-preset-2.6.4.tgz#37ac5dc92d1d13df5f42f7761661952a2ded8f3a"
+  integrity sha512-DJNdR/AuML36mwGy3sVgcFiI1AbJPUUPWHLaqIzXGSX7UR+2jaaIm6hOqwanO2lZORFPZ+fhXtMtLZF1Slaktw==
   dependencies:
     "@anansi/ts-utils" "^0.2.4"
     "@babel/plugin-proposal-class-properties" "^7.13.0"
@@ -32,16 +32,16 @@
     babel-plugin-react-require "^3.1.3"
     babel-plugin-root-import "^6.6.0"
     babel-plugin-transform-react-remove-prop-types "^0.4.24"
-    core-js-compat "^3.13.0"
+    core-js-compat "^3.14.0"
     glob-to-regexp "^0.4.1"
     path "^0.12.7"
     semver "^7.3.5"
     stable "^0.1.8"
 
-"@anansi/browserslist-config@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@anansi/browserslist-config/-/browserslist-config-1.2.0.tgz#60d58a9caf93d730f093084ae8e51fa01310d4e7"
-  integrity sha512-5dssJtY7DAa674IzR//vZ4Jk9Ey/OmwExDuxcvYQ3ob6mKybvt/65lk9dL0ORUJn4+tjxOq5lV/OChPbelP3dg==
+"@anansi/browserslist-config@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@anansi/browserslist-config/-/browserslist-config-1.3.0.tgz#2612e93139fa324021cc7fe56d8c640935b2d3c0"
+  integrity sha512-UhuQUOrS1+EciTavdAPwDEB8RAkSxcGnJ+wi/4WqsuXPggCaG0vK6ZMHmtYccOxip3HUv4NdZEIaA2FvYc1VQQ==
 
 "@anansi/eslint-plugin@0.11.11":
   version "0.11.11"
@@ -5031,10 +5031,10 @@ copyfiles@^2.4.1:
     untildify "^4.0.0"
     yargs "^16.1.0"
 
-core-js-compat@^3.13.0, core-js-compat@^3.9.0, core-js-compat@^3.9.1:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.13.0.tgz#a88f5fa81d8e9b15d7f98abc4447a4dfca2a358f"
-  integrity sha512-jhbI2zpVskgfDC9mGRaDo1gagd0E0i/kYW0+WvibL/rafEHKAHO653hEXIxJHqRlRLITluXtRH3AGTL5qJmifQ==
+core-js-compat@^3.14.0, core-js-compat@^3.9.0, core-js-compat@^3.9.1:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.14.0.tgz#b574dabf29184681d5b16357bd33d104df3d29a5"
+  integrity sha512-R4NS2eupxtiJU+VwgkF9WTpnSfZW4pogwKHd8bclWU2sp93Pr5S1uYJI84cMOubJRou7bcfL0vmwtLslWN5p3A==
   dependencies:
     browserslist "^4.16.6"
     semver "7.0.0"


### PR DESCRIPTION
Fixes #902 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Previously module target was variable based on browser usage, which meant recently since browsers have implemented features like Nullish coalescing, it was no longer being transpiled. This is problematic for near-abandonware like CRA, or simply slowly updated projects that cannot parse ?? (because CRA transpiles node_modules) - even if their target compilation supports it.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We set specific targets for the 'legacy' npm entrypoints that won't change over time:

- main - includes IE and maintained node versions
- module - browsers from start of 2019

For the latest entry point (currently only used in @rest-hooks/test):
- exports - shifting target that sufficiently includes a few generations back