### PR TITLE
enhance: Fetch resolution only removes the optimistic update corresponding to that fetch

### DIFF
--- a/docs/api/Controller.md
+++ b/docs/api/Controller.md
@@ -18,12 +18,13 @@ class Controller {
   resetEntireStore: () => Promise<void>;
   receive(endpoint, ...args, response) => Promise<void>;
   receiveError(endpoint, ...args, error) => Promise<void>;
+  resolve(endpoint, { args, response, fetchedAt, error }) => Promise<void>;
   subscribe(endpoint, ...args) => Promise<void>;
   unsubscribe(endpoint, ...args) => Promise<void>;
   /*************** Data Access ***************/
   getResponse(endpoint, ...args, state)​ => { data, expiryStatus, expiresAt };
   getError(endpoint, ...args, state)​ => ErrorTypes | undefined;
-  snapshot(state: State<unknown>, fetchStart?: number): SnapshotInterface;
+  snapshot(state: State<unknown>, fetchedAt?: number): SnapshotInterface;
 }
 ```
 
@@ -224,6 +225,17 @@ useEffect(() => {
 
 Stores the result of [Endpoint](./Endpoint.md) and args as the error provided.
 
+
+## resolve(endpoint, { args, response, fetchedAt, error }) {#resolve}
+
+Resolves a specific fetch, storing the `response` in cache.
+
+This is similar to receive, except it triggers resolution of an inflight fetch.
+This means the corresponding optimistic update will no longer be applies.
+
+This is used in [NetworkManager](./NetworkManager.md), and should be used when
+processing fetch requests.
+
 ## subscribe(endpoint, ...args) {#subscribe}
 
 Marks a new subscription to a given [Endpoint](./Endpoint.md). This should increment the subscription.
@@ -357,6 +369,6 @@ export default class MyManager implements Manager {
 Gets the error, if any, for a given endpoint. Returns undefined for no errors.
 
 
-## snapshot(state, fetchStart) {#snapshot}
+## snapshot(state, fetchedAt) {#snapshot}
 
 Returns a [Snapshot](./Snapshot.md).

--- a/docs/api/Snapshot.md
+++ b/docs/api/Snapshot.md
@@ -19,7 +19,7 @@ import GenericsTabs from '@site/src/components/GenericsTabs';
 interface Snapshot {
   getResponse(endpoint, ...args)​ => { data, expiryStatus, expiresAt };
   getError(endpoint, ...args)​ => ErrorTypes | undefined;
-  fetchStart: number;
+  fetchedAt: number;
 }
 ```
 <CodeBlock className="language-typescript">{EndpointInterfaceSource}</CodeBlock>
@@ -86,6 +86,6 @@ A number representing time when it expires. Compare to Date.now().
 Gets the error, if any, for a given endpoint. Returns undefined for no errors.
 
 
-## fetchStart
+## fetchedAt
 
 When the fetch was called that resulted in this snapshot.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -482,7 +482,7 @@ pattern for improved user experience.
 
 ## Debugging
 
-<img src={require('@site/static/img/redux-devtools-logo.jpg').default} width="75" height="75" alt="redux-devtools" style={{ float: 'left', "margin-right": "var(--ifm-paragraph-margin-bottom)" }} />
+<img src={require('@site/static/img/redux-devtools-logo.jpg').default} width="75" height="75" alt="redux-devtools" style={{ float: 'left', "marginRight": "var(--ifm-paragraph-margin-bottom)" }} />
 
 Add the Redux DevTools for
 [chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)

--- a/packages/core/src/controller/createFetch.ts
+++ b/packages/core/src/controller/createFetch.ts
@@ -25,7 +25,7 @@ export default function createFetch<
     resolve,
     reject,
     promise,
