### PR TITLE
enhance: useLoading() should consume rejections

### DIFF
--- a/packages/hooks/src/__tests__/useLoading.ts
+++ b/packages/hooks/src/__tests__/useLoading.ts
@@ -84,7 +84,10 @@ describe('useLoading()', () => {
     function fun(value: string) {
       return new Promise<string>((resolve, reject) =>
         setTimeout(() => reject(error), 1000),
-      );
+      ).catch(err => {
+        rejectedError = err;
+        throw err;
+      });
     }
     let rejectedError: Error | null = null;
     const { result, waitForNextUpdate } = renderHook(() => {
@@ -93,9 +96,7 @@ describe('useLoading()', () => {
     const wrappedFunc = result.current[0];
     expect(result.current[1]).toBe(false);
     act(() => {
-      wrappedFunc('test string').catch(err => {
-        rejectedError = err;
-      });
+      wrappedFunc('test string');
     });
     expect(result.current[1]).toBe(true);
     act(() => {
@@ -114,7 +115,10 @@ describe('useLoading()', () => {
     function fun(value: string) {
       return new Promise<string>((resolve, reject) =>
         setTimeout(() => reject(error), 1000),
-      );
+      ).catch(err => {
+        rejectedError = err;
+        throw err;
+      });
     }
     let rejectedError: Error | null = null;
     const { result, waitForNextUpdate } = renderHook(() => {
@@ -123,9 +127,7 @@ describe('useLoading()', () => {
     const wrappedFunc = result.current[0];
     expect(result.current[1]).toBe(false);
     act(() => {
-      wrappedFunc('test string').catch(err => {
-        rejectedError = err;
-      });
+      wrappedFunc('test string');
     });
     expect(result.current[1]).toBe(true);
     act(() => {

--- a/packages/hooks/src/useLoading.ts
+++ b/packages/hooks/src/useLoading.ts
@@ -39,7 +39,6 @@ export default function useLoading<F extends (...args: any) => Promise<any>>(
       ret = await func(...args);
     } catch (e: any) {
       setError(e);
-      throw e;
     } finally {
       if (isMountedRef.current) {
         setLoading(false);


### PR DESCRIPTION
BREAKING CHANGE: useLoading() consumes all promise rejections

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Unhandled errors reach the top.  Without handling the error ourselves we force users to try/catch just to prevent bubbling.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Consume errors. Users can still handle errors differently from within the function passed to useLoading.
