### PR TITLE
feat: Add controller.getResponse()

### DIFF
--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -270,7 +270,7 @@ export default class Controller {
         expiresAt = Infinity;
         // using Object.keys ensures we don't hit `toString` type members
         Object.entries(resolvedEntities).forEach(([key, entities]) =>
-          entities.forEach(pk => {
+          Object.keys(entities).forEach(pk => {
             expiresAt = Math.min(
               expiresAt,
               state.entityMeta[key][pk].expiresAt,

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -269,8 +269,8 @@ export default class Controller {
         // oldest entity dictates age
         expiresAt = Infinity;
         // using Object.keys ensures we don't hit `toString` type members
-        Object.keys(resolvedEntities).forEach(key =>
-          Object.keys(resolvedEntities[key]).forEach(pk => {
+        Object.entries(resolvedEntities).forEach(([key, entities]) =>
+          entities.forEach(pk => {
             expiresAt = Math.min(
               expiresAt,
               state.entityMeta[key][pk].expiresAt,
@@ -315,10 +315,7 @@ function schemaHasEntity(schema: Schema): boolean {
     if (typeof nestedSchema === 'function') {
       return schemaHasEntity(nestedSchema);
     }
-    return Object.values(nestedSchema).reduce(
-      (prev, cur) => prev || schemaHasEntity(cur),
-      false,
-    );
+    return Object.values(nestedSchema).some(x => schemaHasEntity(x));
   }
   return false;
 }

--- a/packages/core/src/controller/__tests__/__snapshots__/fetch.tsx.snap
+++ b/packages/core/src/controller/__tests__/__snapshots__/fetch.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CacheProvider should log error message when user update method throws 1`] = `
+Array [
+  Array [
+    "The following error occured during Endpoint.update() for POST http://test.com/article-cooler/",
+  ],
+  Array [
+    [Error: usererror],
+  ],
+]
+`;
+
+exports[`ExternalCacheProvider should log error message when user update method throws 1`] = `
+Array [
+  Array [
+    "The following error occured during Endpoint.update() for POST http://test.com/article-cooler/",
+  ],
+  Array [
+    [Error: usererror],
+  ],
+]
+`;

--- a/packages/core/src/endpoint/adapter.ts
+++ b/packages/core/src/endpoint/adapter.ts
@@ -1,0 +1,32 @@
+import { Endpoint } from '@rest-hooks/endpoint';
+import type { EndpointInstance } from '@rest-hooks/endpoint';
+import type { FetchShape } from '@rest-hooks/core/endpoint/shapes';
+
+type ShapeTypeToSideEffect<T extends 'read' | 'mutate' | 'delete' | undefined> =
+  T extends 'read' | undefined ? undefined : true;
+
+const SIDEEFFECT_TYPES: (string | undefined)[] = ['mutate', 'delete'];
+
+export default function shapeToEndpoint<
+  Shape extends Partial<FetchShape<any, any>>,
+>(
+  shape: Shape,
+): Shape['fetch'] extends (...args: any) => Promise<any>
+  ? EndpointInstance<
+      Shape['fetch'],
+      Shape['schema'],
+      ShapeTypeToSideEffect<Shape['type']>
+    > &
+      Shape['options']
+  : Shape['options'] & { key: Shape['getFetchKey'] } {
+  const options = {
+    ...shape.options,
+    key: shape.getFetchKey,
+    schema: shape.schema,
+  };
+  if (SIDEEFFECT_TYPES.includes(shape.type)) (options as any).sideEffect = true;
+  if (Object.prototype.hasOwnProperty.call(shape, 'fetch'))
+    return new Endpoint(shape.fetch as any, options);
+
+  return options as any;
+}

--- a/packages/core/src/react-integration/hooks/useCache.ts
+++ b/packages/core/src/react-integration/hooks/useCache.ts
@@ -2,17 +2,13 @@ import { ReadShape, ParamsFromShape } from '@rest-hooks/core/endpoint/index';
 import { DenormalizeNullable } from '@rest-hooks/endpoint';
 import { useDenormalized } from '@rest-hooks/core/state/selectors/index';
 import { useContext, useMemo } from 'react';
-import {
-  DenormalizeCacheContext,
-  StateContext,
-} from '@rest-hooks/core/react-integration/context';
+import { StateContext } from '@rest-hooks/core/react-integration/context';
 import {
   hasUsableData,
   useMeta,
   useError,
 } from '@rest-hooks/core/react-integration/hooks/index';
 import { denormalize, inferResults } from '@rest-hooks/normalizr';
-import useExpiresAt from '@rest-hooks/core/react-integration/hooks/useExpiresAt';
 
 /**
  * Access a resource if it is available.
@@ -27,15 +23,12 @@ export default function useCache<
   params: ParamsFromShape<Shape> | null,
 ): DenormalizeNullable<Shape['schema']> {
   const state = useContext(StateContext);
-  const denormalizeCache = useContext(DenormalizeCacheContext);
 
-  const [denormalized, ready, deleted, entitiesExpireAt] = useDenormalized(
+  const [denormalized, ready, deleted, expiresAt] = useDenormalized(
     fetchShape,
     params,
     state,
-    denormalizeCache,
   );
-  const expiresAt = useExpiresAt(fetchShape, params, entitiesExpireAt);
   const error = useError(fetchShape, params);
   const trigger = deleted && !error;
 

--- a/packages/core/src/state/reducer.ts
+++ b/packages/core/src/state/reducer.ts
@@ -99,7 +99,7 @@ export default function reducer(
           // no reason to completely fail because of user-code error
           // integrity of this state update is still guaranteed
         } catch (error) {
-          console.log(
+          console.error(
             `The following error occured during Endpoint.update() for ${action.meta.key}`,
           );
           console.error(error);
@@ -132,6 +132,7 @@ export default function reducer(
         error.payload = action.payload;
         error.status = 400;
         // this is not always bubbled up, so let's double sure this doesn't fail silently
+        /* istanbul ignore else */
         if (process.env.NODE_ENV !== 'production') {
           console.error(error);
         }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Continuing https://github.com/coinbase/rest-hooks/pull/1239

This extracts the core logic into a more accessible piece.
- Easier implementations for various frameworks
- Easier implementations for different hookups like context selectors
- Programmatic access to same values from hooks, which can be used for procedural pieces

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```tsx
const { data, suspend, expiresAt } = controller.getResponse(UserResource.detail(), { id }, state)
const error = controller.getError(UserResource.detail(), { id }, state)
```

useDenormalized logic moved into controller.getResponse(). Except it's based on [endpoints](https://resthooks.io/docs/getting-started/endpoint) instead of shapes. Because of this useDenormalized first constructs an endpoint with the adapter `shapeToEndpoint()`