### PR TITLE
feat: useLoading() second argument is deps list

### DIFF
--- a/docs/api/useLoading.md
+++ b/docs/api/useLoading.md
@@ -42,13 +42,15 @@ interface Props {
 function TodoListItem({ todo }) {
   const { fetch } = useController();
 
-  const toggle = useCallback(
+  const [toggleHandler, loading, error] = useLoading(
     (e: ChangeEvent<HTMLInputElement>) =>
-      fetch(TodoResource.partialUpdate(), { id }, { completed: e.currentTarget.checked }),
-    [partialUpdate],
+      fetch(
+        TodoResource.partialUpdate(),
+        { id },
+        { completed: e.currentTarget.checked },
+      ),
+    [fetch],
   );
-
-  const [toggleHandler, loading, error] = useLoading(toggle);
 
   return (
     <div>
@@ -64,3 +66,21 @@ function TodoListItem({ todo }) {
   );
 }
 ```
+
+:::tip Eslint configuration
+
+Since we use the deps list, be sure to add useLoading to the 'additionalHooks' configuration
+of [react-hooks/exhaustive-deps](https://www.npmjs.com/package/eslint-plugin-react-hooks) rule if you use it.
+
+```js
+{
+  "rules": {
+    // ...
+    "react-hooks/exhaustive-deps": ["warn", {
+      "additionalHooks": "(useLoading)"
+    }]
+  }
+}
+```
+
+:::

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -177,7 +177,10 @@ import { useLoading } from '@rest-hooks/hooks';
 
 const { fetch } = useController();
 // highlight-next-line
-const [update, loading, error] = useLoading(data => fetch(todoUpdate, { id }, data));
+const [update, loading, error] = useLoading(
+  data => fetch(todoUpdate, { id }, data),
+  [fetch],
+);
 return <ArticleForm onSubmit={update} />;
 ```
 

--- a/packages/hooks/src/__tests__/useLoading.ts
+++ b/packages/hooks/src/__tests__/useLoading.ts
@@ -80,7 +80,6 @@ describe('useLoading()', () => {
   });
 
   it('should call error callback when rejected', async () => {
-    const errcb = jest.fn();
     const error = new Error('ack');
     function fun(value: string) {
       return new Promise<string>((resolve, reject) =>
@@ -89,7 +88,7 @@ describe('useLoading()', () => {
     }
     let rejectedError: Error | null = null;
     const { result, waitForNextUpdate } = renderHook(() => {
-      return useLoading(fun, errcb);
+      return useLoading(fun);
     });
     const wrappedFunc = result.current[0];
     expect(result.current[1]).toBe(false);
@@ -105,7 +104,6 @@ describe('useLoading()', () => {
     await waitForNextUpdate();
     expect(result.current[1]).toBe(false);
     expect(result.current[2]).toBeDefined();
-    expect(errcb).toHaveBeenCalledWith(error);
     expect(rejectedError).toBe(error);
     // maintain referential equality
     expect(result.current[0]).toBe(wrappedFunc);

--- a/packages/hooks/src/useLoading.ts
+++ b/packages/hooks/src/useLoading.ts
@@ -5,7 +5,7 @@ import { useEffect, useState, useRef, useCallback } from 'react';
  *
  * @see https://resthooks.io/docs/api/useLoading
  * @param func A function returning a promise
- * @param onError Callback in case of error (optional)
+ * @param deps Deps list sent to useCallback()
  * @example
  ```
  function Button({ onClick, children, ...props }) {
@@ -21,7 +21,7 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 export default function useLoading<
   F extends (...args: any) => Promise<any>,
   E extends Error,
->(func: F, onError?: (error: E) => void): [F, boolean, E | undefined] {
+>(func: F, deps: readonly any[] = []): [F, boolean, E | undefined] {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<undefined | E>(undefined);
   const isMountedRef = useRef(true);
@@ -38,7 +38,6 @@ export default function useLoading<
       try {
         ret = await func(...args);
       } catch (e: any) {
-        if (onError) onError(e);
         setError(e);
         throw e;
       } finally {
@@ -48,7 +47,7 @@ export default function useLoading<
       }
       return ret;
     },
-    [onError, func],
+    [func, ...deps],
   );
   return [wrappedFunc as any, loading, error];
 }


### PR DESCRIPTION
BREAKING CHANGE: onError() is no longer second argument;
To handle this case, simply .catch() yourself.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Simplify definitions avoiding need to useCallback

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```ts
  const { fetch } = useController();

  const [toggleHandler, loading, error] = useLoading(
    (e: ChangeEvent<HTMLInputElement>) =>
      fetch(
        TodoResource.partialUpdate(),
        { id },
        { completed: e.currentTarget.checked },
      ),
    [fetch],
  );
```

