### PR TITLE
enhance: Remove Resource export from 'rest-hooks' package

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -1,12 +1,13 @@
-import { SchemaList, schemas, ReadShape, SchemaDetail } from 'rest-hooks';
 import {
   AbstractInstanceType,
   DeleteShape,
   MutateShape,
   SimpleRecord,
+  ReadShape,
 } from '@rest-hooks/core';
+import { schema } from '@rest-hooks/normalizr';
 import { Endpoint, EndpointExtraOptions } from '@rest-hooks/endpoint';
-import { Resource } from '@rest-hooks/rest';
+import { Resource, SchemaList, SchemaDetail } from '@rest-hooks/rest';
 import React from 'react';
 
 export class UserResource extends Resource {
@@ -119,7 +120,7 @@ export class ArticleResource extends Resource {
 
   static deleteShape<T extends typeof Resource>(
     this: T,
-  ): DeleteShape<schemas.Delete<T>, Readonly<object>> {
+  ): DeleteShape<schema.Delete<T>, Readonly<object>> {
     return {
       ...(super.deleteShape() as any),
       options: {
@@ -310,7 +311,7 @@ export class UnionResource extends Resource {
   static detailShape<T extends typeof Resource>(
     this: T,
   ): ReadShape<SchemaDetail<AbstractInstanceType<T>>> {
-    const schema = new schemas.Union(
+    const sch = new schema.Union(
       {
         first: FirstUnionResource,
         second: SecondUnionResource,
@@ -319,15 +320,15 @@ export class UnionResource extends Resource {
     );
     return {
       ...super.detailShape(),
-      schema,
+      schema: sch,
     };
   }
 
   static listShape<T extends typeof Resource>(
     this: T,
   ): ReadShape<SchemaList<AbstractInstanceType<T>>> {
-    const schema = [
-      new schemas.Union(
+    const sch = [
+      new schema.Union(
         {
           first: FirstUnionResource,
           second: SecondUnionResource,
@@ -337,7 +338,7 @@ export class UnionResource extends Resource {
     ];
     return {
       ...super.detailShape(),
-      schema,
+      schema: sch,
     };
   }
 }

--- a/packages/core/src/react-integration/__tests__/subscriptions-endpoint.tsx
+++ b/packages/core/src/react-integration/__tests__/subscriptions-endpoint.tsx
@@ -3,9 +3,6 @@ import { renderHook } from '@testing-library/react-hooks';
 import nock from 'nock';
 import { PollingArticleResource, ArticleResource } from '__tests__/new';
 
-// relative imports to avoid circular dependency in tsconfig references
-import { Resource } from 'rest-hooks/resource';
-
 import {
   makeCacheProvider,
   makeExternalCacheProvider,

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -88,8 +88,7 @@
   "dependencies": {
     "@babel/runtime": "^7.7.2",
     "@rest-hooks/core": "^1.5.2",
-    "@rest-hooks/endpoint": "^1.2.2",
-    "@rest-hooks/legacy": "^2.2.0"
+    "@rest-hooks/endpoint": "^1.2.2"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -10,10 +10,6 @@ export {
   useResetter,
   useDenormalized,
   SimpleRecord,
-  Entity as NestedEntity,
-  isEntity,
-  FlatEntity as Entity,
-  schema as schemas,
   // TODO: get rid of these exports once core has been out for a while
   usePromisifiedDispatch,
   Endpoint,
@@ -63,8 +59,6 @@ export type {
   NetworkError,
 } from '@rest-hooks/core';
 
-export { Resource, SimpleResource } from '@rest-hooks/legacy';
-export type { SchemaDetail, SchemaList, Method } from '@rest-hooks/legacy';
 export {
   CacheProvider,
   ExternalCacheProvider,

--- a/packages/rest-hooks/tsconfig.json
+++ b/packages/rest-hooks/tsconfig.json
@@ -10,6 +10,5 @@
     { "path": "../use-enhanced-reducer" },
     { "path": "../endpoint" },
     { "path": "../core" },
-    { "path": "../legacy" },
   ]
 }


### PR DESCRIPTION
BREAKING CHANGE:
- Removed exports from 'rest-hooks': NestedEntity, schemas, isEntity, Entity, Resource, SimpleResource, SchemaDetail, SchemaList, Method
- use @rest-hooks/legacy, or @rest-hooks/rest instead
