### PR TITLE
internal: Use bigger resources for expensive parts of CI flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,14 @@ jobs:
     docker: &docker
       # specify the version you desire here
       - image: circleci/node:16
+    resource_class: large
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v4-dependencies-{{ checksum "yarn.lock" }}
+            - v5-dependencies-{{ checksum "yarn.lock" }}
             # fallback to using the latest cache if no exact match is found
-            - v4-dependencies-
+            - v5-dependencies-
       - run:
           name: yarn install
           command: |
@@ -23,10 +24,28 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-            - packages/*/node_modules
+            - packages/core/node_modules
+            - packages/endpoint/node_modules
+            - packages/experimental/node_modules
+            - packages/graphql/node_modules
+            - packages/hooks/node_modules
+            - packages/img/node_modules
+            - packages/legacy/node_modules
+            - packages/normalizr/node_modules
+            - packages/rest/node_modules
+            - packages/rest-hooks/node_modules
+            - packages/test/node_modules
+            - packages/use-enhanced-reducer/node_modules
+            - examples/benchmark/node_modules
+            - examples/normalizr-bench/node_modules
+            - examples/normalizr-github/node_modules
+            - examples/normalizr-redux/node_modules
+            - examples/normalizr-relationships/node_modules
+            - examples/todo-app/node_modules
+            - examples/github-app/node_modules
             - ~/.cache/yarn
-          key: v4-dependencies-{{ checksum "yarn.lock" }}
-      - run: yarn run build
+          key: v5-dependencies-{{ checksum "yarn.lock" }}
+      - run: yarn run lerna run build --stream
       - persist_to_workspace:
           root: ~/
           paths:
@@ -61,13 +80,16 @@ jobs:
           at: ~/
       - run:
           command: |
+            if [ "<< parameters.react-version >>" != "beta" ]; then
             yarn add -W --dev react@<< parameters.react-version >> react-dom@<< parameters.react-version >> react-test-renderer@<< parameters.react-version >>
+            fi
       - run:
           command: |
             yarn test:ci --maxWorkers=3
 
   test_coverage:
     docker: *docker
+    resource_class: large
     steps:
       - attach_workspace:
           at: ~/
@@ -78,7 +100,7 @@ jobs:
           command: |
             curl -Os https://uploader.codecov.io/latest/linux/codecov;
             chmod +x codecov;
-            yarn run test:coverage --maxWorkers=3 --coverageReporters=text-lcov > ./lcov.info;
+            yarn run test:coverage --maxWorkers=4 --coverageReporters=text-lcov > ./lcov.info;
             if [ "$CODECOV_TOKEN" != "" ]; then
             ./codecov -t ${CODECOV_TOKEN} < ./lcov.info || true;
             else
@@ -119,7 +141,7 @@ workflows:
       - unit_tests:
           matrix:
             parameters:
-              react-version: ["^17.0.0", "next"]
+              react-version: ["^17.0.0", "beta"]
           requires:
             - setup
       - test_coverage:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    # Having many PRs at once resource starves CI
+    open-pull-requests-limit: 2
     labels:
       - "dependencies"
     allow:
@@ -31,13 +33,4 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "internal: "
-  - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/packages/normalizr/examples/redux"
-    # Check the npm registry for updates every day (weekdays)
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
-    commit-message:
-      prefix: "internal: "
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "cross-env NODE_ENV=test jest",
     "test:ci": "yarn test -- --ci",
     "test:coverage": "yarn test -- --coverage",
-    "prepare": "yarn run build:types"
+    "prepare": "yarn build:copy:ambient && ttsc --build",
+    "prepublishOnly": "lerna run build:legacy-types --stream"
   },
   "engines": {
     "node": ">=10.0"
@@ -63,10 +64,10 @@
     "mkdirp": "^1.0.4",
     "nock": "^13.1.0",
     "prettier": "^2.2.1",
-    "react": "next",
-    "react-dom": "next",
+    "react": "beta",
+    "react-dom": "beta",
     "react-native": "^0.66.0",
-    "react-test-renderer": "next",
+    "react-test-renderer": "beta",
     "redux": "^4.0.5",
     "rimraf": "^3.0.2",
     "rollup": "^2.35.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2368,7 +2368,6 @@
 
 "@lerna/conventional-commits@4.0.0", "@lerna/conventional-commits@https://github.com/ntucker/lerna-conventional-commits.git":
   version "3.16.4"
-  uid "4389120475a4f80ac8e4fbe766fa4c9644c6b1c7"
   resolved "https://github.com/ntucker/lerna-conventional-commits.git#4389120475a4f80ac8e4fbe766fa4c9644c6b1c7"
   dependencies:
     "@lerna/validation-error" "^4.0"
@@ -14705,14 +14704,14 @@ react-devtools-core@^4.13.0:
     shell-quote "^1.6.1"
     ws "^7"
 
-react-dom@next:
-  version "18.0.0-alpha-5fa4d79b0-20211008"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-alpha-5fa4d79b0-20211008.tgz#f68526d7b0b76996c7f023e08335ce495109dc5b"
-  integrity sha512-GgavXL73QUFTRB2icXROtpt7lVCeoSIIUmo63V+YvFj9QKSWFESGawgc7PfNj5yY1XQoRueIavi0+4NhaM5LdA==
+react-dom@beta:
+  version "18.0.0-beta-c1220ebdd-20211123"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-beta-c1220ebdd-20211123.tgz#e98d0e28cfc3665730b2a7abf00c087cdd41abeb"
+  integrity sha512-kY++te33IPgLbuRlVrm5uYrxla9y1lkW/icHNHD1zeSa4x0rKOqyW01HLBJPT6bN+PT89b98I5I/Qr0CXN+w6Q==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "0.21.0-alpha-5fa4d79b0-20211008"
+    scheduler "0.21.0-beta-c1220ebdd-20211123"
 
 react-error-boundary@^3.1.0:
   version "3.1.0"
@@ -14733,10 +14732,10 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-is@18.0.0-alpha-5fa4d79b0-20211008:
-  version "18.0.0-alpha-5fa4d79b0-20211008"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.0.0-alpha-5fa4d79b0-20211008.tgz#757d5b370937a7e392c2509d9da2398cf8d5038b"
-  integrity sha512-4KRPXUCMKnDb+NQSxyBnsUW9Gjtl9ht8x/mLIqedpCUxmPO1T5ejPc5UPzM9KsB1QdNmh6HV5JHyDR6Hr62N9Q==
+react-is@18.0.0-beta-c1220ebdd-20211123:
+  version "18.0.0-beta-c1220ebdd-20211123"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.0.0-beta-c1220ebdd-20211123.tgz#4a6fd0ae2a46685badcf16184ea4c835613ca845"
+  integrity sha512-G9xT8i/+JTdAviw6wdlOl32v7xoWKMsh5IsJw4QSrk967hJcHmlCdPflnkFjKxWtJ+W+au/SQchklk4rXLsQ9g==
 
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
@@ -14860,20 +14859,20 @@ react-shallow-renderer@^16.13.1:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0"
 
-react-test-renderer@next:
-  version "18.0.0-alpha-5fa4d79b0-20211008"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.0.0-alpha-5fa4d79b0-20211008.tgz#1217d7894f93a4dd02fd6f184bad006a9c99dd5e"
-  integrity sha512-jNBpvfBeHUNyZN1TCEvgB6BTen7hc5lEAVdN3kFFRfD6rbtTGWxplOPFTslscl4jSPBB3Ssx2eJ2iE36pvQ7wA==
+react-test-renderer@beta:
+  version "18.0.0-beta-c1220ebdd-20211123"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.0.0-beta-c1220ebdd-20211123.tgz#0660a2f1eb91ed03551995414b351a28d24a653c"
+  integrity sha512-GBnkCHXMHp/J0OFp7HnP7dgsaA+OK3lllGX0t5Gl+9PHsXB9ZhPTNh8HPgEhFeXpVccH8BE6d9ZeuvVIzTKdTw==
   dependencies:
     object-assign "^4.1.1"
-    react-is "18.0.0-alpha-5fa4d79b0-20211008"
+    react-is "18.0.0-beta-c1220ebdd-20211123"
     react-shallow-renderer "^16.13.1"
-    scheduler "0.21.0-alpha-5fa4d79b0-20211008"
+    scheduler "0.21.0-beta-c1220ebdd-20211123"
 
-react@next:
-  version "18.0.0-alpha-5fa4d79b0-20211008"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-alpha-5fa4d79b0-20211008.tgz#8654224eb850e7922ef297a173cb59df3f79b566"
-  integrity sha512-uYcdLFLqFqpu5bE2R37XDkJirPrVpEhVp7QV0GNNI1Nn8QwO5SoLkbTuMV3jsvYTLk+h8hpnfJu3pKB7HoFpgg==
+react@beta:
+  version "18.0.0-beta-c1220ebdd-20211123"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-beta-c1220ebdd-20211123.tgz#1577d2e59dfde826e110074c5f20160e0c1d36d9"
+  integrity sha512-yP8Lvre7RS0TXFYEyRkijpaqilwM0kMG1iEkoIWgeNyjBDMeKjmqKDFCNtXoUca0WdJ0Y+DvmjKPce5XksJMaA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -15652,10 +15651,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@0.21.0-alpha-5fa4d79b0-20211008:
-  version "0.21.0-alpha-5fa4d79b0-20211008"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0-alpha-5fa4d79b0-20211008.tgz#3192667e060b3c7cb649bc170ac82c1a3d954807"
-  integrity sha512-eQqzDNt7sXeuVmdNMow/uxuQjKdomZheuhSpG0I2+MeKgcWsnfkZMaSkrT4ZP8eHn3UFXg2LYOfX/51WA7e7Tg==
+scheduler@0.21.0-beta-c1220ebdd-20211123:
+  version "0.21.0-beta-c1220ebdd-20211123"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0-beta-c1220ebdd-20211123.tgz#6a4c3cc426f4316e5f0df448b01e99b364aa7fc7"
+  integrity sha512-3qOlWLIx2gMB5FUgCuycE7vQhXyoTsy5VF9elrsXOSvpM7j4NMYYRf9ehjsllQK+8sSmmAlXHx/8kdcA500tdA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
- Test coverage seems to be running out of memory.
- Setup is both blocking and the longest step

Details:
- cache path does not support wildcard, so expand to explicit paths
- specify resource for specific workflows to increase memory and computational power
- build step explicitly only run build as prepare will cover types
- switch react 18 specification from 'next' to 'beta'