### PR TITLE
internal: publish

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.5.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.4.1...@rest-hooks/core@1.5.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Normalize merges entities, entitymeta, indexes ([#915](https://github.com/coinbase/rest-hooks/issues/915)) ([bd21d8c](https://github.com/coinbase/rest-hooks/commit/bd21d8ce0d004a56e6853918d9fb9ecaa2c730a8))
+* Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
+
+
+### 💅 Enhancement
+
+* Use inferResults() from normalizr ([#901](https://github.com/coinbase/rest-hooks/issues/901)) ([875cb6a](https://github.com/coinbase/rest-hooks/commit/875cb6acf31055e37e2d1faf4414bcbf31f5700f))
+
+
+
 ### [1.4.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.4.0...@rest-hooks/core@1.4.1) (2021-06-09)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -86,9 +86,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/endpoint": "^1.1.6",
-    "@rest-hooks/normalizr": "^7.1.0",
-    "@rest-hooks/use-enhanced-reducer": "^1.0.9",
+    "@rest-hooks/endpoint": "^1.2.0",
+    "@rest-hooks/normalizr": "^7.2.0",
+    "@rest-hooks/use-enhanced-reducer": "^1.1.0",
     "flux-standard-action": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.6...@rest-hooks/endpoint@1.2.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Endpoint.name ([#914](https://github.com/coinbase/rest-hooks/issues/914)) ([aa5f80d](https://github.com/coinbase/rest-hooks/commit/aa5f80db6c47ff975b1d257352315a57b87addce))
+
+
+
 ### [1.1.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.5...@rest-hooks/endpoint@1.1.6) (2021-06-09)
 
 

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -78,6 +78,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/normalizr": "^7.1.0"
+    "@rest-hooks/normalizr": "^7.2.0"
   }
 }

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.5.0...@rest-hooks/experimental@0.6.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Endpoint.name ([#914](https://github.com/coinbase/rest-hooks/issues/914)) ([aa5f80d](https://github.com/coinbase/rest-hooks/commit/aa5f80db6c47ff975b1d257352315a57b87addce))
+* Normalize merges entities, entitymeta, indexes ([#915](https://github.com/coinbase/rest-hooks/issues/915)) ([bd21d8c](https://github.com/coinbase/rest-hooks/commit/bd21d8ce0d004a56e6853918d9fb9ecaa2c730a8))
+* Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
+
+
+
 ## [0.5.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.4.0...@rest-hooks/experimental@0.5.0) (2021-06-09)
 
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.2.2...@rest-hooks/hooks@1.3.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
+
+
+
 ### [1.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.2.1...@rest-hooks/hooks@1.2.2) (2021-06-09)
 
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/img/CHANGELOG.md
+++ b/packages/img/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.2.4...@rest-hooks/img@0.3.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
+
+
+
 ### [0.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.2.3...@rest-hooks/img@0.2.4) (2021-06-09)
 
 

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/img",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.9...@rest-hooks/legacy@2.1.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
+
+
+### 💅 Enhancement
+
+* Use inferResults() from normalizr ([#901](https://github.com/coinbase/rest-hooks/issues/901)) ([875cb6a](https://github.com/coinbase/rest-hooks/commit/875cb6acf31055e37e2d1faf4414bcbf31f5700f))
+
+
+
 ### [2.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.8...@rest-hooks/legacy@2.0.9) (2021-06-09)
 
 

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.1.0...@rest-hooks/normalizr@7.2.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Normalize merges entities, entitymeta, indexes ([#915](https://github.com/coinbase/rest-hooks/issues/915)) ([bd21d8c](https://github.com/coinbase/rest-hooks/commit/bd21d8ce0d004a56e6853918d9fb9ecaa2c730a8))
+
+
+
 ## [7.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.0.3...@rest-hooks/normalizr@7.1.0) (2021-06-09)
 
 

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.2.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.1.4...rest-hooks@5.2.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Normalize merges entities, entitymeta, indexes ([#915](https://github.com/coinbase/rest-hooks/issues/915)) ([bd21d8c](https://github.com/coinbase/rest-hooks/commit/bd21d8ce0d004a56e6853918d9fb9ecaa2c730a8))
+* Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
+
+
+### 💅 Enhancement
+
+* Use inferResults() from normalizr ([#901](https://github.com/coinbase/rest-hooks/issues/901)) ([875cb6a](https://github.com/coinbase/rest-hooks/commit/875cb6acf31055e37e2d1faf4414bcbf31f5700f))
+
+
+
 ### [5.1.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.1.3...rest-hooks@5.1.4) (2021-06-09)
 
 

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "5.1.4",
+  "version": "5.2.0",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -87,8 +87,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/core": "^1.4.1",
-    "@rest-hooks/endpoint": "^1.1.6"
+    "@rest-hooks/core": "^1.5.0",
+    "@rest-hooks/endpoint": "^1.2.0"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@6.0.1...@rest-hooks/test@6.1.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
+
+
+
 ### [6.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@6.0.0...@rest-hooks/test@6.0.1) (2021-06-09)
 
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs",

--- a/packages/use-enhanced-reducer/CHANGELOG.md
+++ b/packages/use-enhanced-reducer/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.9...@rest-hooks/use-enhanced-reducer@1.1.0) (2021-06-13)
+
+
+### 🚀 Features
+
+* Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
+
+
+
 ### [1.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.8...@rest-hooks/use-enhanced-reducer@1.0.9) (2021-06-09)
 
 

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
 - @rest-hooks/core@1.5.0
 - @rest-hooks/endpoint@1.2.0
 - @rest-hooks/experimental@0.6.0
 - @rest-hooks/hooks@1.3.0
 - @rest-hooks/img@0.3.0
 - @rest-hooks/legacy@2.1.0
 - @rest-hooks/normalizr@7.2.0
 - rest-hooks@5.2.0
 - @rest-hooks/test@6.1.0
 - @rest-hooks/use-enhanced-reducer@1.1.0
