### PR TITLE
fix: module build import path

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@ export {
   default as reducer,
   initialState,
 } from '@rest-hooks/core/state/reducer';
-export { useDenormalized } from '@rest-hooks/core/state/selectors';
+export { useDenormalized } from '@rest-hooks/core/state/selectors/index';
 export {
   useCache,
   useFetcher,
@@ -19,15 +19,15 @@ export {
   useInvalidateDispatcher,
   useResetter,
   hasUsableData,
-} from '@rest-hooks/core/react-integration';
-export type { ErrorTypes } from '@rest-hooks/core/react-integration';
+} from '@rest-hooks/core/react-integration/index';
+export type { ErrorTypes } from '@rest-hooks/core/react-integration/index';
 export {
   StateContext,
   DispatchContext,
   DenormalizeCacheContext,
 } from '@rest-hooks/core/react-integration/context';
 
-export * from '@rest-hooks/core/state/actions';
+export * from '@rest-hooks/core/state/actions/index';
 export * as actionTypes from '@rest-hooks/core/actionTypes';
 export * from '@rest-hooks/use-enhanced-reducer';
 export * from '@rest-hooks/endpoint';

--- a/packages/core/src/react-integration/hooks/hasUsableData.ts
+++ b/packages/core/src/react-integration/hooks/hasUsableData.ts
@@ -1,4 +1,4 @@
-import { FetchShape } from '@rest-hooks/core/endpoint';
+import { FetchShape } from '@rest-hooks/core/endpoint/index';
 
 /** If the invalidIfStale option is set we suspend if resource has expired */
 export default function hasUsableData(

--- a/packages/core/src/react-integration/hooks/useCache.ts
+++ b/packages/core/src/react-integration/hooks/useCache.ts
@@ -1,6 +1,6 @@
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import { DenormalizeNullable } from '@rest-hooks/endpoint';
-import { useDenormalized } from '@rest-hooks/core/state/selectors';
+import { useDenormalized } from '@rest-hooks/core/state/selectors/index';
 import { useContext, useMemo } from 'react';
 import {
   DenormalizeCacheContext,
@@ -10,7 +10,7 @@ import {
   hasUsableData,
   useMeta,
   useError,
-} from '@rest-hooks/core/react-integration/hooks';
+} from '@rest-hooks/core/react-integration/hooks/index';
 import { denormalize, inferResults } from '@rest-hooks/normalizr';
 import useExpiresAt from '@rest-hooks/core/react-integration/hooks/useExpiresAt';
 

--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -1,8 +1,8 @@
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import { NetworkError, UnknownError } from '@rest-hooks/core/types';
 import { StateContext } from '@rest-hooks/core/react-integration/context';
 import { useContext } from 'react';
-import { selectMeta } from '@rest-hooks/core/state/selectors';
+import { selectMeta } from '@rest-hooks/core/state/selectors/index';
 
 export type ErrorTypes = NetworkError | UnknownError;
 

--- a/packages/core/src/react-integration/hooks/useExpiresAt.ts
+++ b/packages/core/src/react-integration/hooks/useExpiresAt.ts
@@ -1,4 +1,4 @@
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import useMeta from '@rest-hooks/core/react-integration/hooks/useMeta';
 
 /** Returns whether the data at this url is fresh or stale */

--- a/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetchDispatcher.ts
@@ -5,7 +5,7 @@ import {
   BodyFromShape,
   OptimisticUpdateParams,
   ReturnFromShape,
-} from '@rest-hooks/core/endpoint';
+} from '@rest-hooks/core/endpoint/index';
 import { Schema } from '@rest-hooks/endpoint';
 import { DispatchContext } from '@rest-hooks/core/react-integration/context';
 import createFetch from '@rest-hooks/core/state/actions/createFetch';

--- a/packages/core/src/react-integration/hooks/useFetcher.ts
+++ b/packages/core/src/react-integration/hooks/useFetcher.ts
@@ -3,7 +3,7 @@ import {
   SchemaFromShape,
   OptimisticUpdateParams,
   ReturnFromShape,
-} from '@rest-hooks/core/endpoint';
+} from '@rest-hooks/core/endpoint/index';
 import { Schema } from '@rest-hooks/endpoint';
 import { useRef, useCallback } from 'react';
 import useFetchDispatcher from '@rest-hooks/core/react-integration/hooks/useFetchDispatcher';

--- a/packages/core/src/react-integration/hooks/useInvalidateDispatcher.ts
+++ b/packages/core/src/react-integration/hooks/useInvalidateDispatcher.ts
@@ -1,5 +1,5 @@
 import { useContext, useCallback } from 'react';
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import { DispatchContext } from '@rest-hooks/core/react-integration/context';
 import { INVALIDATE_TYPE } from '@rest-hooks/core/actionTypes';
 

