### PR TITLE
fix: Compatibility with webpack builds for test

### DIFF
--- a/packages/test/src/mockState.ts
+++ b/packages/test/src/mockState.ts
@@ -117,11 +117,13 @@ export default function mockInitialState(results: Fixture[]) {
   ) => State<unknown>;
   // >=6.1 of Rest Hooks / >=3.1 of RH/core
   if ('createReducer' in RestHooks) {
-    reducer = RestHooks.createReducer(new RestHooks.Controller());
+    // `{...RestHooks}` blocks webpack from barfing during compilation if createReducer export isn't available
+    reducer = { ...RestHooks }.createReducer(new RestHooks.Controller());
     // previous versions
   } else {
     reducer = (RestHooks as any).reducer;
   }
+
   const mockState = results.reduce((acc, fixture) => {
     const { action } = actionFromFixture(fixture);
     return reducer(acc, action);


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
```bash
export 'createReducer' (imported as 'RestHooks') was not found in '@rest-hooks/core' (possible exports: CacheProvider, Controller, ControllerContext, DELETED, DenormalizeCacheContext, DispatchContext, Endpoint, Entity, ExpiryStatus, Index, NetworkManager, ResetError, StateContext, __INTERNAL__, actionTypes, applyManager, createFetch, createReceive, createReceiveError, hasUsableData, initialState, isEntity, reducer, schema, useCache, useController, useDenormalized, useError, useFetchDispatcher, useFetcher, useInvalidateDispatcher, useInvalidator, useMeta, usePromisifiedDispatch, useResetter, useResource, useRetrieve, useSubscription)
 @ ../../node_modules/@rest-hooks/test/lib/browser.js 2:0-46 4:0-42
 @ ./src/pages/PostDetail/post.stories.tsx 30:0-48 67:27-39
 @ ././ sync ^\.(?:(?:^%7C\/%7C(?:(?:(?%21(?:^%7C\/)\.).)*?)\/)(?%21\.)(?=.)[^/]*?\.stories\.tsx)$ ./src/pages/PostDetail/post.stories.tsx
 @ ./generated-stories-entry.js 9:37-142

webpack 5.68.0 compiled with 1 error in 14686 ms
    at HarmonyImportSpecifierDependency.getLinkingErrors (/home/ntucker/src/anansi/node_modules/webpack/lib/dependencies/HarmonyImportDependency.js:160:8)
    at HarmonyImportSpecifierDependency._getErrors (/home/ntucker/src/anansi/node_modules/webpack/lib/dependencies/HarmonyImportSpecifierDependency.js:202:15)
    at HarmonyImportSpecifierDependency.getErrors (/home/ntucker/src/anansi/node_modules/webpack/lib/dependencies/HarmonyImportSpecifierDependency.js:191:16)
    at Compilation.reportDependencyErrorsAndWarnings (/home/ntucker/src/anansi/node_modules/webpack/lib/Compilation.js:3139:22)
    at /home/ntucker/src/anansi/node_modules/webpack/lib/Compilation.js:2726:28
    at eval (eval at create (/home/ntucker/src/anansi/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:50:1)
    at /home/ntucker/src/anansi/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:385:11
    at /home/ntucker/src/anansi/node_modules/neo-async/async.js:2830:7
    at Object.each (/home/ntucker/src/anansi/node_modules/neo-async/async.js:2850:39)
    at /home/ntucker/src/anansi/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:361:18
    at /home/ntucker/src/anansi/node_modules/neo-async/async.js:2830:7
    at done (/home/ntucker/src/anansi/node_modules/neo-async/async.js:2865:11)
    at /home/ntucker/src/anansi/node_modules/neo-async/async.js:2818:7
    at /home/ntucker/src/anansi/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:93:11
    at /home/ntucker/src/anansi/node_modules/webpack/lib/Cache.js:85:6
    at /home/ntucker/src/anansi/node_modules/webpack/lib/Cache.js:39:11

ModuleDependencyError: export 'createReducer' (imported as 'RestHooks') was not found in '@rest-hooks/core' (possible exports: CacheProvider, Controller, ControllerContext, DELETED, DenormalizeCacheContext, DispatchContext, Endpoint, Entity, ExpiryStatus, Index, NetworkManager, ResetError, StateContext, __INTERNAL__, actionTypes, applyManager, createFetch, createReceive, createReceiveError, hasUsableData, initialState, isEntity, reducer, schema, useCache, useController, useDenormalized, useError, useFetchDispatcher, useFetcher, useInvalidateDispatcher, useInvalidator, useMeta, usePromisifiedDispatch, useResetter, useResource, useRetrieve, useSubscription)
    at Compilation.reportDependencyErrorsAndWarnings (/home/ntucker/src/anansi/node_modules/webpack/lib/Compilation.js:3144:21)
    at /home/ntucker/src/anansi/node_modules/webpack/lib/Compilation.js:2726:28
    at eval (eval at create (/home/ntucker/src/anansi/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:50:1)
    at /home/ntucker/src/anansi/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:385:11
    at /home/ntucker/src/anansi/node_modules/neo-async/async.js:2830:7
    at Object.each (/home/ntucker/src/anansi/node_modules/neo-async/async.js:2850:39)
    at /home/ntucker/src/anansi/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:361:18
    at /home/ntucker/src/anansi/node_modules/neo-async/async.js:2830:7
    at done (/home/ntucker/src/anansi/node_modules/neo-async/async.js:2865:11)
    at /home/ntucker/src/anansi/node_modules/neo-async/async.js:2818:7
    at /home/ntucker/src/anansi/node_modules/webpack/lib/FlagDependencyExportsPlugin.js:93:11
    at /home/ntucker/src/anansi/node_modules/webpack/lib/Cache.js:85:6
    at /home/ntucker/src/anansi/node_modules/webpack/lib/Cache.js:39:11
    at /home/ntucker/src/anansi/node_modules/webpack/lib/cache/IdleFileCachePlugin.js:77:9
    at /home/ntucker/src/anansi/node_modules/webpack/lib/Cache.js:88:6
    at eval (eval at create (/home/ntucker/src/anansi/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:30:1)

```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Spreading avoid webpack's static analyzer barfing because it does not exist