### PR TITLE
feat: Normalize strings for entities

### DIFF
--- a/packages/legacy/src/resource/__tests__/Entity.test.ts
+++ b/packages/legacy/src/resource/__tests__/Entity.test.ts
@@ -417,7 +417,7 @@ describe(`${Entity.name} normalization`, () => {
         return this.name;
       }
     }
-    const schema = MyEntity;
+    const schema = { data: MyEntity };
     function normalizeBad() {
       normalize('hibho', schema);
     }

--- a/packages/legacy/src/resource/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/Entity.test.ts.snap
@@ -1133,9 +1133,11 @@ exports[`Entity normalization should throw a custom error if data loads with str
 "Unexpected input given to normalize. Expected type to be \\"object\\", found \\"string\\".
 
           Schema: {
-  \\"name\\": \\"MyEntity\\",
-  \\"schema\\": {},
-  \\"key\\": \\"MyEntity\\"
+  \\"data\\": {
+    \\"name\\": \\"MyEntity\\",
+    \\"schema\\": {},
+    \\"key\\": \\"MyEntity\\"
+  }
 }
           Input: \\"hibho\\""
 `;

--- a/packages/legacy/src/resource/__tests__/normalizr.test.js
+++ b/packages/legacy/src/resource/__tests__/normalizr.test.js
@@ -26,12 +26,20 @@ afterAll(() => {
 });
 
 describe('normalize', () => {
-  [42, null, undefined, '42', () => {}].forEach(input => {
-    test(`cannot normalize input that == ${input}`, () => {
+  test.each([42, null, undefined, () => {}])(
+    `cannot normalize input that == %s`,
+    input => {
       class Test extends IDEntity {}
       expect(() => normalize(input, Test)).toThrow();
-    });
-  });
+    },
+  );
+  test.each([42, null, undefined, '42', () => {}])(
+    `cannot normalize input that == %s`,
+    input => {
+      class Test extends IDEntity {}
+      expect(() => normalize(input, { data: Test })).toThrow();
+    },
+  );
 
   test('passthrough with undefined schema', () => {
     const input = {};

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -24,11 +24,24 @@ afterAll(() => {
 });
 
 describe('normalize', () => {
-  [42, null, undefined, '42', () => {}].forEach(input => {
-    test(`cannot normalize input that == ${input}`, () => {
+  test.each([42, null, undefined, () => {}])(
+    `cannot normalize input that == %s`,
+    input => {
       class Test extends IDEntity {}
       expect(() => normalize(input, Test)).toThrow();
-    });
+    },
+  );
+  test.each([42, null, undefined, '42', () => {}])(
+    `cannot normalize input that == %s`,
+    input => {
+      class Test extends IDEntity {}
+      expect(() => normalize(input, { data: Test })).toThrow();
+    },
+  );
+
+  test('can normalize strings for entity (already processed)', () => {
+    class Test extends IDEntity {}
+    expect(normalize('42', Test).result).toEqual('42');
   });
 
   test('passthrough with undefined schema', () => {

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -143,8 +143,6 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     addEntity: (...args: any) => any,
     visitedEntities: Record<string, any>,
   ): any {
-    // pass over already processed entities
-    if (typeof input === 'string') return input;
     const processedEntity = this.process(input, parent, key);
     const id = this.pk(processedEntity, parent, key);
     if (id === undefined || id === '') {

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -65,6 +65,11 @@ describe(`${Entity.name} normalization`, () => {
     expect(normalize({ id: '1' }, MyEntity)).toMatchSnapshot();
   });
 
+  test('normalizes already processed entities', () => {
+    class MyEntity extends IDEntity {}
+    expect(normalize('1', MyEntity)).toMatchSnapshot();
+  });
+
   it('should throw a custom error if data does not include pk', () => {
     class MyEntity extends Entity {
       readonly name: string = '';
@@ -427,7 +432,7 @@ describe(`${Entity.name} normalization`, () => {
         return this.name;
       }
     }
-    const schema = MyEntity;
+    const schema = { data: MyEntity };
     function normalizeBad() {
       normalize('hibho', schema);
     }

--- a/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
@@ -374,6 +374,15 @@ Object {
 }
 `;
 
+exports[`Entity normalization normalizes already processed entities 1`] = `
+Object {
+  "entities": Object {},
+  "entityMeta": Object {},
+  "indexes": Object {},
+  "result": "1",
+}
+`;
+
 exports[`Entity normalization normalizes an entity 1`] = `
 Object {
   "entities": Object {
@@ -702,9 +711,11 @@ exports[`Entity normalization should throw a custom error if data loads with str
 "Unexpected input given to normalize. Expected type to be \\"object\\", found \\"string\\".
 
           Schema: {
-  \\"name\\": \\"MyEntity\\",
-  \\"schema\\": {},
-  \\"key\\": \\"MyEntity\\"
+  \\"data\\": {
+    \\"name\\": \\"MyEntity\\",
+    \\"schema\\": {},
+    \\"key\\": \\"MyEntity\\"
+  }
 }
           Input: \\"hibho\\""
 `;

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -7,6 +7,7 @@ import type {
 import { DELETED } from '@rest-hooks/normalizr/special';
 import { normalize as arrayNormalize } from '@rest-hooks/normalizr/schemas/Array';
 import { normalize as objectNormalize } from '@rest-hooks/normalizr/schemas/Object';
+import { isEntity } from '@rest-hooks/normalizr/entities/Entity';
 
 const visit = (
   value: any,
@@ -189,7 +190,11 @@ export const normalize = <
     };
 
   const schemaType = expectedSchemaType(schema);
-  if (input === null || typeof input !== schemaType) {
+  if (
+    input === null ||
+    (typeof input !== schemaType &&
+      !((schema as any).key !== undefined && typeof input === 'string'))
+  ) {
     /* istanbul ignore else */
     if (process.env.NODE_ENV !== 'production') {
       const parseWorks = (input: string) => {

--- a/packages/normalizr/src/schemas/Delete.ts
+++ b/packages/normalizr/src/schemas/Delete.ts
@@ -35,8 +35,6 @@ export default class Delete<E extends EntityInterface & { process: any }>
     addEntity: (...args: any) => any,
     visitedEntities: Record<string, any>,
   ): string | undefined {
-    // pass over already processed entities
-    if (typeof input === 'string') return input;
     // TODO: what's store needs to be a differing type from fromJS
     const processedEntity = this._entity.process(input, parent, key);
     const id = this._entity.pk(processedEntity, parent, key);

--- a/packages/normalizr/src/schemas/Polymorphic.ts
+++ b/packages/normalizr/src/schemas/Polymorphic.ts
@@ -45,6 +45,7 @@ export default class PolymorphicSchema {
   ) {
     const schema = this.inferSchema(value, parent, key);
     if (!schema) {
+      /* istanbul ignore else */
       if (process.env.NODE_ENV !== 'production') {
         const attr = this.getSchemaAttribute(value, parent, key);
         console.warn(

--- a/packages/normalizr/src/schemas/__tests__/Delete.test.ts
+++ b/packages/normalizr/src/schemas/__tests__/Delete.test.ts
@@ -32,6 +32,19 @@ describe(`${schema.Delete.name} normalization`, () => {
     ).toMatchSnapshot();
   });
 
+  test('normalizes already processed entities', () => {
+    class MyEntity extends IDEntity {}
+    expect(normalize('1', new schema.Delete(MyEntity))).toMatchSnapshot();
+  });
+
+  test('does not infer', () => {
+    class User extends IDEntity {}
+
+    expect(
+      new schema.Delete(User).infer([{ id: 5 }], {}, () => undefined),
+    ).toBeUndefined();
+  });
+
   it('should throw a custom error if data does not include pk', () => {
     class MyEntity extends Entity {
       readonly name: string = '';

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Delete.test.ts.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Delete.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Delete normalization normalizes already processed entities 1`] = `
+Object {
+  "entities": Object {},
+  "entityMeta": Object {},
+  "indexes": Object {},
+  "result": "1",
+}
+`;
+
 exports[`Delete normalization normalizes an object 1`] = `
 Object {
   "entities": Object {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
An api might want to nest ids, rather than forcing them inside objects like: ['1', '3', '5'] vs [{ id: '1'}, { id: '3' }, { id: '5' }]

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Specifically allow string types during normalization for entities. This is handled before Entity.normalize step so we removed the special check. Also apply to delete