### PR TITLE
fix: Job permissions for codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,8 +24,15 @@ on:
   schedule:
     - cron: '25 22 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read # for github/codeql-action/init to get workflow details
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

[StepSecurity](https://github.com/step-security) is working on securing GitHub Actions and [OSSF Scorecards](https://github.com/ossf/scorecard) recommends using the StepSecurity [secure-workflows online tool](https://app.stepsecurity.io/) to improve the security of GitHub workflows.

This repository has a Scorecards score of 6.5/10 with 10 being the most secure. The `Token-Permissions` category has a score of 0/10. The link to the score is [here](https://deps.dev/npm/rest-hooks). 

We have fixed one of the repo's workflows for you by adding permissions for the involved jobs. You can secure the rest of the workflows for improved security by using the StepSecurity [online tool](https://app.stepsecurity.io/).

