### PR TITLE
fix: Cannot update a component while rendering a different component

### DIFF
--- a/packages/core/src/react-integration/__tests__/integration.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration.web.tsx
@@ -459,7 +459,7 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         const params = { id: payload.id };
         mynock.delete('/article-cooler/5').reply(200, '');
 
-        const { result, waitForNextUpdate } = renderRestHook(
+        const { result } = renderRestHook(
           () => {
             const del = useFetcher(CoolerArticleResource.deleteShape());
             const articles = useCache(CoolerArticleResource.listShape(), {});
@@ -478,7 +478,9 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
         expect(result.current.articles).toEqual([
           CoolerArticleResource.fromJS(payload),
         ]);
-        const promise = result.current.del(params);
+        const promise = act(async () => {
+          await result.current.del(params);
+        });
         expect(result.current.articles).toEqual([]);
         await promise;
         expect(result.current.articles).toEqual([]);

--- a/packages/core/src/state/NetworkManager.ts
+++ b/packages/core/src/state/NetworkManager.ts
@@ -60,7 +60,14 @@ export default class NetworkManager implements Manager {
               if (process.env.NODE_ENV !== 'production') {
                 action.meta.nm = true;
               }
-              return next(action);
+              // prevent "Cannot update a component (`CacheProvider`) while rendering a different component"
+              // schedule next as a macro-task
+              // TODO: is there a cleaner way to run other middlewares but not hit reducer so we don't need to schedule this?
+              return action.meta.throttle
+                ? new Promise(resolve =>
+                    setTimeout(() => next(action).then(resolve), 0),
+                  )
+                : next(action);
             case RECEIVE_TYPE:
               // only receive after new state is computed
               return next(action).then(() => {

--- a/packages/experimental/src/__tests__/useController.tsx
+++ b/packages/experimental/src/__tests__/useController.tsx
@@ -178,6 +178,8 @@ describe('resetEntireStore', () => {
      *    this only triggers after commit of reset action so users have a chance to unmount those components if they are no longer relevant (like doing a url redirect from an unauthorized page)
      */
     it('should refetch useResource() after reset', async () => {
+      const consoleSpy = jest.spyOn(console, 'error');
+
       mynock
         .get(`/article-cooler/${9999}`)
         .delay(2000)
@@ -199,13 +201,18 @@ describe('resetEntireStore', () => {
       act(() => {
         resetEntireStore();
       });
-      jest.advanceTimersByTime(5000);
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
       act(() => rerender());
       jest.advanceTimersByTime(5000);
-
       await waitForNextUpdate();
+
       expect(result.current).toBeDefined();
       expect(result.current.title).toEqual(payload.title);
+
+      // ensure it doesn't try to setstate during render (dispatching during fetch - which is called from memo)
+      expect(consoleSpy.mock.calls.length).toBeLessThan(1);
     });
 
     /**


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Apparently this render is triggered event tho state === state in reducer.
This was introduced in https://github.com/coinbase/rest-hooks/pull/1083 which sends through fetch actions so they can be picked up by dev middleware.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
For now just schedule throttled fetches as a macrotask to keep it off same callstack.


### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
Perhaps there's a way to keep this from reducer while still controller which go to middlewares?