### PR TITLE
enhance: Back to avoiding reducer for fetch

### DIFF
--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -43,18 +43,18 @@ export default function reducer(
       });
       return state;
     case FETCH_TYPE: {
-      // If 'fetch' action reaches the reducer there are no middlewares installed to handle it
-      /* istanbul ignore next */
-      if (process.env.NODE_ENV !== 'production' && !action.meta.nm) {
-        console.warn(
-          'Fetch appears unhandled - you are likely missing the NetworkManager middleware',
-        );
-        console.warn(
-          'See https://resthooks.io/docs/guides/redux#indextsx for hooking up redux',
-        );
-      }
       const optimisticResponse = action.meta.optimisticResponse;
       if (optimisticResponse === undefined) {
+        // If 'fetch' action reaches the reducer there are no middlewares installed to handle it
+        /* istanbul ignore next */
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(
+            'Fetch appears unhandled - you are likely missing the NetworkManager middleware',
+          );
+          console.warn(
+            'See https://resthooks.io/docs/guides/redux#indextsx for hooking up redux',
+          );
+        }
         return state;
       }
 

--- a/packages/rest-hooks/src/manager/DevtoolsManager.ts
+++ b/packages/rest-hooks/src/manager/DevtoolsManager.ts
@@ -5,6 +5,7 @@ import {
   Manager,
   State,
   reducer,
+  ActionTypes,
 } from '@rest-hooks/core';
 
 export type DevToolsConfig = {
@@ -24,6 +25,7 @@ export default class DevToolsManager implements Manager {
     config: DevToolsConfig = {
       name: `Rest Hooks: ${globalThis.document?.title}`,
     },
+    skipLogging?: (action: ActionTypes) => boolean,
   ) {
     /* istanbul ignore next */
     this.devTools =
@@ -39,6 +41,7 @@ export default class DevToolsManager implements Manager {
       }: MiddlewareAPI<R>) => {
         return (next: Dispatch<R>) => (action: React.ReducerAction<R>) => {
           return next(action).then(() => {
+            if (skipLogging?.(action)) return;
             const state = getState();
             this.devTools.send(
               action,

--- a/packages/rest-hooks/src/react-integration/provider/index.ts
+++ b/packages/rest-hooks/src/react-integration/provider/index.ts
@@ -1,4 +1,7 @@
-import { CacheProvider as CoreCacheProvider } from '@rest-hooks/core';
+import {
+  CacheProvider as CoreCacheProvider,
+  NetworkManager,
+} from '@rest-hooks/core';
 import {
   SubscriptionManager,
   PollingSubscription,
@@ -18,14 +21,16 @@ CacheProvider.defaultProps = {
 };
 /* istanbul ignore next */
 if (process.env.NODE_ENV !== 'production') {
-  CacheProvider.defaultProps.managers.unshift(new DevToolsManager());
-  if (CacheProvider.defaultProps.managers.length > 1) {
-    // swap so devtools is right after networkmanager
-    [
-      CacheProvider.defaultProps.managers[1],
-      CacheProvider.defaultProps.managers[0],
-    ] = CacheProvider.defaultProps.managers.slice(0, 2);
-  }
+  const networkManager: NetworkManager | undefined =
+    CacheProvider.defaultProps.managers.find(
+      manager => manager instanceof NetworkManager,
+    ) as any;
+  CacheProvider.defaultProps.managers.unshift(
+    new DevToolsManager(
+      undefined,
+      networkManager && networkManager.skipLogging.bind(networkManager),
+    ),
+  );
 }
 
 export { CacheProvider, ExternalCacheProvider, PromiseifyMiddleware };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Turns out react doesn't always short circuit reducers even with ===. It seemed like there were sometimes jank around loading.
Prior: https://github.com/coinbase/rest-hooks/pull/1083 https://github.com/coinbase/rest-hooks/pull/1130

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Back to avoiding reducer - but we introduce `skipLogging` which is sent to devtools to know when to skip logging fetches. This adds an API surface area but is ultimately a cleaner code path.

Effectively https://github.com/coinbase/rest-hooks/pull/1083  is undone in favor of this solution