### PR TITLE
enhance: Remove extraneous hack for expiresAt

### DIFF
--- a/packages/core/src/react-integration/hooks/useExpiresAt.ts
+++ b/packages/core/src/react-integration/hooks/useExpiresAt.ts
@@ -16,14 +16,5 @@ export default function useExpiresAt<
     return entitiesExpireAt;
   }
 
-  // Temporarily prevent infinite loops until invalidIfStale is revised
-  if (
-    fetchShape.options?.invalidIfStale &&
-    meta.prevExpiresAt &&
-    meta.expiresAt - meta.prevExpiresAt < 1000
-  ) {
-    return meta.expiresAt + 2000;
-  }
-
   return meta.expiresAt;
 }


### PR DESCRIPTION
BREAKING CHANGE: Rest Hooks 4 invalidIfStale behavior completely removed

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- This was a workaround for particular behavior in Rest Hooks 4, before the modern invalidation schema
- This is no longer triggerable

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Delete code