### PR TITLE
enhance: Resource.delete() handles empty object response

### DIFF
--- a/packages/experimental/src/rest/Resource.ts
+++ b/packages/experimental/src/rest/Resource.ts
@@ -137,7 +137,7 @@ export default abstract class Resource extends BaseResource {
         fetch(this: RestEndpoint, params: any) {
           return endpoint.fetch
             .call(this, params)
-            .then(res => (res ? res : params));
+            .then(res => (res && Object.keys(res).length ? res : params));
         },
         method: 'DELETE',
         schema: new schema.Delete(this),

--- a/packages/experimental/src/rest/__tests__/Resource.test.ts
+++ b/packages/experimental/src/rest/__tests__/Resource.test.ts
@@ -190,4 +190,16 @@ describe('Resource', () => {
     });
     expect(result.current.article).toEqual({ ...secondResponse, extra: 'hi' });
   });
+
+  it('delete() should fallback to params when response is empty object', async () => {
+    mynock.delete(`/article-paginated/500`).reply(200, {});
+    const res = await PaginatedArticleResource.delete()({ id: 500 });
+    expect(res).toEqual({ id: 500 });
+  });
+
+  it('delete() should fallback to params when response is undefined', async () => {
+    mynock.delete(`/article-paginated/500`).reply(204, undefined);
+    const res = await PaginatedArticleResource.delete()({ id: 500 });
+    expect(res).toEqual({ id: 500 });
+  });
 });


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Empty object is unusable to lookup PK, so for this case we can try to fallback to params

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`Object.keys(res).length`. If response is not an object it's likely going to fail this anyway