### PR TITLE
enhance: Mark compatibility with latest @rest-hooks/core

### DIFF
--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -73,7 +73,7 @@
     "@babel/runtime": "^7.7.2"
   },
   "peerDependencies": {
-    "@rest-hooks/core": "^1.0.5 || ^2.0.0-0",
+    "@rest-hooks/core": "^1.0.5 || ^2.0.0-0 || ^3.0.0-0",
     "@rest-hooks/endpoint": "^1.0.3 || ^2.0.0-0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -95,7 +95,7 @@
     "@testing-library/react-hooks": "~7.0.0"
   },
   "peerDependencies": {
-    "@rest-hooks/core": "^1.0.0-0 || ^2.0.0-0",
+    "@rest-hooks/core": "^1.0.0-0 || ^2.0.0-0 || ^3.0.0-0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
     "redux": "^4.0.0",


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
We bumped core but forgot to mark compat. These all don't even use the interface that changed.
