### PR TITLE
fix: useFetchInit() hook calls same amount every render

### DIFF
--- a/examples/todo-app/src/resources/TodoResource.ts
+++ b/examples/todo-app/src/resources/TodoResource.ts
@@ -17,11 +17,12 @@ export default class TodoResource extends PlaceholderBaseResource {
   }
 
   static create<T extends typeof Resource>(this: T) {
+    const listkey = this.list().key({});
     return super.create().extend({
       schema: this,
       optimisticUpdate: optimisticCreate,
       update: (newResourceId: string) => ({
-        [this.list().key({})]: (resourceIds: string[] = []) => [
+        [listkey]: (resourceIds: string[] = []) => [
           ...resourceIds,
           newResourceId,
         ],

--- a/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/useResource-endpoint.web.tsx
@@ -559,6 +559,7 @@ describe('useResource()', () => {
     });
 
     it('should use latest context when making requests', async () => {
+      const consoleSpy = jest.spyOn(console, 'error');
       const wrapper = ({
         children,
         authToken,
@@ -574,6 +575,7 @@ describe('useResource()', () => {
           return {
             data: useResource(ContextAuthdArticle.detail(), payload),
             fetch: useFetcher(ContextAuthdArticle.detail()),
+            create: useFetcher(ContextAuthdArticle.create()),
           };
         },
         {
@@ -589,6 +591,8 @@ describe('useResource()', () => {
       const data = await result.current.fetch(payload);
       expect(data).toEqual(payload);
       expect(result.current.data.title).toEqual(payload.title);
+      // ensure we don't violate call-order changes
+      expect(consoleSpy.mock.calls.length).toBeLessThan(1);
     });
   });
 });

--- a/packages/experimental/src/rest/BaseResource.ts
+++ b/packages/experimental/src/rest/BaseResource.ts
@@ -222,8 +222,9 @@ export default abstract class BaseResource extends EntityRecord {
     true
   > {
     const instanceFetch = this.fetch.bind(this);
+    const endpoint = this.endpoint();
     return this.memo('#endpointMutate', () =>
-      this.endpoint().extend({
+      endpoint.extend({
         fetch(this: RestEndpoint, params: any, body: any) {
           return instanceFetch(this.url(params), this.getFetchInit(body));
         },

--- a/packages/experimental/src/rest/Resource.ts
+++ b/packages/experimental/src/rest/Resource.ts
@@ -23,8 +23,9 @@ export default abstract class Resource extends BaseResource {
     SchemaDetail<AbstractInstanceType<T>>,
     undefined
   > {
+    const endpoint = this.endpoint();
     return this.memo('#detail', () =>
-      this.endpoint().extend({
+      endpoint.extend({
         schema: this,
       }),
     );
@@ -40,8 +41,9 @@ export default abstract class Resource extends BaseResource {
       undefined
     >
   > {
+    const endpoint = this.endpoint();
     return this.memo('#list', () =>
-      this.endpoint().extend({
+      endpoint.extend({
         schema: [this],
         url: this.listUrl.bind(this),
         paginated(
@@ -78,8 +80,9 @@ export default abstract class Resource extends BaseResource {
     true
   > {
     //Partial<AbstractInstanceType<T>>
+    const endpoint = this.endpointMutate();
     return this.memo('#create', () =>
-      this.endpointMutate().extend({
+      endpoint.extend({
         schema: this,
         url: this.listUrl.bind(this),
       }),
@@ -94,8 +97,9 @@ export default abstract class Resource extends BaseResource {
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
+    const endpoint = this.endpointMutate();
     return this.memo('#update', () =>
-      this.endpointMutate().extend({
+      endpoint.extend({
         method: 'PUT',
         schema: this,
       }),
@@ -110,8 +114,9 @@ export default abstract class Resource extends BaseResource {
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
+    const endpoint = this.endpointMutate();
     return this.memo('#partialUpdate', () =>
-      this.endpointMutate().extend({
+      endpoint.extend({
         method: 'PATCH',
         schema: this,
       }),

--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -183,8 +183,9 @@ export default abstract class SimpleResource extends EntityRecord {
     true
   > {
     const instanceFetch = this.fetch.bind(this);
+    const endpoint = this.endpoint();
     return this.memo('#endpointMutate', () =>
-      this.endpoint().extend({
+      endpoint.extend({
         fetch(this: RestEndpoint, params: any, body: any) {
           return instanceFetch(this.url(params), this.getFetchInit(body));
         },
@@ -202,8 +203,9 @@ export default abstract class SimpleResource extends EntityRecord {
     SchemaDetail<AbstractInstanceType<T>>,
     undefined
   > {
+    const endpoint = this.endpoint();
     return this.memo('#detail', () =>
-      this.endpoint().extend({
+      endpoint.extend({
         schema: this,
       }),
     );
@@ -217,8 +219,9 @@ export default abstract class SimpleResource extends EntityRecord {
     SchemaList<AbstractInstanceType<T>>,
     undefined
   > {
+    const endpoint = this.endpoint();
     return this.memo('#list', () =>
-      this.endpoint().extend({
+      endpoint.extend({
         schema: [this],
         url: this.listUrl.bind(this),
       }),
@@ -234,8 +237,9 @@ export default abstract class SimpleResource extends EntityRecord {
     true
   > {
     //Partial<AbstractInstanceType<T>>
+    const endpoint = this.endpointMutate();
     return this.memo('#create', () =>
-      this.endpointMutate().extend({
+      endpoint.extend({
         schema: this,
         url: this.listUrl.bind(this),
       }),
@@ -250,8 +254,9 @@ export default abstract class SimpleResource extends EntityRecord {
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
+    const endpoint = this.endpointMutate();
     return this.memo('#update', () =>
-      this.endpointMutate().extend({
+      endpoint.extend({
         method: 'PUT',
         schema: this,
       }),
@@ -266,8 +271,9 @@ export default abstract class SimpleResource extends EntityRecord {
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
+    const endpoint = this.endpointMutate();
     return this.memo('#partialUpdate', () =>
-      this.endpointMutate().extend({
+      endpoint.extend({
         method: 'PATCH',
         schema: this,
       }),


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #1101 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
useFetchInit() can call hooks, so we need to ensure it is called only from top level and not conditionally

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Hoist all endpoint calls to top level.

Validated against example usage from https://github.com/coinbase/rest-hooks/issues/1101

### Open questions

We should think about suggesting use-prefix for endpoints that use this to ensure linter helps avoid these scenarios.