### PR TITLE
docs(fix): Javascript runs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -295,14 +295,14 @@ module.exports = {
               label: 'Blog',
               to: '/blog',
             },
-            {
+            /*{
               html: `<iframe
               src="https://ghbtns.com/github-btn.html?user=coinbase&amp;repo=rest-hooks&amp;type=star&amp;count=true&amp;size=small"
               width="110"
               height="19.6"
               title="GitHub Stars"
             />`,
-            },
+            },*/
           ],
         },
       ],


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Not exactly sure why this happens, but this block prevents javascript loading on all docs pages.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Comment out for now. Possibly figure out how to use in the future.