### PR TITLE
feat: Add useSuspense()

### DIFF
--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -82,7 +82,7 @@
     "@babel/runtime": "^7.7.2"
   },
   "peerDependencies": {
-    "@rest-hooks/core": "^2.1.0",
+    "@rest-hooks/core": "^3.0.0-0",
     "@rest-hooks/endpoint": "^2.0.0",
     "@rest-hooks/rest": "^3.0.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/experimental/src/hooks/__tests__/__snapshots__/useFetch.web.tsx.snap
+++ b/packages/experimental/src/hooks/__tests__/__snapshots__/useFetch.web.tsx.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useFetch should dispatch singles 1`] = `
+Object {
+  "endpoint": [Function],
+  "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+    ],
+    "key": "GET http://test.com/article-cooler/5",
+    "options": [Function],
+    "promise": Promise {},
+    "reject": [Function],
+    "resolve": [Function],
+    "schema": [Function],
+    "throttle": true,
+    "type": "read",
+  },
+  "payload": [Function],
+  "type": "rest-hooks/fetch",
+}
+`;
+
+exports[`useFetch should dispatch with fetch shape defined dataExpiryLength 1`] = `
+Object {
+  "endpoint": [Function],
+  "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+    ],
+    "key": "GET http://test.com/article-static/5",
+    "options": [Function],
+    "promise": Promise {},
+    "reject": [Function],
+    "resolve": [Function],
+    "schema": [Function],
+    "throttle": true,
+    "type": "read",
+  },
+  "payload": [Function],
+  "type": "rest-hooks/fetch",
+}
+`;
+
+exports[`useFetch should dispatch with fetch shape defined errorExpiryLength 1`] = `
+Object {
+  "endpoint": [Function],
+  "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+    ],
+    "key": "GET http://test.com/article-static/5",
+    "options": [Function],
+    "promise": Promise {},
+    "reject": [Function],
+    "resolve": [Function],
+    "schema": [Function],
+    "throttle": true,
+    "type": "read",
+  },
+  "payload": [Function],
+  "type": "rest-hooks/fetch",
+}
+`;
+
+exports[`useFetch should dispatch with resource defined dataExpiryLength 1`] = `
+Object {
+  "endpoint": [Function],
+  "meta": Object {
+    "args": Array [
+      Object {
+        "content": "whatever",
+        "id": 5,
+        "tags": Array [
+          "a",
+          "best",
+          "react",
+        ],
+        "title": "hi ho",
+      },
+    ],
+    "key": "GET http://test.com/article-static/5",
+    "options": [Function],
+    "promise": Promise {},
+    "reject": [Function],
+    "resolve": [Function],
+    "schema": [Function],
+    "throttle": true,
+    "type": "read",
+  },
+  "payload": [Function],
+  "type": "rest-hooks/fetch",
+}
+`;

--- a/packages/experimental/src/hooks/__tests__/__snapshots__/useSuspense.web.tsx.snap
+++ b/packages/experimental/src/hooks/__tests__/__snapshots__/useSuspense.web.tsx.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useSuspense() should dispatch an action that fetches 1`] = `
+Object {
+  "endpoint": [Function],
+  "meta": Object {
+    "args": Array [
+      Object {
+        "id": 5,
+      },
+    ],
+    "key": "GET http://test.com/article-cooler/5",
+    "options": [Function],
+    "promise": Promise {},
+    "reject": [Function],
+    "resolve": [Function],
+    "schema": [Function],
+    "throttle": true,
+    "type": "read",
+  },
+  "payload": [Function],
+  "type": "rest-hooks/fetch",
+}
+`;
+
+exports[`useSuspense() should throw error when response is {} when expecting entity 1`] = `
+[Error: Error processing GET http://test.com/article-cooler/400
+
+Full Schema: {
+  "name": "CoolerArticleResource",
+  "schema": {
+    "author": {
+      "name": "UserResource",
+      "schema": {},
+      "key": "http://test.com/user/"
+    }
+  },
+  "key": "http://test.com/article-cooler/"
+}
+
+Error:
+Attempted to initialize CoolerArticleResource with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+First three members: []]
+`;
+
+exports[`useSuspense() should throw error when response is array when expecting entity 1`] = `
+[Error: Error processing GET http://test.com/article-cooler/400
+
+Full Schema: {
+  "name": "CoolerArticleResource",
+  "schema": {
+    "author": {
+      "name": "UserResource",
+      "schema": {},
+      "key": "http://test.com/user/"
+    }
+  },
+  "key": "http://test.com/article-cooler/"
+}
+
+Error:
+Attempted to initialize CoolerArticleResource with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+First three members: []]
+`;
+
+exports[`useSuspense() should throw error when response is number when expecting entity 1`] = `
+[Error: Error processing GET http://test.com/article-cooler/400
+
+Full Schema: {
+  "name": "CoolerArticleResource",
+  "schema": {
+    "author": {
+      "name": "UserResource",
+      "schema": {},
+      "key": "http://test.com/user/"
+    }
+  },
+  "key": "http://test.com/article-cooler/"
+}
+
+Error:
+Attempted to initialize CoolerArticleResource with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+First three members: []]
+`;
+
+exports[`useSuspense() should throw error when response is string when expecting entity 1`] = `
+[Error: Error processing GET http://test.com/article-cooler/400
+
+Full Schema: {
+  "name": "CoolerArticleResource",
+  "schema": {
+    "author": {
+      "name": "UserResource",
+      "schema": {},
+      "key": "http://test.com/user/"
+    }
+  },
+  "key": "http://test.com/article-cooler/"
+}
+
+Error:
+Attempted to initialize CoolerArticleResource with an array, but named members were expected
+
+This is likely due to a malformed response.
+Try inspecting the network response or fetch() return value.
+Or use debugging tools: https://resthooks.io/docs/guides/debugging
+Learn more about schemas: https://resthooks.io/docs/api/schema
+If this is a mistake, you can disable this check by setting static automaticValidation = 'silent'
+
+First three members: []]
+`;

