### PR TITLE
enhance: validate during denormalization

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,8 +10,8 @@ Dynamic data at scale. Performance, consistency, typing for REST, proto, GraphQL
 
 <div align="center">
 
-**[📖Read The Docs](https://resthooks.io)** &nbsp;|&nbsp; [🏁Getting Started](https://resthooks.io/docs/getting-started/installation) &nbsp;|&nbsp;
-[🎮Demo](https://codesandbox.io/s/rest-hooks-hinux?fontsize=14&module=%2Fsrc%2Fpages%2FIssueList.tsx)
+**[📖Read The Docs](https://resthooks.io/docs)** &nbsp;|&nbsp; [🏁Getting Started](https://resthooks.io/docs/getting-started/installation) &nbsp;|&nbsp;
+[🎮Demo](https://github.com/coinbase/rest-hooks/tree/master/examples/todo-app)
 
 </div>
 
@@ -67,8 +67,9 @@ For the small price of 7kb gziped. &nbsp;&nbsp; [🏁Get started now](https://re
 
 - [x] ![TS](./typescript.svg?sanitize=true) Strong [Typescript](https://www.typescriptlang.org/) types
 - [x] 🛌 React [Suspense](https://resthooks.io/docs/guides/loading-state) support
-- [x] ⛓️ React [Concurrent mode](https://reactjs.org/docs/concurrent-mode-patterns.html) compatible
-- [x] 🎣 Simple declarative API
+- [x] 🧵 React 18 [Concurrent mode](https://reactjs.org/docs/concurrent-mode-patterns.html) compatible
+- [x] 🎣 [Declarative API](https://resthooks.io/docs/getting-started/data-dependency)
+- [x] 📝 Composition over configuration
 - [x] 💰 Normalized response [configurable](https://resthooks.io/docs/guides/resource-lifetime) caching
 - [x] 💥 Tiny bundle footprint
 - [x] 🛑 Automatic overfetching elimination

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -604,6 +604,8 @@ describe('denormalize', () => {
         author: User,
         comments: [Comment],
       };
+
+      static validate() {}
     }
 
     const entities = {

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -622,7 +622,7 @@ describe(`${Entity.name} denormalization`, () => {
   test('denormalizes an entity', () => {
     const entities = {
       Tacos: {
-        '1': { id: '1', type: 'foo' },
+        '1': { id: '1', name: 'foo' },
       },
     };
     expect(denormalize('1', Tacos, entities)).toMatchSnapshot();

--- a/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
@@ -31,8 +31,7 @@ Array [
   Tacos {
     "alias": undefined,
     "id": "1",
-    "name": "",
-    "type": "foo",
+    "name": "foo",
   },
   true,
   false,
@@ -44,8 +43,7 @@ Array [
   Tacos {
     "alias": undefined,
     "id": "1",
-    "name": "",
-    "type": "foo",
+    "name": "foo",
   },
   true,
   false,

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -54,7 +54,7 @@ export interface SchemaSimple<T = any> {
     // eslint-disable-next-line @typescript-eslint/ban-types
     input: {} | undefined,
     unvisit: UnvisitFunction,
-  ): [T, boolean, boolean];
+  ): [denormalized: T, found: boolean, suspend: boolean];
   infer(
     args: any[],
     indexes: NormalizedIndex,
@@ -97,7 +97,7 @@ export class Array<S extends Schema = Schema> implements SchemaClass {
     // eslint-disable-next-line @typescript-eslint/ban-types
     input: {} | undefined,
     unvisit: UnvisitFunction,
-  ): [Denormalize<S>[], boolean, boolean];
+  ): [denormalized: Denormalize<S>[], found: boolean, suspend: boolean];
 
   _denormalizeNullable(): [Denormalize<S>[] | undefined, false, boolean];
 
@@ -129,7 +129,7 @@ export class Object<O extends Record<string, any> = Record<string, Schema>>
     // eslint-disable-next-line @typescript-eslint/ban-types
     input: {} | undefined,
     unvisit: UnvisitFunction,
-  ): [DenormalizeObject<O>, boolean, boolean];
+  ): [denormalized: DenormalizeObject<O>, found: boolean, suspend: boolean];
 
   _denormalizeNullable(): [DenormalizeNullableObject<O>, false, boolean];
 
@@ -167,7 +167,11 @@ export class Union<Choices extends EntityMap = any> implements SchemaClass {
     // eslint-disable-next-line @typescript-eslint/ban-types
     input: {} | undefined,
     unvisit: UnvisitFunction,
-  ): [AbstractInstanceType<Choices[keyof Choices]>, boolean, boolean];
+  ): [
+    denormalized: AbstractInstanceType<Choices[keyof Choices]>,
+    found: boolean,
+    suspend: boolean,
+  ];
 
   _denormalizeNullable(): [
     AbstractInstanceType<Choices[keyof Choices]> | undefined,
@@ -227,12 +231,12 @@ export class Values<Choices extends Schema = any> implements SchemaClass {
     input: {} | undefined,
     unvisit: UnvisitFunction,
   ): [
-    Record<
+    denormalized: Record<
       string,
       Choices extends EntityMap<infer T> ? T : Denormalize<Choices>
     >,
-    boolean,
-    boolean,
+    found: boolean,
+    suspend: boolean,
   ];
 
   _denormalizeNullable(): [

--- a/packages/normalizr/src/schemas/Array.ts
+++ b/packages/normalizr/src/schemas/Array.ts
@@ -41,7 +41,7 @@ export const denormalize = (
   schema: any,
   input: any,
   unvisit: any,
-): [denormalized: any, found: boolean, deleted: boolean] => {
+): [denormalized: any, found: boolean, suspend: boolean] => {
   schema = validateSchema(schema);
   let deleted = false;
   let found = true;

--- a/packages/normalizr/src/schemas/Delete.ts
+++ b/packages/normalizr/src/schemas/Delete.ts
@@ -71,7 +71,7 @@ export default class Delete<E extends EntityInterface & { process: any }>
   denormalize(
     id: string,
     unvisit: UnvisitFunction,
-  ): [AbstractInstanceType<E>, boolean, boolean] {
+  ): [denormalized: AbstractInstanceType<E>, found: boolean, suspend: boolean] {
     return unvisit(id, this._entity) as any;
   }
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Entities can come from different endpoints than they are retrieved from.

This enables cases where you might want to send only partial fields for a short list, and then send the rest in longer. In this case you don't want to use partial entities.

```ts
class ArticlePreview extends Entity {
  readonly id: string = '';
  readonly title: string = '';

  pk() { return this.id; }
  static key() { return 'Article'; }
}
const articleList = new Endpoint(fetchList, { schema: [ArticlePreview] });

class ArticleFull extends ArticlePreview {
  readonly content: string = '';
  readonly createdAt: Date = new Date(0);

  static schema = {
    createdAt: Date,
  }

  static validate(processedEntity) {
    if (!Object.hasOwn(processedEntity, 'content')) return 'Missing content';
  }
}
const articleDetail = new Endpoint(fetchDetail, { schema: ArticleFull });
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Thus, we can specify which fields are needed in `validate()` and if a validation error occurs, we mark that result as needing to do a full fetch (aka deleted).

This changes validate() from throwing errors to returning errormessages. This is a breaking change for this method, however validate is currently unreleased, so it is not necessary to document this in the release notes.

Infinite loops are not possible as the moment validation fails in normalization, it is cut short due throw errors instead of suspending.