### PR TITLE
enhance: Dispatch new receive action if new fetch triggered it

### DIFF
--- a/packages/core/src/state/NetworkManager.ts
+++ b/packages/core/src/state/NetworkManager.ts
@@ -177,23 +177,24 @@ export default class NetworkManager implements Manager {
 
           // don't update state with promises started before last clear
           if (createdAt >= lastReset) {
-            /*if (action.endpoint) {
+            // we still check for controller in case someone didn't have type protection since this didn't always exist
+            if (action.endpoint && controller) {
               controller.receive(
                 action.endpoint,
                 ...(action.meta.args as Parameters<typeof action.endpoint>),
                 data,
               );
-            } TODO - once we reliably get controller */
-
-            // does this throw if the reducer fails? - no because reducer is wrapped in try/catch
-            dispatch(
-              createReceive(data, {
-                ...action.meta,
-                dataExpiryLength:
-                  action.meta.options?.dataExpiryLength ??
-                  this.dataExpiryLength,
-              }),
-            );
+            } else {
+              // does this throw if the reducer fails? - no because reducer is wrapped in try/catch
+              dispatch(
+                createReceive(data, {
+                  ...action.meta,
+                  dataExpiryLength:
+                    action.meta.options?.dataExpiryLength ??
+                    this.dataExpiryLength,
+                }),
+              );
+            }
           }
           return data;
         })


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Access to endpoint in action is useful

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
In case of users extending NetworkManager without TypeScript we conditionally check controller existance for legacy protection
