### PR TITLE
fix: Only import from explicit dependencies

### DIFF
--- a/packages/rest/src/EntityRecord.ts
+++ b/packages/rest/src/EntityRecord.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { Entity } from '@rest-hooks/normalizr';
-import type { AbstractInstanceType } from '@rest-hooks/normalizr';
+import { Entity } from '@rest-hooks/endpoint';
+import type { AbstractInstanceType } from '@rest-hooks/endpoint';
 
 const DefinedMembersKey = Symbol('Defined Members');
 const UniqueIdentifierKey = Symbol('unq');

--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -1,7 +1,7 @@
-import { schema } from '@rest-hooks/normalizr';
-import type { AbstractInstanceType, Schema } from '@rest-hooks/normalizr';
-import { Endpoint } from '@rest-hooks/endpoint';
+import { Endpoint, schema } from '@rest-hooks/endpoint';
 import type {
+  AbstractInstanceType,
+  Schema,
   EndpointExtraOptions,
   SchemaDetail,
   SchemaList,

--- a/packages/rest/src/legacy.ts
+++ b/packages/rest/src/legacy.ts
@@ -1,5 +1,5 @@
 import type { EndpointExtraOptions } from '@rest-hooks/endpoint';
-import { Schema } from '@rest-hooks/normalizr';
+import { Schema } from '@rest-hooks/endpoint';
 
 /** Defines the shape of a network request */
 export interface FetchShape<

--- a/packages/rest/src/types.ts
+++ b/packages/rest/src/types.ts
@@ -1,5 +1,4 @@
-import { Schema } from '@rest-hooks/normalizr';
-import { EndpointInstance, FetchFunction } from '@rest-hooks/endpoint';
+import { EndpointInstance, FetchFunction, Schema } from '@rest-hooks/endpoint';
 
 export type RestFetch<
   P = any,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Newer tools are stricter about this sort of thing.