--- a/packages/core/src/react-integration/hooks/useInvalidator.ts
+++ b/packages/core/src/react-integration/hooks/useInvalidator.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react';
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import useInvalidateDispatcher from '@rest-hooks/core/react-integration/hooks/useInvalidateDispatcher';
 
 /**

--- a/packages/core/src/react-integration/hooks/useMeta.ts
+++ b/packages/core/src/react-integration/hooks/useMeta.ts
@@ -1,6 +1,6 @@
-import { FetchShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { FetchShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import { StateContext } from '@rest-hooks/core/react-integration/context';
-import { selectMeta } from '@rest-hooks/core/state/selectors';
+import { selectMeta } from '@rest-hooks/core/state/selectors/index';
 import { useContext, useMemo } from 'react';
 
 /**

--- a/packages/core/src/react-integration/hooks/useResource.ts
+++ b/packages/core/src/react-integration/hooks/useResource.ts
@@ -1,6 +1,6 @@
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import { Denormalize, DenormalizeNullable } from '@rest-hooks/endpoint';
-import { useDenormalized } from '@rest-hooks/core/state/selectors';
+import { useDenormalized } from '@rest-hooks/core/state/selectors/index';
 import {
   DenormalizeCacheContext,
   StateContext,

--- a/packages/core/src/react-integration/hooks/useRetrieve.ts
+++ b/packages/core/src/react-integration/hooks/useRetrieve.ts
@@ -1,4 +1,4 @@
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import { useMemo } from 'react';
 import useFetchDispatcher from '@rest-hooks/core/react-integration/hooks/useFetchDispatcher';
 import useExpiresAt from '@rest-hooks/core/react-integration/hooks/useExpiresAt';

--- a/packages/core/src/react-integration/hooks/useSubscription.ts
+++ b/packages/core/src/react-integration/hooks/useSubscription.ts
@@ -1,5 +1,5 @@
 import { DispatchContext } from '@rest-hooks/core/react-integration/context';
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import { SUBSCRIBE_TYPE, UNSUBSCRIBE_TYPE } from '@rest-hooks/core/actionTypes';
 import { useContext, useEffect, useRef } from 'react';
 

--- a/packages/core/src/react-integration/index.ts
+++ b/packages/core/src/react-integration/index.ts
@@ -1,2 +1,2 @@
-export * from '@rest-hooks/core/react-integration/provider';
-export * from '@rest-hooks/core/react-integration/hooks';
+export * from '@rest-hooks/core/react-integration/provider/index';
+export * from '@rest-hooks/core/react-integration/hooks/index';

--- a/packages/core/src/state/NetworkManager.ts
+++ b/packages/core/src/state/NetworkManager.ts
@@ -13,7 +13,7 @@ import RIC from '@rest-hooks/core/state/RIC';
 import {
   createReceive,
   createReceiveError,
-} from '@rest-hooks/core/state/actions';
+} from '@rest-hooks/core/state/actions/index';
 
 /** Handles all async network dispatches
  *

--- a/packages/core/src/state/actions/createFetch.ts
+++ b/packages/core/src/state/actions/createFetch.ts
@@ -7,7 +7,7 @@ import {
   ParamsFromShape,
   BodyFromShape,
   OptimisticUpdateParams,
-} from '@rest-hooks/core/endpoint';
+} from '@rest-hooks/core/endpoint/index';
 
 interface Options<
   Shape extends FetchShape<

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -1,6 +1,6 @@
 import { normalize } from '@rest-hooks/normalizr';
 import { ActionTypes, State, ReceiveAction } from '@rest-hooks/core/types';
-import { createReceive } from '@rest-hooks/core/state/actions';
+import { createReceive } from '@rest-hooks/core/state/actions/index';
 import {
   RECEIVE_TYPE,
   INVALIDATE_TYPE,

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -1,5 +1,5 @@
 import { State } from '@rest-hooks/core/types';
-import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint';
+import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import { DenormalizeNullable } from '@rest-hooks/endpoint';
 import { isEntity, Schema } from '@rest-hooks/endpoint';
 import {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,7 +9,7 @@ import type {
   EndpointExtraOptions,
 } from '@rest-hooks/endpoint';
 import { ErrorableFSAWithPayloadAndMeta } from '@rest-hooks/core/fsa';
-import { FetchShape } from '@rest-hooks/core/endpoint';
+import { FetchShape } from '@rest-hooks/core/endpoint/index';
 import {
   RECEIVE_TYPE,
   RESET_TYPE,

--- a/packages/legacy/src/index.ts
+++ b/packages/legacy/src/index.ts
@@ -1,4 +1,4 @@
-export * from '@rest-hooks/legacy/resource';
+export * from '@rest-hooks/legacy/resource/index';
 export { default as useStatefulResource } from '@rest-hooks/legacy/useStatefulResource';
 export type {
   FetchShape,

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -64,14 +64,17 @@ export {
   PromiseifyMiddleware,
   NetworkErrorBoundary,
   mapMiddleware,
-} from './react-integration';
+} from 'rest-hooks/react-integration/index';
 
 export {
   PollingSubscription,
   DevToolsManager,
   SubscriptionManager,
   DefaultConnectionListener,
-} from './manager';
-export type { ConnectionListener, DevToolsConfig } from './manager';
-export { default as useSelectionUnstable } from './react-integration/hooks/useSelection';
-export * as __INTERNAL__ from './internal';
+} from 'rest-hooks/manager/index';
+export type {
+  ConnectionListener,
+  DevToolsConfig,
+} from 'rest-hooks/manager/index';
+export { default as useSelectionUnstable } from 'rest-hooks/react-integration/hooks/useSelection';
+export * as __INTERNAL__ from 'rest-hooks/internal';

--- a/packages/rest-hooks/src/manager/DefaultConnectionListener.ts
+++ b/packages/rest-hooks/src/manager/DefaultConnectionListener.ts
@@ -1,4 +1,4 @@
-import ConnectionListener from './ConnectionListener';
+import ConnectionListener from 'rest-hooks/manager/ConnectionListener';
 
 export class BrowserConnectionListener implements ConnectionListener {
   isOnline() {

--- a/packages/rest-hooks/src/manager/PollingSubscription.ts
+++ b/packages/rest-hooks/src/manager/PollingSubscription.ts
@@ -1,8 +1,10 @@
 import { actionTypes, Dispatch, Schema, State } from '@rest-hooks/core';
-
-import { Subscription, SubscriptionInit } from './SubscriptionManager';
-import DefaultConnectionListener from './DefaultConnectionListener';
-import ConnectionListener from './ConnectionListener';
+import {
+  Subscription,
+  SubscriptionInit,
+} from 'rest-hooks/manager/SubscriptionManager';
+import DefaultConnectionListener from 'rest-hooks/manager/DefaultConnectionListener';
+import ConnectionListener from 'rest-hooks/manager/ConnectionListener';
 
 const { FETCH_TYPE } = actionTypes;
 

--- a/packages/rest-hooks/src/manager/index.ts
+++ b/packages/rest-hooks/src/manager/index.ts
@@ -1,6 +1,6 @@
-export type { default as ConnectionListener } from './ConnectionListener';
-export { default as DefaultConnectionListener } from './DefaultConnectionListener';
-export { default as PollingSubscription } from './PollingSubscription';
-export { default as SubscriptionManager } from './SubscriptionManager';
-export { default as DevToolsManager } from './DevtoolsManager';
-export type { DevToolsConfig } from './DevtoolsManager';
+export type { default as ConnectionListener } from 'rest-hooks/manager/ConnectionListener';
+export { default as DefaultConnectionListener } from 'rest-hooks/manager/DefaultConnectionListener';
+export { default as PollingSubscription } from 'rest-hooks/manager/PollingSubscription';
+export { default as SubscriptionManager } from 'rest-hooks/manager/SubscriptionManager';
+export { default as DevToolsManager } from 'rest-hooks/manager/DevtoolsManager';
+export type { DevToolsConfig } from 'rest-hooks/manager/DevtoolsManager';

--- a/packages/rest-hooks/src/react-integration/index.ts
+++ b/packages/rest-hooks/src/react-integration/index.ts
@@ -1,5 +1,5 @@
-import NetworkErrorBoundary from './NetworkErrorBoundary';
+import NetworkErrorBoundary from 'rest-hooks/react-integration/NetworkErrorBoundary';
 
-export * from './provider';
-export { default as useSelectionUnstable } from './hooks/useSelection';
+export * from 'rest-hooks/react-integration/provider/index';
+export { default as useSelectionUnstable } from 'rest-hooks/react-integration/hooks/useSelection';
 export { NetworkErrorBoundary };

--- a/packages/rest-hooks/src/react-integration/provider/index.ts
+++ b/packages/rest-hooks/src/react-integration/provider/index.ts
@@ -3,10 +3,9 @@ import {
   SubscriptionManager,
   PollingSubscription,
   DevToolsManager,
-} from 'rest-hooks/manager';
-
-import PromiseifyMiddleware from './PromiseifyMiddleware';
-import ExternalCacheProvider from './ExternalCacheProvider';
+} from 'rest-hooks/manager/index';
+import PromiseifyMiddleware from 'rest-hooks/react-integration/provider/PromiseifyMiddleware';
+import ExternalCacheProvider from 'rest-hooks/react-integration/provider/ExternalCacheProvider';
 
 const CacheProvider: typeof CoreCacheProvider = props =>
   CoreCacheProvider(props);
@@ -22,4 +21,4 @@ if (process.env.NODE_ENV !== 'production')
   CacheProvider.defaultProps.managers.unshift(new DevToolsManager());
 
 export { CacheProvider, ExternalCacheProvider, PromiseifyMiddleware };
-export { default as mapMiddleware } from './mapMiddleware';
+export { default as mapMiddleware } from 'rest-hooks/react-integration/provider/mapMiddleware';


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`Could not find module in path: '@rest-hooks/core/legacy/state/actions.js' relative to '/node_modules/@rest-hooks/core/legacy/state/NetworkManager.js'`

The renaming to .js doesn't work with directories

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Just refer directly to the index file for now until tooling is bettter

Previously `export { useDenormalized } from '@rest-hooks/core/state/selectors';` -> `export { useDenormalized } from './state/selectors.js'`

Now `export { useDenormalized } from '@rest-hooks/core/state/selectors/index';` -> `export { useDenormalized } from './state/selectors/index.js'`