### PR TITLE
internal: Reduce max workers for codecoverage CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           command: |
             curl -Os https://uploader.codecov.io/latest/linux/codecov;
             chmod +x codecov;
-            yarn run test:coverage --maxWorkers=4 --coverageReporters=text-lcov > ./lcov.info;
+            yarn run test:coverage --maxWorkers=3 --coverageReporters=text-lcov > ./lcov.info;
             if [ "$CODECOV_TOKEN" != "" ]; then
             ./codecov -t ${CODECOV_TOKEN} < ./lcov.info || true;
             else


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Coverage CI is still stalling some of the time.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
If it's memory related, reducing max worker count should help. Coverage uses a lot more memory than tests without coverage.
