### PR TITLE
enhance: Use BackupBoundary to help debug setup issues

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
   useMeta,
   useError,
   CacheProvider,
+  BackupBoundary,
   useInvalidator,
   useInvalidateDispatcher,
   useResetter,

--- a/packages/core/src/react-integration/provider/index.ts
+++ b/packages/core/src/react-integration/provider/index.ts
@@ -1,3 +1,4 @@
 import CacheProvider from '@rest-hooks/core/react-integration/provider/CacheProvider';
+import BackupBoundary from '@rest-hooks/core/react-integration/provider/BackupBoundary';
 
-export { CacheProvider };
+export { CacheProvider, BackupBoundary };

--- a/packages/rest-hooks/src/react-integration/provider/ExternalCacheProvider.tsx
+++ b/packages/rest-hooks/src/react-integration/provider/ExternalCacheProvider.tsx
@@ -8,6 +8,7 @@ import {
   usePromisifiedDispatch,
   DenormalizeCacheContext,
   Controller,
+  BackupBoundary,
 } from '@rest-hooks/core';
 import React, {
   ReactNode,
@@ -66,7 +67,7 @@ export default function ExternalCacheProvider<S>({
       <StateContext.Provider value={state}>
         <ControllerContext.Provider value={controller}>
           <DenormalizeCacheContext.Provider value={controller.globalCache}>
-            {children}
+            <BackupBoundary>{children}</BackupBoundary>
           </DenormalizeCacheContext.Provider>
         </ControllerContext.Provider>
       </StateContext.Provider>


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Triggered by hydration mismatch which occurs when Suspense boundaries don't match during SSR hydration.

BackupBoundary was originally added to help with people missing Suspense in their setup. However, we missed adding it to ExternalCacheProvider. That alone is enough to add, however, for SSR to hydrate an ExternalCacheProvider into a CacheProvider, one must ensure the same amount and placement of Suspense, which makes this even more critical as concurrent partial hydration outright disables when those don't match.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Export from core. Use in ExternalCacheProvider