### PR TITLE
enhance: Loosen SnapshotInterface to allow compatible but distinct versions

### DIFF
--- a/packages/endpoint/src/Expiry.ts
+++ b/packages/endpoint/src/Expiry.ts
@@ -3,3 +3,5 @@ export const enum ExpiryStatus {
   InvalidIfStale,
   Valid,
 }
+// looser version to allow for cross-package version compatibility
+export type ExpiryStatusInterface = 1 | 2 | 3;

--- a/packages/endpoint/src/SnapshotInterface.ts
+++ b/packages/endpoint/src/SnapshotInterface.ts
@@ -1,6 +1,6 @@
 import type { DenormalizeNullable } from '@rest-hooks/endpoint/normal';
 import type { EndpointInterface } from '@rest-hooks/endpoint/interface';
-import type { ExpiryStatus } from '@rest-hooks/endpoint/Expiry';
+import type { ExpiryStatusInterface } from '@rest-hooks/endpoint/Expiry';
 import type { ErrorTypes } from '@rest-hooks/endpoint/ErrorTypes';
 
 export default interface SnapshotInterface {
@@ -12,7 +12,7 @@ export default interface SnapshotInterface {
     ...args: Args
   ) => {
     data: DenormalizeNullable<E['schema']>;
-    expiryStatus: ExpiryStatus;
+    expiryStatus: ExpiryStatusInterface;
     expiresAt: number;
   };
 

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -31,6 +31,7 @@ export type {
   ErrorTypes,
 } from '@rest-hooks/endpoint/types';
 export { ExpiryStatus } from '@rest-hooks/endpoint/Expiry';
+export type { ExpiryStatusInterface } from '@rest-hooks/endpoint/Expiry';
 export type {
   ResolveType,
   EndpointParam,

--- a/packages/endpoint/src/types.ts
+++ b/packages/endpoint/src/types.ts
@@ -1,8 +1,7 @@
 import { schema, Schema } from '@rest-hooks/normalizr';
-import { Normalize, DenormalizeNullable } from '@rest-hooks/endpoint/normal';
+import { Normalize } from '@rest-hooks/endpoint/normal';
 import { EndpointInterface } from '@rest-hooks/endpoint/interface';
 import { ResolveType } from '@rest-hooks/endpoint/utility';
-import { ExpiryStatus } from '@rest-hooks/endpoint/Expiry';
 import SnapshotInterface from '@rest-hooks/endpoint/SnapshotInterface';
 
 export interface EndpointExtraOptions<F extends FetchFunction = FetchFunction> {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
With multiple versions of @rest-hooks/endpoint installed, this could result in hooks not matching the types expected.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
`ExpiryStatusInterface` has identical structural type, but lacks the nominal typing restriction that breaks multi-package compatibility.