### PR TITLE
fix: Resource.url properties are enumerable when provided

### DIFF
--- a/packages/experimental/src/rest/BaseResource.ts
+++ b/packages/experimental/src/rest/BaseResource.ts
@@ -52,8 +52,6 @@ export default abstract class BaseResource extends EntityRecord {
   /** URL to find this SimpleResource */
   declare readonly url: string;
 
-  private declare __url?: string;
-
   /** Get the url for a SimpleResource
    *
    * Default implementation conforms to common REST patterns
@@ -236,21 +234,24 @@ export default abstract class BaseResource extends EntityRecord {
       }),
     );
   }
-}
 
-// We're only allowing this to get set for descendants but
-// by default we want Typescript to treat it as readonly.
-Object.defineProperty(BaseResource.prototype, 'url', {
-  get(): string {
-    if (this.__url !== undefined) return this.__url;
-    // typescript thinks constructor is just a function
-    const Static = this.constructor as typeof BaseResource;
-    return Static.url(this);
-  },
-  set(url: string) {
-    this.__url = url;
-  },
-});
+  static {
+    Object.defineProperty(this.prototype, 'url', {
+      get(): string {
+        // typescript thinks constructor is just a function
+        const Static = this.constructor as typeof BaseResource;
+        return Static.url(this);
+      },
+      set(v: string) {
+        Object.defineProperty(this, 'url', {
+          value: v,
+          writable: true,
+          enumerable: true,
+        });
+      },
+    });
+  }
+}
 
 const proto = Object.prototype;
 const gpo = Object.getPrototypeOf;

--- a/packages/experimental/src/rest/__tests__/Resource.test.ts
+++ b/packages/experimental/src/rest/__tests__/Resource.test.ts
@@ -67,6 +67,10 @@ export class PaginatedArticleResource extends Resource {
   }
 }
 
+export class UrlArticleResource extends PaginatedArticleResource {
+  readonly url: string = 'happy.com';
+}
+
 describe('Resource', () => {
   const renderRestHook: ReturnType<typeof makeRenderRestHook> =
     makeRenderRestHook(makeCacheProvider);
@@ -244,5 +248,22 @@ describe('Resource', () => {
     mynock.delete(`/article-paginated/500`).reply(204, undefined);
     const res = await PaginatedArticleResource.delete()({ id: 500 });
     expect(res).toEqual({ id: 500 });
+  });
+
+  it('should spread `url` member', () => {
+    const entity = UrlArticleResource.fromJS({ url: 'five' });
+    const spread = { ...entity };
+    expect(spread.url).toBe('five');
+    expect(Object.prototype.hasOwnProperty.call(entity, 'url')).toBeTruthy();
+  });
+
+  it('should not spread `url` member if not a member', () => {
+    const entity = PaginatedArticleResource.fromJS({ id: 5, title: 'five' });
+    expect(entity.url).toMatchInlineSnapshot(
+      `"http://test.com/article-paginated/5"`,
+    );
+    const spread = { ...entity };
+    expect(spread.url).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(entity, 'url')).toBeFalsy();
   });
 });

--- a/packages/rest/src/SimpleResource.ts
+++ b/packages/rest/src/SimpleResource.ts
@@ -1,11 +1,11 @@
 import { Endpoint, schema } from '@rest-hooks/endpoint';
 import type {
-  AbstractInstanceType,
   Schema,
   EndpointExtraOptions,
   SchemaDetail,
   SchemaList,
 } from '@rest-hooks/endpoint';
+import type { AbstractInstanceType } from '@rest-hooks/endpoint';
 import EntityRecord from '@rest-hooks/rest/EntityRecord';
 import { ReadShape, MutateShape, DeleteShape } from '@rest-hooks/rest/legacy';
 import { NotImplementedError } from '@rest-hooks/rest/errors';
@@ -46,8 +46,6 @@ export default abstract class SimpleResource extends EntityRecord {
 
   /** URL to find this SimpleResource */
   declare readonly url: string;
-
-  private declare __url?: string;
 
   /** Get the url for a SimpleResource
    *
@@ -377,21 +375,24 @@ export default abstract class SimpleResource extends EntityRecord {
     const fetch = endpoint.fetch.bind(endpoint as any);
     return { ...endpoint, fetch };
   }
-}
 
-// We're only allowing this to get set for descendants but
-// by default we want Typescript to treat it as readonly.
-Object.defineProperty(SimpleResource.prototype, 'url', {
-  get(): string {
-    if (this.__url !== undefined) return this.__url;
-    // typescript thinks constructor is just a function
-    const Static = this.constructor as typeof SimpleResource;
-    return Static.url(this);
-  },
-  set(url: string) {
-    this.__url = url;
-  },
-});
+  static {
+    Object.defineProperty(this.prototype, 'url', {
+      get(): string {
+        // typescript thinks constructor is just a function
+        const Static = this.constructor as typeof SimpleResource;
+        return Static.url(this);
+      },
+      set(v: string) {
+        Object.defineProperty(this, 'url', {
+          value: v,
+          writable: true,
+          enumerable: true,
+        });
+      },
+    });
+  }
+}
 
 const proto = Object.prototype;
 const gpo = Object.getPrototypeOf;

--- a/packages/rest/src/__tests__/resource-endpoint.ts
+++ b/packages/rest/src/__tests__/resource-endpoint.ts
@@ -75,6 +75,23 @@ describe('Resource', () => {
     expect(urlArticle.url).toBe('five');
   });
 
+  it('should spread `url` member', () => {
+    const entity = UrlArticleResource.fromJS({ url: 'five' });
+    const spread = { ...entity };
+    expect(spread.url).toBe('five');
+    expect(Object.prototype.hasOwnProperty.call(entity, 'url')).toBeTruthy();
+  });
+
+  it('should not spread `url` member if not a member', () => {
+    const entity = CoolerArticleResource.fromJS({ id: 5, title: 'five' });
+    expect(entity.url).toMatchInlineSnapshot(
+      `"http://test.com/article-cooler/5"`,
+    );
+    const spread = { ...entity };
+    expect(spread.url).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(entity, 'url')).toBeFalsy();
+  });
+
   it('should convert class to string', () => {
     expect(CoolerArticleResource.toString()).toBeDefined();
     expect(CoolerArticleResource.toString()).toMatchInlineSnapshot(


### PR DESCRIPTION
Fixes #1727 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Resources should return the same object initialized with fromJS() when they are enumerated through spread. This matches normally expected behavior.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We can still provide a non-enumerable url getter in the prototype by making the setter define url in the instance with `Object.defineProperty`. Previous attempts to do this failed due to not using the special method. We also test hasOwnProperty() behavior