### PR TITLE
docs(fix): Make Rest Hooks image work with dark/light mode SSR

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -3,15 +3,18 @@ import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import useThemeContext from '@theme/hooks/useThemeContext';
+import ThemedImage from '@theme/ThemedImage';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import styles from './index.module.css';
 import HomepageFeatures from '../components/HomepageFeatures';
 import Demo from '../components/Demo/index';
 
 const ProjectTitle = () => {
-  const { siteConfig } = useDocusaurusContext();
-  const { isDarkTheme } = useThemeContext();
+  const sources = {
+    light: useBaseUrl('img/rest_hooks_logo_and_text_subtitle--light.svg'),
+    dark: useBaseUrl('img/rest_hooks_logo_and_text_subtitle--dark.svg'),
+  };
   return (
     <React.Fragment>
       <div
@@ -22,12 +25,8 @@ const ProjectTitle = () => {
           marginBottom: '30px',
         }}
       >
-        <img
-          src={
-            isDarkTheme
-              ? 'img/rest_hooks_logo_and_text_subtitle--dark.svg'
-              : 'img/rest_hooks_logo_and_text_subtitle--light.svg'
-          }
+        <ThemedImage
+          sources={sources}
           alt="Rest Hooks - An API client for dynamic applications"
           height={110}
           width={512}


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
#1392 introduces dark/light image for the main logo on homepage. However, doesn't work with SSR so it shows up wrong on first load.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
ThemedImage makes this work