### PR TITLE
enhance: Improve NetworkError debuggability

### DIFF
--- a/packages/experimental/src/rest/BaseResource.ts
+++ b/packages/experimental/src/rest/BaseResource.ts
@@ -10,7 +10,9 @@ class NetworkError extends Error {
   declare response: Response;
 
   constructor(response: Response) {
-    super(response.statusText);
+    super(
+      response.statusText || `Network response not 'ok': ${response.status}`,
+    );
     this.status = response.status;
     this.response = response;
   }

--- a/packages/legacy/src/resource/Resource.ts
+++ b/packages/legacy/src/resource/Resource.ts
@@ -8,7 +8,9 @@ class NetworkError extends Error {
   declare response: Response;
 
   constructor(response: Response) {
-    super(response.statusText);
+    super(
+      response.statusText || `Network response not 'ok': ${response.status}`,
+    );
     this.status = response.status;
     this.response = response;
   }

--- a/packages/rest/src/Resource.ts
+++ b/packages/rest/src/Resource.ts
@@ -5,7 +5,9 @@ class NetworkError extends Error {
   declare response: Response;
 
   constructor(response: Response) {
-    super(response.statusText);
+    super(
+      response.statusText || `Network response not 'ok': ${response.status}`,
+    );
     this.status = response.status;
     this.response = response;
   }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Sometimes `response.statusText` is empty, making the error message empty

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Fallback to response.status