### PR TITLE
feat: Entity.useIncoming() for race condition handling

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -39,7 +39,7 @@ export class VisSettings extends Resource implements Vis {
   static urlRoot = 'http://test.com/vis-settings/';
 
   static merge(existing: any, incoming: any) {
-    if (existing.updatedAt < incoming.updatedAt) {
+    if (existing.updatedAt <= incoming.updatedAt) {
       return {
         ...existing,
         ...incoming,

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -38,14 +38,13 @@ export class VisSettings extends Resource implements Vis {
 
   static urlRoot = 'http://test.com/vis-settings/';
 
-  static merge(existing: any, incoming: any) {
-    if (existing.updatedAt <= incoming.updatedAt) {
-      return {
-        ...existing,
-        ...incoming,
-      };
-    }
-    return existing;
+  static useIncoming(
+    existingMeta: { date: number },
+    incomingMeta: { date: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return existing.updatedAt <= incoming.updatedAt;
   }
 
   protected static endpointMutate(): RestEndpoint<

--- a/docs/api/Entity.md
+++ b/docs/api/Entity.md
@@ -124,20 +124,18 @@ pk() {
 This defines the key for the Entity itself, rather than an instance. This needs to be a globally
 unique value.
 
-### static merge(existing, incoming, existingMeta, incomingMeta): mergedValue {#merge}
+### static useIncoming(existingMeta, incomingMeta, existing, incoming): mergedValue {#useincoming}
 
 ```typescript
-static merge<T extends typeof SimpleRecord>(
-  existing: InstanceType<T>,
-  incoming: InstanceType<T>,
+static useIncoming(
   existingMeta: { date: number },
   incomingMeta: { date: number },
-  ) => InstanceType<T>
+  existing: any,
+  incoming: any,
+) {
+  return existingMeta.date <= incomingMeta.date;
+}
 ```
-
-Merge is used to resolve the same entity. This can be because it was previously put in the cache,
-or it was found in multiple places nested in one response. By default it is the SimpleRecord merge, which
-prefers values from the newer item but only if they are actually set.
 
 Override this to change the algorithm - for instance if having the absolutely correct latest value is important,
 adding a timestamp to the entity and then using it to select the return value will solve any race conditions.
@@ -151,15 +149,29 @@ class LatestPriceEntity extends Entity {
   readonly price: string = '0.0';
   readonly symbol: string = '';
 
-  static merge<T extends typeof SimpleRecord>(
-    existing: InstanceType<T>,
-    incoming: InstanceType<T>,
+  static useIncoming(
+    existingMeta: { date: number },
+    incomingMeta: { date: number },
+    existing: any,
+    incoming: any,
   ) {
-    if (existing.timestamp > incoming.timestamp) return existing;
-    return incoming;
+    return existing.timestamp <= incoming.timestamp;
   }
 }
 ```
+
+### static merge(existing, incoming): mergedValue {#merge}
+
+```typescript
+static merge<T extends typeof SimpleRecord>(
+  existing: InstanceType<T>,
+  incoming: InstanceType<T>,
+  ) => InstanceType<T>
+```
+
+Merge is used to resolve the same entity. This can be because it was previously put in the cache,
+or it was found in multiple places nested in one response. By default it is the SimpleRecord merge, which
+prefers values from the newer item but only if they are actually set.
 
 ### static validate(processedEntity): errorMessage? {#validate}
 

--- a/docs/guides/optimistic-updates.md
+++ b/docs/guides/optimistic-updates.md
@@ -260,7 +260,7 @@ The client can then choose to ignore responses that are out of date by their tim
 ### Tracking order with updatedAt
 
 To handle potential out of order resolutions, we can track the last update time in `updatedAt`.
-Overriding our [merge](../api/Entity.md#merge), we can check which data is newer, and disregard old data
+Overriding our [useIncoming](../api/Entity.md#useincoming), we can check which data is newer, and disregard old data
 that resolves out of order.
 
 We use [snap.fetchedAt](../api/Snapshot.md#fetchedat) in our [getOptimisticResponse](../api/Endpoint.md#getoptimisticresponse). This respresents the moment the fetch is triggered,
@@ -277,14 +277,8 @@ class CountEntity extends Entity {
     return `SINGLETON`;
   }
 
-  static merge(existing, incoming) {
-    if (existing.updatedAt < incoming.updatedAt) {
-      return {
-        ...existing,
-        ...incoming,
-      };
-    }
-    return existing;
+  static useIncoming(existingMeta, incomingMeta, existing, incoming) {
+    return existing.updatedAt <= incoming.updatedAt;
   }
 }
 const getCount = new Endpoint(

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ const baseConfig = {
     'packages/test',
     'packages/experimental',
     'packages/graphql',
+    'packages/ssr',
     'packages/legacy/src/resource',
     'packages/core/src/react-integration/hooks/hasUsableData',
   ],

--- a/packages/core/src/controller/createOptimistic.ts
+++ b/packages/core/src/controller/createOptimistic.ts
@@ -18,7 +18,7 @@ export default function createOptimistic<
     fetchedAt: number;
   },
 ): OptimisticAction {
-  const expiryLength: number = endpoint.dataExpiryLength ?? 1000;
+  const expiryLength: number = endpoint.dataExpiryLength ?? 60000;
   /* istanbul ignore next */
   if (process.env.NODE_ENV === 'development' && expiryLength < 0) {
     throw new Error('Negative expiry length are not allowed.');

--- a/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
@@ -307,11 +307,6 @@ describe.each([
                 return new Promise(resolve => {
                   resolves.push(resolve);
                 });
-                /*return Promise.resolve({
-                ...payload,
-                title: 'first',
-                content: 'first',
-              })*/
               },
             }),
             params,
@@ -384,7 +379,9 @@ describe.each([
       );
 
       // resolve second request while first is in flight
-      act(() => resolves[1]({ ...payload, title: 'second' }));
+      act(() => {
+        setTimeout(() => resolves[1]({ ...payload, title: 'second' }), 1);
+      });
       await act(() => fetches[1]);
 
       // first and second optimistic should be cleared with only third optimistic left to be layerd
@@ -416,6 +413,16 @@ describe.each([
     });
 
     describe('race conditions', () => {
+      let errorspy: jest.SpyInstance;
+      beforeEach(() => {
+        errorspy = jest
+          .spyOn(global.console, 'error')
+          .mockImplementation(() => {});
+      });
+      afterEach(() => {
+        errorspy.mockRestore();
+      });
+
       class Toggle extends Entity {
         readonly id: number = 0;
         readonly visible: boolean = true;
@@ -725,7 +732,7 @@ describe.each([
 
           expect(result.current.vis?.visType).toEqual('line');
           // the server is not aware of our client's last increment, so we +1 to response
-          expect(result.current.vis?.numCols).toEqual(6);
+          expect(result.current.vis?.numCols).toEqual(7);
 
           jest.advanceTimersByTime(100);
           const finalObject = {

--- a/packages/core/src/state/createReducer.ts
+++ b/packages/core/src/state/createReducer.ts
@@ -93,7 +93,6 @@ export default function createReducer(controller: Controller) {
         }
         try {
           let payload: any;
-          let meta: State<unknown>['meta'][string];
           // for true receives payload is contained in action
           if (action.type === OPTIMISTIC_TYPE) {
             if (!action.endpoint.getOptimisticResponse) return state;
@@ -114,20 +113,6 @@ export default function createReducer(controller: Controller) {
             }
           } else {
             payload = action.payload;
-          }
-          if (action.type === OPTIMISTIC_TYPE && state.meta[action.meta.key]) {
-            const prev = state.meta[action.meta.key];
-            meta = {
-              date: Math.max(action.meta.date, prev.date),
-              expiresAt: Math.max(action.meta.expiresAt, prev.expiresAt),
-              prevExpiresAt: prev.expiresAt,
-            };
-          } else {
-            meta = {
-              date: action.meta.date,
-              expiresAt: action.meta.expiresAt,
-              prevExpiresAt: state.meta[action.meta.key]?.expiresAt,
-            };
           }
           const { result, entities, indexes, entityMeta } = normalize(
             payload,
@@ -173,7 +158,11 @@ export default function createReducer(controller: Controller) {
             entityMeta,
             meta: {
               ...state.meta,
-              [action.meta.key]: meta,
+              [action.meta.key]: {
+                date: action.meta.date,
+                expiresAt: action.meta.expiresAt,
+                prevExpiresAt: state.meta[action.meta.key]?.expiresAt,
+              },
             },
             optimistic: filterOptimistic(state, action),
             lastReset: state.lastReset,

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -84,7 +84,17 @@ export default abstract class Entity {
     existingMeta?: { date: number },
     incomingMeta?: { date: number },
   ) {
-    return { ...existing, ...incoming };
+    if (
+      !existingMeta ||
+      !incomingMeta ||
+      existingMeta.date <= incomingMeta.date
+    ) {
+      return {
+        ...existing,
+        ...incoming,
+      };
+    }
+    return existing;
   }
 
   /** Factory method to convert from Plain JS Objects.

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -76,25 +76,22 @@ export default abstract class Entity {
     return this.prototype.pk.call(value, parent, key);
   }
 
-  /** Creates new instance copying over defined values of arguments */
-  static merge<T extends typeof Entity>(
-    this: T,
-    existing: Partial<AbstractInstanceType<T>>,
-    incoming: Partial<AbstractInstanceType<T>>,
-    existingMeta?: { date: number },
-    incomingMeta?: { date: number },
+  /** Return true to merge incoming data; false keeps existing entity */
+  static useIncoming(
+    existingMeta: { date: number },
+    incomingMeta: { date: number },
+    existing: any,
+    incoming: any,
   ) {
-    if (
-      !existingMeta ||
-      !incomingMeta ||
-      existingMeta.date <= incomingMeta.date
-    ) {
-      return {
-        ...existing,
-        ...incoming,
-      };
-    }
-    return existing;
+    return existingMeta.date <= incomingMeta.date;
+  }
+
+  /** Creates new instance copying over defined values of arguments */
+  static merge(existing: any, incoming: any) {
+    return {
+      ...existing,
+      ...incoming,
+    };
   }
 
   /** Factory method to convert from Plain JS Objects.

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -112,10 +112,13 @@ const addEntities =
               );
         }
 
-        entityMeta[schemaKey][id] =
-          entityMeta[schemaKey][id]?.expiresAt >= entityExpiresAt
-            ? entityMeta[schemaKey][id]
-            : { expiresAt: entityExpiresAt, date: meta.date };
+        entityMeta[schemaKey][id] = {
+          expiresAt: Math.max(
+            entityExpiresAt,
+            entityMeta[schemaKey][id]?.expiresAt,
+          ),
+          date: Math.max(meta.date, entityMeta[schemaKey][id]?.date),
+        };
       } else {
         entities[schemaKey][id] = processedEntity;
         entityMeta[schemaKey][id] = {

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -70,13 +70,7 @@ const addEntities =
 
     const existingEntity = entities[schemaKey][id];
     if (existingEntity) {
-      // TODO: maybe have distinct merge function for this case
-      entities[schemaKey][id] = schema.merge(
-        existingEntity,
-        processedEntity,
-        entityMeta[schemaKey][id],
-        meta,
-      );
+      entities[schemaKey][id] = schema.merge(existingEntity, processedEntity);
     } else {
       // TODO: eventually assume this exists and don't check for conditional. probably early 2022
       const entityExpiresAt = schema.expiresAt
@@ -87,29 +81,21 @@ const addEntities =
       // this case we already have this entity in store
       if (inStoreEntity) {
         const inStoreMeta = entityMeta[schemaKey][id];
-        const incomingMeta = meta;
-        // if either of these is undefined, it resolves to 'false' which
-        // means we fallback to 'newer' (processedEntity) takes priority
-        const preferExisting = entityMeta[schemaKey][id]?.date > meta.date;
-        if (typeof processedEntity !== typeof inStoreEntity) {
-          entities[schemaKey][id] = preferExisting
-            ? inStoreEntity
-            : processedEntity;
+        const useIncoming =
+          // we may have in store but not in meta; so this existance check is still important
+          !inStoreMeta ||
+          schema.useIncoming(inStoreMeta, meta, inStoreEntity, processedEntity);
+        if (useIncoming) {
+          if (typeof processedEntity !== typeof inStoreEntity) {
+            entities[schemaKey][id] = processedEntity;
+          } else {
+            entities[schemaKey][id] = schema.merge(
+              inStoreEntity,
+              processedEntity,
+            );
+          }
         } else {
-          // second argument takes priority over first
-          entities[schemaKey][id] = preferExisting
-            ? schema.merge(
-                processedEntity,
-                inStoreEntity,
-                incomingMeta,
-                inStoreMeta,
-              )
-            : schema.merge(
-                inStoreEntity,
-                processedEntity,
-                inStoreMeta,
-                incomingMeta,
-              );
+          entities[schemaKey][id] = inStoreEntity;
         }
 
         entityMeta[schemaKey][id] = {

--- a/packages/normalizr/src/schemas/Delete.ts
+++ b/packages/normalizr/src/schemas/Delete.ts
@@ -91,4 +91,13 @@ export default class Delete<E extends EntityInterface & { process: any }>
   merge(existing: any, incoming: any) {
     return incoming;
   }
+
+  useIncoming(
+    existingMeta: { date: number },
+    incomingMeta: { date: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return existingMeta.date <= incomingMeta.date;
+  }
 }

--- a/website/src/components/Playground/resources/TodoResource.ts
+++ b/website/src/components/Playground/resources/TodoResource.ts
@@ -16,14 +16,8 @@ export default class TodoResource extends PlaceholderBaseResource {
 
   static urlRoot = '/api/todos';
 
-  static merge(existing, incoming) {
-    if (existing.updatedAt < incoming.updatedAt) {
-      return {
-        ...existing,
-        ...incoming,
-      };
-    }
-    return existing;
+  static useIncoming(existing, incoming) {
+    return existing.updatedAt <= incoming.updatedAt;
   }
 
   protected static endpointMutate(): RestEndpoint<

--- a/website/static/mockServiceWorker.js
+++ b/website/static/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.36.8).
+ * Mock Service Worker (0.38.1).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://github.com/coinbase/rest-hooks/pull/1653 enables full race condition handling when server sends its date. However, without such special handling common cases were subject the client race conditions that were previously avoided.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Previously we had logic to try to solve the common case; this pulls this out into overridable function that makes it simple. This also has advantage of improved legacy compat as noone will have previously defined this so previous merge overrides still work.