### PR TITLE
feat: Endpoint.name

### DIFF
--- a/packages/endpoint/src/__tests__/endpoint.ts
+++ b/packages/endpoint/src/__tests__/endpoint.ts
@@ -102,6 +102,22 @@ describe('Endpoint', () => {
       }).rejects.toBeDefined();
     });
 
+    it('should have a name', () => {
+      const UserDetail = new Endpoint(fetchUsersIdParam);
+      expect(UserDetail.name).toBe('fetchUsersIdParam');
+      const Next = new Endpoint(fetchUsersIdParam, { name: 'specialName' });
+      expect(Next.name).toBe('specialName');
+      const Another = Next.extend({ name: 'new' });
+      expect(Another.name).toBe('new');
+      const Third = Another.extend({ method: 'POST' }).extend({ extra: 5 });
+      expect(Third.name).toBe('new');
+      expect(Third.key('5')).toMatchInlineSnapshot(`"new [\\"5\\"]"`);
+      const Fourth = Third.extend({ fetch: fetchUserList });
+      expect(Fourth.name).toBe('fetchUserList');
+      const Weird = new Endpoint(fetchUsersIdParam, { fetch: fetchUserList });
+      expect(Weird.name).toBe(`fetchUsersIdParam`);
+    });
+
     it('should work when called with string parameter', async () => {
       const UserDetail = new Endpoint(fetchUsersIdParam);
 

--- a/packages/endpoint/src/endpoint.js
+++ b/packages/endpoint/src/endpoint.js
@@ -38,7 +38,19 @@ export default class Endpoint extends Function {
     self.getFetchKey = params => self.key(params);
 
     if (fetchFunction) self.fetch = fetchFunction;
+
+    if (options && 'name' in options) {
+      self.__name = options.name;
+      delete options.name;
+    } else if (fetchFunction) {
+      self.__name = fetchFunction.name;
+    }
     Object.assign(self, options);
+    Object.defineProperty(self, 'name', {
+      get: function () {
+        return this.__name;
+      },
+    });
 
     /** The following is for compatibility with FetchShape */
     runCompat(self, options);
@@ -46,7 +58,7 @@ export default class Endpoint extends Function {
   }
 
   key(...args) {
-    return `${this.fetch.name} ${JSON.stringify(args)}`;
+    return `${this.name} ${JSON.stringify(args)}`;
   }
 
   bind(thisArg, ...args) {

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "@rest-hooks/core": "^1.2.1",
-    "@rest-hooks/endpoint": "^1.1.3",
+    "@rest-hooks/endpoint": "^1.2.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"
   },

--- a/packages/experimental/src/rest/BaseResource.ts
+++ b/packages/experimental/src/rest/BaseResource.ts
@@ -147,13 +147,22 @@ export default abstract class BaseResource extends Entity {
    *
    * Relies on existance of runInit() member.
    */
-  protected static memo<T>(name: string, construct: () => T): T {
+  protected static memo<T extends { extend: (...args: any) => any }>(
+    name: string,
+    construct: () => T,
+  ): T {
     if (!Object.hasOwnProperty.call(this, this.cacheSymbol)) {
       (this as any)[this.cacheSymbol] = {};
     }
     const cache = (this as any)[this.cacheSymbol];
     if (!(name in cache)) {
-      cache[name] = construct();
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const resource: any = this;
+      cache[name] = construct().extend({
+        get name() {
+          return `${resource.name}.${name.replace(/#/, '')}`;
+        },
+      });
     }
     return cache[name].useFetchInit() as T;
   }

--- a/packages/experimental/src/rest/__tests__/Resource.test.ts
+++ b/packages/experimental/src/rest/__tests__/Resource.test.ts
@@ -96,6 +96,21 @@ describe('Resource', () => {
     nock.cleanAll();
   });
 
+  it('should automatically name methods', () => {
+    expect(PaginatedArticleResource.detail().name).toBe(
+      'PaginatedArticleResource.detail',
+    );
+    expect(PaginatedArticleResource.list().name).toBe(
+      'PaginatedArticleResource.list',
+    );
+    expect(PaginatedArticleResource.create().name).toBe(
+      'PaginatedArticleResource.create',
+    );
+    expect(PaginatedArticleResource.delete().name).toBe(
+      'PaginatedArticleResource.delete',
+    );
+  });
+
   it('should update on get for a paginated resource', async () => {
     mynock.get(`/article-paginated/`).reply(200, paginatedFirstPage);
     mynock.get(`/article-paginated/?cursor=2`).reply(200, paginatedSecondPage);


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
function names are already a staple of javascript and can be useful for logging purposes. Endpoints try to be like functions as much as possible.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- automatically infer names that are available
- allow setting name explicitly during init
- @rest-hooks/experimental resource endpoints get 'ResourceName.method' names
  - e.g.) 'ArticleResource.detail'

```typescript
const fetchUser = (id) => fetch(`/users/${id}`).then(res=>res.json();
const UserDetail = new Endpoint(fetchUser);

UserDetail.name === 'fetchUser'

const UserExtraDetail = UserDetail.extend({ name: 'extraDetail' });

UserExtraDetail .name === 'extraDetail';
```


```ts
import { Resource } from '@rest-hooks/experimental';

class User extends Resource {
  readonly id: string = '';
  readonly username: string = '';

  pk() { return this.id }
  static urlRoot = '/users';
}


User.detail().name === 'User.detail'
User.list().name === 'User.list'
User.create().name === 'User.create'
```