### PR TITLE
fix: remove unwanted string in CacheProvider

### DIFF
--- a/packages/core/src/react-integration/provider/CacheProvider.tsx
+++ b/packages/core/src/react-integration/provider/CacheProvider.tsx
@@ -51,7 +51,7 @@ export default function CacheProvider({
           initialState={initialState}
         >
           {children}
-        </CacheStore>{' '}
+        </CacheStore>
       </DenormalizeCacheContext.Provider>
     </ControllerContext.Provider>
   );


### PR DESCRIPTION
Fixes #1306

### Motivation
This prevent react-native app from crashing when using default `<CacheProvider />` component. 
