### PR TITLE
docs(fix): Correct endpoint.dataExpiryLength in getting started

### DIFF
--- a/docs/getting-started/expiry-policy.md
+++ b/docs/getting-started/expiry-policy.md
@@ -45,9 +45,9 @@ no components care about this data no action will be taken.
 
 ## Expiry Time
 
-### Endpoint.dataExpiryTime
+### Endpoint.dataExpiryLength
 
-[Endpoint.dataExpiryTime](../api/Endpoint#dataexpirylength) sets how long (in miliseconds) it takes for data
+[Endpoint.dataExpiryLength](../api/Endpoint#dataexpirylength) sets how long (in miliseconds) it takes for data
 to transition from 'fresh' to 'stale' status. Try setting it to a very low number like '50'
 to make it becomes stale almost instantly; or a very large number to stay around for a long time.
 

--- a/website/versioned_docs/version-5.0/getting-started/expiry-policy.md
+++ b/website/versioned_docs/version-5.0/getting-started/expiry-policy.md
@@ -55,7 +55,7 @@ no components care about this data no action will be taken.
 
 ## Expiry Time
 
-[Endpoint.dataExpiryTime](../api/Endpoint#dataexpirylength) sets how long (in miliseconds) it takes for data
+[Endpoint.dataExpiryLength](../api/Endpoint#dataexpirylength) sets how long (in miliseconds) it takes for data
 to transition from 'fresh' to 'stale' status. Try setting it to a very low number like '50'
 to make it becomes stale almost instantly; or a very large number to stay around for a long time.
 

--- a/website/versioned_docs/version-6.0/getting-started/expiry-policy.md
+++ b/website/versioned_docs/version-6.0/getting-started/expiry-policy.md
@@ -55,7 +55,7 @@ no components care about this data no action will be taken.
 
 ## Expiry Time
 
-[Endpoint.dataExpiryTime](../api/Endpoint#dataexpirylength) sets how long (in miliseconds) it takes for data
+[Endpoint.dataExpiryLength](../api/Endpoint#dataexpirylength) sets how long (in miliseconds) it takes for data
 to transition from 'fresh' to 'stale' status. Try setting it to a very low number like '50'
 to make it becomes stale almost instantly; or a very large number to stay around for a long time.
 

--- a/website/versioned_docs/version-6.1/getting-started/expiry-policy.md
+++ b/website/versioned_docs/version-6.1/getting-started/expiry-policy.md
@@ -45,9 +45,9 @@ no components care about this data no action will be taken.
 
 ## Expiry Time
 
-### Endpoint.dataExpiryTime
+### Endpoint.dataExpiryLength
 
-[Endpoint.dataExpiryTime](../api/Endpoint#dataexpirylength) sets how long (in miliseconds) it takes for data
+[Endpoint.dataExpiryLength](../api/Endpoint#dataexpirylength) sets how long (in miliseconds) it takes for data
 to transition from 'fresh' to 'stale' status. Try setting it to a very low number like '50'
 to make it becomes stale almost instantly; or a very large number to stay around for a long time.
 


### PR DESCRIPTION
Typo before