### PR TITLE
enhance: Detect multiple normalizr copies installed

### DIFF
--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -407,6 +407,19 @@ describe('denormalize', () => {
     ).toMatchSnapshot();
   });
 
+  test('denormalizes throws when unknown symbol is found as entity', () => {
+    const entities = {
+      Tacos: {
+        1: Symbol('ENTITY WAS DELETED'),
+      },
+    };
+    expect(() => denormalize(['1', '2'], [Tacos], entities))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Unrecognized symbol detected.
+      Make sure you do not have multiple versions of @rest-hooks/normalizr installed."
+    `);
+  });
+
   test('denormalizes ignoring deleted entities in arrays', () => {
     const entities = {
       Tacos: {

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -37,6 +37,16 @@ const unvisitEntity = (
   if (entity === DELETED) {
     return [undefined, true, true];
   }
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    typeof entity === 'symbol' &&
+    (entity as symbol).toString().includes('DELETED')
+  ) {
+    throw new Error(
+      `Unrecognized symbol detected.
+Make sure you do not have multiple versions of @rest-hooks/normalizr installed.`,
+    );
+  }
   if (typeof entity !== 'object' || entity === null) {
     return [entity, false, false];
   }


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #1312 (assuming this is the cause)

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
If someone accidentally installs multiple versions of normalizr, identity of Symbols won't work, but it won't manifest in an obvious way.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Outright throw an error during denormalization. We only do this during dev mode as packages are not expected to change from dev to production and this would incur a cost for a very extreme edge case.