### PR TITLE
fix: RESET clears inflight fetches

### DIFF
--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
@@ -9,7 +9,6 @@ Object {
         "content": "hi",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
       "errorPolicy": [Function],
@@ -43,7 +42,6 @@ Object {
         "content": "changed",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PUT http://test.com/article-cooler/1",
     "options": Object {
       "errorPolicy": [Function],
@@ -77,7 +75,6 @@ Object {
         "content": "changed",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PATCH http://test.com/article-cooler/1",
     "optimisticResponse": Object {
       "content": "changed",
@@ -114,7 +111,6 @@ Object {
         "content": "hi",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article/",
     "optimisticResponse": Object {
       "content": "hi",
@@ -151,7 +147,6 @@ Object {
         "content": "hi",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
       "errorPolicy": [Function],
@@ -184,7 +179,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/1",
     "options": Object {
       "errorPolicy": [Function],
@@ -223,7 +217,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
       "errorPolicy": [Function],
@@ -262,7 +255,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "dataExpiryLength": 3600000,
@@ -302,7 +294,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "errorExpiryLength": Infinity,
@@ -342,7 +333,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "errorPolicy": [Function],

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks.web.tsx.snap
@@ -9,7 +9,6 @@ Object {
         "content": "hi",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
       "errorPolicy": [Function],
@@ -43,7 +42,6 @@ Object {
         "content": "changed",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PUT http://test.com/article-cooler/1",
     "options": Object {
       "errorPolicy": [Function],
@@ -77,7 +75,6 @@ Object {
         "content": "changed",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "PATCH http://test.com/article-cooler/1",
     "optimisticResponse": Object {
       "content": "changed",
@@ -108,7 +105,6 @@ Object {
         "content": "hi",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article/",
     "optimisticResponse": Object {
       "content": "hi",
@@ -139,7 +135,6 @@ Object {
         "content": "hi",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
       "errorPolicy": [Function],
@@ -172,7 +167,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/1",
     "options": Object {
       "errorPolicy": [Function],
@@ -211,7 +205,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
       "errorPolicy": [Function],
@@ -250,7 +243,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "dataExpiryLength": 3600000,
@@ -290,7 +282,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "errorExpiryLength": Infinity,
@@ -330,7 +321,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-static/5",
     "options": Object {
       "errorPolicy": [Function],

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useFetchDispatcher.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useFetchDispatcher.tsx.snap
@@ -9,7 +9,6 @@ Object {
         "content": "hi",
       },
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "POST http://test.com/article-cooler/",
     "options": Object {
       "errorPolicy": [Function],

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource-endpoint.web.tsx.snap
@@ -9,7 +9,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
       "errorPolicy": [Function],
@@ -41,7 +40,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
       "errorPolicy": [Function],
@@ -71,7 +69,6 @@ Object {
       Object {},
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/user/",
     "options": Object {
       "errorPolicy": [Function],

--- a/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/useResource.web.tsx.snap
@@ -9,7 +9,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
       "errorPolicy": [Function],
@@ -41,7 +40,6 @@ Object {
       },
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/article-cooler/5",
     "options": Object {
       "errorPolicy": [Function],
@@ -71,7 +69,6 @@ Object {
       Object {},
       undefined,
     ],
-    "createdAt": 1970-01-01T00:00:00.000Z,
     "key": "GET http://test.com/user/",
     "options": Object {
       "errorPolicy": [Function],

--- a/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
@@ -18,7 +18,13 @@ import {
   mockInitialState,
 } from '../../../../test';
 import { DispatchContext, StateContext } from '../context';
-import { useFetcher, useRetrieve, useInvalidator, useResetter } from '../hooks';
+import {
+  useFetcher,
+  useRetrieve,
+  useInvalidator,
+  useResetter,
+  useResource,
+} from '../hooks';
 import { initialState } from '../../state/reducer';
 import { State, ActionTypes } from '../../types';
 import { INVALIDATE_TYPE, RESET_TYPE } from '../../actionTypes';
@@ -40,6 +46,7 @@ async function testDispatchFetch(
   expect(dispatch).toHaveBeenCalledTimes(payloads.length);
   let i = 0;
   for (const call of dispatch.mock.calls) {
+    delete call[0]?.meta?.createdAt;
     expect(call[0]).toMatchSnapshot();
     const action = call[0];
     const res = await action.payload();
@@ -269,7 +276,11 @@ describe('useInvalidate', () => {
 });
 
 describe('useResetter', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   it('should return a function that dispatches an action to reset the cache', () => {
+    jest.useFakeTimers();
     const state = mockInitialState([
       {
         request: PaginatedArticleResource.list(),
@@ -289,6 +300,7 @@ describe('useResetter', () => {
     reset({});
     expect(dispatch).toHaveBeenCalledWith({
       type: RESET_TYPE,
+      date: new Date(),
     });
   });
   it('should return the same === function each time', () => {

--- a/packages/core/src/react-integration/__tests__/hooks.web.tsx
+++ b/packages/core/src/react-integration/__tests__/hooks.web.tsx
@@ -40,6 +40,7 @@ async function testDispatchFetch(
   expect(dispatch).toHaveBeenCalledTimes(payloads.length);
   let i = 0;
   for (const call of dispatch.mock.calls) {
+    delete call[0]?.meta?.createdAt;
     expect(call[0]).toMatchSnapshot();
     const action = call[0];
     const res = await action.payload();
@@ -269,7 +270,11 @@ describe('useInvalidate', () => {
 });
 
 describe('useResetter', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
   it('should return a function that dispatches an action to reset the cache', () => {
+    jest.useFakeTimers();
     const state = mockInitialState([
       {
         request: PaginatedArticleResource.listShape(),
@@ -289,6 +294,7 @@ describe('useResetter', () => {
     reset({});
     expect(dispatch).toHaveBeenCalledWith({
       type: RESET_TYPE,
+      date: new Date(),
     });
   });
   it('should return the same === function each time', () => {

--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -3,13 +3,10 @@ import {
   ArticleResource,
   PaginatedArticleResource,
   UserResource,
-  ArticleResourceWithOtherListUrl,
   ListPaginatedArticle,
   CoolerArticleDetail,
   TypedArticleResource,
-  IndexedUserResource,
   UnionResource,
-  FutureArticleResource,
 } from '__tests__/new';
 import nock from 'nock';
 import { act } from '@testing-library/react-hooks';
@@ -18,7 +15,6 @@ import { act } from '@testing-library/react-hooks';
 import { schema, Entity } from '@rest-hooks/normalizr';
 import { SimpleRecord } from '@rest-hooks/legacy';
 import { Endpoint } from '@rest-hooks/endpoint';
-import { useContext } from 'react';
 
 import {
   makeRenderRestHook,
@@ -41,7 +37,6 @@ import {
   paginatedSecondPage,
   valuesFixture,
 } from '../test-fixtures';
-import { StateContext } from '../context';
 
 function onError(e: any) {
   e.preventDefault();

--- a/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
+++ b/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
@@ -67,6 +67,7 @@ describe('useExpiresAt()', () => {
       results: { [ListTaco.key({})]: ['1', '2'] },
       meta: {},
       optimistic: [],
+      lastReset: -Infinity,
     };
 
     const wrapper = function ConfiguredCacheProvider({
@@ -102,7 +103,7 @@ describe('useExpiresAt()', () => {
       schema: Tacos,
       key: ({ id }: { id: any }) => `detailtaco ${id}`,
     });
-    const state = {
+    const state: State<unknown> = {
       entities: {
         Tacos: {
           1: { id: '1', type: 'foo', ingredients: ['1'] },
@@ -129,6 +130,7 @@ describe('useExpiresAt()', () => {
       results: { [ListTaco.key({})]: ['1', '2'] },
       meta: {},
       optimistic: [],
+      lastReset: -Infinity,
     };
 
     const wrapper = function ConfiguredCacheProvider({

--- a/packages/core/src/react-integration/__tests__/useFetchDispatcher.tsx
+++ b/packages/core/src/react-integration/__tests__/useFetchDispatcher.tsx
@@ -23,6 +23,7 @@ async function testDispatchFetch(
   expect(dispatch).toHaveBeenCalledTimes(payloads.length);
   let i = 0;
   for (const call of dispatch.mock.calls) {
+    delete call[0]?.meta?.createdAt;
     expect(call[0]).toMatchSnapshot();
     const action = call[0];
     const res = await action.payload();

--- a/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
@@ -47,6 +47,7 @@ async function testDispatchFetch(
   expect(dispatch.mock.calls.length).toBe(payloads.length);
   let i = 0;
   for (const call of dispatch.mock.calls) {
+    delete call[0]?.meta?.createdAt;
     expect(call[0]).toMatchSnapshot();
     const action = call[0];
     const res = await action.payload();

--- a/packages/core/src/react-integration/__tests__/useResource.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource.web.tsx
@@ -43,6 +43,7 @@ async function testDispatchFetch(
   expect(dispatch.mock.calls.length).toBe(payloads.length);
   let i = 0;
   for (const call of dispatch.mock.calls) {
+    delete call[0]?.meta?.createdAt;
     expect(call[0]).toMatchSnapshot();
     const action = call[0];
     const res = await action.payload();

--- a/packages/core/src/react-integration/hooks/useResetter.ts
+++ b/packages/core/src/react-integration/hooks/useResetter.ts
@@ -12,6 +12,7 @@ export default function useResetter(): () => void {
   const resetDispatcher = useCallback(() => {
     dispatch({
       type: RESET_TYPE,
+      date: new Date(),
     });
   }, [dispatch]);
 

--- a/packages/core/src/react-integration/hooks/useRetrieve.ts
+++ b/packages/core/src/react-integration/hooks/useRetrieve.ts
@@ -1,7 +1,8 @@
 import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
-import { useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import useFetchDispatcher from '@rest-hooks/core/react-integration/hooks/useFetchDispatcher';
 import useExpiresAt from '@rest-hooks/core/react-integration/hooks/useExpiresAt';
+import { StateContext } from '@rest-hooks/core/react-integration/context';
 
 /**
  * Request a resource if it is not in cache.\
@@ -15,6 +16,7 @@ export default function useRetrieve<Shape extends ReadShape<any, any>>(
 ) {
   const dispatchFetch: any = useFetchDispatcher(true);
   const expiresAt = useExpiresAt(fetchShape, params, entitiesExpireAt);
+  const { lastReset } = useContext(StateContext);
 
   return useMemo(() => {
     // null params mean don't do anything
@@ -27,5 +29,6 @@ export default function useRetrieve<Shape extends ReadShape<any, any>>(
     dispatchFetch,
     params && fetchShape.getFetchKey(params),
     triggerFetch,
+    lastReset,
   ]);
 }

--- a/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
@@ -20,6 +20,7 @@ Object {
     },
   },
   "indexes": Object {},
+  "lastReset": -Infinity,
   "meta": Object {
     "http://test.com/article-cooler/5": Object {
       "date": 50,

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -5,6 +5,7 @@ Object {
   "entities": Object {},
   "entityMeta": Object {},
   "indexes": Object {},
+  "lastReset": -Infinity,
   "meta": Object {
     "http://test.com/article/20": Object {
       "date": 5000000000,
@@ -38,6 +39,7 @@ Object {
     },
   },
   "indexes": Object {},
+  "lastReset": -Infinity,
   "meta": Object {
     "http://test.com/article/20": Object {
       "date": 5000000000,

--- a/packages/core/src/state/__tests__/networkManager.ts
+++ b/packages/core/src/state/__tests__/networkManager.ts
@@ -5,10 +5,11 @@ import NetworkManager from '../NetworkManager';
 import { FetchAction, ResetAction } from '../../types';
 import { FETCH_TYPE, RECEIVE_TYPE, RESET_TYPE } from '../../actionTypes';
 import { createFetch } from '../actions';
+import { initialState } from '../reducer';
 
 describe('NetworkManager', () => {
   const manager = new NetworkManager();
-  const getState = () => {};
+  const getState = () => initialState;
 
   afterAll(() => {
     manager.cleanup();

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -680,6 +680,7 @@ describe('reducer', () => {
   it('reset should delete all entries', () => {
     const action: ResetAction = {
       type: RESET_TYPE,
+      date: new Date(0),
     };
     const iniState: any = {
       ...initialState,

--- a/packages/core/src/state/actions/createFetch.ts
+++ b/packages/core/src/state/actions/createFetch.ts
@@ -62,10 +62,7 @@ export default function createFetch<
     resolve,
     reject,
     promise,
-    createdAt:
-      process.env.NODE_ENV === 'test'
-        ? new Date(0)
-        : /* istanbul ignore next */ new Date(),
+    createdAt: new Date(),
   };
 
   if (fetchShape.update) {

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -15,8 +15,6 @@ import {
 } from '@rest-hooks/core/actionTypes';
 import applyUpdatersToResults from '@rest-hooks/core/state/applyUpdatersToResults';
 
-import { NoErrorFluxStandardActionWithPayloadAndMeta } from '../fsa';
-
 export const initialState: State<unknown> = {
   entities: {},
   indexes: {},
@@ -24,6 +22,7 @@ export const initialState: State<unknown> = {
   meta: {},
   entityMeta: {},
   optimistic: [],
+  lastReset: -Infinity,
 };
 
 export default function reducer(
@@ -124,6 +123,7 @@ export default function reducer(
             },
           },
           optimistic: filterOptimistic(state, action),
+          lastReset: state.lastReset,
         };
         // reducer must update the state, so in case of processing errors we simply compute the results inline
       } catch (error) {
@@ -161,7 +161,7 @@ export default function reducer(
       };
     }
     case RESET_TYPE:
-      return initialState;
+      return { ...initialState, lastReset: action.date };
 
     default:
       // A reducer must always return a valid state.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -62,6 +62,7 @@ export type State<T> = Readonly<{
     };
   };
   optimistic: ReceiveAction[];
+  lastReset: Date | number;
 }>;
 
 export type FetchOptions<F extends FetchFunction = FetchFunction> =
@@ -91,7 +92,10 @@ export type ReceiveAction<
   ReceiveMeta<S>
 >;
 
-export type ResetAction = FSA<typeof RESET_TYPE>;
+export interface ResetAction {
+  type: typeof RESET_TYPE;
+  date: Date;
+}
 
 interface FetchMeta<
   Payload extends object | string | number | null =

--- a/packages/experimental/src/createFetch.ts
+++ b/packages/experimental/src/createFetch.ts
@@ -29,10 +29,7 @@ export default function createFetch<
     resolve,
     reject,
     promise,
-    createdAt:
-      process.env.NODE_ENV === 'test'
-        ? new Date(0)
-        : /* istanbul ignore next */ new Date(),
+    createdAt: new Date(),
   };
 
   if (endpoint.update) {

--- a/packages/experimental/src/useController.ts
+++ b/packages/experimental/src/useController.ts
@@ -50,6 +50,7 @@ export default function useController(throttle = false): Controller {
     () =>
       dispatch({
         type: actionTypes.RESET_TYPE,
+        date: new Date(),
       }),
     [dispatch],
   );

--- a/packages/rest-hooks/src/manager/PollingSubscription.ts
+++ b/packages/rest-hooks/src/manager/PollingSubscription.ts
@@ -137,10 +137,7 @@ export default class PollingSubscription implements Subscription {
           // never break when data already exists
           errorPolicy: () => 'soft' as const,
         },
-        createdAt:
-          process.env.NODE_ENV === 'test'
-            ? new Date(0)
-            : /* istanbul ignore next */ new Date(),
+        createdAt: new Date(),
         resolve: () => {},
         reject: () => {},
       },

--- a/packages/rest-hooks/src/manager/PollingSubscription.ts
+++ b/packages/rest-hooks/src/manager/PollingSubscription.ts
@@ -137,6 +137,10 @@ export default class PollingSubscription implements Subscription {
           // never break when data already exists
           errorPolicy: () => 'soft' as const,
         },
+        createdAt:
+          process.env.NODE_ENV === 'test'
+            ? new Date(0)
+            : /* istanbul ignore next */ new Date(),
         resolve: () => {},
         reject: () => {},
       },

--- a/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
+++ b/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
@@ -4,7 +4,6 @@ exports[`PollingSubscription fresh data should call after period 1`] = `
 Array [
   Object {
     "meta": Object {
-      "createdAt": 1970-01-01T00:00:00.000Z,
       "key": "test.com",
       "options": Object {
         "dataExpiryLength": 2500,
@@ -27,7 +26,6 @@ exports[`PollingSubscription fresh data should call after period 2`] = `
 Array [
   Object {
     "meta": Object {
-      "createdAt": 1970-01-01T00:00:00.000Z,
       "key": "test.com",
       "options": Object {
         "dataExpiryLength": 2500,

--- a/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
+++ b/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription-endpoint.ts.snap
@@ -4,6 +4,7 @@ exports[`PollingSubscription fresh data should call after period 1`] = `
 Array [
   Object {
     "meta": Object {
+      "createdAt": 1970-01-01T00:00:00.000Z,
       "key": "test.com",
       "options": Object {
         "dataExpiryLength": 2500,
@@ -26,6 +27,7 @@ exports[`PollingSubscription fresh data should call after period 2`] = `
 Array [
   Object {
     "meta": Object {
+      "createdAt": 1970-01-01T00:00:00.000Z,
       "key": "test.com",
       "options": Object {
         "dataExpiryLength": 2500,

--- a/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription.ts.snap
+++ b/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription.ts.snap
@@ -4,7 +4,6 @@ exports[`PollingSubscription should call after period 1`] = `
 Array [
   Object {
     "meta": Object {
-      "createdAt": 1970-01-01T00:00:00.000Z,
       "key": "test.com",
       "options": Object {
         "dataExpiryLength": 2500,
@@ -27,7 +26,6 @@ exports[`PollingSubscription should call after period 2`] = `
 Array [
   Object {
     "meta": Object {
-      "createdAt": 1970-01-01T00:00:00.000Z,
       "key": "test.com",
       "options": Object {
         "dataExpiryLength": 2500,

--- a/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription.ts.snap
+++ b/packages/rest-hooks/src/manager/__tests__/__snapshots__/pollingSubscription.ts.snap
@@ -4,6 +4,7 @@ exports[`PollingSubscription should call after period 1`] = `
 Array [
   Object {
     "meta": Object {
+      "createdAt": 1970-01-01T00:00:00.000Z,
       "key": "test.com",
       "options": Object {
         "dataExpiryLength": 2500,
@@ -26,6 +27,7 @@ exports[`PollingSubscription should call after period 2`] = `
 Array [
   Object {
     "meta": Object {
+      "createdAt": 1970-01-01T00:00:00.000Z,
       "key": "test.com",
       "options": Object {
         "dataExpiryLength": 2500,

--- a/packages/rest-hooks/src/manager/__tests__/pollingSubscription-endpoint.ts
+++ b/packages/rest-hooks/src/manager/__tests__/pollingSubscription-endpoint.ts
@@ -178,9 +178,16 @@ describe('PollingSubscription', () => {
       dispatch.mockReset();
       jest.advanceTimersByTime(5000);
       expect(dispatch.mock.calls.length).toBe(1);
+      dispatch.mock.calls[0].forEach((element: any) => {
+        delete element?.meta?.createdAt;
+      });
       expect(dispatch.mock.calls[0]).toMatchSnapshot();
       jest.advanceTimersByTime(5000);
       expect(dispatch.mock.calls.length).toBe(2);
+      dispatch.mock.calls[1].forEach((element: any) => {
+        delete element?.meta?.createdAt;
+      });
+
       expect(dispatch.mock.calls[1]).toMatchSnapshot();
     });
 

--- a/packages/rest-hooks/src/manager/__tests__/pollingSubscription.ts
+++ b/packages/rest-hooks/src/manager/__tests__/pollingSubscription.ts
@@ -118,9 +118,16 @@ describe('PollingSubscription', () => {
     dispatch.mockReset();
     jest.advanceTimersByTime(5000);
     expect(dispatch.mock.calls.length).toBe(1);
+    dispatch.mock.calls[0].forEach((element: any) => {
+      delete element?.meta?.createdAt;
+    });
     expect(dispatch.mock.calls[0]).toMatchSnapshot();
     jest.advanceTimersByTime(5000);
     expect(dispatch.mock.calls.length).toBe(2);
+    dispatch.mock.calls[1].forEach((element: any) => {
+      delete element?.meta?.createdAt;
+    });
+
     expect(dispatch.mock.calls[1]).toMatchSnapshot();
   });
 

--- a/packages/test/src/managers.ts
+++ b/packages/test/src/managers.ts
@@ -1,17 +1,19 @@
-import { NetworkManager, FetchAction } from '@rest-hooks/core';
-import type { ReceiveAction, Dispatch } from '@rest-hooks/core';
+import { NetworkManager } from '@rest-hooks/core';
+import type { ReceiveAction } from '@rest-hooks/core';
 import { PollingSubscription } from 'rest-hooks';
 import { act } from '@testing-library/react-hooks';
 
 export class MockNetworkManager extends NetworkManager {
-  handleFetch(action: FetchAction, dispatch: Dispatch<any>) {
+  handleFetch(
+    ...[action, dispatch, ...rest]: Parameters<NetworkManager['handleFetch']>
+  ) {
     const mockDispatch: typeof dispatch = (v: any) => {
       act(() => {
         dispatch(v);
       });
       return Promise.resolve();
     };
-    return super.handleFetch(action, mockDispatch);
+    return super.handleFetch(action, mockDispatch, ...rest);
   }
 
   handleReceive(action: ReceiveAction) {


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #1072 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
[reset](https://resthooks.io/docs/api/useResetter) clears inflight promises, not just state already established.

This is critical when using RESET for auth logout as the subsequent promises will likely reject with auth errors.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### Visible Behavior

- unmounting CacheProvider with inflight requests will not attempt to dispatch after unmount causing react error
  - promises are neither resolved nor rejected
- upon reset, all inflight requests will not dispatch receives
  - promises still reject so external listeners know (abort signals do this as well)
- useResource(), useRetrive() will re-issue needed fetches upon reset so they never end up loading infinitely
  - this only triggers *after* commit of reset action so users have a chance to unmount those components if they are no longer relevant (like doing a url redirect from an unauthorized page)

#### Implementation details
- Reset action includes date. This is stored in state as 'lastReset'. This is used to trigger refetches in useRetrieve()
  - NetworkManager now relies on getState() - using it to find the lastReset time. This determines whether to dispatch actions after a fetch completes
  - Since reset is a 'singleton action', tracking the last time allows us to simply compare current fetch times with last reset to know whether to process their dispatches.
- No special test code for fetch date - instead remove it from snapshots so tests don't break on every run