-    createdAt: new Date(),
+    createdAt: Date.now(),
   };
 
   if (endpoint.update) {

--- a/packages/core/src/controller/createOptimistic.ts
+++ b/packages/core/src/controller/createOptimistic.ts
@@ -12,8 +12,10 @@ export default function createOptimistic<
   endpoint: E,
   {
     args,
+    fetchedAt,
   }: {
     args: readonly [...Parameters<E>];
+    fetchedAt: number;
   },
 ): OptimisticAction {
   const expiryLength: number = endpoint.dataExpiryLength ?? 1000;
@@ -26,6 +28,7 @@ export default function createOptimistic<
     schema: endpoint.schema,
     key: endpoint.key(...args),
     args,
+    fetchedAt,
     date: now,
     expiresAt: now + expiryLength,
     errorPolicy: endpoint.errorPolicy,

--- a/packages/core/src/controller/createReceive.ts
+++ b/packages/core/src/controller/createReceive.ts
@@ -12,6 +12,7 @@ export default function createReceive<
   options: {
     args: readonly [...Parameters<E>];
     response: Error;
+    fetchedAt?: number;
     error: true;
   },
 ): ReceiveAction;
@@ -25,6 +26,7 @@ export default function createReceive<
   options: {
     args: readonly [...Parameters<E>];
     response: ResolveType<E>;
+    fetchedAt?: number;
     error?: false;
   },
 ): ReceiveAction;
