### PR TITLE
enhance: Improve compatibility with SSR and React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,5 @@
   },
   "resolutions": {
     "@lerna/conventional-commits": "https://github.com/ntucker/lerna-conventional-commits.git"
-  },
-  "version": "0.0.0"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -112,14 +112,10 @@
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
-    "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
-    "react-native": ">=0.59"
+    "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"
   },
   "peerDependenciesMeta": {
     "@types/react": {
-      "optional": true
-    },
-    "react-native": {
       "optional": true
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,8 +52,8 @@
     "./rest_hooks_logo_and_text.svg"
   ],
   "scripts": {
-    "build:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV='2020' RESOLVER_ALIAS='{\"^@rest-hooks/core(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
-    "build:legacy:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV='2018' RESOLVER_ALIAS='{\"^@rest-hooks/core(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir legacy --source-maps inline --extensions '.ts,.tsx,.js' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV='2020' RESOLVER_ALIAS='{\"^@rest-hooks/core(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir lib --source-maps inline --extensions '.ts,.tsx,.js,.jsx' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
+    "build:legacy:lib": "cross-env NODE_ENV=production BROWSERSLIST_ENV='2018' RESOLVER_ALIAS='{\"^@rest-hooks/core(.+)$\":\"./src/\\\\1.js\"}' babel --root-mode upward src --out-dir legacy --source-maps inline --extensions '.ts,.tsx,.js,.jsx' --ignore '**/__tests__/**' --ignore '**/*.d.ts'",
     "build:js:node": "cross-env BROWSERSLIST_ENV=node12 rollup -c",
     "build:js:browser": "cross-env BROWSERSLIST_ENV=legacy rollup -c",
     "build:bundle": "run-p build:js:* && echo '{\"type\":\"commonjs\"}' > dist/package.json",
@@ -112,10 +112,14 @@
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
-    "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"
+    "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
+    "react-native": ">=0.59"
   },
   "peerDependenciesMeta": {
     "@types/react": {
+      "optional": true
+    },
+    "react-native": {
       "optional": true
     }
   }

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -15,7 +15,7 @@ const dependencies = Object.keys(pkg.dependencies)
       !['@rest-hooks/use-enhanced-reducer', '@babel/runtime'].includes(dep),
   );
 
-const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node'];
+const extensions = ['.js', '.ts', '.tsx', '.mjs', '.json', '.node', '.jsx'];
 const nativeExtensions = ['.native.ts', ...extensions];
 process.env.NODE_ENV = 'production';
 process.env.RESOLVER_ALIAS = '{"@rest-hooks/core":"./src"}';

--- a/packages/core/src/react-integration/provider/BackupBoundary.native.js
+++ b/packages/core/src/react-integration/provider/BackupBoundary.native.js
@@ -1,0 +1,43 @@
+/* eslint-disable react/prop-types */
+import React, { Suspense, memo, useEffect } from 'react';
+import { Text, Linking, View } from 'react-native';
+
+function BackupBoundary({ children }) {
+  return <Suspense fallback={<Loading />}>{children}</Suspense>;
+}
+export default memo(BackupBoundary);
+
+function Loading() {
+  let message = <Text>loading...</Text>;
+  /* istanbul ignore else */
+  if (process.env.NODE_ENV !== 'production') {
+    // env should not change during runtime and this excludes from build
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      console.warn(
+        `Uncaught suspense.
+Make sure to add your own Suspense boundaries: https://resthooks.io/docs/getting-started/data-dependency#async-fallbacks`,
+      );
+    }, []);
+
+    message = (
+      <>
+        <Text>Uncaught Suspense.</Text>
+        <Text>
+          Try
+          <Text
+            style={{ color: 'blue' }}
+            onPress={() =>
+              Linking.openURL(
+                'https://resthooks.io/docs/getting-started/data-dependency#async-fallbacks',
+              )
+            }
+          >
+            adding a suspense boundary
+          </Text>
+        </Text>
+      </>
+    );
+  }
+  return <View>{message}</View>;
+}

--- a/packages/core/src/react-integration/provider/BackupBoundary.tsx
+++ b/packages/core/src/react-integration/provider/BackupBoundary.tsx
@@ -1,7 +1,16 @@
-import React, { Suspense, memo } from 'react';
-import { useMemo } from 'react';
+import React, { Suspense, memo, useMemo, version } from 'react';
 
-function BackupBoundary({ children }: { children: React.ReactNode }) {
+function BackupBoundary({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element {
+  // since Suspense does not introduce DOM elements, this should not affect rehydration.
+  if (
+    (version.startsWith('16') || version.startsWith('17')) &&
+    typeof window === 'undefined'
+  )
+    return children as JSX.Element;
   return <Suspense fallback={<Loading />}>{children}</Suspense>;
 }
 export default memo(BackupBoundary);
@@ -22,7 +31,7 @@ Make sure to add your own Suspense boundaries: https://resthooks.io/docs/getting
     message = (
       <>
         <span>Uncaught Suspense.</span>
-        Try{' '}
+        Try
         <a href="https://resthooks.io/docs/getting-started/data-dependency#async-fallbacks">
           adding a suspense boundary
         </a>

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -39,6 +39,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
+    "resolveJsonModule": true,
     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     //"baseUrl": "packages/rest-hooks/src",                       /* Base directory to resolve non-absolute module names. */
     // "rootDirs": ["./src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,7 +2128,6 @@
 
 "@lerna/conventional-commits@4.0.0", "@lerna/conventional-commits@https://github.com/ntucker/lerna-conventional-commits.git":
   version "3.16.4"
-  uid "4389120475a4f80ac8e4fbe766fa4c9644c6b1c7"
   resolved "https://github.com/ntucker/lerna-conventional-commits.git#4389120475a4f80ac8e4fbe766fa4c9644c6b1c7"
   dependencies:
     "@lerna/validation-error" "^4.0"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
CacheProvider is needed in all installs, so ensure it works in all compatible cases.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- .native extension allows for RN specific version that uses <Text>
- Don't use <Suspense/> in React 16, 17 when doing SSR - as it will show fallback which will likely block entire app