### PR TITLE
fix: useFetcher() work with zero argument Endpoint

### DIFF
--- a/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
@@ -112,6 +112,27 @@ describe('useFetcher', () => {
     await testDispatchFetch(DispatchTester, [payload]);
   });
 
+  it('should handle zero argument Endpoints', async () => {
+    const endpoint = CoolerArticleResource.list().extend({
+      fetch() {
+        return CoolerArticleResource.list().call(this as any, {});
+      },
+      url() {
+        return '';
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    function DispatchTester() {
+      const a = useFetcher(endpoint);
+      a(undefined).then(v => {
+        v[0].author;
+        //@ts-expect-error
+        v.jasfdasdf;
+      });
+      return null;
+    }
+  });
+
   it('should dispatch an action with updater in the meta if update shapes params are passed in', async () => {
     mynock.post(`/article-cooler/`).reply(201, payload);
 

--- a/packages/endpoint/src/endpoint.d.ts
+++ b/packages/endpoint/src/endpoint.d.ts
@@ -148,7 +148,11 @@ export interface EndpointInstance<
     : IfAny<M, any, IfTypeScriptLooseNull<'read', 'mutate'>>;
 
   /** @deprecated */
-  getFetchKey(params: Parameters<F>[0]): string;
+  getFetchKey(
+    ...args: Parameters<F>[0] extends undefined
+      ? []
+      : [params: Parameters<F>[0]]
+  ): string;
   /** @deprecated */
   options?: EndpointExtraOptions<F>;
 }


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #1474 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
New endpoints allow any number of arguments. Zero arguments are still valid with legacy hooks, so there's no reason to not make this work.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Update getFetchKey to be aware of the possibilities for no arguments