--- a/packages/experimental/src/hooks/__tests__/useFetch.web.tsx
+++ b/packages/experimental/src/hooks/__tests__/useFetch.web.tsx
@@ -1,0 +1,183 @@
+import { CoolerArticleResource, StaticArticleResource } from '__tests__/new';
+import React, { Suspense } from 'react';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import nock from 'nock';
+
+// relative imports to avoid circular dependency in tsconfig references
+import {
+  StateContext,
+  initialState,
+  State,
+  ActionTypes,
+  ControllerContext,
+  Controller,
+} from '@rest-hooks/core';
+
+import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import useFetch from '../useFetch';
+import { users, payload } from '../test-fixtures';
+
+async function testDispatchFetch(
+  Component: React.FunctionComponent<any>,
+  payloads: any[],
+) {
+  const dispatch = jest.fn();
+  const controller = new Controller({ dispatch });
+
+  const tree = (
+    <ControllerContext.Provider value={controller}>
+      <Suspense fallback={null}>
+        <Component />
+      </Suspense>
+    </ControllerContext.Provider>
+  );
+  render(tree);
+  expect(dispatch).toHaveBeenCalled();
+  expect(dispatch.mock.calls.length).toBe(payloads.length);
+  let i = 0;
+  for (const call of dispatch.mock.calls) {
+    delete call[0]?.meta?.createdAt;
+    expect(call[0]).toMatchSnapshot();
+    const action = call[0];
+    const res = await action.payload();
+    expect(res).toEqual(payloads[i]);
+    i++;
+  }
+}
+
+function testRestHook(
+  callback: () => void,
+  state: State<unknown>,
+  dispatch = (v: ActionTypes) => Promise.resolve(),
+) {
+  const controller = new Controller({ dispatch });
+
+  return renderHook(callback, {
+    wrapper: function Wrapper({ children }) {
+      return (
+        <ControllerContext.Provider value={controller}>
+          <StateContext.Provider value={state}>
+            {children}
+          </StateContext.Provider>
+        </ControllerContext.Provider>
+      );
+    },
+  });
+}
+
+let mynock: nock.Scope;
+
+beforeAll(() => {
+  nock(/.*/)
+    .persist()
+    .defaultReplyHeaders({
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json',
+    })
+    .options(/.*/)
+    .reply(200);
+  mynock = nock(/.*/).defaultReplyHeaders({
+    'Access-Control-Allow-Origin': '*',
+    'Content-Type': 'application/json',
+  });
+});
+
+afterAll(() => {
+  nock.cleanAll();
+});
+
+describe('useFetch', () => {
+  let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+  beforeEach(() => {
+    mynock.get(`/article-cooler/${payload.id}`).reply(200, payload);
+    mynock.get(`/article-static/${payload.id}`).reply(200, payload);
+    mynock.get(`/user/`).reply(200, users);
+    renderRestHook = makeRenderRestHook(makeCacheProvider);
+  });
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('should dispatch singles', async () => {
+    function FetchTester() {
+      useFetch(CoolerArticleResource.detail(), payload);
+      return null;
+    }
+    await testDispatchFetch(FetchTester, [payload]);
+  });
+
+  it('should not dispatch will null params', () => {
+    const dispatch = jest.fn();
+    let params: any = null;
+    const { rerender } = testRestHook(
+      () => {
+        useFetch(CoolerArticleResource.detail(), params);
+      },
+      initialState,
+      dispatch,
+    );
+    expect(dispatch).toBeCalledTimes(0);
+    params = payload;
+    rerender();
+    expect(dispatch).toBeCalled();
+  });
+
+  it('should dispatch with resource defined dataExpiryLength', async () => {
+    function FetchTester() {
+      useFetch(StaticArticleResource.detail(), payload);
+      return null;
+    }
+    await testDispatchFetch(FetchTester, [payload]);
+  });
+
+  it('should dispatch with fetch shape defined dataExpiryLength', async () => {
+    function FetchTester() {
+      useFetch(StaticArticleResource.longLiving(), payload);
+      return null;
+    }
+    await testDispatchFetch(FetchTester, [payload]);
+  });
+
+  it('should dispatch with fetch shape defined errorExpiryLength', async () => {
+    function FetchTester() {
+      useFetch(StaticArticleResource.neverRetryOnError(), payload);
+      return null;
+    }
+    await testDispatchFetch(FetchTester, [payload]);
+  });
+
+  it('should not refetch after expiry and render', async () => {
+    let time = 1000;
+    global.Date.now = jest.fn(() => time);
+    nock.cleanAll();
+    const fetchMock = jest.fn(() => payload);
+    mynock.get(`/article-cooler/${payload.id}`).reply(200, fetchMock).persist();
+    const results: any[] = [
+      {
+        request: CoolerArticleResource.detail(),
+        params: payload,
+        result: payload,
+      },
+    ];
+    const { result, rerender } = renderRestHook(
+      () => {
+        return useFetch(CoolerArticleResource.detail(), payload);
+      },
+      { results },
+    );
+    await result.current;
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+    time += 100;
+    rerender();
+    await result.current;
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+    // eslint-disable-next-line require-atomic-updates
+    time += 610000000;
+    rerender();
+    await result.current;
+    rerender();
+    await result.current;
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/experimental/src/hooks/__tests__/useSuspense.web.tsx
+++ b/packages/experimental/src/hooks/__tests__/useSuspense.web.tsx
@@ -1,0 +1,487 @@
+import {
+  CoolerArticleResource,
+  InvalidIfStaleArticleResource,
+  GetPhoto,
+  GetPhotoUndefined,
+  GetNoEntities,
+  ArticleTimedResource,
+  ContextAuthdArticle,
+  AuthContext,
+} from '__tests__/new';
+import { createEntityMeta } from '__tests__/utils';
+import {
+  State,
+  useController,
+  ControllerContext,
+  StateContext,
+  initialState,
+  Controller,
+} from '@rest-hooks/core';
+import React, { Suspense, useContext, useMemo } from 'react';
+import { render } from '@testing-library/react';
+import nock from 'nock';
+
+// relative imports to avoid circular dependency in tsconfig references
+
+import { normalize } from '@rest-hooks/normalizr';
+import { ReadEndpoint } from '@rest-hooks/endpoint';
+
+import {
+  makeRenderRestHook,
+  makeCacheProvider,
+  mockInitialState,
+} from '../../../../test';
+import useSuspense from '../useSuspense';
+import { payload, users, nested } from '../test-fixtures';
+
+async function testDispatchFetch(
+  Component: React.FunctionComponent<any>,
+  payloads: any[],
+) {
+  const dispatch = jest.fn();
+  const controller = new Controller({ dispatch });
+
+  const tree = (
+    <ControllerContext.Provider value={controller}>
+      <Suspense fallback={null}>
+        <Component />
+      </Suspense>
+    </ControllerContext.Provider>
+  );
+  render(tree);
+  expect(dispatch).toHaveBeenCalled();
+  expect(dispatch.mock.calls.length).toBe(payloads.length);
+  let i = 0;
+  for (const call of dispatch.mock.calls) {
+    delete call[0]?.meta?.createdAt;
+    expect(call[0]).toMatchSnapshot();
+    const action = call[0];
+    const res = await action.payload();
+    expect(res).toEqual(payloads[i]);
+    i++;
+  }
+}
+
+function ArticleComponentTester({ invalidIfStale = false }) {
+  const resource = invalidIfStale
+    ? InvalidIfStaleArticleResource
+    : CoolerArticleResource;
+  const article = useSuspense(resource.detail(), {
+    id: payload.id,
+  });
+  return (
+    <div>
+      <h3>{article.title}</h3>
+      <p>{article.content}</p>
+    </div>
+  );
+}
+
+describe('useSuspense()', () => {
+  let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+  const fbmock = jest.fn();
+
+  async function testMalformedResponse(
+    payload: any,
+    endpoint: ReadEndpoint = CoolerArticleResource.detail(),
+  ) {
+    nock(/.*/)
+      .persist()
+      .defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': '*',
+        'Content-Type': 'application/json',
+      })
+      .get(`/article-cooler/400`)
+      .reply(200, payload);
+
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useSuspense(endpoint as any, {
+        id: 400,
+      });
+    });
+    expect(result.current).toBeUndefined();
+    await waitForNextUpdate();
+    expect(result.error).toBeDefined();
+    expect((result.error as any).status).toBeGreaterThan(399);
+    expect(result.error).toMatchSnapshot();
+  }
+
+  function Fallback() {
+    fbmock();
+    return null;
+  }
+
+  beforeAll(() => {
+    nock(/.*/)
+      .persist()
+      .defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Access-Token',
+        'Content-Type': 'application/json',
+      })
+      .options(/.*/)
+      .reply(200)
+      .get(`/article-cooler/${payload.id}`)
+      .reply(200, payload)
+      .get(`/article-time/${payload.id}`)
+      .reply(200, { ...payload, createdAt: '2020-06-07T02:00:15+0000' })
+      .delete(`/article-cooler/${payload.id}`)
+      .reply(204, '')
+      .delete(`/article/${payload.id}`)
+      .reply(200, {})
+      .get(`/article-cooler/0`)
+      .reply(403, {})
+      .get(`/article-cooler/666`)
+      .reply(200, '')
+      .get(`/article-cooler/`)
+      .reply(200, nested)
+      .get(`/user/`)
+      .reply(200, users);
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+  });
+
+  beforeEach(() => {
+    renderRestHook = makeRenderRestHook(makeCacheProvider);
+  });
+
+  it('should dispatch an action that fetches', async () => {
+    await testDispatchFetch(ArticleComponentTester, [payload]);
+  });
+
+  it('should NOT suspend if result already in cache and options.invalidIfStale is false', () => {
+    const state: State<unknown> = mockInitialState([
+      {
+        request: CoolerArticleResource.detail(),
+        params: payload,
+        result: payload,
+      },
+    ]) as any;
+
+    const tree = (
+      <StateContext.Provider value={state}>
+        <Suspense fallback={<Fallback />}>
+          <ArticleComponentTester />
+        </Suspense>
+      </StateContext.Provider>
+    );
+    const { getByText } = render(tree);
+    expect(fbmock).not.toBeCalled();
+    const title = getByText(payload.title);
+    expect(title).toBeDefined();
+    expect(title.tagName).toBe('H3');
+  });
+  it('should NOT suspend even when result is stale and options.invalidIfStale is false', () => {
+    const { entities, result } = normalize(payload, CoolerArticleResource);
+    const fetchKey = CoolerArticleResource.detail().key(payload);
+    const state = {
+      ...initialState,
+      entities,
+      entityMeta: createEntityMeta(entities),
+      results: {
+        [fetchKey]: result,
+      },
+      meta: {
+        [fetchKey]: {
+          date: 0,
+          expiresAt: 0,
+        },
+      },
+    };
+    const controller = new Controller({ dispatch: () => Promise.resolve() });
+    const tree = (
+      <StateContext.Provider value={state}>
+        <ControllerContext.Provider value={controller}>
+          <Suspense fallback={<Fallback />}>
+            <ArticleComponentTester />
+          </Suspense>{' '}
+        </ControllerContext.Provider>
+      </StateContext.Provider>
+    );
+    const { getByText } = render(tree);
+    expect(fbmock).not.toBeCalled();
+    const title = getByText(payload.title);
+    expect(title).toBeDefined();
+    expect(title.tagName).toBe('H3');
+  });
+  it('should NOT suspend if result is not stale and options.invalidIfStale is true', () => {
+    const { entities, result } = normalize(
+      payload,
+      InvalidIfStaleArticleResource,
+    );
+    const fetchKey = InvalidIfStaleArticleResource.detail().key(payload);
+    const state = {
+      ...initialState,
+      entities,
+      results: {
+        [fetchKey]: result,
+      },
+      entityMeta: createEntityMeta(entities),
+      meta: {
+        [fetchKey]: {
+          date: Infinity,
+          expiresAt: Infinity,
+        },
+      },
+    };
+
+    const tree = (
+      <StateContext.Provider value={state}>
+        <Suspense fallback={<Fallback />}>
+          <ArticleComponentTester invalidIfStale />
+        </Suspense>
+      </StateContext.Provider>
+    );
+    const { getByText } = render(tree);
+    expect(fbmock).not.toBeCalled();
+    const title = getByText(payload.title);
+    expect(title).toBeDefined();
+    expect(title.tagName).toBe('H3');
+  });
+  it('should suspend if result stale in cache and options.invalidIfStale is true', () => {
+    const { entities, result } = normalize(
+      payload,
+      InvalidIfStaleArticleResource,
+    );
+    const fetchKey =
+      InvalidIfStaleArticleResource.detail().getFetchKey(payload);
+    const state = {
+      ...initialState,
+      entities,
+      results: {
+        [fetchKey]: result,
+      },
+      entityMeta: createEntityMeta(entities),
+      meta: {
+        [fetchKey]: {
+          date: 0,
+          expiresAt: 0,
+        },
+      },
+    };
+    const controller = new Controller({ dispatch: () => Promise.resolve() });
+
+    const tree = (
+      <StateContext.Provider value={state}>
+        <ControllerContext.Provider value={controller}>
+          <Suspense fallback={<Fallback />}>
+            <ArticleComponentTester invalidIfStale />
+          </Suspense>
+        </ControllerContext.Provider>
+      </StateContext.Provider>
+    );
+    render(tree);
+    expect(fbmock).toHaveBeenCalled();
+  });
+
+  // taken from integration
+  it('should throw errors on bad network', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useSuspense(CoolerArticleResource.detail(), {
+        id: '0',
+      });
+    });
+    expect(result.current).toBeUndefined();
+    await waitForNextUpdate();
+    expect(result.error).toBeDefined();
+    expect((result.error as any).status).toBe(403);
+  });
+
+  it('should throw error when response is array when expecting entity', async () => {
+    await testMalformedResponse([]);
+  });
+
+  it('should throw error when response is {} when expecting entity', async () => {
+    await testMalformedResponse({});
+  });
+
+  it('should throw error when response is number when expecting entity', async () => {
+    await testMalformedResponse(5);
+  });
+
+  it('should throw error when response is string when expecting entity', async () => {
+    await testMalformedResponse('hi');
+  });
+
+  /* TODO: Add these back when we have opt-in required
+  it('should throw error when response is string when expecting nested entity', async () => {
+    const endpoint = CoolerArticleResource.detail().extend({
+      schema: { data: CoolerArticleResource },
+    });
+    await testMalformedResponse('hi', endpoint);
+  });
+
+  it('should throw error when response is nested string when expecting nested entity', async () => {
+    const endpoint = CoolerArticleResource.detail().extend({
+      schema: { data: CoolerArticleResource },
+    });
+    await testMalformedResponse({ data: 5, parcel: 2 }, endpoint);
+  });
+
+  it('should throw error when response is nested missing id when expecting nested entity', async () => {
+    const endpoint = CoolerArticleResource.detail().extend({
+      schema: { data: CoolerArticleResource },
+    });
+    await testMalformedResponse(
+      { data: { ...payload, id: undefined }, parcel: 2 },
+      endpoint,
+    );
+  });
+
+  it('should throw error when response is expected Resource inside Record', async () => {
+    class Scheme extends SimpleRecord {
+      data: CoolerArticleResource = CoolerArticleResource.fromJS();
+      optional: UserResource | null = null;
+      static schema = {
+        data: CoolerArticleResource,
+        optional: UserResource,
+      };
+    }
+    const endpoint = CoolerArticleResource.detail().extend({
+      schema: Scheme,
+    });
+    await testMalformedResponse({ data: null }, endpoint);
+  });*/
+
+  it('should not suspend with no params to useSuspense()', () => {
+    let article: any;
+    const { result } = renderRestHook(() => {
+      article = useSuspense(CoolerArticleResource.detail(), null);
+      return 'done';
+    });
+    expect(result.current).toBe('done');
+    expect(article).toBeUndefined();
+  });
+
+  it('should work with shapes with no entities', async () => {
+    const userId = '5';
+    const response = { firstThing: '', someItems: [{ a: 5 }] };
+    nock(/.*/)
+      .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
+      .get(`/users/${userId}/simple`)
+      .reply(200, response);
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useSuspense(GetNoEntities, { userId });
+    });
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
+    await waitForNextUpdate();
+    expect(result.current).toStrictEqual(response);
+  });
+
+  it('should work with ArrayBuffer shapes', async () => {
+    const userId = '5';
+    const response = new ArrayBuffer(10);
+    nock(/.*/)
+      .defaultReplyHeaders({ 'access-control-allow-origin': '*' })
+      .get(`/users/${userId}/photo`)
+      .reply(200, response);
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useSuspense(GetPhoto, { userId });
+    });
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
+    await waitForNextUpdate();
+    expect(result.current).toEqual(response);
+  });
+
+  it('should work with ArrayBuffer endpoint with undefined schema', async () => {
+    const userId = '5';
+    const response = new ArrayBuffer(99);
+    nock(/.*/)
+      .defaultReplyHeaders({
+        'access-control-allow-origin': '*',
+      })
+      .get(`/users/${userId}/photo2`)
+      .reply(200, response);
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useSuspense(GetPhotoUndefined, { userId });
+    });
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
+    await waitForNextUpdate();
+    expect(result.current).toEqual(response);
+  });
+
+  it('should work with Serializable shapes', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useSuspense(ArticleTimedResource.detail(), payload);
+    });
+    // undefined means it threw
+    expect(result.current).toBeUndefined();
+    await waitForNextUpdate();
+    expect(result.current.createdAt.getDate()).toBe(
+      result.current.createdAt.getDate(),
+    );
+    expect(result.current.createdAt).toEqual(
+      new Date('2020-06-07T02:00:15+0000'),
+    );
+    expect(result.current.id).toEqual(payload.id);
+    expect(result.current).toBeInstanceOf(ArticleTimedResource);
+  });
+
+  describe('context authentication', () => {
+    beforeAll(() => {
+      const mynock = nock(/.*/)
+        .persist()
+        .defaultReplyHeaders({
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Access-Token',
+          'Content-Type': 'application/json',
+        })
+        .options(/.*/)
+        .reply(200);
+
+      mynock
+        .get(`/article/${payload.id}`)
+        .matchHeader('access-token', '')
+        .reply(200, { ...payload, title: 'unauthorized' })
+        .get(`/article/${payload.id}`)
+        .matchHeader('access-token', 'thepassword')
+        .reply(200, payload);
+    });
+
+    it('should use latest context when making requests', async () => {
+      const consoleSpy = jest.spyOn(console, 'error');
+      const wrapper = ({
+        children,
+        authToken,
+      }: React.PropsWithChildren<{
+        authToken: string;
+      }>) => (
+        <AuthContext.Provider value={authToken}>
+          {children}
+        </AuthContext.Provider>
+      );
+      const { result, waitForNextUpdate, rerender } = renderRestHook(
+        () => {
+          return {
+            data: useSuspense(ContextAuthdArticle.detail(), payload),
+            controller: useController(),
+            endpoint: ContextAuthdArticle.detail(),
+          };
+        },
+        {
+          wrapper,
+          initialProps: { authToken: '' },
+        },
+      );
+      // undefined means it threw (suspended)
+      expect(result.current).toBeUndefined();
+      await waitForNextUpdate();
+      expect(result.current.data.title).toBe('unauthorized');
+      rerender({ authToken: 'thepassword' });
+      const data = await result.current.controller.fetch(
+        result.current.endpoint,
+        payload,
+      );
+      expect(data).toEqual(payload);
+      expect(result.current.data.title).toEqual(payload.title);
+      // ensure we don't violate call-order changes
+      expect(consoleSpy.mock.calls.length).toBeLessThan(1);
+    });
+  });
+});

