### PR TITLE
enhance: setInterval types based on node/web rather than hardcoded

### DIFF
--- a/packages/rest-hooks/src/manager/PollingSubscription.ts
+++ b/packages/rest-hooks/src/manager/PollingSubscription.ts
@@ -19,9 +19,9 @@ export default class PollingSubscription implements Subscription {
   protected frequencyHistogram: Map<number, number> = new Map();
   protected declare dispatch: Dispatch<any>;
   protected declare getState: () => State<unknown>;
-  protected declare intervalId?: NodeJS.Timeout;
-  protected declare lastIntervalId?: NodeJS.Timeout;
-  protected declare startId?: NodeJS.Timeout;
+  protected declare intervalId?: ReturnType<typeof setInterval>;
+  protected declare lastIntervalId?: ReturnType<typeof setInterval>;
+  protected declare startId?: ReturnType<typeof setTimeout>;
   private declare connectionListener: ConnectionListener;
 
   constructor(


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Node and Dom have different types here, so let a users' environment dictate the types

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Use ReturnType