@@ -37,11 +39,13 @@ export default function createReceive<
   endpoint: E,
   {
     args,
+    fetchedAt = 0,
     response,
     error = false,
   }: {
     args: readonly [...Parameters<E>];
     response: any;
+    fetchedAt?: number;
     error?: boolean;
   },
 ): ReceiveAction {
@@ -57,6 +61,7 @@ export default function createReceive<
     schema: endpoint.schema,
     key: endpoint.key(...args),
     args,
+    fetchedAt,
     date: now,
     expiresAt: now + expiryLength,
     errorPolicy: endpoint.errorPolicy,

--- a/packages/core/src/controller/createReset.ts
+++ b/packages/core/src/controller/createReset.ts
@@ -4,6 +4,6 @@ import { RESET_TYPE } from '@rest-hooks/core/actionTypes';
 export default function createReset(): ResetAction {
   return {
     type: RESET_TYPE,
-    date: new Date(),
+    date: Date.now(),
   };
 }

--- a/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
@@ -322,7 +322,7 @@ describe('useResetter', () => {
     reset({});
     expect(dispatch).toHaveBeenCalledWith({
       type: RESET_TYPE,
-      date: new Date(),
+      date: Date.now(),
     });
   });
   it('should return the same === function each time', () => {

--- a/packages/core/src/react-integration/__tests__/hooks.web.tsx
+++ b/packages/core/src/react-integration/__tests__/hooks.web.tsx
@@ -295,7 +295,7 @@ describe('useResetter', () => {
     reset({});
     expect(dispatch).toHaveBeenCalledWith({
       type: RESET_TYPE,
-      date: new Date(),
+      date: Date.now(),
     });
   });
   it('should return the same === function each time', () => {

--- a/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
@@ -360,12 +360,14 @@ describe.each([
       jest.advanceTimersByTime(51);
       await waitForNextUpdate();
 
-      // first and second optimistic should be cleared with only third optimistic left to be layerd
+      // second optimistic should be cleared with the first and third optimistic left to be layerd
       // on top of second's network response
       expect(result.current.article).toEqual(
         CoolerArticleResource.fromJS({
           ...payload,
-          title: 'second',
+          title: 'firstoptimistic',
+          content: 'firstoptimistic',
+          tags: ['thirdoptimistic'],
         }),
       );
     });
@@ -578,7 +580,7 @@ describe.each([
         expect(result.current.fetchError).toMatchSnapshot();
       });
 
-      describe('Vector Clocks', () => {
+      describe('with timestamps', () => {
         it('should handle out of order server responses', async () => {
           jest.useFakeTimers('modern');
 
@@ -586,7 +588,7 @@ describe.each([
             id: 5,
             visType: 'graph',
             numCols: 0,
-            updatedAt: { client: Date.now(), server: Date.now() },
+            updatedAt: Date.now(),
           };
 
           const { result } = renderRestHook(
@@ -673,7 +675,7 @@ describe.each([
               id: 5,
               visType: 'line',
               numCols: 5,
-              updatedAt: { client: betweenDate, server: Date.now() },
+              updatedAt: betweenDate,
             });
             return partialPromise;
           });
@@ -687,7 +689,7 @@ describe.each([
             id: 5,
             visType: 'graph',
             numCols: 100,
-            updatedAt: { client: afterDate, server: Date.now() },
+            updatedAt: afterDate,
           };
           await act(() => {
             resolveIncrement2(finalObject);
@@ -701,7 +703,7 @@ describe.each([
               id: 5,
               visType: 'line',
               numCols: 0,
-              updatedAt: { client: 0, server: 0 },
+              updatedAt: 0,
             });
             return incrementPromise;
           });

--- a/packages/core/src/react-integration/hooks/useResetter.ts
+++ b/packages/core/src/react-integration/hooks/useResetter.ts
@@ -12,7 +12,7 @@ export default function useResetter(): () => void {
   const resetDispatcher = useCallback(() => {
     dispatch({
       type: RESET_TYPE,
-      date: new Date(),
+      date: Date.now(),
     });
   }, [dispatch]);
 

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -666,7 +666,7 @@ describe('reducer', () => {
         reject: (v: any) => null,
         resolve: (v: any) => null,
         promise: new Promise((v: any) => null),
-        createdAt: new Date(0),
+        createdAt: 0,
       },
     };
     const iniState = {
@@ -700,7 +700,34 @@ describe('reducer', () => {
     it('reset should delete all entries', () => {
       const action: ResetAction = {
         type: RESET_TYPE,
-        date: new Date(0),
+        date: Date.now(),
+      };
+      const iniState: any = {
+        ...initialState,
+        entities: {
+          [ArticleResource.key]: {
+            '10': ArticleResource.fromJS({ id: 10 }),
+            '20': ArticleResource.fromJS({ id: 20 }),
+            '25': ArticleResource.fromJS({ id: 25 }),
+          },
+          [PaginatedArticleResource.key]: {
+            hi: PaginatedArticleResource.fromJS({ id: 5 }),
+          },
+          '5': undefined,
+        },
+        results: { abc: '20' },
+      };
+      const newState = reducer(iniState, action);
+      expect(newState.results).toEqual({});
+      expect(newState.meta).toEqual({});
+      expect(newState.entities).toEqual({});
+    });
+
+    // TODO(breaking): Remove once Date support is removed from action
+    it('reset should delete all entries (legacy format)', () => {
+      const action: ResetAction = {
+        type: RESET_TYPE,
+        date: new Date(),
       };
       const iniState: any = {
         ...initialState,
@@ -747,7 +774,7 @@ describe('reducer', () => {
       expect(newState.meta).toEqual({});
       expect(newState.entities).toEqual({});
       expect(newState.lastReset).toBeDefined();
-      expect(newState.lastReset).toBeInstanceOf(Date);
+      expect(newState.lastReset).toBeGreaterThan(0);
       expect(warnspy.mock.calls).toMatchInlineSnapshot(`
 Array [
   Array [

--- a/packages/core/src/state/actions/createFetch.ts
+++ b/packages/core/src/state/actions/createFetch.ts
@@ -62,7 +62,7 @@ export default function createFetch<
     resolve,
     reject,
     promise,
-    createdAt: new Date(),
+    createdAt: Date.now(),
   };
 
   if (fetchShape.update) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -68,6 +68,7 @@ export interface ReceiveMeta<S extends Schema | undefined> {
   args?: readonly any[];
   updaters?: Record<string, UpdateFunction<S, any>>;
   update?: (result: any, ...args: any) => Record<string, (...args: any) => any>;
+  fetchedAt?: number;
   date: number;
   expiresAt: number;
   errorPolicy?: (error: any) => 'soft' | undefined;
@@ -102,6 +103,7 @@ export type OptimisticAction<
       result: any,
       ...args: any
     ) => Record<string, (...args: any) => any>;
+    fetchedAt: number;
     date: number;
     expiresAt: number;
     errorPolicy?: (error: any) => 'soft' | undefined;
@@ -112,7 +114,7 @@ export type OptimisticAction<
 
 export interface ResetAction {
   type: typeof RESET_TYPE;
-  date: Date;
+  date: number | Date;
 }
 
 interface FetchMeta<
@@ -134,7 +136,7 @@ interface FetchMeta<
   resolve: (value?: any | PromiseLike<any>) => void;
   reject: (reason?: any) => void;
   promise: PromiseLike<any>;
-  createdAt: Date;
+  createdAt: number | Date;
   optimisticResponse?: Payload;
   // indicates whether network manager processed it
   nm?: boolean;

--- a/packages/endpoint/src/SnapshotInterface.ts
+++ b/packages/endpoint/src/SnapshotInterface.ts
@@ -20,5 +20,5 @@ export default interface SnapshotInterface {
     ...args: readonly [...Parameters<E['key']>] | readonly [null]
   ) => ErrorTypes | undefined;
 
-  readonly fetchStart: number;
+  readonly fetchedAt: number;
 }

--- a/website/package.json
+++ b/website/package.json
@@ -24,10 +24,10 @@
     "@docusaurus/plugin-client-redirects": "^2.0.0-beta.14",
     "@docusaurus/preset-classic": "^2.0.0-beta.14",
     "@docusaurus/theme-live-codeblock": "^2.0.0-beta.14",
-    "@rest-hooks/endpoint": "^2.1.0",
-    "@rest-hooks/hooks": "^2.1.0",
-    "@rest-hooks/graphql": "^0.1.1",
-    "@rest-hooks/rest": "^3.0.1",
+    "@rest-hooks/endpoint": "file:../packages/endpoint",
+    "@rest-hooks/hooks": "file:../packages/hooks",
+    "@rest-hooks/graphql": "file:../packages/graphql",
+    "@rest-hooks/rest": "file:../packages/rest",
     "bignumber.js": "^9.0.2",
     "clsx": "^1.1.1",
     "msw": "^0.36.7",
@@ -35,8 +35,17 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-json-tree": "^0.16.1",
-    "rest-hooks": "^6.2.0-beta.2",
+    "rest-hooks": "file:../packages/rest-hooks",
     "typescript": "^4.5.5"
+  },
+  "resolutions": {
+    "@rest-hooks/core": "file:../packages/core",
+    "@rest-hooks/normalizr": "file:../packages/normalizr",
+    "@rest-hooks/use-enhanced-reducer": "file:../packages/use-enhanced-reducer",
+    "@rest-hooks/endpoint": "file:../packages/endpoint",
+    "@rest-hooks/hooks": "file:../packages/hooks",
+    "@rest-hooks/graphql": "file:../packages/graphql",
+    "@rest-hooks/rest": "file:../packages/rest"
   },
   "msw": {
     "workerDirectory": "static"

--- a/website/src/components/Playground/Tree.tsx
+++ b/website/src/components/Playground/Tree.tsx
@@ -29,7 +29,7 @@ export default function Output({ value }: { value: any }) {
           flex: '4 1 70%',
           margin: 0,
           padding: '0 0.5rem',
-          'background-color': isDarkTheme
+          backgroundColor: isDarkTheme
             ? 'var(--ifm-pre-background)'
             : 'rgb(41, 45, 62)',
           font: 'var(--ifm-code-font-size) / var(--ifm-pre-line-height) var(--ifm-font-family-monospace) !important',
@@ -37,7 +37,7 @@ export default function Output({ value }: { value: any }) {
         arrowContainer: ({ style }, arrowStyle) => ({
           style: {
             ...style,
-            'font-family': 'arial',
+            fontFamily: 'arial',
           },
         }),
         arrowSign: {

--- a/website/src/mocks/handlers.js
+++ b/website/src/mocks/handlers.js
@@ -1,6 +1,8 @@
 import { rest, graphql } from 'msw';
 
-const TODOS = [
+const pageInitAt = Date.now();
+
+let TODOS = [
   {
     userId: 1,
     id: 1,
@@ -31,11 +33,44 @@ const TODOS = [
     title: 'laboriosam mollitia et enim quasi adipisci quia provident illum',
     completed: false,
   },
-];
+].map(todo => ({ ...todo, updatedAt: pageInitAt }));
+
+let MAX_ID = TODOS.reduce((todo, prev) => Math.max(todo.id, prev), 0);
+
+let simulatedServerStateCount = 0;
 
 export const handlers = [
+  // todos
   rest.get('/api/todos', (req, res, ctx) => {
     return res(ctx.status(200), ctx.delay(150), ctx.json(TODOS));
+  }),
+  rest.get('/api/todos/:id', (req, res, ctx) => {
+    const { id } = req.params;
+    const todo = TODOS.find(todo => todo.id == id);
+    if (!todo) return res(ctx.status(404), ctx.delay(150));
+    return res(ctx.status(200), ctx.delay(150), ctx.json(todo));
+  }),
+  rest.patch('/api/todos/:id', (req, res, ctx) => {
+    const { id } = req.params;
+    const i = TODOS.findIndex(todo => todo.id == id);
+    if (i < 0) return res(ctx.status(404), ctx.delay(150));
+    TODOS[i] = { ...TODOS[i], updatedAt: Date.now(), ...req.body };
+    return res(ctx.status(200), ctx.delay(150), ctx.json(TODOS[i]));
+  }),
+  rest.post('/api/todos', (req, res, ctx) => {
+    TODOS.push({ id: MAX_ID++, updatedAt: Date.now(), ...req.body });
+    return res(
+      ctx.status(201),
+      ctx.delay(150),
+      ctx.json(TODOS[TODOS.length - 1]),
+    );
+  }),
+  rest.delete('/api/todos/:id', (req, res, ctx) => {
+    const { id } = req.params;
+    const i = TODOS.findIndex(todo => todo.id == id);
+    if (i < 0) return res(ctx.status(204), ctx.delay(150));
+    TODOS = TODOS.slice(0, i).concat(TODOS.slice(i + 1));
+    return res(ctx.status(200), ctx.delay(150), ctx.json(''));
   }),
 
   rest.get('/api/currentTime/:id', (req, res, ctx) => {
@@ -71,5 +106,26 @@ export const handlers = [
       ...todo,
     };
     return res(ctx.data({ updateTodo: newTodo }));
+  }),
+
+  // optimistic updates
+  rest.get('/api/count', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.delay(150),
+      ctx.json({ count: simulatedServerStateCount, updatedAt: pageInitAt }),
+    );
+  }),
+  rest.post('/api/count/increment', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      // resolve from 500ms -> 5 seconds. Represents network variance.
+      // making state computed before hand allows demonstrating out of order race conditions
+      ctx.delay(500 + Math.random() * 4500),
+      ctx.json({
+        count: ++simulatedServerStateCount,
+        updatedAt: req.body.updatedAt,
+      }),
+    );
   }),
 ];

--- a/website/src/mocks/init.js
+++ b/website/src/mocks/init.js
@@ -1,7 +1,19 @@
 if (typeof window !== 'undefined') {
   const { worker } = require('./browser');
-  worker.start();
+  worker.start({
+    onUnhandledRequest: ({ method, url }) => {
+      if (url.pathname.startsWith('/api')) {
+        console.warn(`Unhandled ${method} request to ${url}`);
+      }
+    },
+  });
 } else {
   const { server } = require('./server');
-  server.listen();
+  server.listen({
+    onUnhandledRequest: ({ method, url }) => {
+      if (url.pathname.startsWith('/api')) {
+        console.warn(`Unhandled ${method} request to ${url}`);
+      }
+    },
+  });
 }

--- a/website/static/mockServiceWorker.js
+++ b/website/static/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.36.4).
+ * Mock Service Worker (0.36.7).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/website/versioned_docs/version-5.0/introduction.md
+++ b/website/versioned_docs/version-5.0/introduction.md
@@ -451,7 +451,7 @@ const { user } = useResource(userDetail, { name: 'Fong' });
 
 ## Debugging
 
-<img src={require('@site/static/img/redux-devtools-logo.jpg').default} width="75" height="75" alt="redux-devtools" style={{ float: 'left', "margin-right": "var(--ifm-paragraph-margin-bottom)" }} />
+<img src={require('@site/static/img/redux-devtools-logo.jpg').default} width="75" height="75" alt="redux-devtools" style={{ float: 'left', "marginRight": "var(--ifm-paragraph-margin-bottom)" }} />
 
 Add the Redux DevTools for
 [chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)

--- a/website/versioned_docs/version-6.0/introduction.md
+++ b/website/versioned_docs/version-6.0/introduction.md
@@ -451,7 +451,7 @@ const { user } = useResource(userDetail, { name: 'Fong' });
 
 ## Debugging
 
-<img src={require('@site/static/img/redux-devtools-logo.jpg').default} width="75" height="75" alt="redux-devtools" style={{ float: 'left', "margin-right": "var(--ifm-paragraph-margin-bottom)" }} />
+<img src={require('@site/static/img/redux-devtools-logo.jpg').default} width="75" height="75" alt="redux-devtools" style={{ float: 'left', "marginRight": "var(--ifm-paragraph-margin-bottom)" }} />
 
 Add the Redux DevTools for
 [chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)

--- a/website/versioned_docs/version-6.1/introduction.md
+++ b/website/versioned_docs/version-6.1/introduction.md
@@ -482,7 +482,7 @@ pattern for improved user experience.
 
 ## Debugging
 
-<img src={require('@site/static/img/redux-devtools-logo.jpg').default} width="75" height="75" alt="redux-devtools" style={{ float: 'left', "margin-right": "var(--ifm-paragraph-margin-bottom)" }} />
+<img src={require('@site/static/img/redux-devtools-logo.jpg').default} width="75" height="75" alt="redux-devtools" style={{ float: 'left', "marginRight": "var(--ifm-paragraph-margin-bottom)" }} />
 
 Add the Redux DevTools for
 [chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2171,57 +2171,43 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.19.tgz#2c94db828794aa53e7a420809dac870348819233"
   integrity sha512-kHR9OHwP9WLpyC0i/WCAQCgf5hXkR9C+/21qxmrn+YwRlDRnBlqrcrFpXxhJTA9LDHJWa/FjoO2LJ12q8iWlEQ==
 
-"@rest-hooks/core@^3.1.0-beta.2":
-  version "3.1.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@rest-hooks/core/-/core-3.1.0-beta.2.tgz#29f1e0061e5c40b1d9ede18f0b994bf49d22cb8c"
-  integrity sha512-+K7xPn5zH9XDHr+LE8YKwPs0ImMkDGE1a7dgKsiWZsryEE1VXcJT6DW2v+dR1XhOVD8LXvHW3diEoUZOib1lAw==
+"@rest-hooks/core@^3.1.0-beta.3", "@rest-hooks/core@file:../packages/core":
+  version "3.1.0-beta.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@rest-hooks/endpoint" "^2.1.0"
-    "@rest-hooks/normalizr" "^8.1.0"
+    "@rest-hooks/endpoint" "^2.2.0-beta.0"
+    "@rest-hooks/normalizr" "^8.2.0-beta.0"
     "@rest-hooks/use-enhanced-reducer" "^1.1.1"
     flux-standard-action "^2.1.1"
 
-"@rest-hooks/endpoint@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@rest-hooks/endpoint/-/endpoint-2.1.0.tgz#33ae10c795ec4ada1d34bacca4b61b2d607aba5a"
-  integrity sha512-cS2k+Wy6JMx6oIEWaKWSewHSvXKN9vDn7DCMH1a8BclDTS3DiCt9N5+CEkV7ZKVI0pdWDJm136HADJnpQLmb8Q==
+"@rest-hooks/endpoint@^2.2.0-beta.0", "@rest-hooks/endpoint@file:../packages/endpoint":
+  version "2.2.0-beta.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@rest-hooks/normalizr" "^8.1.0"
+    "@rest-hooks/normalizr" "^8.2.0-beta.0"
 
-"@rest-hooks/graphql@^0.1.1":
+"@rest-hooks/graphql@file:../packages/graphql":
   version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@rest-hooks/graphql/-/graphql-0.1.1.tgz#2f25b854cf6b1a5a144aee333035aea8d1c0b29d"
-  integrity sha512-J5vu9mQSlNc+TFu9xx40SmDGPrEV4S6X4sWGjPHvww4pRknDOojcHuc7rmEglXkyWw7FtcU7rTKzs4pj3bQ0nw==
   dependencies:
     "@babel/runtime" "^7.7.2"
 
-"@rest-hooks/hooks@^2.1.0":
+"@rest-hooks/hooks@file:../packages/hooks":
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@rest-hooks/hooks/-/hooks-2.1.0.tgz#2dba91a17f7cae468c2bff80b457ff14cc1e553d"
-  integrity sha512-640qmK6e5rv5bBSshqIiAUXMVw9tLecpPhm5CaAoVoF0mCpH2DDPJFusYplc4iBWg1Tkrear7ldYxCScaJJPig==
   dependencies:
     "@babel/runtime" "^7.7.2"
 
-"@rest-hooks/normalizr@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@rest-hooks/normalizr/-/normalizr-8.1.0.tgz#50946696720c8b132d1b1a6e23972da0901e6eac"
-  integrity sha512-/RXfeMWIKGx4hIgOxtTi9ERqtkMV1gP/Jd/kTTwbL8xWSOxdDKN4fSlADMfklqQa5jM1rTw7PR1SdIzEreHpsQ==
+"@rest-hooks/normalizr@^8.2.0-beta.0", "@rest-hooks/normalizr@file:../packages/normalizr":
+  version "8.2.0-beta.0"
   dependencies:
     "@babel/runtime" "^7.7.2"
 
-"@rest-hooks/rest@^3.0.1":
+"@rest-hooks/rest@file:../packages/rest":
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@rest-hooks/rest/-/rest-3.0.1.tgz#bb37cacdd421b7aa4e3dfc48de754dc9a44deb5a"
-  integrity sha512-05fQPlaYdRr3naTJEcv3+96P1Qdsm03WtJjCr/wBe3ByupTooZ2w7qpzczp0seabWTfDewqzy/0BadM3Z1hCPg==
   dependencies:
     "@babel/runtime" "^7.7.2"
 
-"@rest-hooks/use-enhanced-reducer@^1.1.1":
+"@rest-hooks/use-enhanced-reducer@^1.1.1", "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@rest-hooks/use-enhanced-reducer/-/use-enhanced-reducer-1.1.1.tgz#d7d267ca11aa3891773e92538b16c7a4f3b55637"
-  integrity sha512-XTnLekC+2dussBo4ujvA6Y1Ii/PRMCiKIxWisizAjiDd2EaGVKSMCbImLR1BulOtQOy4+nhLuIKDV/0IvengRQ==
 
 "@sideway/address@^4.1.0":
   version "4.1.2"
@@ -9971,14 +9957,12 @@ responselike@^1.0.2:
   dependencies:
     lowercase-keys "^1.0.0"
 
-rest-hooks@^6.2.0-beta.2:
-  version "6.2.0-beta.2"
-  resolved "https://registry.yarnpkg.com/rest-hooks/-/rest-hooks-6.2.0-beta.2.tgz#9a6476a01bf7539305dd17e8df4dff939edae5a0"
-  integrity sha512-N866tbLg7SWnEVpq5XxILdPQMQHm1ow6Y5ws80rAas9B61i+iQOqeyuAORzvtAaep6y1508QCE1DTYjBM4eMrg==
+"rest-hooks@file:../packages/rest-hooks":
+  version "6.2.0-beta.3"
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@rest-hooks/core" "^3.1.0-beta.2"
-    "@rest-hooks/endpoint" "^2.1.0"
+    "@rest-hooks/core" "^3.1.0-beta.3"
+    "@rest-hooks/endpoint" "^2.2.0-beta.0"
 
 restore-cursor@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
We need to ensure only one optimistic response is removed from queue per fetch. This requires exact timestamp matching.

Previously, we did not copy the timestamp but create it twice - this means time between each resulted in them not precisely equally.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

- Add `Controller.resolve(endpoint, { args, response, fetchedAt, error })`
  - This is similar to receive, except it triggers resolution of an inflight fetch.
- Make docs site use relative package paths to use the latest packages for rest hooks
- Track fetch createdAt with timestamp as it has milisecond resolution. This is used in the receive action as 'fetchedAt' to find the specific corresponding optimistic update to filter away.
- Remove vector clocks example for now as this is only requires for edits on other clients.
