### PR TITLE
feat: Send controller to middlewares

### DIFF
--- a/docs/api/SimpleRecord.md
+++ b/docs/api/SimpleRecord.md
@@ -3,9 +3,9 @@ title: SimpleRecord
 ---
 import LanguageTabs from '@site/src/components/LanguageTabs';
 
-:::caution
+:::caution Deprecated
 
-Deprecated. Used [schema.Object](./Object) instead.
+Use [schema.Object](./Object) instead.
 
 :::
 

--- a/docs/api/useFetcher.md
+++ b/docs/api/useFetcher.md
@@ -118,9 +118,9 @@ function PostListItem({ post }: { post: PostResource }) {
 
 ## updateParams: [destEndpoint, destParams, updateFunction][]
 
-:::caution
+:::caution Deprecated
 
-Deprecated - use [Endpoint.update](./Endpoint.md#update) instead
+Use [Endpoint.update](./Endpoint.md#update) instead
 
 :::
 

--- a/docs/api/useLoading.md
+++ b/docs/api/useLoading.md
@@ -5,7 +5,7 @@ title: useLoading()
 ```typescript
 export default function useLoading<F extends (...args: any) => Promise<any>>(
   func: F,
-  onError?: (error: Error) => void,
+  deps: readonly any[] = [],
 ): [F, boolean];
 ```
 

--- a/docs/guides/redux.md
+++ b/docs/guides/redux.md
@@ -2,6 +2,7 @@
 id: redux
 title: Redux integration
 ---
+
 import PkgTabs from '@site/src/components/PkgTabs';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -19,8 +20,8 @@ First make sure you have redux installed:
 
 Note: react-redux is _not_ needed for this integration (though you will need it if you want to use redux directly as well).
 
-Then you'll want to use the [\<ExternalCacheProvider />](../api/ExternalCacheProvider.md) instead of
-[\<CacheProvider />](../api/CacheProvider.md) and pass in the store and a selector function to grab
+Then you'll want to use the [<ExternalCacheProvider /\>](../api/ExternalCacheProvider.md) instead of
+[<CacheProvider /\>](../api/CacheProvider.md) and pass in the store and a selector function to grab
 the rest-hooks specific part of the state.
 
 > Note: You should only use ONE provider; nested another provider will override the previous.
@@ -46,19 +47,24 @@ import {
   ExternalCacheProvider,
   PromiseifyMiddleware,
 } from 'rest-hooks';
-import { initialState, reducer, NetworkManager } from '@rest-hooks/core';
+import {
+  initialState,
+  reducer,
+  NetworkManager,
+  Controller,
+} from '@rest-hooks/core';
 import { createStore, applyMiddleware } from 'redux';
 import ReactDOM from 'react-dom';
 
 const networkManager = new NetworkManager();
 const subscriptionManager = new SubscriptionManager(PollingSubscription);
+const controller = new Controller();
 
 const store = createStore(
   reducer,
   initialState,
   applyMiddleware(
-    networkManager.getMiddleware(),
-    subscriptionManager.getMiddleware(),
+    ...applyManager([networkManager, subscriptionManager], controller),
     // place Rest Hooks built middlewares before PromiseifyMiddleware
     PromiseifyMiddleware,
     // place redux middlewares after PromiseifyMiddleware
@@ -96,8 +102,7 @@ const store = createStore(
   }),
   applyMiddleware(
     ...mapMiddleware(selector)(
-      manager.getMiddleware(),
-      subscriptionManager.getMiddleware(),
+      ...applyManager([networkManager, subscriptionManager], controller),
     ),
     PromiseifyMiddleware,
   ),
@@ -117,20 +122,25 @@ import {
   ExternalCacheProvider,
   PromiseifyMiddleware,
 } from 'rest-hooks';
-import { initialState, reducer, NetworkManager } from '@rest-hooks/core';
+import {
+  initialState,
+  reducer,
+  NetworkManager,
+  Controller,
+} from '@rest-hooks/core';
 import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import ReactDOM from 'react-dom';
 
 const manager = new NetworkManager();
 const subscriptionManager = new SubscriptionManager(PollingSubscription);
+const controller = new Controller();
 
 const store = createStore(
   reducer,
   initialState,
   applyMiddleware(
-    networkManager.getMiddleware(),
-    subscriptionManager.getMiddleware(),
+    ...applyManager([networkManager, subscriptionManager], controller),
     // place Rest Hooks built middlewares before PromiseifyMiddleware
     PromiseifyMiddleware,
     // place redux middlewares after PromiseifyMiddleware
@@ -165,8 +175,7 @@ const store = createStore(
   }),
   applyMiddleware(
     ...mapMiddleware(selector)(
-      manager.getMiddleware(),
-      subscriptionManager.getMiddleware(),
+      ...applyManager([networkManager, subscriptionManager], controller),
     ),
     PromiseifyMiddleware,
   ),
@@ -197,8 +206,7 @@ const store = createStore(
     trace: true,
   })(
     applyMiddleware(
-      manager.getMiddleware(),
-      subscriptionManager.getMiddleware(),
+      ...applyManager([networkManager, subscriptionManager], controller),
       // place Rest Hooks built middlewares before PromiseifyMiddleware
       PromiseifyMiddleware,
       // place redux middlewares after PromiseifyMiddleware

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -14,7 +14,7 @@ import type { DenormalizeCache } from '@rest-hooks/normalizr';
 type RHDispatch = (value: ActionTypes) => Promise<void>;
 
 interface ConstructorProps {
-  dispatch: RHDispatch;
+  dispatch?: RHDispatch;
   globalCache?: DenormalizeCache;
 }
 
@@ -27,12 +27,12 @@ export default class Controller {
   declare readonly globalCache: DenormalizeCache;
 
   constructor({
-    dispatch,
+    dispatch = () => Promise.reject('dispatch not set'),
     globalCache = {
       entities: {},
       results: {},
     },
-  }: ConstructorProps) {
+  }: ConstructorProps = {}) {
     this.dispatch = dispatch;
     this.globalCache = globalCache;
   }

--- a/packages/core/src/controller/createFetch.ts
+++ b/packages/core/src/controller/createFetch.ts
@@ -50,7 +50,6 @@ export default function createFetch<
   endpoint,
   meta: {
     args,
-    throttle,
     createdAt,
     promise,
     resolve,

--- a/packages/core/src/controller/createSubscription.ts
+++ b/packages/core/src/controller/createSubscription.ts
@@ -11,7 +11,9 @@ export function createSubscription<E extends EndpointInterface>(
 ): SubscribeAction {
   return {
     type: SUBSCRIBE_TYPE,
+    endpoint,
     meta: {
+      args,
       key: endpoint.key(...args),
       fetch: () => endpoint(...args),
       schema: endpoint.schema,
@@ -19,6 +21,14 @@ export function createSubscription<E extends EndpointInterface>(
     },
   };
 }
+/** Future action shape
+{
+  type: SUBSCRIBE_TYPE,
+  endpoint,
+  meta: {
+    args,
+  },
+} */
 
 export function createUnsubscription<E extends EndpointInterface>(
   endpoint: E,
@@ -26,9 +36,19 @@ export function createUnsubscription<E extends EndpointInterface>(
 ): UnsubscribeAction {
   return {
     type: UNSUBSCRIBE_TYPE,
+    endpoint,
     meta: {
+      args,
       key: endpoint.key(...args),
       options: endpoint,
     },
   };
 }
+/** Future action shape
+{
+  type: UNSUBSCRIBE_TYPE,
+  endpoint,
+  meta: {
+    args,
+  },
+} */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export {
   default as reducer,
   initialState,
 } from '@rest-hooks/core/state/reducer';
+export { default as applyManager } from '@rest-hooks/core/state/applyManager';
 export { useDenormalized } from '@rest-hooks/core/state/selectors/index';
 export {
   useCache,
@@ -36,7 +37,7 @@ export { default as Controller } from '@rest-hooks/core/controller/Controller';
 export * from '@rest-hooks/core/controller/types';
 export * from '@rest-hooks/core/state/actions/index';
 export * as actionTypes from '@rest-hooks/core/actionTypes';
-export * from '@rest-hooks/use-enhanced-reducer';
+export { usePromisifiedDispatch } from '@rest-hooks/use-enhanced-reducer';
 export * from '@rest-hooks/endpoint';
 /* istanbul ignore next */
 export * from '@rest-hooks/core/types';

--- a/packages/core/src/react-integration/provider/CacheStore.tsx
+++ b/packages/core/src/react-integration/provider/CacheStore.tsx
@@ -1,0 +1,60 @@
+import masterReducer from '@rest-hooks/core/state/reducer';
+import { State, Manager } from '@rest-hooks/core/types';
+import useEnhancedReducer from '@rest-hooks/use-enhanced-reducer';
+import React, { ReactNode, useEffect, useMemo, memo } from 'react';
+import {
+  StateContext,
+  DispatchContext,
+} from '@rest-hooks/core/react-integration/context';
+import BackupBoundary from '@rest-hooks/core/react-integration/provider/BackupBoundary';
+import type { Middleware } from '@rest-hooks/use-enhanced-reducer';
+
+interface StoreProps {
+  children: ReactNode;
+  managers: Manager[];
+  middlewares: Middleware[];
+  initialState: State<unknown>;
+}
+/**
+ * This part of the provider concerns only the parts that matter for store changes
+ * It expects its props to have referential stability
+ */
+function CacheStore({
+  children,
+  managers,
+  middlewares,
+  initialState,
+}: StoreProps) {
+  const [state, dispatch] = useEnhancedReducer(
+    masterReducer,
+    initialState,
+    middlewares,
+  );
+  const optimisticState = useMemo(
+    () => state.optimistic.reduce(masterReducer, state),
+    [state],
+  );
+
+  // if we change out the manager we need to make sure it has no hanging async
+  useEffect(() => {
+    for (let i = 0; i < managers.length; ++i) {
+      managers[i].init?.(state);
+    }
+    return () => {
+      for (let i = 0; i < managers.length; ++i) {
+        managers[i].cleanup();
+      }
+    };
+    // we're ignoring state here, because it shouldn't trigger inits
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [managers]);
+
+  return (
+    <DispatchContext.Provider value={dispatch}>
+      <StateContext.Provider value={optimisticState}>
+        <BackupBoundary>{children}</BackupBoundary>
+      </StateContext.Provider>
+    </DispatchContext.Provider>
+  );
+}
+export default memo(CacheStore);

--- a/packages/core/src/state/__tests__/networkManager.ts
+++ b/packages/core/src/state/__tests__/networkManager.ts
@@ -1,9 +1,9 @@
 import { ArticleResource } from '__tests__/common';
-import { Middleware } from '@rest-hooks/use-enhanced-reducer';
+import { Controller, Middleware } from '@rest-hooks/core';
 
 import NetworkManager from '../NetworkManager';
-import { FetchAction, ResetAction } from '../../types';
-import { FETCH_TYPE, RECEIVE_TYPE, RESET_TYPE } from '../../actionTypes';
+import { FetchAction } from '../../types';
+import { RECEIVE_TYPE } from '../../actionTypes';
 import { createFetch } from '../actions';
 import { initialState } from '../reducer';
 
@@ -108,8 +108,9 @@ describe('NetworkManager', () => {
     it('should handle fetch actions and dispatch on success', async () => {
       const next = jest.fn();
       const dispatch = jest.fn();
+      const controller = new Controller({ dispatch });
 
-      middleware({ dispatch, getState })(next)(fetchResolveAction);
+      middleware({ dispatch, getState, controller })(next)(fetchResolveAction);
 
       const data = await fetchResolveAction.payload();
 
@@ -131,8 +132,11 @@ describe('NetworkManager', () => {
     it('should handle fetch receive action and dispatch on success with updaters', async () => {
       const next = jest.fn();
       const dispatch = jest.fn();
+      const controller = new Controller({ dispatch });
 
-      middleware({ dispatch, getState })(next)(fetchReceiveWithUpdatersAction);
+      middleware({ dispatch, getState, controller })(next)(
+        fetchReceiveWithUpdatersAction,
+      );
 
       const data = await fetchReceiveWithUpdatersAction.payload();
 
@@ -157,8 +161,11 @@ describe('NetworkManager', () => {
     it('should handle fetch rpc action and dispatch on success with updaters', async () => {
       const next = jest.fn();
       const dispatch = jest.fn();
+      const controller = new Controller({ dispatch });
 
-      middleware({ dispatch, getState })(next)(fetchRpcWithUpdatersAction);
+      middleware({ dispatch, getState, controller })(next)(
+        fetchRpcWithUpdatersAction,
+      );
 
       const data = await fetchRpcWithUpdatersAction.payload();
 
@@ -181,8 +188,9 @@ describe('NetworkManager', () => {
     it('should handle fetch rpc action with optimistic response and dispatch on success with updaters', async () => {
       const next = jest.fn();
       const dispatch = jest.fn();
+      const controller = new Controller({ dispatch });
 
-      middleware({ dispatch, getState })(next)(
+      middleware({ dispatch, getState, controller })(next)(
         fetchRpcWithUpdatersAndOptimisticAction,
       );
 
@@ -205,8 +213,9 @@ describe('NetworkManager', () => {
     });
     it('should use dataExpireLength from action if specified', async () => {
       const dispatch = jest.fn();
+      const controller = new Controller({ dispatch });
 
-      middleware({ dispatch, getState })(() => Promise.resolve())({
+      middleware({ dispatch, getState, controller })(() => Promise.resolve())({
         ...fetchResolveAction,
         meta: {
           ...fetchResolveAction.meta,
@@ -222,8 +231,9 @@ describe('NetworkManager', () => {
     });
     it('should use dataExpireLength from NetworkManager if not specified in action', async () => {
       const dispatch = jest.fn();
+      const controller = new Controller({ dispatch });
 
-      middleware({ dispatch, getState })(() => Promise.resolve())({
+      middleware({ dispatch, getState, controller })(() => Promise.resolve())({
         ...fetchResolveAction,
         meta: {
           ...fetchResolveAction.meta,
@@ -240,9 +250,12 @@ describe('NetworkManager', () => {
     it('should handle fetch actions and dispatch on error', async () => {
       const next = jest.fn();
       const dispatch = jest.fn();
+      const controller = new Controller({ dispatch });
 
       try {
-        await middleware({ dispatch, getState })(next)(fetchRejectAction);
+        await middleware({ dispatch, getState, controller })(next)(
+          fetchRejectAction,
+        );
       } catch (error) {
         expect(next).not.toHaveBeenCalled();
         expect(dispatch).toHaveBeenCalledWith({
@@ -260,9 +273,12 @@ describe('NetworkManager', () => {
     });
     it('should use errorExpireLength from action if specified', async () => {
       const dispatch = jest.fn();
+      const controller = new Controller({ dispatch });
 
       try {
-        await middleware({ dispatch, getState })(() => Promise.resolve())({
+        await middleware({ dispatch, getState, controller })(() =>
+          Promise.resolve(),
+        )({
           ...fetchRejectAction,
           meta: {
             ...fetchRejectAction.meta,
@@ -277,9 +293,12 @@ describe('NetworkManager', () => {
     });
     it('should use errorExpireLength from NetworkManager if not specified in action', async () => {
       const dispatch = jest.fn();
+      const controller = new Controller({ dispatch });
 
       try {
-        await middleware({ dispatch, getState })(() => Promise.resolve())({
+        await middleware({ dispatch, getState, controller })(() =>
+          Promise.resolve(),
+        )({
           ...fetchRejectAction,
           meta: {
             ...fetchRejectAction.meta,

--- a/packages/core/src/state/applyManager.ts
+++ b/packages/core/src/state/applyManager.ts
@@ -1,0 +1,16 @@
+import { Middleware } from '@rest-hooks/use-enhanced-reducer';
+import { Manager } from '@rest-hooks/core/types';
+import type Controller from '@rest-hooks/core/controller/Controller';
+
+export default function applyManager(
+  managers: Manager[],
+  controller: Controller,
+): Middleware[] {
+  return managers.map(manager => {
+    const middleware = manager.getMiddleware();
+    return ({ dispatch, getState }) => {
+      (controller as any).dispatch = dispatch;
+      return middleware({ controller, dispatch, getState });
+    };
+  });
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,6 @@
 import { NormalizedIndex } from '@rest-hooks/normalizr';
-import { Middleware } from '@rest-hooks/use-enhanced-reducer';
-import { FSAWithPayloadAndMeta, FSAWithMeta, FSA } from 'flux-standard-action';
+import { Dispatch } from '@rest-hooks/use-enhanced-reducer';
+import { FSAWithPayloadAndMeta, FSAWithMeta } from 'flux-standard-action';
 import type {
   UpdateFunction,
   AbstractInstanceType,
@@ -20,6 +20,7 @@ import {
   INVALIDATE_TYPE,
   GC_TYPE,
 } from '@rest-hooks/core/actionTypes';
+import type Controller from '@rest-hooks/core/controller/Controller';
 
 export type { AbstractInstanceType, UpdateFunction };
 
@@ -90,7 +91,7 @@ export type ReceiveAction<
   typeof RECEIVE_TYPE,
   Payload,
   ReceiveMeta<S>
->;
+> & { endpoint?: EndpointInterface };
 
 export interface ResetAction {
   type: typeof RESET_TYPE;
@@ -140,7 +141,9 @@ export interface FetchAction<
 
 export interface SubscribeAction
   extends FSAWithMeta<typeof SUBSCRIBE_TYPE, undefined, any> {
+  endpoint?: EndpointInterface;
   meta: {
+    args?: readonly any[];
     schema: Schema | undefined;
     fetch: () => Promise<any>;
     key: string;
@@ -150,7 +153,9 @@ export interface SubscribeAction
 
 export interface UnsubscribeAction
   extends FSAWithMeta<typeof UNSUBSCRIBE_TYPE, undefined, any> {
+  endpoint?: EndpointInterface;
   meta: {
+    args?: readonly any[];
     key: string;
     options: FetchOptions | undefined;
   };
@@ -186,3 +191,17 @@ export interface Manager {
   cleanup(): void;
   init?: (state: State<any>) => void;
 }
+
+export type Middleware = <R extends React.Reducer<any, any>>(
+  options: MiddlewareAPI<R>,
+) => (next: Dispatch<R>) => Dispatch<R>;
+
+export interface MiddlewareAPI<
+  R extends React.Reducer<any, any> = React.Reducer<any, any>,
+> {
+  getState: () => React.ReducerState<R>;
+  dispatch: Dispatch<R>;
+  controller: Controller;
+}
+
+export type { Dispatch };

--- a/packages/rest-hooks/src/manager/__tests__/subscriptionManager.ts
+++ b/packages/rest-hooks/src/manager/__tests__/subscriptionManager.ts
@@ -3,6 +3,7 @@ import {
   SubscribeAction,
   UnsubscribeAction,
   actionTypes,
+  Controller,
 } from '@rest-hooks/core';
 
 import SubscriptionManager, { Subscription } from '../SubscriptionManager';
@@ -82,10 +83,11 @@ describe('SubscriptionManager', () => {
     const middleware = manager.getMiddleware();
     const next = jest.fn();
     const dispatch = () => Promise.resolve();
+    const controller = new Controller({ dispatch });
 
     it('subscribe should add a subscription', () => {
       const action = createSubscribeAction({ id: 5 });
-      middleware({ dispatch, getState })(next)(action);
+      middleware({ dispatch, getState, controller })(next)(action);
 
       expect(next).not.toHaveBeenCalled();
       expect((manager as any).subscriptions[action.meta.key]).toBeDefined();
@@ -93,7 +95,7 @@ describe('SubscriptionManager', () => {
     it('subscribe should add a subscription (no frequency)', () => {
       const action = createSubscribeAction({ id: 597 });
       delete action.meta.options;
-      middleware({ dispatch, getState })(next)(action);
+      middleware({ dispatch, getState, controller })(next)(action);
 
       expect(next).not.toHaveBeenCalled();
       expect((manager as any).subscriptions[action.meta.key]).toBeDefined();
@@ -101,19 +103,19 @@ describe('SubscriptionManager', () => {
 
     it('subscribe with same should call subscription.add', () => {
       const action = createSubscribeAction({ id: 5, title: 'four' });
-      middleware({ dispatch, getState })(next)(action);
+      middleware({ dispatch, getState, controller })(next)(action);
 
       expect(
         (manager as any).subscriptions[action.meta.key].add.mock.calls.length,
       ).toBe(1);
-      middleware({ dispatch, getState })(next)(action);
+      middleware({ dispatch, getState, controller })(next)(action);
       expect(
         (manager as any).subscriptions[action.meta.key].add.mock.calls.length,
       ).toBe(2);
     });
     it('subscribe with another should create another', () => {
       const action = createSubscribeAction({ id: 7, title: 'four cakes' });
-      middleware({ dispatch, getState })(next)(action);
+      middleware({ dispatch, getState, controller })(next)(action);
 
       expect((manager as any).subscriptions[action.meta.key]).toBeDefined();
       expect(
@@ -133,13 +135,13 @@ describe('SubscriptionManager', () => {
         () => true,
       );
 
-      middleware({ dispatch, getState })(next)(action);
+      middleware({ dispatch, getState, controller })(next)(action);
 
       expect((manager as any).subscriptions[action.meta.key]).not.toBeDefined();
     });
 
     it('unsubscribe should delete when remove returns true (no frequency)', () => {
-      middleware({ dispatch, getState })(next)(
+      middleware({ dispatch, getState, controller })(next)(
         createSubscribeAction({ id: 50, title: 'four cakes' }),
       );
 
@@ -149,7 +151,7 @@ describe('SubscriptionManager', () => {
         () => true,
       );
 
-      middleware({ dispatch, getState })(next)(action);
+      middleware({ dispatch, getState, controller })(next)(action);
 
       expect((manager as any).subscriptions[action.meta.key]).not.toBeDefined();
     });
@@ -160,7 +162,7 @@ describe('SubscriptionManager', () => {
         () => false,
       );
 
-      middleware({ dispatch, getState })(next)(action);
+      middleware({ dispatch, getState, controller })(next)(action);
 
       expect((manager as any).subscriptions[action.meta.key]).toBeDefined();
       expect(
@@ -175,7 +177,7 @@ describe('SubscriptionManager', () => {
 
       const action = createUnsubscribeAction({ id: 25 });
 
-      middleware({ dispatch, getState })(next)(action);
+      middleware({ dispatch, getState, controller })(next)(action);
 
       expect((manager as any).subscriptions[action.meta.key]).not.toBeDefined();
 
@@ -191,7 +193,7 @@ describe('SubscriptionManager', () => {
       const action = { type: RECEIVE_TYPE };
       next.mockReset();
 
-      middleware({ dispatch, getState })(next)(action as any);
+      middleware({ dispatch, getState, controller })(next)(action as any);
 
       expect(next.mock.calls.length).toBe(1);
     });

--- a/packages/rest-hooks/src/react-integration/provider/mapMiddleware.ts
+++ b/packages/rest-hooks/src/react-integration/provider/mapMiddleware.ts
@@ -1,4 +1,5 @@
-import { Middleware, MiddlewareAPI, State } from '@rest-hooks/core';
+import { Middleware, MiddlewareAPI } from '@rest-hooks/use-enhanced-reducer';
+import { State } from '@rest-hooks/core';
 
 const mapMiddleware =
   <M extends Middleware[]>(selector: (state: any) => State<unknown>) =>

--- a/packages/test/src/managers.ts
+++ b/packages/test/src/managers.ts
@@ -7,12 +7,14 @@ export class MockNetworkManager extends NetworkManager {
   handleFetch(
     ...[action, dispatch, ...rest]: Parameters<NetworkManager['handleFetch']>
   ) {
+    // TODO: we should make dispatch always 'act' instead
     const mockDispatch: typeof dispatch = (v: any) => {
       act(() => {
         dispatch(v);
       });
       return Promise.resolve();
     };
+    if (rest[0]) (rest[0] as any).dispatch = mockDispatch;
     return super.handleFetch(action, mockDispatch, ...rest);
   }
 


### PR DESCRIPTION
- applyManager()
- controller in middlewares

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Controller provides a cleaner and more consistent interface to the store. This also makes the interaction points more discoverable as any TypeScript supporting editor will autocomplete (even if the user is using javascript).

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Added to middleware api

```ts
export interface MiddlewareAPI<
  R extends React.Reducer<any, any> = React.Reducer<any, any>,
> {
  getState: () => React.ReducerState<R>;
  dispatch: Dispatch<R>;
  controller: Controller;
}
```

This is adapted to still be redux-middleware compatible via the `applyManager()` method. This turns a manager into a redux-middleware

Due to the way typescript handles function parameter typing, this will not break compatibility with any existing middlewares since it is only an addition.

Also, by not using controller yet, those who aren't using applyManager() in redux case will not have to worry about it breaking.

```tsx
import type { Manager, Middleware } from '@rest-hooks/core';
import type { EndpointInterface } from '@rest-hooks/endpoint';

export default class StreamManager implements Manager
{
  protected declare middleware: Middleware;
  protected declare websocket: Websocket;
  protected declare endpoints: Record<string, EndpointInterface>;

  constructor(url: string, endpoints: Record<string, EndpointInterface>) {
    this.websocket = new Websocket(url);
    this.endpoints = endpoints;

    this.middleware = ({ controller, getState }) => {
      this.websocket.onmessage = (event) => {
        controller.receive(this.endpoints[event.type], ...event.args, event.data);
      }
      return (next) => async (action) => next(action);
    }
  }

  cleanup() {
    this.websocket.close();
  }

  getMiddleware<T extends StreamManager>(this: T) {
    return this.middleware;
  }
}
```

#### CacheStore

[`<CacheProvider />`](https://resthooks.io/docs/api/CacheProvider) is now split into two components. The outer processes all the input parameters creating reverentially stable props for `<CacheStore />`. `<CacheStore />` only contains the minimal pieces needed to handle store changes as to minimize code run when the store updates, which is frequently. This separation also places a clean boundary to make it slightly easier to read.