### PR TITLE
docs: Maintain code editor tab position when changing tabs

### DIFF
--- a/website/src/components/Demo/CodeEditor.tsx
+++ b/website/src/components/Demo/CodeEditor.tsx
@@ -1,28 +1,30 @@
-import React, { useContext, memo } from 'react';
+import React, { useContext, memo, useRef, forwardRef } from 'react';
 
 import CodeProvider from './CodeProvider';
 import HooksPlayground from '../HooksPlayground';
 import CodeTabContext from './CodeTabContext';
 
 // eslint-disable-next-line react/display-name
-const DemoPlayground = memo(() => {
-  const { selectedValue, values } = useContext(CodeTabContext);
+const DemoPlayground = memo(
+  forwardRef((props, ref: React.RefObject<HTMLDivElement>) => {
+    const { selectedValue, values } = useContext(CodeTabContext);
 
-  return (
-    <>
-      {values.map(({ value, code }) => (
-        <HooksPlayground
-          groupId="homepage-demo"
-          row
-          key={value}
-          hidden={value !== selectedValue}
-        >
-          {code}
-        </HooksPlayground>
-      ))}
-    </>
-  );
-});
+    return (
+      <div ref={ref}>
+        {values.map(({ value, code }) => (
+          <HooksPlayground
+            groupId="homepage-demo"
+            row
+            key={value}
+            hidden={value !== selectedValue}
+          >
+            {code}
+          </HooksPlayground>
+        ))}
+      </div>
+    );
+  }),
+);
 
 interface Props<T extends string> {
   codes: { label: string; value: T; code: string }[];
@@ -33,9 +35,16 @@ export default function CodeEditor<T extends string>({
   codes,
   defaultValue,
 }: Props<T>) {
+  const playgroundRef = useRef();
+
   return (
-    <CodeProvider defaultValue={defaultValue} groupId="protocol" values={codes}>
-      <DemoPlayground />
+    <CodeProvider
+      defaultValue={defaultValue}
+      groupId="protocol"
+      values={codes}
+      playgroundRef={playgroundRef}
+    >
+      <DemoPlayground ref={playgroundRef} />
     </CodeProvider>
   );
 }

--- a/website/src/components/Demo/CodeProvider.tsx
+++ b/website/src/components/Demo/CodeProvider.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useState } from 'react';
 import useUserPreferencesContext from '@theme/hooks/useUserPreferencesContext';
+import { useScrollPositionBlocker } from '@docusaurus/theme-common';
 
 import CodeTabContext from './CodeTabContext';
 
@@ -8,16 +9,20 @@ interface Props<V extends { label: string; value: string }[]> {
   groupId?: string | null;
   defaultValue: V[number]['value'];
   children: React.ReactNode;
+  playgroundRef: React.RefObject<HTMLElement>;
 }
 
 export function CodeProvider<V extends { label: string; value: string }[]>({
   defaultValue,
   groupId = null,
   values,
+  playgroundRef,
   children,
 }: Props<V>) {
   const { tabGroupChoices, setTabGroupChoices } = useUserPreferencesContext();
   const [selectedValue, setLocalSelectedValue] = useState(defaultValue);
+  const { blockElementScrollPositionUntilNextRender } =
+    useScrollPositionBlocker();
 
   if (groupId != null) {
     const choice = tabGroupChoices[groupId];
@@ -30,11 +35,20 @@ export function CodeProvider<V extends { label: string; value: string }[]>({
     }
   }
 
-  const setSelectedValue = (selectedTabValue: string) => {
-    setLocalSelectedValue(selectedTabValue);
+  const setSelectedValue = (
+    event: React.FocusEvent<HTMLLIElement> | React.MouseEvent<HTMLLIElement>,
+  ) => {
+    const newTab = event.currentTarget;
+    const newTabValue = newTab.getAttribute('value');
+    console.log(newTab);
 
-    if (groupId != null) {
-      setTabGroupChoices(groupId, selectedTabValue);
+    if (newTabValue !== selectedValue) {
+      blockElementScrollPositionUntilNextRender(playgroundRef.current);
+      setLocalSelectedValue(newTabValue);
+
+      if (groupId != null) {
+        setTabGroupChoices(groupId, newTabValue);
+      }
     }
   };
 

--- a/website/src/components/Demo/CodeTabContext.ts
+++ b/website/src/components/Demo/CodeTabContext.ts
@@ -2,7 +2,9 @@ import { createContext } from 'react';
 
 const CodeTabContext = createContext({
   selectedValue: '',
-  setSelectedValue: (value: string): void => {
+  setSelectedValue: (
+    event: React.FocusEvent<HTMLLIElement> | React.MouseEvent<HTMLLIElement>,
+  ): void => {
     throw new Error('No Tab provider');
   },
   values: [],

--- a/website/src/components/Playground/index.js
+++ b/website/src/components/Playground/index.js
@@ -58,14 +58,19 @@ function HeaderTabs() {
   const { selectedValue, setSelectedValue, values } =
     useContext(CodeTabContext);
   return (
-    <div className={styles.tabs}>
+    <div className={styles.tabs} role="tablist" aria-orientation="horizontal">
       {values.map(({ value, label }) => (
         <div
+          role="tab"
+          tabIndex={selectedValue === value ? 0 : -1}
+          aria-selected={selectedValue === value}
           key={value}
           className={clsx(styles.tab, {
             [styles.selected]: selectedValue === value,
           })}
-          onClick={() => setSelectedValue(value)}
+          onFocus={setSelectedValue}
+          onClick={setSelectedValue}
+          value={value}
         >
           {label}
         </div>


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
When users change tabs it can change the amount of content on the page, this means the existing scroll position might move the element they are clicking on.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Using the infrastructure from https://github.com/facebook/docusaurus/pull/5618
