### PR TITLE
enhance: Hooks should type return value based on 'null' arg

### DIFF
--- a/packages/core/src/react-integration/hooks/useCache.ts
+++ b/packages/core/src/react-integration/hooks/useCache.ts
@@ -27,7 +27,10 @@ export default function useCache<
         ? readonly [...Parameters<E['key']>]
         : readonly [ParamsFromShape<E>])
     | readonly [null],
->(endpoint: E, ...args: Args): DenormalizeNullable<E['schema']> {
+>(
+  endpoint: E,
+  ...args: Args
+): Args extends [null] ? undefined : DenormalizeNullable<E['schema']> {
   const adaptedEndpoint: any = useMemo(() => {
     return shapeToEndpoint(endpoint);
     // we currently don't support shape changes

--- a/packages/core/src/react-integration/hooks/useError.ts
+++ b/packages/core/src/react-integration/hooks/useError.ts
@@ -7,7 +7,7 @@ import { EndpointInterface, Schema, FetchFunction } from '@rest-hooks/endpoint';
 
 export type ErrorTypes = NetworkError | UnknownError;
 
-type UseErrorReturn<P> = P extends null ? undefined : ErrorTypes | undefined;
+type UseErrorReturn<P> = P extends [null] ? undefined : ErrorTypes | undefined;
 
 /**
  * Get any errors for a given request
@@ -25,7 +25,7 @@ export default function useError<
         ? readonly [...Parameters<E['key']>]
         : readonly [ParamsFromShape<E>])
     | readonly [null],
->(endpoint: E, ...args: Args): UseErrorReturn<typeof args[0]> {
+>(endpoint: E, ...args: Args): UseErrorReturn<typeof args> {
   const adaptedEndpoint: any = useMemo(() => {
     return shapeToEndpoint(endpoint);
     // we currently don't support shape changes

--- a/packages/core/src/react-integration/newhooks/__tests__/useCache.tsx
+++ b/packages/core/src/react-integration/newhooks/__tests__/useCache.tsx
@@ -73,6 +73,9 @@ describe('useCache()', () => {
     const { result } = renderRestHook(() => {
       return useCache(endpoint, null);
     });
+    const b: undefined = result.current;
+    // @ts-expect-error
+    const c: object = result.current;
     expect(result.current).toBeUndefined();
   });
 

--- a/packages/core/src/react-integration/newhooks/__tests__/useSuspense.web.tsx
+++ b/packages/core/src/react-integration/newhooks/__tests__/useSuspense.web.tsx
@@ -421,9 +421,12 @@ describe('useSuspense()', () => {
   });
 
   it('should not suspend with null params to useSuspense()', () => {
-    let article: any;
+    let article: undefined;
     const { result } = renderRestHook(() => {
-      article = useSuspense(CoolerArticleResource.detail(), null);
+      const a = useSuspense(CoolerArticleResource.detail(), null);
+      article = a;
+      // @ts-expect-error
+      const b: CoolerArticleResource = a;
       return 'done';
     });
     expect(result.current).toBe('done');

--- a/packages/core/src/react-integration/newhooks/constants.ts
+++ b/packages/core/src/react-integration/newhooks/constants.ts
@@ -1,0 +1,7 @@
+import { ExpiryStatus } from '@rest-hooks/endpoint';
+
+export const nullResponse = {
+  data: undefined as any,
+  expiryStatus: ExpiryStatus.Invalid,
+  expiresAt: 0,
+};

--- a/packages/core/src/react-integration/newhooks/useError.ts
+++ b/packages/core/src/react-integration/newhooks/useError.ts
@@ -7,7 +7,7 @@ import { useContext } from 'react';
 
 export type ErrorTypes = NetworkError | UnknownError;
 
-type UseErrorReturn<P> = P extends null ? undefined : ErrorTypes | undefined;
+type UseErrorReturn<P> = P extends [null] ? undefined : ErrorTypes | undefined;
 
 /**
  * Get any errors for a given request
@@ -16,11 +16,12 @@ type UseErrorReturn<P> = P extends null ? undefined : ErrorTypes | undefined;
 export default function useError<
   E extends Pick<EndpointInterface, 'key'>,
   Args extends readonly [...Parameters<E['key']>] | readonly [null],
->(endpoint: E, ...args: Args): UseErrorReturn<typeof args[0]> {
+>(endpoint: E, ...args: Args): UseErrorReturn<Args> {
   const state = useContext(StateContext);
 
   const controller = useController();
 
+  if (args[0] === null) return;
   // @ts-ignore
-  return controller.getError(endpoint, ...args, state) as any;
+  return controller.getError(endpoint, ...args, state);
 }

--- a/packages/core/src/react-integration/newhooks/useFetch.ts
+++ b/packages/core/src/react-integration/newhooks/useFetch.ts
@@ -9,6 +9,7 @@ import {
   FetchFunction,
 } from '@rest-hooks/endpoint';
 import { useContext, useMemo } from 'react';
+import { nullResponse } from '@rest-hooks/core/react-integration/newhooks/constants';
 
 /**
  * Request a resource if it is not in cache.
@@ -22,11 +23,12 @@ export default function useFetch<
   const controller = useController();
 
   const key = args[0] !== null ? endpoint.key(...args) : '';
-  const cacheResults = args[0] !== null && state.results[key];
+  const cacheResults = key && state.results[key];
   const meta = state.meta[key];
 
   // Compute denormalized value
   const { expiryStatus, expiresAt } = useMemo(() => {
+    if (!key) return nullResponse;
     // @ts-ignore
     return controller.getResponse(endpoint, ...args, state) as {
       data: Denormalize<E['schema']>;

--- a/packages/core/src/react-integration/newhooks/useSubscription.tsx
+++ b/packages/core/src/react-integration/newhooks/useSubscription.tsx
@@ -16,10 +16,12 @@ export default function useSubscription<
 
   useEffect(() => {
     if (!key) return;
+    // typescript cannot infer truthy key means args is not null
+    const cleanedArgs = args as readonly [...Parameters<E>];
 
-    controller.subscribe(endpoint, ...args);
+    controller.subscribe(endpoint, ...cleanedArgs);
     return () => {
-      controller.unsubscribe(endpoint, ...args);
+      controller.unsubscribe(endpoint, ...cleanedArgs);
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -5,7 +5,7 @@ import { Schema } from '@rest-hooks/endpoint';
 import { useMemo } from 'react';
 import useController from '@rest-hooks/core/react-integration/hooks/useController';
 import shapeToEndpoint from '@rest-hooks/core/endpoint/adapter';
-import type { ExpiryStatus } from '@rest-hooks/endpoint';
+import { ExpiryStatus } from '@rest-hooks/endpoint';
 
 /**
  * @deprecated use https://resthooks.io/docs/api/Controller#getResponse directly instead
@@ -47,6 +47,12 @@ export default function useDenormalized<
 
   // Compute denormalized value
   return useMemo(() => {
+    if (key === '')
+      return {
+        data: undefined as any,
+        expiryStatus: ExpiryStatus.Invalid,
+        expiresAt: 0,
+      };
     return controller.getResponse(endpoint, params, state) as {
       data: DenormalizeNullable<Shape['schema']>;
       expiryStatus: ExpiryStatus;

--- a/packages/endpoint/src/SnapshotInterface.ts
+++ b/packages/endpoint/src/SnapshotInterface.ts
@@ -6,18 +6,22 @@ import type { ErrorTypes } from '@rest-hooks/endpoint/ErrorTypes';
 export default interface SnapshotInterface {
   getResponse: <
     E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
+    Args extends readonly [...Parameters<E['key']>],
   >(
     endpoint: E,
-    ...args: readonly [...Parameters<E['key']>] | readonly [null]
+    ...args: Args
   ) => {
     data: DenormalizeNullable<E['schema']>;
     expiryStatus: ExpiryStatus;
     expiresAt: number;
   };
 
-  getError: <E extends Pick<EndpointInterface, 'key'>>(
+  getError: <
+    E extends Pick<EndpointInterface, 'key'>,
+    Args extends readonly [...Parameters<E['key']>],
+  >(
     endpoint: E,
-    ...args: readonly [...Parameters<E['key']>] | readonly [null]
+    ...args: Args
   ) => ErrorTypes | undefined;
 
   readonly fetchedAt: number;

--- a/packages/legacy/src/useStatefulResource.ts
+++ b/packages/legacy/src/useStatefulResource.ts
@@ -72,6 +72,12 @@ export default function useStatefulResource<
   // Compute denormalized value
   // eslint-disable-next-line prefer-const
   let { data, expiryStatus, expiresAt } = useMemo(() => {
+    if (!key)
+      return {
+        data: undefined,
+        expiryStatus: ExpiryStatus.Invalid,
+        expiresAt: 0,
+      };
     // @ts-ignore
     return controller.getResponse(adaptedEndpoint, ...args, state) as {
       data: DenormalizeNullable<E['schema']> | undefined;
@@ -88,8 +94,9 @@ export default function useStatefulResource<
     key,
   ]);
 
-  // @ts-ignore
-  const error = controller.getError(adaptedEndpoint, ...args, state);
+  const error = key
+    ? controller.getError(adaptedEndpoint, ...args, state)
+    : undefined;
 
   // If we are hard invalid we must fetch regardless of triggering or staleness
   const forceFetch = expiryStatus === ExpiryStatus.Invalid;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Precisely handle null case.

Reduce type and runtime complexity by moving 'null' handling where it belongs. `null` arguments are only a concept needed for hooks since hooks cannot be called conditionally. Therefore, that logic should be tied to the hooks, and removed from further callstacks as early as possible

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
 - Hoist null check to as early as possible
 - Simplify snapshot types to alleviate typescript pressure. No reason some should need null params in a getOptimisticResponse
 - We keep null handling in existing controller methods for back compatibility. However, in the future we should remove these as null is a leaky abstraction beyond hooks
 - Ensure new hooks type handle null parameters as 'undefined' data

Note: making the title of this based on the external impact, since that trumps any internal changes