### PR TITLE
feat: Add Entity.expiresAt() - entity TTL configuration

### DIFF
--- a/packages/experimental/src/entity/Entity.ts
+++ b/packages/experimental/src/entity/Entity.ts
@@ -298,6 +298,13 @@ First three members: ${JSON.stringify(processedEntity.slice(0, 3), null, 2)}`;
     return undefined;
   }
 
+  static expiresAt(
+    { expiresAt }: { expiresAt: number; date: number },
+    input: any,
+  ): number {
+    return expiresAt;
+  }
+
   static denormalize<T extends typeof Entity>(
     this: T,
     input: Readonly<Partial<AbstractInstanceType<T>>>,

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -239,6 +239,13 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     return id;
   }
 
+  static expiresAt(
+    { expiresAt }: { expiresAt: number; date: number },
+    input: any,
+  ): number {
+    return expiresAt;
+  }
+
   static infer(args, indexes, infer): any {
     if (!args[0]) return undefined as any;
     const id = this.pk(args[0], undefined, '');

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -61,7 +61,7 @@ const addEntities =
         };
       };
     },
-    { expiresAt, date }: { expiresAt: number; date: number },
+    meta: { expiresAt: number; date: number },
   ) =>
   (schema: any, processedEntity: any, id: any) => {
     const schemaKey = schema.key;
@@ -82,7 +82,7 @@ const addEntities =
 
         // if either of these is undefined, it resolves to 'false' which
         // means we fallback to 'newer' (processedEntity) takes priority
-        const preferExisting = entityMeta[schemaKey][id]?.date > date;
+        const preferExisting = entityMeta[schemaKey][id]?.date > meta.date;
         if (typeof processedEntity !== typeof inStoreEntity) {
           entities[schemaKey][id] = preferExisting
             ? inStoreEntity
@@ -135,10 +135,14 @@ Entity: ${JSON.stringify(entity, undefined, 2)}`);
     }
     // set this after index updates so we know what indexes to remove from
     existingEntities[schemaKey][id] = entities[schemaKey][id];
+    // TODO: eventually assume this exists and don't check for conditional. probably early 2022
+    const entityExpiresAt = schema.expiresAt
+      ? schema.expiresAt(meta, processedEntity)
+      : meta.expiresAt;
     entityMeta[schemaKey][id] =
-      entityMeta[schemaKey][id]?.expiresAt >= expiresAt
+      entityMeta[schemaKey][id]?.expiresAt >= entityExpiresAt
         ? entityMeta[schemaKey][id]
-        : { expiresAt, date };
+        : { expiresAt: entityExpiresAt, date: meta.date };
   };
 
 function expectedSchemaType(schema: Schema) {


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #876 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Configurable/Programmable TTL for entities

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Entities+Resources get `expiresAt()`

```ts
class Entity {
  static expiresAt(
    { expiresAt }: { expiresAt: number; date: number },
    input: any,
  ): number {
    return expiresAt;
  }
}
```

By default as above, just uses the fetch's expiry time.

However, this can also check for complete members, to not count toward an entity's expiry time.

#### Example

```ts
class MyResource extends Resource {
  readonly id: string = '';
  readonly basic: string = '';
  readonly extendedContent?: { stuff: string };

  pk() { return this.id }
  static urlRoot = '/myresource/';

  static expiresAt(
    { expiresAt }: { expiresAt: number; date: number },
    input: any,
  ): number {
     // extendedContent only exists when returning full results, so it's safe to infer this entity
    return input.extendedContent ? expiresAt : 0;
  }
}
```

This would allow a partial result returned in a `list()`, and then when visiting `detail()` since the entity will be considered expired, it will stale-while-revalidate. Whereas now it may avoid additional fetch within a time period, as the entity would have specified its expiry as sometime in the future.