### PR TITLE
enhance: SimpleResource is deprecated

### DIFF
--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -12,10 +12,13 @@ import { NotImplementedError } from '@rest-hooks/rest/errors';
 import paramsToString from '@rest-hooks/rest/paramsToString';
 import { RestEndpoint } from '@rest-hooks/rest/types';
 
-/** Represents an entity to be retrieved from a server.
+/**
+ * Represents an entity to be retrieved from a server.
  * Typically 1:1 with a url endpoint.
  *
  * This can be a useful organization for many REST-like API patterns.
+ *
+ * @deprecated Use Resource directly in the future
  */
 export default abstract class SimpleResource extends EntityRecord {
   // typescript todo: require subclasses to implement


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Removing `SimpleResource` allows for `BaseResource` (see experimental pkg) without endpoints, which is more flexible root.
Fetch code is very small now so not having a fetch implementation is a very small win.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Step 1: deprecate