### PR TITLE
fix: InvalidIfStale should be respected in no-schema endpoints

### DIFF
--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -264,7 +264,7 @@ export default class Controller {
         data: results,
         expiryStatus: meta?.invalidated
           ? ExpiryStatus.Invalid
-          : cacheResults
+          : cacheResults && !endpoint.invalidIfStale
           ? ExpiryStatus.Valid
           : ExpiryStatus.InvalidIfStale,
         expiresAt: expiresAt || 0,


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
So rarely don't use endpoints with no schema so just noticed this. InvalidIfStale should be suspending on stale data for endpoints with no schema.
