### PR TITLE
feat: Allow normalizing entities that are just ids

### DIFF
--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -1,6 +1,5 @@
 // eslint-env jest
 import { fromJS } from 'immutable';
-import { after } from 'lodash';
 
 import { denormalizeSimple as denormalize } from '../denormalize';
 import { normalize, schema } from '../';
@@ -37,8 +36,21 @@ describe('normalize', () => {
     expect(normalize(input).result).toBe(input);
   });
 
+  test('passthrough with id in place of entity', () => {
+    const input = { taco: 5 };
+    expect(normalize(input, { taco: Tacos }).result).toStrictEqual(input);
+  });
+
   test('cannot normalize with null input', () => {
     expect(() => normalize(null, Tacos)).toThrow(/null/);
+  });
+
+  test('passthrough primitive schema', () => {
+    expect(normalize({ happy: { bob: 5 } }, { happy: 5 }).result).toStrictEqual(
+      {
+        happy: { bob: 5 },
+      },
+    );
   });
 
   test('can normalize string', () => {

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -16,18 +16,13 @@ const visit = (
   addEntity: any,
   visitedEntities: any,
 ) => {
-  if (!value || !schema || !['function', 'object'].includes(typeof schema)) {
+  if (!value || !schema) {
     return value;
   }
 
-  if (!schema.normalize || typeof schema.normalize !== 'function') {
-    // serializable
-    if (typeof schema === 'function') {
-      return new schema(value);
-    }
-    const method = Array.isArray(schema) ? arrayNormalize : objectNormalize;
-    return method(
-      schema,
+  if (schema.normalize && typeof schema.normalize === 'function') {
+    if (typeof value !== 'object') return value;
+    return schema.normalize(
       value,
       parent,
       key,
@@ -37,14 +32,15 @@ const visit = (
     );
   }
 
-  return schema.normalize(
-    value,
-    parent,
-    key,
-    visit,
-    addEntity,
-    visitedEntities,
-  );
+  // serializable
+  if (typeof schema === 'function') {
+    return new schema(value);
+  }
+
+  if (typeof value !== 'object' || typeof schema !== 'object') return value;
+
+  const method = Array.isArray(schema) ? arrayNormalize : objectNormalize;
+  return method(schema, value, parent, key, visit, addEntity, visitedEntities);
 };
 
 const addEntities =


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Use case is to allow for flexible fetch combinations that denormalize with entities retrieved elsewise.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
New policy is all validation/checking is done on denorm side. Normalize should allow as much as possible. This was originally allowed by the normalizr library.