### PR TITLE
fix: Loosen PromiseifyMiddleware types to only what is needed

### DIFF
--- a/packages/rest-hooks/src/react-integration/provider/PromiseifyMiddleware.ts
+++ b/packages/rest-hooks/src/react-integration/provider/PromiseifyMiddleware.ts
@@ -1,8 +1,8 @@
 import React from 'react';
-import { MiddlewareAPI, Dispatch } from '@rest-hooks/core';
+import { Dispatch } from '@rest-hooks/core';
 
 const PromiseifyMiddleware =
-  <R extends React.Reducer<any, any>>(_: MiddlewareAPI<R>) =>
+  <R extends React.Reducer<any, any>>(_: unknown) =>
   (next: Dispatch<R>) =>
   (action: React.ReducerAction<R>): Promise<void> => {
     next(action);


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Previously it imported `MiddlewareAPI` from @rest-hooks/core which now has controller type. The controller is actually not used at this point because it's redux-compatible middlewares, so this was causing typing errors with redux setup.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Since we don't actually use the middleware api, let it match anything with `unknown`.