### PR TITLE
feat: Add component prop to Img

### DIFF
--- a/packages/img/src/Img.tsx
+++ b/packages/img/src/Img.tsx
@@ -1,12 +1,23 @@
-import React, { ImgHTMLAttributes } from 'react';
+import React from 'react';
 import { useResource } from '@rest-hooks/core';
 
 import getImage from './getImage';
 
-export default function Img(
-  props: ImgHTMLAttributes<HTMLImageElement>,
-): React.ReactElement {
-  const { src, alt } = props;
-  useResource(getImage, src ? { src } : null);
-  return <img alt={alt} {...props} />;
+type Props<
+  C extends
+    | keyof JSX.IntrinsicElements
+    | React.JSXElementConstructor<{ src: string }> = 'img',
+> = React.ComponentProps<C> & { component: C };
+
+export default function Img<
+  C extends
+    | keyof JSX.IntrinsicElements
+    | React.JSXElementConstructor<any> = 'img',
+>(props: Props<C>): React.ReactElement {
+  const { component, ...rest } = props;
+  useResource(getImage, rest.src ? { src: rest.src } : null);
+  return React.createElement(component, rest);
 }
+Img.defaultProps = {
+  component: 'img',
+};


### PR DESCRIPTION
Fixes #1723 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
When using design systems sometimes you want to use a specific element to render your media.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Using the same signature as `React.ComponentProps` generic allows us to ensure prop enforcement for both components and 'string' components.