### PR TITLE
enhance: Hide throttled fetches from devtools

### DIFF
--- a/packages/core/src/state/__tests__/networkManager.ts
+++ b/packages/core/src/state/__tests__/networkManager.ts
@@ -112,8 +112,7 @@ describe('NetworkManager', () => {
 
       const data = await fetchResolveAction.payload();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(dispatch).toHaveBeenCalledWith({
+      const action = {
         type: RECEIVE_TYPE,
         payload: data,
         meta: {
@@ -124,7 +123,9 @@ describe('NetworkManager', () => {
           date: expect.any(Number),
           expiresAt: expect.any(Number),
         },
-      });
+      };
+      expect(dispatch).toHaveBeenCalledWith(action);
+      expect(next).not.toHaveBeenCalledWith(action);
     });
     it('should handle fetch receive action and dispatch on success with updaters', async () => {
       const next = jest.fn();
@@ -134,8 +135,7 @@ describe('NetworkManager', () => {
 
       const data = await fetchReceiveWithUpdatersAction.payload();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(dispatch).toHaveBeenCalledWith({
+      const action = {
         type: RECEIVE_TYPE,
         payload: data,
         meta: {
@@ -149,7 +149,9 @@ describe('NetworkManager', () => {
           date: expect.any(Number),
           expiresAt: expect.any(Number),
         },
-      });
+      };
+      expect(dispatch).toHaveBeenCalledWith(action);
+      expect(next).not.toHaveBeenCalledWith(action);
     });
     it('should handle fetch rpc action and dispatch on success with updaters', async () => {
       const next = jest.fn();
@@ -159,8 +161,7 @@ describe('NetworkManager', () => {
 
       const data = await fetchRpcWithUpdatersAction.payload();
 
-      expect(next).not.toHaveBeenCalled();
-      expect(dispatch).toHaveBeenCalledWith({
+      const action = {
         type: RECEIVE_TYPE,
         payload: data,
         meta: {
@@ -172,7 +173,9 @@ describe('NetworkManager', () => {
           date: expect.any(Number),
           expiresAt: expect.any(Number),
         },
-      });
+      };
+      expect(dispatch).toHaveBeenCalledWith(action);
+      expect(next).not.toHaveBeenCalledWith(action);
     });
     it('should handle fetch rpc action with optimistic response and dispatch on success with updaters', async () => {
       const next = jest.fn();

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -37,18 +37,18 @@ export default function reducer(
       });
       return state;
     case FETCH_TYPE: {
+      // If 'fetch' action reaches the reducer there are no middlewares installed to handle it
+      /* istanbul ignore next */
+      if (process.env.NODE_ENV !== 'production' && !action.meta.nm) {
+        console.warn(
+          'Fetch appears unhandled - you are likely missing the NetworkManager middleware',
+        );
+        console.warn(
+          'See https://resthooks.io/docs/guides/redux#indextsx for hooking up redux',
+        );
+      }
       const optimisticResponse = action.meta.optimisticResponse;
       if (optimisticResponse === undefined) {
-        // If 'fetch' action reaches the reducer there are no middlewares installed to handle it
-        /* istanbul ignore next */
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn(
-            'Fetch appears unhandled - you are likely missing the NetworkManager middleware',
-          );
-          console.warn(
-            'See https://resthooks.io/docs/guides/redux#indextsx for hooking up redux',
-          );
-        }
         return state;
       }
 

--- a/packages/rest-hooks/src/react-integration/provider/index.ts
+++ b/packages/rest-hooks/src/react-integration/provider/index.ts
@@ -17,8 +17,16 @@ CacheProvider.defaultProps = {
   ],
 };
 /* istanbul ignore next */
-if (process.env.NODE_ENV !== 'production')
+if (process.env.NODE_ENV !== 'production') {
   CacheProvider.defaultProps.managers.unshift(new DevToolsManager());
+  if (CacheProvider.defaultProps.managers.length > 1) {
+    // swap so devtools is right after networkmanager
+    [
+      CacheProvider.defaultProps.managers[1],
+      CacheProvider.defaultProps.managers[0],
+    ] = CacheProvider.defaultProps.managers.slice(0, 2);
+  }
+}
 
 export { CacheProvider, ExternalCacheProvider, PromiseifyMiddleware };
 export { default as mapMiddleware } from 'rest-hooks/react-integration/provider/mapMiddleware';


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #1071 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
For nested members, TTL eliminates fetches. However, with siblings fetches must be throttled. If this happens, devtools fills up with duplicate fetches that have no actual impact on the state.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- NetworkManager passes through all non-throttled fetch actions
- Place devtools after networkmanager
- Update reducer tracking to ensure NM is still installed