### PR TITLE
feat: useController()

### DIFF
--- a/packages/experimental/src/__tests__/useController.tsx
+++ b/packages/experimental/src/__tests__/useController.tsx
@@ -1,0 +1,151 @@
+import { useEffect } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import nock from 'nock';
+import { FutureArticleResource } from '__tests__/new';
+import { FixtureEndpoint } from '@rest-hooks/test/mockState';
+import { act } from '@testing-library/react-hooks';
+import { useCache } from '@rest-hooks/core';
+
+import { makeRenderRestHook, makeCacheProvider } from '../../../test';
+import useController from '../useController';
+
+export const payload = {
+  id: 5,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
+export const createPayload = {
+  id: 1,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
+export const detail: FixtureEndpoint = {
+  endpoint: FutureArticleResource.detail(),
+  args: [5],
+  response: payload,
+};
+
+export const nested: FixtureEndpoint = {
+  endpoint: FutureArticleResource.list(),
+  args: [{}],
+  response: [
+    {
+      id: 5,
+      title: 'hi ho',
+      content: 'whatever',
+      tags: ['a', 'best', 'react'],
+      author: {
+        id: 23,
+        username: 'bob',
+      },
+    },
+    {
+      id: 3,
+      title: 'the next time',
+      content: 'whatever',
+      author: {
+        id: 23,
+        username: 'charles',
+        email: 'bob@bob.com',
+      },
+    },
+  ],
+};
+let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+
+beforeEach(() => {
+  renderRestHook = makeRenderRestHook(makeCacheProvider);
+});
+
+describe('invalidate', () => {
+  it('should not invalidate anything if params is null', async () => {
+    const { result } = renderRestHook(
+      () => {
+        return {
+          data: useCache(FutureArticleResource.detail(), 5),
+          controller: useController(),
+        };
+      },
+      { initialFixtures: [detail] },
+    );
+    expect(result.current.data).toBeDefined();
+    await act(async () => {
+      await result.current.controller.invalidate(
+        FutureArticleResource.detail(),
+        null,
+      );
+    });
+    expect(result.current.data).toBeDefined();
+  });
+
+  it('should result in useCache having no entry', async () => {
+    const { result } = renderRestHook(
+      () => {
+        return {
+          data: useCache(FutureArticleResource.detail(), 5),
+          controller: useController(),
+        };
+      },
+      { initialFixtures: [detail] },
+    );
+    expect(result.current.data).toBeDefined();
+    await act(async () => {
+      await result.current.controller.invalidate(
+        FutureArticleResource.detail(),
+        5,
+      );
+    });
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('should return the same === function each time', () => {
+    const track = jest.fn();
+
+    const { rerender } = renderHook(() => {
+      const invalidate = useController().invalidate;
+      useEffect(track, [invalidate]);
+    });
+    expect(track.mock.calls.length).toBe(1);
+    for (let i = 0; i < 4; ++i) {
+      rerender();
+    }
+    expect(track.mock.calls.length).toBe(1);
+  });
+});
+
+describe('resetEntireStore', () => {
+  it('should result in useCache having no entry', async () => {
+    const { result } = renderRestHook(
+      () => {
+        return {
+          data: useCache(FutureArticleResource.detail(), 5),
+          controller: useController(),
+        };
+      },
+      { initialFixtures: [detail] },
+    );
+    expect(result.current.data).toBeDefined();
+    await act(async () => {
+      await result.current.controller.resetEntireStore();
+    });
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('should return the same === function each time', () => {
+    const track = jest.fn();
+
+    const { rerender } = renderHook(() => {
+      const reset = useController().resetEntireStore;
+      useEffect(track, [reset]);
+    });
+    expect(track.mock.calls.length).toBe(1);
+    for (let i = 0; i < 4; ++i) {
+      rerender();
+    }
+    expect(track.mock.calls.length).toBe(1);
+  });
+});

--- a/packages/experimental/src/__tests__/useFetcher.ts
+++ b/packages/experimental/src/__tests__/useFetcher.ts
@@ -1,10 +1,9 @@
 import { FutureArticleResource } from '__tests__/new';
 import nock from 'nock';
 import { useCache, useResource, ResolveType } from '@rest-hooks/core';
-
-// relative imports to avoid circular dependency in tsconfig references
 import { act } from '@testing-library/react-hooks';
 
+// relative imports to avoid circular dependency in tsconfig references
 import {
   makeRenderRestHook,
   makeCacheProvider,

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -1,4 +1,6 @@
 export { default as useFetcher } from './useFetcher';
+export { default as useController } from './useController';
+export type { Controller } from './useController';
 export { default as createFetch } from './createFetch';
 export { default as Resource } from './rest/Resource';
 export { default as BaseResource } from './rest/BaseResource';

--- a/packages/experimental/src/useController.ts
+++ b/packages/experimental/src/useController.ts
@@ -1,0 +1,70 @@
+import { EndpointInterface } from '@rest-hooks/endpoint';
+import { DispatchContext } from '@rest-hooks/core';
+import { useContext, useCallback } from 'react';
+import { actionTypes } from '@rest-hooks/core';
+
+import createFetch from './createFetch';
+import { UpdateFunction } from './types';
+
+/**
+ * Imperative control of Rest Hooks store
+ * @see https://resthooks.io/docs/api/useController
+ */
+export default function useController(throttle = false): Controller {
+  const dispatch = useContext(DispatchContext);
+
+  // TODO: elevate into CacheProvider and simply useContext
+  const fetch = useCallback(
+    <E extends EndpointInterface>(
+      endpoint: E,
+      ...args: readonly [...Parameters<E>]
+    ) => {
+      const action = createFetch(endpoint, {
+        args,
+        throttle,
+      });
+      dispatch(action);
+
+      return action.meta.promise as any;
+    },
+    [dispatch, throttle],
+  );
+
+  const invalidate = useCallback(
+    <E extends EndpointInterface>(
+      endpoint: E,
+      ...args: readonly [...Parameters<E>] | readonly [null]
+    ) =>
+      args?.[0] !== null
+        ? dispatch({
+            type: actionTypes.INVALIDATE_TYPE,
+            meta: {
+              key: endpoint.key(...args),
+            },
+          })
+        : Promise.resolve(),
+    [dispatch],
+  );
+
+  const resetEntireStore = useCallback(
+    () =>
+      dispatch({
+        type: actionTypes.RESET_TYPE,
+      }),
+    [dispatch],
+  );
+
+  return { fetch, invalidate, resetEntireStore };
+}
+
+export interface Controller {
+  fetch: <E extends EndpointInterface & { update?: UpdateFunction<E> }>(
+    endpoint: E,
+    ...args: readonly [...Parameters<E>]
+  ) => ReturnType<E>;
+  invalidate: <E extends EndpointInterface>(
+    endpoint: E,
+    ...args: readonly [...Parameters<E>] | readonly [null]
+  ) => Promise<void>;
+  resetEntireStore: () => Promise<void>;
+}

--- a/packages/experimental/src/useController.ts
+++ b/packages/experimental/src/useController.ts
@@ -35,7 +35,7 @@ export default function useController(throttle = false): Controller {
       endpoint: E,
       ...args: readonly [...Parameters<E>] | readonly [null]
     ) =>
-      args?.[0] !== null
+      args[0] !== null
         ? dispatch({
             type: actionTypes.INVALIDATE_TYPE,
             meta: {

--- a/packages/experimental/src/useFetcher.ts
+++ b/packages/experimental/src/useFetcher.ts
@@ -1,9 +1,7 @@
 import { EndpointInterface } from '@rest-hooks/endpoint';
-import { DispatchContext } from '@rest-hooks/core';
-import { useContext, useCallback } from 'react';
 
-import createFetch from './createFetch';
 import { UpdateFunction } from './types';
+import useController from './useController';
 
 /**
  * Build an imperative dispatcher to issue network requests.
@@ -15,21 +13,5 @@ export default function useFetcher(
   endpoint: E,
   ...args: readonly [...Parameters<E>]
 ) => ReturnType<E> {
-  const dispatch = useContext(DispatchContext);
-
-  return useCallback(
-    <E extends EndpointInterface>(
-      endpoint: E,
-      ...args: readonly [...Parameters<E>]
-    ) => {
-      const action = createFetch(endpoint, {
-        args,
-        throttle,
-      });
-      dispatch(action);
-
-      return action.meta.promise as any;
-    },
-    [dispatch, throttle],
-  );
+  return useController(throttle).fetch;
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Consolidate, simplify hooks

Consistent interface between managers and hooks

Global referential equality available everywhere (managers and updaters)

Simplify and consolidate TTL and error concepts

Less code in hooks = less work on rendering leaf nodes

Icing on cake: ez migration to EndpointInterface and flexible args support for hooks

Future breaking changes can allow ez migration with version strings sent to `useController('v2')`

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

We're introducing fetch, invalidate, resetEntireStore today into experimental.

Full future plan:

```ts
const controller = useController();

// actions
controller.fetch(UserResource.detail(), { id }) // sideEffects means no throttle, otherwise throttle
controller.receive(payload, UserResource.detail(), { id })
controller.invalidate(UserResource.detail(), { id })
controller.resetEntireStore()
controller.subscribe(UserResource.detail(), { id })
controller.unsubscribe(UserResource.detail(), { id })
// posisble new
controller.abort(UserResource.detail(), { id }) // only aborts if in flight
// note: to force fetch of sideEffect: undefined - call abort first
// this should enable good offline/online managers

// retrieval
const state = useContext(StateContext);
const [value, expiresAt] = controller.getResponse(state, UserResource.detail(), { id })
const error = controller.getError(state, UserResource.detail(), { id })
```

