### PR TITLE
fix: Legacy cjs and unpkg should target 'legacy'

### DIFF
--- a/packages/legacy/rollup.config.js
+++ b/packages/legacy/rollup.config.js
@@ -14,6 +14,7 @@ const dependencies = Object.keys(pkg.peerDependencies).filter(
 
 const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
 process.env.NODE_ENV = 'production';
+process.env.BROWSERSLIST_ENV = 'legacy';
 
 function isExternal(id) {
   const ret = dependencies.includes(id);


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
For some reason all other packages had BROWSERSLIST_ENV set correctly for the rollup step, but not this one.
The result is not transpiling to work on legacy node versions correctly.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`process.env.BROWSERSLIST_ENV = 'legacy';` in rollup just like every other package