### PR TITLE
docs: Set 6.2 as unreleased

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -75,9 +75,9 @@ module.exports = {
             return `https://github.com/coinbase/rest-hooks/edit/master/${nextVersionDocsDirPath}/${docPath}`;
           },
           path: '../docs',
-          lastVersion: 'current',
+          lastVersion: '6.1',
           versions: {
-            current: { label: '6.1', path: '' },
+            current: { label: '6.2', path: '/next' },
           },
         },
         blog: {
@@ -193,14 +193,14 @@ module.exports = {
             },
             {
               label: '6.2',
-              to: 'docs/',
-              activeBaseRegex:
-                'docs/(?!2.2|3.0|4.0|4.1|4.2|4.3|4.5|5.0|6.0|6.1|6.2)',
+              to: 'docs/next/',
+              rel: 'nofollow',
             },
             {
               label: '6.1',
-              to: 'docs/6.1/',
-              rel: 'nofollow',
+              to: 'docs/',
+              activeBaseRegex:
+                'docs/(?!2.2|3.0|4.0|4.1|4.2|4.3|4.5|5.0|6.0|6.1|6.2)',
             },
             {
               label: '6.0',


### PR DESCRIPTION
This allows release of updates to 6.1 docs without replacing the default to the yet-unreleased 6.2. Also allows people to navigate to 6.2 if they want.
