### PR TITLE
enhance: Only import from packages in package.json

### DIFF
--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -83,7 +83,7 @@
   },
   "peerDependencies": {
     "@rest-hooks/core": "^3.0.0-0",
-    "@rest-hooks/endpoint": "^2.0.0",
+    "@rest-hooks/endpoint": "^2.2.0-beta.2",
     "@rest-hooks/rest": "^3.0.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"

--- a/packages/graphql/src/GQLEndpoint.ts
+++ b/packages/graphql/src/GQLEndpoint.ts
@@ -1,5 +1,5 @@
 import { Endpoint, EndpointOptions } from '@rest-hooks/endpoint';
-import type { Schema } from '@rest-hooks/normalizr';
+import type { Schema } from '@rest-hooks/endpoint';
 import GQLNetworkError from '@rest-hooks/graphql/GQLNetworkError';
 
 export default class GQLEndpoint<

--- a/packages/graphql/src/GQLEntity.ts
+++ b/packages/graphql/src/GQLEntity.ts
@@ -1,4 +1,4 @@
-import { Entity } from '@rest-hooks/normalizr';
+import { Entity } from '@rest-hooks/endpoint';
 
 export default class GQLEntity extends Entity {
   readonly id: string = '';

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -8,7 +8,6 @@
   "include": ["src"],
   "references": [
     { "path": "../../__tests__" },
-    { "path": "../normalizr" },
     { "path": "../endpoint" }
   ]
 }

--- a/packages/legacy/src/resource/Delete.ts
+++ b/packages/legacy/src/resource/Delete.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { schema, AbstractInstanceType, DELETED } from '@rest-hooks/normalizr';
+import { schema, AbstractInstanceType, DELETED } from '@rest-hooks/core';
 
 export default class Delete<E extends schema.EntityInterface & { fromJS: any }>
   implements schema.SchemaClass

--- a/packages/legacy/src/resource/Entity.ts
+++ b/packages/legacy/src/resource/Entity.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { AbstractInstanceType, Schema, schema } from '@rest-hooks/normalizr';
+import { AbstractInstanceType, Schema, schema } from '@rest-hooks/core';
 import {
   isImmutable,
   denormalizeImmutable,

--- a/packages/legacy/src/shapeToEndpoint.ts
+++ b/packages/legacy/src/shapeToEndpoint.ts
@@ -1,6 +1,5 @@
-import { Endpoint } from '@rest-hooks/endpoint';
-import type { EndpointInstance } from '@rest-hooks/endpoint';
-import type { FetchShape } from '@rest-hooks/core';
+import { Endpoint } from '@rest-hooks/core';
+import type { FetchShape, EndpointInstance } from '@rest-hooks/core';
 
 type ShapeTypeToSideEffect<T extends 'read' | 'mutate' | 'delete' | undefined> =
   T extends 'read' | undefined ? undefined : true;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
For PNP, yarn 2 compatibility as well as not having issues with other package managers.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Only import from packages referenced in package.json