### PR TITLE
fix: lastReset should serialize

### DIFF
--- a/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
@@ -20,7 +20,7 @@ Object {
     },
   },
   "indexes": Object {},
-  "lastReset": -Infinity,
+  "lastReset": 0,
   "meta": Object {
     "http://test.com/article-cooler/5": Object {
       "date": 50,

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -5,7 +5,7 @@ Object {
   "entities": Object {},
   "entityMeta": Object {},
   "indexes": Object {},
-  "lastReset": -Infinity,
+  "lastReset": 0,
   "meta": Object {
     "http://test.com/article/20": Object {
       "date": 5000000000,
@@ -39,7 +39,7 @@ Object {
     },
   },
   "indexes": Object {},
-  "lastReset": -Infinity,
+  "lastReset": 0,
   "meta": Object {
     "http://test.com/article/20": Object {
       "date": 5000000000,

--- a/packages/core/src/state/__tests__/networkManager.ts
+++ b/packages/core/src/state/__tests__/networkManager.ts
@@ -14,6 +14,13 @@ describe('NetworkManager', () => {
   afterAll(() => {
     manager.cleanup();
   });
+  let errorspy: jest.SpyInstance;
+  beforeEach(() => {
+    errorspy = jest.spyOn(global.console, 'error');
+  });
+  afterEach(() => {
+    errorspy.mockRestore();
+  });
 
   it('getState() should have initialState before middleware run', () => {
     class Hacked extends NetworkManager {
@@ -323,6 +330,26 @@ describe('NetworkManager', () => {
         const { meta } = dispatch.mock.calls[0][0];
         expect(meta.expiresAt - meta.date).toBe(7);
       }
+    });
+
+    it('getLastReset() should handle Date object', async () => {
+      const mgr = new NetworkManager();
+      jest.spyOn(mgr, 'getState' as any).mockImplementation((): any => ({
+        ...initialState,
+        lastReset: new Date(0),
+      }));
+
+      expect((mgr as any).getLastReset()).toBeLessThan(Date.now());
+    });
+
+    it('getLastReset() should handle null', async () => {
+      const mgr = new NetworkManager();
+      jest.spyOn(mgr, 'getState' as any).mockImplementation((): any => ({
+        ...initialState,
+        lastReset: null,
+      }));
+
+      expect((mgr as any).getLastReset()).toBeLessThan(Date.now());
     });
   });
 });

--- a/packages/core/src/state/createReducer.ts
+++ b/packages/core/src/state/createReducer.ts
@@ -26,7 +26,7 @@ export const initialState: State<unknown> = {
   meta: {},
   entityMeta: {},
   optimistic: [],
-  lastReset: -Infinity,
+  lastReset: 0,
 };
 
 export default function createReducer(controller: Controller) {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Store must be 100% serializable to make SSR work.

I ran into this issue when building out React 18 SSR. The fetches would all stall. After investigation I realized -Infinity serializes to null since it isn't part of JSON spec to have infinity.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Since the error is so catastrophic but not visible, we do two fold protection:

- Assume nothing about correctness of cache and do comprehensive checks in getLastReset()
- Use 0 as initial value. This should be just as sufficient as -Infinity since time is currently well in the future of 1970.