### PR TITLE
enhance: More flexible fetch types to help with inheritance

### DIFF
--- a/packages/experimental/src/rest/types.ts
+++ b/packages/experimental/src/rest/types.ts
@@ -1,17 +1,19 @@
 import { Schema } from '@rest-hooks/normalizr';
 import { EndpointInstance, FetchFunction } from '@rest-hooks/endpoint';
 
-export type RestFetch<
-  P = any,
-  B = RequestInit['body'] | Record<string, any>,
-  R = any,
-> = (this: RestEndpoint, params?: P, body?: B, ...rest: any) => Promise<R>;
+export type RestFetch<P = any, B = any, R = any> = (
+  this: RestEndpoint,
+  params?: P,
+  body?: B,
+  ...rest: any
+) => Promise<R>;
 
-export type FetchMutate<
-  P = any,
-  B = RequestInit['body'] | Record<string, any>,
-  R = any,
-> = (this: RestEndpoint, params: P, body: B) => Promise<R>;
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type FetchMutate<P = any, B = {}, R = any> = (
+  this: RestEndpoint,
+  params: P,
+  body: B,
+) => Promise<R>;
 
 export type FetchGet<P = any, R = any> = (
   this: RestEndpoint,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Due to every part of a union needing to match in inheritance, this was limiting overriding to specifics. We want to prioritize customizing specific types rather than being more specific in the base class

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Mutates are expected to have a body, so use {} to represent non-void, otherwise any for reads.