### PR TITLE
fix: Return type of useSuspense should factor in null params

### DIFF
--- a/packages/experimental/src/hooks/__tests__/useSuspense.web.tsx
+++ b/packages/experimental/src/hooks/__tests__/useSuspense.web.tsx
@@ -360,9 +360,13 @@ describe('useSuspense()', () => {
   });
 
   it('should not suspend with null params to useSuspense()', () => {
-    let article: any;
+    let article: undefined;
     const { result } = renderRestHook(() => {
-      article = useSuspense(CoolerArticleResource.detail(), null);
+      const a = useSuspense(CoolerArticleResource.detail(), null);
+      // this validates it must have void in its union type
+      // @ts-expect-error
+      () => a.pk();
+      if (!a) article = a;
       return 'done';
     });
     expect(result.current).toBe('done');

--- a/packages/experimental/src/hooks/useSuspense.ts
+++ b/packages/experimental/src/hooks/useSuspense.ts
@@ -3,6 +3,7 @@ import { StateContext, useController, ExpiryStatus } from '@rest-hooks/core';
 import {
   EndpointInterface,
   Denormalize,
+  DenormalizeNullable,
   Schema,
   FetchFunction,
 } from '@rest-hooks/endpoint';
@@ -24,8 +25,12 @@ export default function useSuspense<
   endpoint: E,
   ...args: Args
 ): E['schema'] extends Exclude<Schema, null>
-  ? Denormalize<E['schema']>
-  : ReturnType<E> {
+  ? CondNull<
+      Args[0],
+      DenormalizeNullable<E['schema']>,
+      Denormalize<E['schema']>
+    >
+  : CondNull<Args[0], undefined, ReturnType<E>> {
   const state = useContext(StateContext);
   const controller = useController();
 
@@ -72,5 +77,7 @@ export default function useSuspense<
 
   if (error) throw error;
 
-  return data;
+  return data as any;
 }
+
+type CondNull<P, A, B> = P extends null ? A : B;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Need protection in case a user passes null

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```ts
E['schema'] extends Exclude<Schema, null>
  ? CondNull<
      Args[0],
      DenormalizeNullable<E['schema']>,
      Denormalize<E['schema']>
    >
  : CondNull<Args[0], undefined, ReturnType<E>>
```