### PR TITLE
internal: Don't fail coverage if coveralls is down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,10 @@ jobs:
             yarn add -W --dev react@next react-dom@next react-test-renderer@next
       - run:
           command: |
-            if [ "$COVERALLS_REPO_TOKEN" != "" ]; then yarn run test:coverage --maxWorkers=4 --coverageReporters=text-lcov | yarn run coveralls; fi
+            if [ "$COVERALLS_REPO_TOKEN" != "" ]; then
+            yarn run test:coverage --maxWorkers=4 --coverageReporters=text-lcov > ./lcov.info;
+            yarn run coveralls < ./lcov.info || true;
+            fi
 
   salus:
     machine: true


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Coveralls has been down for days blocking progress. Sometimes their services has issues as well - these shouldn't block progress.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We will fail on test:coverage, but the actual sending to coveralls we don't fail