### PR TITLE
internal: publish 6.1

### DIFF
--- a/examples/github-app/CHANGELOG.md
+++ b/examples/github-app/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.4](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.3...github-app@0.1.4) (2021-09-19)
+
+
+### 💅 Enhancement
+
+* useController() in examples ([#1270](https://github.com/coinbase/rest-hooks/issues/1270)) ([9f0e874](https://github.com/coinbase/rest-hooks/commit/9f0e87401856c0b51f12cd4cfc672aecb1f9a24e))
+
+
+
 ### [0.1.3](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.2...github-app@0.1.3) (2021-09-14)
 
 **Note:** Version bump only for package github-app

--- a/examples/github-app/package.json
+++ b/examples/github-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "github-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -47,6 +47,6 @@
     "react-error-boundary": "^3.1.3",
     "react-markdown": "^7.0.1",
     "react-router-dom": "^5.2.1",
-    "rest-hooks": "^6.0.1"
+    "rest-hooks": "^6.1.0"
   }
 }

--- a/examples/todo-app/CHANGELOG.md
+++ b/examples/todo-app/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.7](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.6...todo-app@0.1.7) (2021-09-19)
+
+
+### 💅 Enhancement
+
+* useController() in examples ([#1270](https://github.com/coinbase/rest-hooks/issues/1270)) ([9f0e874](https://github.com/coinbase/rest-hooks/commit/9f0e87401856c0b51f12cd4cfc672aecb1f9a24e))
+
+
+
 ### [0.1.6](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.5...todo-app@0.1.6) (2021-09-14)
 
 **Note:** Version bump only for package todo-app

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-app",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "todo-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -33,7 +33,7 @@
     "@rest-hooks/rest": "^3.0.0",
     "@types/react-dom": "17.0.9",
     "react-refresh": "next",
-    "rest-hooks": "^6.0.1",
+    "rest-hooks": "^6.1.0",
     "serve": "12.0.1",
     "webpack": "5.53.0",
     "webpack-cli": "4.8.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.1...@rest-hooks/core@2.1.0) (2021-09-19)
+
+
+### 🚀 Features
+
+* Add Controller ([#1239](https://github.com/coinbase/rest-hooks/issues/1239)) ([321dbaa](https://github.com/coinbase/rest-hooks/commit/321dbaa905744b5d331a163d4a0f219809f740ee))
+* Send controller to middlewares ([#1271](https://github.com/coinbase/rest-hooks/issues/1271)) ([29db53c](https://github.com/coinbase/rest-hooks/commit/29db53c8ee7f5d770dd43b6e3d97346bc77f76d7))
+
+
+### 📝 Documentation
+
+* Random fixes ([#1261](https://github.com/coinbase/rest-hooks/issues/1261)) ([ec90154](https://github.com/coinbase/rest-hooks/commit/ec901542a5157b35e20a346b7794f986f775138c))
+
+
+
 ### [2.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.0...@rest-hooks/core@2.0.1) (2021-09-14)
 
 **Note:** Version bump only for package @rest-hooks/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@1.0.1...@rest-hooks/experimental@2.0.0) (2021-09-19)
+
+
+### ⚠ 💥 BREAKING CHANGES
+
+* Requires @rest-hooks/core>=2.1
+Throttle is inferred from Endpoint.sideEffect
+
+### 💅 Enhancement
+
+* Use @rest-hooks/core controller ([#1249](https://github.com/coinbase/rest-hooks/issues/1249)) ([3cd40f1](https://github.com/coinbase/rest-hooks/commit/3cd40f179f91c08d5720cb0337e11c58263abf38))
+
+
+
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@1.0.0...@rest-hooks/experimental@1.0.1) (2021-09-14)
 
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.5.0...@rest-hooks/hooks@2.0.0) (2021-09-19)
+
+
+### ⚠ 💥 BREAKING CHANGES
+
+* onError() is no longer second argument;
+To handle this case, simply .catch() yourself.
+
+### 🚀 Features
+
+* useLoading() second argument is deps list ([#1250](https://github.com/coinbase/rest-hooks/issues/1250)) ([898599a](https://github.com/coinbase/rest-hooks/commit/898599a878e83f3435c0006f53fb64db8f8b38af))
+
+
+
 ## [1.5.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.5.0-beta.1...@rest-hooks/hooks@1.5.0) (2021-09-08)
 
 **Note:** Version bump only for package @rest-hooks/hooks

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.1.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.1...rest-hooks@6.1.0) (2021-09-19)
+
+
+### 🚀 Features
+
+* Add Controller ([#1239](https://github.com/coinbase/rest-hooks/issues/1239)) ([321dbaa](https://github.com/coinbase/rest-hooks/commit/321dbaa905744b5d331a163d4a0f219809f740ee))
+* Export useController() ([#1269](https://github.com/coinbase/rest-hooks/issues/1269)) ([baa31d8](https://github.com/coinbase/rest-hooks/commit/baa31d8c78aa26cd8da88b93804f8a014fbbe63c))
+* Send controller to middlewares ([#1271](https://github.com/coinbase/rest-hooks/issues/1271)) ([29db53c](https://github.com/coinbase/rest-hooks/commit/29db53c8ee7f5d770dd43b6e3d97346bc77f76d7))
+
+
+
 ### [6.0.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.0...rest-hooks@6.0.1) (2021-09-14)
 
 

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -105,7 +105,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.7.2",
-    "@rest-hooks/core": "^2.0.1",
+    "@rest-hooks/core": "^2.1.0",
     "@rest-hooks/endpoint": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.0.0...@rest-hooks/test@7.1.0) (2021-09-19)
+
+
+### 🚀 Features
+
+* Send controller to middlewares ([#1271](https://github.com/coinbase/rest-hooks/issues/1271)) ([29db53c](https://github.com/coinbase/rest-hooks/commit/29db53c8ee7f5d770dd43b6e3d97346bc77f76d7))
+
+
+
 ## [7.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.0.0-beta.3...@rest-hooks/test@7.0.0) (2021-09-08)
 
 **Note:** Version bump only for package @rest-hooks/test

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",


### PR DESCRIPTION
 - @rest-hooks/core@2.1.0
 - @rest-hooks/experimental@2.0.0
 - @rest-hooks/hooks@2.0.0
 - rest-hooks@6.1.0
 - @rest-hooks/test@7.1.0
