### PR TITLE
internal: Fix some test async behavior

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ const baseConfig = {
     'packages/experimental',
     'packages/legacy/src/resource',
   ],
+  testEnvironment: 'jsdom',
   testURL: 'http://localhost',
 };
 

--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -811,7 +811,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
           }),
         );
 
-        // second optimistic
+        // third optimistic
         mynock
           .patch('/article-cooler/5')
           .delay(500)

--- a/packages/endpoint/src/__tests__/endpoint.ts
+++ b/packages/endpoint/src/__tests__/endpoint.ts
@@ -94,7 +94,7 @@ describe('Endpoint', () => {
       const a: 'mutate' = UserDetail.type;
 
       // these are all meant to fail - are typescript tests
-      expect(async () => {
+      await expect(async () => {
         // @ts-expect-error
         await UserDetail({ id: 5 });
         // @ts-expect-error
@@ -140,7 +140,7 @@ describe('Endpoint', () => {
       const a: 'mutate' = UserDetail.type;
 
       // these are all meant to fail - are typescript tests
-      expect(async () => {
+      await expect(async () => {
         // @ts-expect-error
         await UserDetail({ id: payload.id });
         // @ts-expect-error
@@ -172,7 +172,7 @@ describe('Endpoint', () => {
       const a: 'mutate' = UserList.type;
 
       // these are all meant to fail - are typescript tests
-      expect(async () => {
+      await expect(async () => {
         // @ts-expect-error
         await UserList({ id: payload.id });
         // @ts-expect-error
@@ -586,10 +586,10 @@ describe('Endpoint', () => {
       expect(user.username).toBe(payload.username);
     });
 
-    it('should reject when aborted', () => {
+    it('should reject when aborted', async () => {
       const abort = new AbortController();
       const AbortUser = UserDetail.extend({ signal: abort.signal });
-      expect(async () => {
+      await expect(async () => {
         const promise = AbortUser({ id: payload.id });
         abort.abort();
         return await promise;

--- a/packages/hooks/src/__tests__/useCancelling.ts
+++ b/packages/hooks/src/__tests__/useCancelling.ts
@@ -34,6 +34,10 @@ describe('useCancelling()', () => {
       .delay(2000)
       .reply(200, payload2);
   });
+  afterAll(() => {
+    jest.useRealTimers();
+    nock.cleanAll();
+  });
 
   it('should abort when props change and resolve when kept the same', async () => {
     const { result, rerender } = renderHook(


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Some typos around async behavior found when doing https://github.com/coinbase/rest-hooks/pull/553
