### PR TITLE
enhance: Warn users if they are missing Suspense boundary

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -2,3 +2,4 @@ export { DELETED } from '@rest-hooks/endpoint';
 
 export { inferResults } from '@rest-hooks/normalizr';
 export { default as RIC } from '@rest-hooks/core/state/RIC';
+export { default as BackupBoundary } from '@rest-hooks/core/react-integration/provider/BackupBoundary';

--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -176,14 +176,25 @@ for (const makeProvider of [makeCacheProvider, makeExternalCacheProvider]) {
       });
     });
 
-    it('should resolve useResource()', async () => {
-      const { result, waitForNextUpdate } = renderRestHook(() => {
-        return useResource(CoolerArticleResource.detail(), payload);
+    describe('renderRestHook()', () => {
+      let warnspy: jest.SpyInstance;
+      beforeEach(() => {
+        warnspy = jest.spyOn(global.console, 'warn');
       });
-      expect(result.current).toBeUndefined();
-      await waitForNextUpdate();
-      expect(result.current instanceof CoolerArticleResource).toBe(true);
-      expect(result.current.title).toBe(payload.title);
+      afterEach(() => {
+        warnspy.mockRestore();
+      });
+
+      it('should resolve useResource()', async () => {
+        const { result, waitForNextUpdate } = renderRestHook(() => {
+          return useResource(CoolerArticleResource.detail(), payload);
+        });
+        expect(result.current).toBeUndefined();
+        await waitForNextUpdate();
+        expect(result.current instanceof CoolerArticleResource).toBe(true);
+        expect(result.current.title).toBe(payload.title);
+        expect(warnspy).not.toHaveBeenCalled();
+      });
     });
 
     it('should denormalize schema.Values()', async () => {

--- a/packages/core/src/react-integration/provider/BackupBoundary.tsx
+++ b/packages/core/src/react-integration/provider/BackupBoundary.tsx
@@ -1,0 +1,36 @@
+import React, { Suspense } from 'react';
+import { useMemo } from 'react';
+
+export default function BackupBoundary({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <Suspense fallback={<Loading />}>{children}</Suspense>;
+}
+
+function Loading() {
+  let message: React.ReactNode = 'loading...';
+  /* istanbul ignore else */
+  if (process.env.NODE_ENV !== 'production') {
+    // env should not change during runtime and this excludes from build
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useMemo(() => {
+      console.warn(
+        `Uncaught suspense.
+Make sure to add your own Suspense boundaries: https://resthooks.io/docs/getting-started/data-dependency#async-fallbacks`,
+      );
+    }, []);
+
+    message = (
+      <>
+        <span>Uncaught Suspense.</span>
+        Try{' '}
+        <a href="https://resthooks.io/docs/getting-started/data-dependency#async-fallbacks">
+          adding a suspense boundary
+        </a>
+      </>
+    );
+  }
+  return <div>{message}</div>;
+}

--- a/packages/core/src/react-integration/provider/CacheProvider.tsx
+++ b/packages/core/src/react-integration/provider/CacheProvider.tsx
@@ -11,6 +11,7 @@ import {
   DispatchContext,
   DenormalizeCacheContext,
 } from '@rest-hooks/core/react-integration/context';
+import BackupBoundary from '@rest-hooks/core/react-integration/provider/BackupBoundary';
 
 interface ProviderProps {
   children: ReactNode;
@@ -59,7 +60,7 @@ export default function CacheProvider({
     <DispatchContext.Provider value={dispatch}>
       <StateContext.Provider value={optimisticState}>
         <DenormalizeCacheContext.Provider value={denormalizeCache.current}>
-          {children}
+          <BackupBoundary>{children}</BackupBoundary>
         </DenormalizeCacheContext.Provider>
       </StateContext.Provider>
     </DispatchContext.Provider>

--- a/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
@@ -34,3 +34,12 @@ Object {
   },
 }
 `;
+
+exports[`<CacheProvider /> should warn users about missing Suspense 1`] = `
+Array [
+  Array [
+    "Uncaught suspense.
+Make sure to add your own Suspense boundaries: https://resthooks.io/docs/getting-started/data-dependency#async-fallbacks",
+  ],
+]
+`;

--- a/packages/test/src/makeRenderRestHook.tsx
+++ b/packages/test/src/makeRenderRestHook.tsx
@@ -1,6 +1,6 @@
 import { State, Manager } from '@rest-hooks/core';
 import { SubscriptionManager } from 'rest-hooks';
-import React, { memo } from 'react';
+import React, { memo, Suspense } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import mockInitialState, {
   Fixture,
@@ -56,7 +56,7 @@ export default function makeRenderRestHook(
         : Provider;
 
     const Wrapper = options?.wrapper;
-    const wrapper = Wrapper
+    const ProviderWithWrapper = Wrapper
       ? function ProviderWrapped(props: React.PropsWithChildren<P>) {
           return (
             <ProviderWithResolver>
@@ -65,6 +65,15 @@ export default function makeRenderRestHook(
           );
         }
       : ProviderWithResolver;
+
+    const wrapper: React.ComponentType<any> = ({
+      children,
+      ...props
+    }: React.PropsWithChildren<P>) => (
+      <ProviderWithWrapper {...(props as any)}>
+        <Suspense fallback={null}>{children}</Suspense>
+      </ProviderWithWrapper>
+    );
 
     return renderHook(callback, {
       ...options,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
It's very confusing if a user misses Suspense or puts in the wrong place. Point them to the correct documentation when this occurs.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Put Suspense just below rest of CacheProvider. Fallback will do the warning.
- [makeRenderRestHook](https://resthooks.io/docs/api/makeRenderRestHook) needs a suspense boundary so it doesn't trigger the warning in console for tests
