### PR TITLE
enhance: Experimental fetcher resolves before react render

### DIFF
--- a/packages/core/src/state/__tests__/networkManager.ts
+++ b/packages/core/src/state/__tests__/networkManager.ts
@@ -92,6 +92,7 @@ describe('NetworkManager', () => {
       body: { id: 5, title: 'hi' },
       throttle: false,
     });
+    (fetchRejectAction.meta.promise as any).catch(e => {});
 
     let NM: NetworkManager;
     let middleware: Middleware;
@@ -278,7 +279,10 @@ describe('NetworkManager', () => {
           ...fetchRejectAction,
           meta: {
             ...fetchRejectAction.meta,
-            options: { errorExpiryLength: undefined },
+            options: {
+              ...fetchRejectAction.meta.options,
+              errorExpiryLength: undefined,
+            },
           },
         });
       } catch (error) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,6 +7,7 @@ import type {
   Schema,
   FetchFunction,
   EndpointExtraOptions,
+  EndpointInterface,
 } from '@rest-hooks/endpoint';
 import { ErrorableFSAWithPayloadAndMeta } from '@rest-hooks/core/fsa';
 import { FetchShape } from '@rest-hooks/core/endpoint/index';
@@ -130,6 +131,7 @@ export interface FetchAction<
     FetchMeta<any, any>
   > {
   meta: FetchMeta<Payload, S>;
+  endpoint?: EndpointInterface;
 }
 
 export interface SubscribeAction

--- a/packages/experimental/src/createFetch.ts
+++ b/packages/experimental/src/createFetch.ts
@@ -47,6 +47,7 @@ export default function createFetch<
     type: actionTypes.FETCH_TYPE,
     payload: () => endpoint(...args),
     meta,
+    endpoint,
   };
 }
 

--- a/packages/experimental/src/rest/__tests__/Resource.test.ts
+++ b/packages/experimental/src/rest/__tests__/Resource.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { useResource } from '@rest-hooks/core';
+import { act } from '@testing-library/react-hooks';
 
 import Resource from '../Resource';
 import useFetcher from '../../useFetcher';
@@ -124,8 +125,10 @@ describe('Resource', () => {
       return { articles, nextPage, fetch };
     });
     await waitForNextUpdate();
-    await result.current.fetch(PaginatedArticleResource.listPage(), {
-      cursor: 2,
+    await act(async () => {
+      await result.current.fetch(PaginatedArticleResource.listPage(), {
+        cursor: 2,
+      });
     });
     expect(
       result.current.articles.map(
@@ -180,8 +183,10 @@ describe('Resource', () => {
     };
 
     mynock.get(`/complex-thing/5`).reply(200, secondResponse);
-    await result.current.fetch(ComplexResource.detail(), {
-      id: '5',
+    await act(async () => {
+      await result.current.fetch(ComplexResource.detail(), {
+        id: '5',
+      });
     });
     expect(result.current.article).toEqual({ ...secondResponse, extra: 'hi' });
   });


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Part of https://github.com/coinbase/rest-hooks/issues/760

This makes little difference in React 18 since renders are batched; however in React < 18, this means that code after promise resolution will be executed before react renders - allowing actions that need to take place as a result of successful fetch. For example navigating off a deleted page after delete.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Using promise chaining allows us to order microtasks so the resolution of useFetcher()'s promise happens before dispatch of receive.

This has many consequences for existing behaviors so we are opting in via the new fetch mechanism.

It's now recommended to wrap all fetches in act when testing like so:

```ts
    await act(async () => {
      await result.current.fetch(ComplexResource.detail(), {
        id: '5',
      });
    });
```