### PR TITLE
enhance: Use .js for cjs like other packages

### DIFF
--- a/packages/test/node.mjs
+++ b/packages/test/node.mjs
@@ -1,1 +1,1 @@
-export * from './dist/index.cjs';
+export * from './dist/index.js';

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -3,7 +3,7 @@
   "version": "6.1.0",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "module": "legacy/browser.js",
   "types": "lib/index.d.ts",
   "typesVersions": {
@@ -39,7 +39,7 @@
   },
   "type": "module",
   "engines": {
-    "node": "^12.20 || ^13.7 || >=14"
+    "node": "^12.17 || ^13.7 || >=14"
   },
   "files": [
     "src",
@@ -54,7 +54,7 @@
   "scripts": {
     "build:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV=2020 BROWSERSLIST_ENV='modern' RESOLVER_ALIAS='{\"^@rest-hooks/test(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:legacy:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV=2018 RESOLVER_ALIAS='{\"^@rest-hooks/test(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir legacy --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:bundle": "rollup -c",
+    "build:bundle": "rollup -c && echo '{\"type\":\"commonjs\"}' > dist/package.json",
     "build:clean": "rimraf lib dist ts3.4 legacy *.tsbuildinfo",
     "build:legacy-types": "yarn run downlevel-dts lib ts3.4",
     "build": "yarn run build:lib && yarn run build:legacy:lib && yarn run build:bundle",

--- a/packages/test/rollup.config.js
+++ b/packages/test/rollup.config.js
@@ -22,7 +22,7 @@ export default [
   {
     input: 'src/index.ts',
     external: id => id === '..' || isExternal(id),
-    output: [{ file: 'dist/index.cjs', format: 'cjs' }],
+    output: [{ file: pkg.main, format: 'cjs' }],
     plugins: [
       babel({
         exclude: ['node_modules/**', '**/__tests__/**', '**/*.d.ts'],


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
New way to deal with tooling that for some reason doesn't know what a .cjs is, but does know how to find package.json and understands the types fields in there.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This was in previous change for other packages, but it including a breaking symbol so we moved the test updates to here.