### PR TITLE
enhance: useError() only checks meta error

### DIFF
--- a/packages/core/src/react-integration/__tests__/useError-endpoint.tsx
+++ b/packages/core/src/react-integration/__tests__/useError-endpoint.tsx
@@ -11,7 +11,7 @@ describe('useError()', () => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
 
-  it('should return 404 when cache not ready and no error in meta', () => {
+  it('should return undefined when cache not ready and no error in meta', () => {
     const results = [
       {
         request: CoolerArticleResource.detail(),
@@ -21,30 +21,11 @@ describe('useError()', () => {
     ];
     const { result } = renderRestHook(
       () => {
-        return useError(CoolerArticleResource.detail(), payload, false);
+        return useError(CoolerArticleResource.detail(), payload);
       },
       { results },
     );
 
-    expect(result.current).toBeDefined();
-    expect((result.current as any).status).toBe(400);
-    expect(result.current).toMatchInlineSnapshot(`
-      [Error: Entity from "GET http://test.com/article-cooler/5" not found in cache.
-
-              This is likely due to a malformed response.
-              Try inspecting the network response or fetch() return value.
-
-              Schema: {
-        "name": "CoolerArticleResource",
-        "schema": {
-          "author": {
-            "name": "UserResource",
-            "schema": {},
-            "key": "http://test.com/user/"
-          }
-        },
-        "key": "http://test.com/article-cooler/"
-      }]
-    `);
+    expect(result.current).toBeUndefined();
   });
 });

--- a/packages/core/src/react-integration/__tests__/useError.tsx
+++ b/packages/core/src/react-integration/__tests__/useError.tsx
@@ -11,7 +11,7 @@ describe('useError()', () => {
     renderRestHook = makeRenderRestHook(makeCacheProvider);
   });
 
-  it('should return 404 when cache not ready and no error in meta', () => {
+  it('should return undefined when cache not ready and no error in meta', () => {
     const results = [
       {
         request: CoolerArticleResource.detailShape(),
@@ -21,30 +21,11 @@ describe('useError()', () => {
     ];
     const { result } = renderRestHook(
       () => {
-        return useError(CoolerArticleResource.detailShape(), payload, false);
+        return useError(CoolerArticleResource.detailShape(), payload);
       },
       { results },
     );
 
-    expect(result.current).toBeDefined();
-    expect((result.current as any).status).toBe(400);
-    expect(result.current).toMatchInlineSnapshot(`
-      [Error: Entity from "GET http://test.com/article-cooler/5" not found in cache.
-
-              This is likely due to a malformed response.
-              Try inspecting the network response or fetch() return value.
-
-              Schema: {
-        "name": "CoolerArticleResource",
-        "schema": {
-          "author": {
-            "name": "UserResource",
-            "schema": {},
-            "key": "http://test.com/user/"
-          }
-        },
-        "key": "http://test.com/article-cooler/"
-      }]
-    `);
+    expect(result.current).toBeUndefined();
   });
 });

--- a/packages/core/src/react-integration/hooks/useCache.ts
+++ b/packages/core/src/react-integration/hooks/useCache.ts
@@ -32,7 +32,7 @@ export default function useCache<
     denormalizeCache,
   );
   const expiresAt = useExpiresAt(fetchShape, params, entitiesExpireAt);
-  const error = useError(fetchShape, params, ready);
+  const error = useError(fetchShape, params);
   const trigger = deleted && !error;
 
   /*********** This block is to ensure results are only filled when they would not suspend **************/

--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -27,37 +27,8 @@ export default function useError<
 >(
   fetchShape: Shape,
   params: ParamsFromShape<Shape> | null,
-  cacheReady: boolean,
 ): UseErrorReturn<typeof params> {
   const meta = useMeta(fetchShape, params);
   if (!params) return;
-  if (!cacheReady) {
-    if (!meta) return;
-    // this means the response is missing an expected entity
-    if (!meta.error && !meta.invalidated) {
-      let error: Error & { status?: number; synthetic?: boolean };
-      /* istanbul ignore else */
-      if (process.env.NODE_ENV !== 'production') {
-        error = new Error(
-          `Entity from "${fetchShape.getFetchKey(params)}" not found in cache.
-
-        This is likely due to a malformed response.
-        Try inspecting the network response or fetch() return value.
-
-        Schema: ${JSON.stringify(fetchShape.schema, null, 2)}`,
-        );
-      } /* istanbul ignore next */ else {
-        error = new Error(
-          `Missing required entity in "${fetchShape.getFetchKey(
-            params,
-          )}" likely due to malformed response.`,
-        );
-      }
-      error.status = 400;
-      error.synthetic = true;
-      return error as any;
-    } else {
-      return meta.error as any;
-    }
-  }
+  return meta?.error as any;
 }

--- a/packages/core/src/react-integration/hooks/useResource.ts
+++ b/packages/core/src/react-integration/hooks/useResource.ts
@@ -37,7 +37,7 @@ function useOneResource<
     state,
     denormalizeCache,
   );
-  const error = useError(fetchShape, params, ready);
+  const error = useError(fetchShape, params);
 
   const maybePromise = useRetrieve(
     fetchShape,
@@ -89,7 +89,7 @@ function useManyResources<A extends ResourceArgs<any, any>[]>(
       i: number,
     ) =>
       // eslint-disable-next-line react-hooks/rules-of-hooks
-      useError(fetchShape, params, denormalizedValues[i][1]),
+      useError(fetchShape, params),
   );
   const promises = resourceList
     .map(([fetchShape, params], i) =>

--- a/packages/legacy/src/useStatefulResource.ts
+++ b/packages/legacy/src/useStatefulResource.ts
@@ -49,7 +49,7 @@ export default function useStatefulResource<
     params,
     state,
   );
-  const error = useError(fetchShape, params, ready);
+  const error = useError(fetchShape, params);
 
   const maybePromise: Promise<any> | undefined = useRetrieve(
     fetchShape,


### PR DESCRIPTION
BREAKING CHANGE: useError() will no longer create synthetic
errors for missing entities

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- At this point all error handling that can be done is handled during normalization
- We want to be more lenient on entity requirements for some use cases
  - Previously this was needed as we were less explicit about inferring results

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
useError() now just returns the error in meta