### PR TITLE
enhance: Improve robustness for legacy RESET actions

### DIFF
--- a/docs/rest/usage.md
+++ b/docs/rest/usage.md
@@ -113,7 +113,7 @@ export default function ArticleList({ sortBy }: { sortBy: string }) {
 </Tabs>
 
 [useResource()](../api/useresource) guarantees access to data with sufficient [freshness](../api/Endpoint#dataexpirylength-number).
-This means it may issue network calls, and it may [suspend](../guides/loading-state) until the the fetch completes.
+This means it may issue network calls, and it may [suspend](../guides/loading-state) until the fetch completes.
 Param changes will result in accessing the appropriate data, which also sometimes results in new network calls and/or
 suspends.
 

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -677,30 +677,74 @@ describe('reducer', () => {
     const newState = reducer(iniState, action);
     expect(newState).toBe(iniState);
   });
-  it('reset should delete all entries', () => {
-    const action: ResetAction = {
-      type: RESET_TYPE,
-      date: new Date(0),
-    };
-    const iniState: any = {
-      ...initialState,
-      entities: {
-        [ArticleResource.key]: {
-          '10': ArticleResource.fromJS({ id: 10 }),
-          '20': ArticleResource.fromJS({ id: 20 }),
-          '25': ArticleResource.fromJS({ id: 25 }),
+  describe('RESET', () => {
+    let warnspy: jest.SpyInstance;
+    beforeEach(() => {
+      warnspy = jest.spyOn(global.console, 'warn');
+    });
+    afterEach(() => {
+      warnspy.mockRestore();
+    });
+
+    it('reset should delete all entries', () => {
+      const action: ResetAction = {
+        type: RESET_TYPE,
+        date: new Date(0),
+      };
+      const iniState: any = {
+        ...initialState,
+        entities: {
+          [ArticleResource.key]: {
+            '10': ArticleResource.fromJS({ id: 10 }),
+            '20': ArticleResource.fromJS({ id: 20 }),
+            '25': ArticleResource.fromJS({ id: 25 }),
+          },
+          [PaginatedArticleResource.key]: {
+            hi: PaginatedArticleResource.fromJS({ id: 5 }),
+          },
+          '5': undefined,
         },
-        [PaginatedArticleResource.key]: {
-          hi: PaginatedArticleResource.fromJS({ id: 5 }),
+        results: { abc: '20' },
+      };
+      const newState = reducer(iniState, action);
+      expect(newState.results).toEqual({});
+      expect(newState.meta).toEqual({});
+      expect(newState.entities).toEqual({});
+    });
+
+    it('reset without date should warn about deprecation', () => {
+      const action: any = {
+        type: RESET_TYPE,
+      };
+      const iniState: any = {
+        ...initialState,
+        entities: {
+          [ArticleResource.key]: {
+            '10': ArticleResource.fromJS({ id: 10 }),
+            '20': ArticleResource.fromJS({ id: 20 }),
+            '25': ArticleResource.fromJS({ id: 25 }),
+          },
+          [PaginatedArticleResource.key]: {
+            hi: PaginatedArticleResource.fromJS({ id: 5 }),
+          },
+          '5': undefined,
         },
-        '5': undefined,
-      },
-      results: { abc: '20' },
-    };
-    const newState = reducer(iniState, action);
-    expect(newState.results).toEqual({});
-    expect(newState.meta).toEqual({});
-    expect(newState.entities).toEqual({});
+        results: { abc: '20' },
+      };
+      const newState = reducer(iniState, action);
+      expect(newState.results).toEqual({});
+      expect(newState.meta).toEqual({});
+      expect(newState.entities).toEqual({});
+      expect(newState.lastReset).toBeDefined();
+      expect(newState.lastReset).toBeInstanceOf(Date);
+      expect(warnspy.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "rest-hooks/reset sent without 'date' member. This is deprecated. Please use createReset() action creator to ensure correct action shape.",
+  ],
+]
+`);
+    });
   });
 
   describe('GC action', () => {

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -156,7 +156,12 @@ export default function reducer(
       };
     }
     case RESET_TYPE:
-      return { ...initialState, lastReset: action.date };
+      if (process.env.NODE_ENV !== 'production' && action.date === undefined) {
+        console.warn(
+          `${RESET_TYPE} sent without 'date' member. This is deprecated. Please use createReset() action creator to ensure correct action shape.`,
+        );
+      }
+      return { ...initialState, lastReset: action.date ?? new Date() };
 
     default:
       // A reducer must always return a valid state.


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
If action types aren't typed correctly it's easy for someone dispatching these to be missing dates. Doing so will stall the entire store and no useResource() suspense will ever complete.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Warn in non-prod; and add fallback so things still work.