### PR TITLE
fix: Correct controller override

### DIFF
--- a/packages/core/src/controller/__tests__/fetch.tsx
+++ b/packages/core/src/controller/__tests__/fetch.tsx
@@ -149,6 +149,33 @@ describe.each([
     };
   });
 
+  it('should fetch with resolver', async () => {
+    // we use this id because it is not nock'd
+    const id = 10000;
+    const fixture = {
+      endpoint: FutureArticleResource.detail(),
+      args: [10000],
+      response: payload,
+    };
+    const { result } = renderRestHook(
+      () => {
+        return {
+          data: useCache(FutureArticleResource.detail(), id),
+          fetch: useController().fetch,
+        };
+      },
+      { resolverFixtures: [fixture] },
+    );
+    expect(result.current.data).toBeUndefined();
+    let response;
+    await act(async () => {
+      result.current.fetch(FutureArticleResource.detail(), id);
+      result.current.fetch(FutureArticleResource.detail(), id);
+      result.current.fetch(FutureArticleResource.detail(), id);
+      response = await result.current.fetch(FutureArticleResource.detail(), id);
+    });
+  });
+
   it('should update on create', async () => {
     const endpoint = FutureArticleResource.create();
     const response: ResolveType<typeof endpoint> = createPayload;

--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -97,9 +97,11 @@ export default function MockResolver({
     [dispatch, fetchToReceiveAction, silenceMissing],
   );
   const controllerInterceptor = useMemo(() => {
-    const newController = Object.create(controller);
-    newController.dispatch = dispatchInterceptor;
-    return newController;
+    if (!RestHooksCore.Controller) return controller;
+    return new RestHooksCore.Controller({
+      ...controller,
+      dispatch: dispatchInterceptor,
+    });
   }, [controller, dispatchInterceptor]);
 
   return (


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Previous solution assumed normal javascript instance calling (object.method()), which we don't enforce. Instead controller methods bind 'this' so people can use as destructured.

Because of this, we cannot use a prototype to build our child as calls to methods not overridden will have the parent class as 'this' and thus not use the overrides.

```ts
const { fetch } = useController();
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- add test to validate this actually works
- construct new controller. we spread the entire thing in so we are future compatible with any additions to controller