### PR TITLE
docs(fix): Google analytics integration with website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -86,6 +86,9 @@ module.exports = {
         theme: {
           customCss: ['../src/css/customTheme.css', '../src/mocks/init.js'],
         },
+        gtag: {
+          trackingID: 'UA-138752992-1',
+        },
       },
     ],
   ],
@@ -333,9 +336,6 @@ module.exports = {
         debug: process.env.NODE_ENV === 'development',
         facetFilters: ['docusaurus_tag:docs-default-current'],
       },
-    },
-    gtag: {
-      trackingID: 'UA-138752992-1',
     },
   },
 };


### PR DESCRIPTION
They moved the config in https://github.com/facebook/docusaurus/pull/5832 kinda hidden in changelog
