### PR TITLE
fix: exports.require filepath

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -28,7 +28,7 @@
     ".": {
       "node": {
         "import": "./node.mjs",
-        "require": "./dist/index.cjs"
+        "require": "./dist/index.js"
       },
       "default": "./lib/browser.js"
     },


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Missed this when moving the files around. Noticed this when experimenting with PNP for package mgmt

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Remember we already put a package.json with `{"type":"commonjs"}` in the dist dir so this should be read as cjs.