### PR TITLE
enhance: Maintain order during pagination

### DIFF
--- a/docs/graphql/auth.md
+++ b/docs/graphql/auth.md
@@ -1,5 +1,6 @@
 ---
 title: GraphQL Authentication
+sidebar_label: Authentication
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/graphql/usage.md
+++ b/docs/graphql/usage.md
@@ -1,6 +1,7 @@
 ---
 id: usage
-title: Usage
+title: GraphQL
+sidebar_label: Usage
 ---
 
 import LanguageTabs from '@site/src/components/LanguageTabs';

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -1,5 +1,6 @@
 ---
-title: Authentication
+title: Resource Authentication
+sidebar_label: Authentication
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/rest/usage.md
+++ b/docs/rest/usage.md
@@ -1,6 +1,7 @@
 ---
 id: usage
-title: Usage
+title: REST / CRUD
+sidebar_label: Usage
 ---
 import LanguageTabs from '@site/src/components/LanguageTabs';
 import Tabs from '@theme/Tabs';

--- a/packages/experimental/src/rest/test-fixtures.ts
+++ b/packages/experimental/src/rest/test-fixtures.ts
@@ -80,7 +80,7 @@ export const nested = [
   },
 ];
 
-const moreNested = [
+export const moreNested = [
   {
     id: 7,
     title: 'article 7',


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Order is typically very important for list results

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Instead of placing in a giant set - we explicitly iterate only added to end.