--- a/packages/experimental/src/hooks/test-fixtures.ts
+++ b/packages/experimental/src/hooks/test-fixtures.ts
@@ -1,0 +1,149 @@
+export const payload = {
+  id: 5,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
+export const createPayload = {
+  id: 1,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
+export const articlesPages = {
+  prevPage: '23asdl',
+  nextPage: 's3f3',
+  results: [
+    {
+      id: 23,
+      title: 'the first draft',
+      content: 'the best things in life com efree',
+      tags: ['one', 'two'],
+    },
+    {
+      id: 44,
+      title: 'the second book',
+      content: 'the best things in life com efree',
+      tags: ['hbh', 'wew'],
+    },
+    {
+      id: 2,
+      title: 'the third novel',
+      content: 'the best things in life com efree',
+      tags: ['free', 'honey'],
+    },
+    {
+      id: 643,
+      title: 'a long time ago',
+      content: 'the best things in life com efree',
+    },
+  ],
+};
+
+export const users = [
+  {
+    id: 23,
+    username: 'bob',
+    email: 'bob@bob.com',
+    isAdmin: false,
+  },
+  {
+    id: 7342,
+    username: 'lindsey',
+    email: 'lindsey@bob.com',
+    isAdmin: true,
+  },
+];
+
+export const nested = [
+  {
+    id: 5,
+    title: 'hi ho',
+    content: 'whatever',
+    tags: ['a', 'best', 'react'],
+    author: {
+      id: 23,
+      username: 'bob',
+    },
+  },
+  {
+    id: 3,
+    title: 'the next time',
+    content: 'whatever',
+    author: {
+      id: 23,
+      username: 'charles',
+      email: 'bob@bob.com',
+    },
+  },
+];
+
+const moreNested = [
+  {
+    id: 7,
+    title: 'article 7',
+    content: 'whatever',
+    tags: ['blah'],
+    author: {
+      id: 23,
+      username: 'bob',
+    },
+  },
+  {
+    id: 8,
+    title: 'article 8',
+    content: 'whatever',
+    author: {
+      id: 27,
+      username: 'zac',
+      email: 'zac@bob.com',
+    },
+  },
+];
+
+export const coAuthored = {
+  id: 5,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+  author: {
+    id: 23,
+    username: 'bob',
+  },
+  coAuthors: [
+    {
+      id: 42,
+      username: 'charles',
+      email: 'charles@gmail.com',
+    },
+    {
+      id: 51,
+      username: 'xavier',
+    },
+  ],
+};
+
+export const valuesFixture = {
+  first: {
+    id: 1,
+    title: 'first thing',
+    content: 'blah',
+    tags: [],
+  },
+  second: {
+    id: 2,
+    name: 'second thing',
+    content: 'blah',
+    tags: [],
+  },
+};
+
+export const paginatedFirstPage = {
+  results: nested,
+};
+
+export const paginatedSecondPage = {
+  results: moreNested,
+};

--- a/packages/experimental/src/hooks/useFetch.ts
+++ b/packages/experimental/src/hooks/useFetch.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { StateContext, useController } from '@rest-hooks/core';
+import { ExpiryStatus } from '@rest-hooks/core/controller/Expiry';
+import {
+  EndpointInterface,
+  Denormalize,
+  Schema,
+  FetchFunction,
+} from '@rest-hooks/endpoint';
+import { useContext, useMemo } from 'react';
+
+/**
+ * Request a resource if it is not in cache.
+ * @see https://resthooks.io/docs/api/useFetch
+ */
+export default function useFetch<
+  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  Args extends readonly [...Parameters<E>] | readonly [null],
+>(endpoint: E, ...args: Args) {
+  const state = useContext(StateContext);
+  const controller = useController();
+
+  const key = args[0] !== null ? endpoint.key(...args) : '';
+  const cacheResults = args[0] !== null && state.results[key];
+
+  // Compute denormalized value
+  const { expiryStatus, expiresAt } = useMemo(() => {
+    // @ts-ignore
+    return controller.getResponse(endpoint, ...args, state) as {
+      data: Denormalize<E['schema']>;
+      expiryStatus: ExpiryStatus;
+      expiresAt: number;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    cacheResults,
+    state.indexes,
+    state.entities,
+    state.entityMeta,
+    key,
+    cacheResults,
+  ]);
+
+  // If we are hard invalid we must fetch regardless of triggering or staleness
+  const forceFetch = expiryStatus === ExpiryStatus.Invalid;
+
+  const maybePromise = useMemo(() => {
+    // null params mean don't do anything
+    if ((Date.now() <= expiresAt && !forceFetch) || !key) return;
+    // @ts-ignore
+    return controller.fetch(endpoint, ...args);
+    // we need to check against serialized params, since params can change frequently
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expiresAt, controller, key, forceFetch, state.lastReset]);
+
+  return maybePromise;
+}

--- a/packages/experimental/src/hooks/useSuspense.ts
+++ b/packages/experimental/src/hooks/useSuspense.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { StateContext, useController } from '@rest-hooks/core';
+import { ExpiryStatus } from '@rest-hooks/core/controller/Expiry';
+import {
+  EndpointInterface,
+  Denormalize,
+  Schema,
+  FetchFunction,
+} from '@rest-hooks/endpoint';
+import { useContext, useMemo } from 'react';
+
+/**
+ * Ensure an endpoint is available.
+ * Suspends until it is.
+ *
+ * `useSuspense` guarantees referential equality globally.
+ * @see https://resthooks.io/docs/api/useSuspense
+ * @throws {Promise} If data is not yet available.
+ * @throws {NetworkError} If fetch fails.
+ */
+export default function useSuspense<
+  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  Args extends readonly [...Parameters<E>] | readonly [null],
+>(
+  endpoint: E,
+  ...args: Args
+): E['schema'] extends Exclude<Schema, null>
+  ? Denormalize<E['schema']>
+  : ReturnType<E> {
+  const state = useContext(StateContext);
+  const controller = useController();
+
+  const key = args[0] !== null ? endpoint.key(...args) : '';
+  const cacheResults = args[0] !== null && state.results[key];
+
+  // Compute denormalized value
+  const { data, expiryStatus, expiresAt } = useMemo(() => {
+    // @ts-ignore
+    return controller.getResponse(endpoint, ...args, state) as {
+      data: Denormalize<E['schema']>;
+      expiryStatus: ExpiryStatus;
+      expiresAt: number;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    cacheResults,
+    state.indexes,
+    state.entities,
+    state.entityMeta,
+    key,
+    cacheResults,
+  ]);
+
+  // @ts-ignore
+  const error = controller.getError(endpoint, ...args, state);
+
+  // If we are hard invalid we must fetch regardless of triggering or staleness
+  const forceFetch = expiryStatus === ExpiryStatus.Invalid;
+
+  const maybePromise = useMemo(() => {
+    // null params mean don't do anything
+    if ((Date.now() <= expiresAt && !forceFetch) || !key) return;
+    // @ts-ignore
+    return controller.fetch(endpoint, ...args);
+    // we need to check against serialized params, since params can change frequently
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expiresAt, controller, key, forceFetch, state.lastReset]);
+
+  // fully "valid" data will not suspend even if it is not fresh
+  if (expiryStatus !== ExpiryStatus.Valid && maybePromise) {
+    throw maybePromise;
+  }
+
+  if (error) throw error;
+
+  return data;
+}

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -1,5 +1,7 @@
 export { default as useFetcher } from './useFetcher';
 export { Controller, useController } from '@rest-hooks/core';
+export { default as useSuspense } from './hooks/useSuspense';
+export { default as useFetch } from './hooks/useFetch';
 export { default as Resource } from './rest/Resource';
 export { default as BaseResource } from './rest/BaseResource';
 import { schema, Entity } from '@rest-hooks/endpoint';


### PR DESCRIPTION
BREAKING CHANGE: Require @rest-hooks/core@3

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Use EndpointInterface instead of ancient FetchShape.
Improve naming.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
After many discussions `useSuspense()` was determined to be most clear naming.