### PR TITLE
feat: Add errorPolicy to endpoint options

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -44,7 +44,7 @@ export class ArticleResource extends Resource {
   };
 
   static urlRoot = 'http://test.com/article/';
-  static url<T extends typeof Resource>(this: T, urlParams?: any): string {
+  static url(urlParams?: any): string {
     if (urlParams && !urlParams.id) {
       return `${this.urlRoot}${urlParams.title}`;
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,7 @@ export {
   useResetter,
   hasUsableData,
 } from './react-integration';
-export type { SyntheticError, ErrorTypes } from './react-integration';
+export type { ErrorTypes } from './react-integration';
 export {
   StateContext,
   DispatchContext,

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
@@ -12,6 +12,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "POST",
@@ -45,6 +46,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PUT http://test.com/article-cooler/1",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "PUT",
@@ -82,6 +84,7 @@ Object {
       "id": 1,
     },
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "PATCH",
@@ -117,6 +120,7 @@ Object {
       "content": "hi",
     },
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "POST",
@@ -150,6 +154,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "POST",
@@ -182,6 +187,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/1",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -220,6 +226,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -259,6 +266,7 @@ Object {
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "dataExpiryLength": 3600000,
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -298,6 +306,7 @@ Object {
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "errorExpiryLength": Infinity,
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -336,6 +345,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
@@ -12,6 +12,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "POST",
@@ -45,6 +46,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PUT http://test.com/article-cooler/1",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "PUT",
@@ -82,6 +84,7 @@ Object {
       "id": 1,
     },
     "options": Object {
+      "errorPolicy": [Function],
       "optimisticUpdate": [Function],
     },
     "promise": Promise {},
@@ -111,6 +114,7 @@ Object {
       "content": "hi",
     },
     "options": Object {
+      "errorPolicy": [Function],
       "optimisticUpdate": [Function],
     },
     "promise": Promise {},
@@ -138,6 +142,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "POST",
@@ -170,6 +175,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/1",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -208,6 +214,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -247,6 +254,7 @@ Object {
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "dataExpiryLength": 3600000,
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -286,6 +294,7 @@ Object {
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "errorExpiryLength": Infinity,
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -324,6 +333,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useFetchDispatcher.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useFetchDispatcher.tsx.snap
@@ -12,6 +12,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "POST",

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
@@ -12,6 +12,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -43,6 +44,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -72,6 +74,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/user/",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
@@ -12,6 +12,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -43,6 +44,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",
@@ -72,6 +74,7 @@ Object {
     "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/user/",
     "options": Object {
+      "errorPolicy": [Function],
       "fetchInit": Object {},
       "getFetchInit": [Function],
       "method": "GET",

--- a/packages/core/src/react-integration/hooks/index.ts
+++ b/packages/core/src/react-integration/hooks/index.ts
@@ -11,7 +11,7 @@ import useResetter from './useResetter';
 import useFetchDispatcher from './useFetchDispatcher';
 import useInvalidateDispatcher from './useInvalidateDispatcher';
 export { default as hasUsableData } from './hasUsableData';
-export type { SyntheticError, ErrorTypes } from './useError';
+export type { ErrorTypes } from './useError';
 
 export {
   useFetcher,

--- a/packages/core/src/react-integration/hooks/useResource.ts
+++ b/packages/core/src/react-integration/hooks/useResource.ts
@@ -6,7 +6,6 @@ import {
   StateContext,
 } from '@rest-hooks/core/react-integration/context';
 import { useMemo, useContext } from 'react';
-import { NetworkError } from '@rest-hooks/core/types';
 
 import useRetrieve from './useRetrieve';
 import useError from './useError';
@@ -46,9 +45,6 @@ function useOneResource<
     deleted && !error,
     entitiesExpireAt,
   );
-
-  // refetching won't ever save us if the network response is bad.
-  if (error && error.synthetic) throw error;
 
   if (
     !hasUsableData(
@@ -117,11 +113,10 @@ function useManyResources<A extends ResourceArgs<any, any>[]>(
   // throw first valid error
   for (let i = 0; i < resourceList.length; i++) {
     const err = errorValues[i];
-    // either the error is synthetic (not from network), or we aren't fetching at all
+    // we aren't fetching at all
     // then throw that error
-    if (err && (err.synthetic || !promises[i])) throw err;
+    if (err && !promises[i]) throw err;
   }
-
   const promise = useMemo(() => {
     const activePromises = promises.filter(p => p);
     if (activePromises.length) {

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -9,6 +9,7 @@ Object {
     "http://test.com/article/20": Object {
       "date": 5000000000,
       "error": [Error: hi],
+      "errorPolicy": undefined,
       "expiresAt": 5000500000,
     },
   },

--- a/packages/core/src/state/actions/createReceiveError.ts
+++ b/packages/core/src/state/actions/createReceiveError.ts
@@ -7,13 +7,13 @@ import {
 import { RECEIVE_TYPE } from '@rest-hooks/core/actionTypes';
 
 interface Options<S extends Schema | undefined = any>
-  extends Pick<FetchAction<any, S>['meta'], 'schema' | 'key'> {
+  extends Pick<FetchAction<any, S>['meta'], 'schema' | 'key' | 'options'> {
   errorExpiryLength: NonNullable<FetchOptions['errorExpiryLength']>;
 }
 
 export default function createReceiveError<S extends Schema | undefined = any>(
   error: Error,
-  { schema, key, errorExpiryLength }: Options<S>,
+  { schema, key, options, errorExpiryLength }: Options<S>,
 ): ReceiveAction {
   /* istanbul ignore next */
   if (process.env.NODE_ENV === 'development' && errorExpiryLength < 0) {
@@ -28,6 +28,7 @@ export default function createReceiveError<S extends Schema | undefined = any>(
       key,
       date: now,
       expiresAt: now + errorExpiryLength,
+      errorPolicy: options?.errorPolicy,
     },
     error: true,
   };

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -171,6 +171,7 @@ function reduceError(
         date: action.meta.date,
         error,
         expiresAt: action.meta.expiresAt,
+        errorPolicy: action.meta.errorPolicy?.(error),
       },
     },
     optimistic: filterOptimistic(state, action),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -50,6 +50,7 @@ export type State<T> = Readonly<{
       readonly expiresAt: number;
       readonly prevExpiresAt?: number;
       readonly invalidated?: boolean;
+      readonly errorPolicy?: 'soft' | undefined;
     };
   };
   entityMeta: {
@@ -74,6 +75,7 @@ export interface ReceiveMeta<S extends Schema | undefined> {
   update?: (result: any, ...args: any) => Record<string, (...args: any) => any>;
   date: number;
   expiresAt: number;
+  errorPolicy?: (error: any) => 'soft' | undefined;
 }
 
 export type ReceiveAction<

--- a/packages/endpoint/src/types.ts
+++ b/packages/endpoint/src/types.ts
@@ -15,6 +15,8 @@ export interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {
   readonly invalidIfStale?: boolean;
   /** Enables optimistic updates for this request - uses return value as assumed network response */
   readonly optimisticUpdate?: (...args: Parameters<F>) => ResolveType<F>;
+  /** Determines whether to throw or fallback to */
+  readonly errorPolicy?: (error: any) => 'soft' | undefined;
   /** User-land extra data to send */
   readonly extra?: any;
 }

--- a/packages/experimental/src/rest/BaseResource.ts
+++ b/packages/experimental/src/rest/BaseResource.ts
@@ -138,7 +138,10 @@ export default abstract class BaseResource extends EntityRecord {
 
   /** Get the request options for this SimpleResource */
   static getEndpointExtra(): EndpointExtraOptions | undefined {
-    return;
+    return {
+      errorPolicy: error =>
+        error.status >= 500 ? ('soft' as const) : undefined,
+    };
   }
 
   /** Field where endpoint cache is stored */

--- a/packages/legacy/src/resource/SimpleResource.ts
+++ b/packages/legacy/src/resource/SimpleResource.ts
@@ -99,7 +99,9 @@ export default abstract class SimpleResource extends FlatEntity {
   /** @deprecated */
   /** Get the request options for this SimpleResource  */
   static getFetchOptions(): FetchOptions | undefined {
-    return;
+    return {
+      errorPolicy: () => 'soft' as const,
+    };
   }
 
   /** Init options for fetch - run at fetch */

--- a/packages/rest-hooks/src/manager/PollingSubscription.ts
+++ b/packages/rest-hooks/src/manager/PollingSubscription.ts
@@ -132,6 +132,8 @@ export default class PollingSubscription implements Subscription {
         options: {
           dataExpiryLength: this.frequency / 2,
           errorExpiryLength: this.frequency / 10,
+          // never break when data already exists
+          errorPolicy: () => 'soft' as const,
         },
         resolve: () => {},
         reject: () => {},

--- a/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
+++ b/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
@@ -8,6 +8,7 @@ Array [
       "options": Object {
         "dataExpiryLength": 2500,
         "errorExpiryLength": 500,
+        "errorPolicy": [Function],
       },
       "reject": [Function],
       "resolve": [Function],
@@ -29,6 +30,7 @@ Array [
       "options": Object {
         "dataExpiryLength": 2500,
         "errorExpiryLength": 500,
+        "errorPolicy": [Function],
       },
       "reject": [Function],
       "resolve": [Function],

--- a/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription.ts.snap
+++ b/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription.ts.snap
@@ -8,6 +8,7 @@ Array [
       "options": Object {
         "dataExpiryLength": 2500,
         "errorExpiryLength": 500,
+        "errorPolicy": [Function],
       },
       "reject": [Function],
       "resolve": [Function],
@@ -29,6 +30,7 @@ Array [
       "options": Object {
         "dataExpiryLength": 2500,
         "errorExpiryLength": 500,
+        "errorPolicy": [Function],
       },
       "reject": [Function],
       "resolve": [Function],

--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -105,7 +105,10 @@ export default abstract class SimpleResource extends EntityRecord {
 
   /** Get the request options for this SimpleResource */
   static getEndpointExtra(): EndpointExtraOptions | undefined {
-    return;
+    return {
+      errorPolicy: error =>
+        error.status >= 500 ? ('soft' as const) : undefined,
+    };
   }
 
   /** Field where endpoint cache is stored */


### PR DESCRIPTION
BREAKING CHANGE:
- Removed: SyntheticError (untriggerable since https://github.com/coinbase/rest-hooks/pull/938)
- @rest-hooks/rest: 500s are 'soft', else 'hard'
- PollingSubscription: all errors are 'soft'
- @rest-hooks/endpoint: no default errorPolicy, therefore all errors are
'hard'

<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #288 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Configurable cache policy for errors
- More sane defaults for errors

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### EndpointExtraOptions

```ts
interface EndpointExtraOptions {
  //...rest
  errorPolicy?: (error: any) => 'soft' | undefined;
}
```

#### 'soft' vs `undefined`

- 'soft' avoids errors if existing results are still available (even if stale)
- `undefined` (hard error) means any error always falls

#### @rest-hooks/rest

New default policy: 5xx are soft, else hard.

`@rest-hooks/rest` is where errors have 'status' members. This concept does not exist in base Endpoints.

```ts
  static getEndpointExtra(): EndpointExtraOptions | undefined {
    return;
    return {
      errorPolicy: error =>
        error.status >= 500 ? ('soft' as const) : undefined,
    };
  }
```

#### PollingSubscription

```ts
          // never break when data already exists
          errorPolicy: () => 'soft' as const,
```

#### @rest-hooks/legacy - Resource

Existing policy was to always be 'soft' no matter what. This maintains that behavior.

```ts
  /** @deprecated */
  /** Get the request options for this SimpleResource  */
  static getFetchOptions(): FetchOptions | undefined {
    return {
      errorPolicy: () => 'soft' as const,
    };
  }
```

### Open Questions

- 'hard' vs undefined for other case?