### PR TITLE
fix: Expiry defaults for useSuspense() should match useResource()

### DIFF
--- a/packages/core/src/controller/createReceive.ts
+++ b/packages/core/src/controller/createReceive.ts
@@ -50,8 +50,8 @@ export default function createReceive<
   },
 ): ReceiveAction {
   const expiryLength: number = error
-    ? endpoint.errorExpiryLength ?? 60000
-    : endpoint.dataExpiryLength ?? 1000;
+    ? endpoint.errorExpiryLength ?? 1000
+    : endpoint.dataExpiryLength ?? 60000;
   /* istanbul ignore next */
   if (process.env.NODE_ENV === 'development' && expiryLength < 0) {
     throw new Error('Negative expiry length are not allowed.');


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Noticing fetching was increasing when moving to useSuspense(). Realized, the defaults in useSuspense() had error and success expiry times reversed from the defaults specified here: https://github.com/coinbase/rest-hooks/blob/master/packages/core/src/state/NetworkManager.ts#L48

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Now:
1 minute for success
1 second for error