### PR TITLE
fix: NetworkErrorBoundary should render Element

### DIFF
--- a/packages/rest-hooks/src/react-integration/NetworkErrorBoundary.tsx
+++ b/packages/rest-hooks/src/react-integration/NetworkErrorBoundary.tsx
@@ -37,9 +37,9 @@ export default class NetworkErrorBoundary<
 
   state: State<E> = {};
 
-  render() {
+  render(): JSX.Element {
     if (!this.state.error) {
-      return this.props.children;
+      return this.props.children as any;
     }
     return <this.props.fallbackComponent error={this.state.error} />;
   }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
For legacy support TypeScript has a weird expectation that components all render elements, even tho children are nodes.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Explicit return type