### PR TITLE
enhance: infer() args are readonly

### DIFF
--- a/packages/legacy/src/resource/Entity.ts
+++ b/packages/legacy/src/resource/Entity.ts
@@ -248,7 +248,11 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     return expiresAt;
   }
 
-  static infer(args: any[], indexes: Record<string, any>, infer: any): any {
+  static infer(
+    args: readonly any[],
+    indexes: Record<string, any>,
+    infer: any,
+  ): any {
     if (!args[0]) return undefined as any;
     const id = this.pk(args[0], undefined, '');
     // Was able to infer the entity's primary key from params

--- a/packages/legacy/src/resource/Object.ts
+++ b/packages/legacy/src/resource/Object.ts
@@ -55,7 +55,12 @@ export const denormalize = (schema: any, input: any, unvisit: any) => {
   return [object, found, deleted];
 };
 
-export function infer(schema: any, args: any[], indexes: any, recurse: any) {
+export function infer(
+  schema: any,
+  args: readonly any[],
+  indexes: any,
+  recurse: any,
+) {
   const resultObject: any = {};
   for (const k of Object.keys(schema)) {
     resultObject[k] = recurse(schema[k], args, indexes);
@@ -93,7 +98,7 @@ export default class ObjectSchema {
     return denormalize(this.schema, ...args);
   }
 
-  infer(args: any, indexes: any, recurse: any) {
+  infer(args: readonly any[], indexes: any, recurse: any) {
     return infer(this.schema, args, indexes, recurse);
   }
 }

--- a/packages/legacy/src/resource/SimpleRecord.ts
+++ b/packages/legacy/src/resource/SimpleRecord.ts
@@ -123,7 +123,7 @@ export default abstract class SimpleRecord {
 
   static infer<T extends typeof SimpleRecord>(
     this: T,
-    args: any[],
+    args: readonly any[],
     indexes: any,
     recurse: any,
   ): NormalizedEntity<T> {

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -301,7 +301,11 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     }
   }
 
-  static infer(args: any[], indexes: NormalizedIndex, recurse: any): any {
+  static infer(
+    args: readonly any[],
+    indexes: NormalizedIndex,
+    recurse: any,
+  ): any {
     if (!args[0]) return undefined;
     const id = this.pk(args[0], undefined, '');
     // Was able to infer the entity's primary key from params

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -56,7 +56,7 @@ export interface SchemaSimple<T = any> {
     unvisit: UnvisitFunction,
   ): [denormalized: T, found: boolean, suspend: boolean];
   infer(
-    args: any[],
+    args: readonly any[],
     indexes: NormalizedIndex,
     recurse: (...args: any) => any,
   ): any;
@@ -102,7 +102,7 @@ export class Array<S extends Schema = Schema> implements SchemaClass {
   _denormalizeNullable(): [Denormalize<S>[] | undefined, false, boolean];
 
   infer(
-    args: any[],
+    args: readonly any[],
     indexes: NormalizedIndex,
     recurse: (...args: any) => any,
   ): any;
@@ -134,7 +134,7 @@ export class Object<O extends Record<string, any> = Record<string, Schema>>
   _denormalizeNullable(): [DenormalizeNullableObject<O>, false, boolean];
 
   infer(
-    args: any[],
+    args: readonly any[],
     indexes: NormalizedIndex,
     recurse: (...args: any) => any,
   ): any;
@@ -180,7 +180,7 @@ export class Union<Choices extends EntityMap = any> implements SchemaClass {
   ];
 
   infer(
-    args: any[],
+    args: readonly any[],
     indexes: NormalizedIndex,
     recurse: (...args: any) => any,
   ): any;
@@ -251,7 +251,7 @@ export class Values<Choices extends Schema = any> implements SchemaClass {
   ];
 
   infer(
-    args: any[],
+    args: readonly any[],
     indexes: NormalizedIndex,
     recurse: (...args: any) => any,
   ): any;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Stronger types

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This doesn't break back compat as you can send non-readonly things as args