### PR TITLE
enhance: Improve list().paginated() types

### DIFF
--- a/packages/experimental/src/rest/Resource.ts
+++ b/packages/experimental/src/rest/Resource.ts
@@ -48,7 +48,9 @@ export default abstract class Resource extends BaseResource {
         url: this.listUrl.bind(this),
         paginated(
           this: any,
-          removeCursor: (...args: Parameters<typeof this>) => any[],
+          removeCursor: (...args: Parameters<typeof this>) => {
+            [k in keyof Parameters<typeof this>]: any;
+          },
         ) {
           // infer path from schema. if schema is undefined assume array is top level
           const path = getArrayPath(this.schema);

--- a/packages/experimental/src/rest/__tests__/Resource.test.ts
+++ b/packages/experimental/src/rest/__tests__/Resource.test.ts
@@ -4,6 +4,7 @@ import { act } from '@testing-library/react-hooks';
 
 import Resource from '../Resource';
 import useFetcher from '../../useFetcher';
+import type { Paginatable, RestEndpoint, RestFetch } from '../types';
 import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
 import {
   payload,
@@ -44,7 +45,15 @@ export class PaginatedArticleResource extends Resource {
 
   static urlRoot = 'http://test.com/article-paginated/';
 
-  static list<T extends typeof Resource>(this: T) {
+  static list<T extends typeof Resource>(
+    this: T,
+  ): Paginatable<
+    RestEndpoint<
+      RestFetch<[{ cursor?: number }]>,
+      { nextPage: string; results: T[] },
+      undefined
+    >
+  > {
     return super.list().extend({
       schema: {
         nextPage: '',
@@ -126,6 +135,11 @@ describe('Resource', () => {
       return { articles, nextPage, fetch };
     });
     await waitForNextUpdate();
+    () =>
+      result.current.fetch(PaginatedArticleResource.listPage(), {
+        // @ts-expect-error
+        cursor: 'five',
+      });
     await act(async () => {
       await result.current.fetch(PaginatedArticleResource.listPage(), {
         cursor: 2,

--- a/packages/experimental/src/rest/types.ts
+++ b/packages/experimental/src/rest/types.ts
@@ -4,23 +4,20 @@ import type {
   Schema,
 } from '@rest-hooks/endpoint';
 
-export type RestFetch<P = any, B = any, R = any> = (
+export type RestFetch<A extends readonly any[] = any, R = any> = (
   this: RestEndpoint,
-  params?: P,
-  body?: B,
-  ...rest: any
+  ...args: A
 ) => Promise<R>;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type FetchMutate<P = any, B = {}, R = any> = (
+export type FetchMutate<A extends readonly any[] = [any, {}], R = any> = (
   this: RestEndpoint,
-  params: P,
-  body: B,
+  ...args: A
 ) => Promise<R>;
 
-export type FetchGet<P = any, R = any> = (
+export type FetchGet<A extends readonly any[] = [any], R = any> = (
   this: RestEndpoint,
-  params: P,
+  ...args: A
 ) => Promise<R>;
 
 /** Endpoint from a Resource
@@ -42,7 +39,7 @@ export interface RestEndpoint<
   ) => any;
   method: string;
   signal: AbortSignal | undefined;
-  paginated?: <T>(this: T, ...args: any) => T;
+  paginated?: (this: any, ...args: Parameters<F>) => any;
 }
 
 export type Paginatable<
@@ -52,8 +49,8 @@ export type Paginatable<
     true | undefined
   >,
 > = E & {
-  paginated(
-    this: E,
+  paginated<T extends Paginatable<E>>(
+    this: T,
     removeCursor: (...args: Parameters<E>) => any,
-  ): Paginatable<E>;
+  ): T;
 };


### PR DESCRIPTION
BREAKING CHANGE: Updated types of RestEndpoint, RestFetch, FetchGet, FetchMutate

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Couldn't specify return types in inheritance

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- RestEndpoint was too restrictive
- Improve RestFetch to be more usable with variable args