### PR TITLE
fix: Default optimistic race condition assume in-order fetch timings

### DIFF
--- a/docs/api/Entity.md
+++ b/docs/api/Entity.md
@@ -128,12 +128,12 @@ unique value.
 
 ```typescript
 static useIncoming(
-  existingMeta: { date: number },
-  incomingMeta: { date: number },
+  existingMeta: { date: number; fetchedAt: number },
+  incomingMeta: { date: number; fetchedAt: number },
   existing: any,
   incoming: any,
 ) {
-  return existingMeta.date <= incomingMeta.date;
+  return existingMeta.fetchedAt <= incomingMeta.fetchedAt;
 }
 ```
 
@@ -150,8 +150,8 @@ class LatestPriceEntity extends Entity {
   readonly symbol: string = '';
 
   static useIncoming(
-    existingMeta: { date: number },
-    incomingMeta: { date: number },
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
     existing: any,
     incoming: any,
   ) {

--- a/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
+++ b/packages/core/src/react-integration/__tests__/useExpiresAt.tsx
@@ -56,11 +56,11 @@ describe('useExpiresAt()', () => {
       },
       entityMeta: {
         Tacos: {
-          '1': { date: 0, expiresAt: 1000 },
-          '2': { date: 0, expiresAt: 2000 },
+          '1': { date: 0, expiresAt: 1000, fetchedAt: 0 },
+          '2': { date: 0, expiresAt: 2000, fetchedAt: 0 },
         },
         Ingredients: {
-          '1': { date: 0, expiresAt: 500 },
+          '1': { date: 0, expiresAt: 500, fetchedAt: 0 },
         },
       },
       indexes: {},
@@ -116,13 +116,13 @@ describe('useExpiresAt()', () => {
       },
       entityMeta: {
         Tacos: {
-          1: { date: 0, expiresAt: 1000 },
-          2: { date: 0, expiresAt: 2000 },
-          3: { date: 0, expiresAt: 0 },
+          1: { date: 0, expiresAt: 1000, fetchedAt: 0 },
+          2: { date: 0, expiresAt: 2000, fetchedAt: 0 },
+          3: { date: 0, expiresAt: 0, fetchedAt: 0 },
         },
         Ingredients: {
-          1: { date: 0, expiresAt: 500 },
-          2: { date: 0, expiresAt: 0 },
+          1: { date: 0, expiresAt: 500, fetchedAt: 0 },
+          2: { date: 0, expiresAt: 0, fetchedAt: 0 },
         },
       },
       indexes: {},

--- a/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
+++ b/packages/core/src/react-integration/provider/__tests__/__snapshots__/provider.tsx.snap
@@ -16,6 +16,7 @@ Object {
       "5": Object {
         "date": 50,
         "expiresAt": 55,
+        "fetchedAt": 50,
       },
     },
   },

--- a/packages/core/src/state/NetworkManager.ts
+++ b/packages/core/src/state/NetworkManager.ts
@@ -208,6 +208,7 @@ export default class NetworkManager implements Manager {
               dispatch(
                 createReceive(data, {
                   ...action.meta,
+                  fetchedAt: createdAt,
                   dataExpiryLength:
                     action.meta.options?.dataExpiryLength ??
                     this.dataExpiryLength,
@@ -235,6 +236,7 @@ export default class NetworkManager implements Manager {
                   errorExpiryLength:
                     action.meta.options?.errorExpiryLength ??
                     this.errorExpiryLength,
+                  fetchedAt: createdAt,
                 }),
               );
             }

--- a/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
+++ b/packages/core/src/state/__tests__/__snapshots__/reducer.ts.snap
@@ -35,6 +35,7 @@ Object {
       "20": Object {
         "date": 5000000000,
         "expiresAt": 5000500000,
+        "fetchedAt": 5000000000,
       },
     },
   },

--- a/packages/core/src/state/__tests__/networkManager.ts
+++ b/packages/core/src/state/__tests__/networkManager.ts
@@ -141,6 +141,7 @@ describe('NetworkManager', () => {
           key: fetchResolveAction.meta.key,
           date: expect.any(Number),
           expiresAt: expect.any(Number),
+          fetchedAt: expect.any(Number),
         },
       };
       expect(dispatch).toHaveBeenCalledWith(action);
@@ -170,6 +171,7 @@ describe('NetworkManager', () => {
           key: fetchReceiveWithUpdatersAction.meta.key,
           date: expect.any(Number),
           expiresAt: expect.any(Number),
+          fetchedAt: expect.any(Number),
         },
       };
       expect(dispatch).toHaveBeenCalledWith(action);
@@ -197,6 +199,7 @@ describe('NetworkManager', () => {
           key: fetchRpcWithUpdatersAction.meta.key,
           date: expect.any(Number),
           expiresAt: expect.any(Number),
+          fetchedAt: expect.any(Number),
         },
       };
       expect(dispatch).toHaveBeenCalledWith(action);
@@ -225,6 +228,7 @@ describe('NetworkManager', () => {
           key: fetchRpcWithUpdatersAndOptimisticAction.meta.key,
           date: expect.any(Number),
           expiresAt: expect.any(Number),
+          fetchedAt: expect.any(Number),
         },
       });
     });

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -48,6 +48,7 @@ describe('reducer', () => {
         key: ArticleResource.url({ id }),
         date: 5000000000,
         expiresAt: 5000500000,
+        fetchedAt: 5000000000,
       },
     };
     const partialResultAction = {
@@ -131,6 +132,7 @@ describe('reducer', () => {
           ...partialResultAction.meta,
           date: partialResultAction.meta.date / 2,
           expiresAt: partialResultAction.meta.expiresAt / 2,
+          fetchedAt: partialResultAction.meta.date / 2,
         },
       };
       const getMeta = (state: any): { date: number } =>
@@ -171,6 +173,7 @@ describe('reducer', () => {
           schema: ExpiresSoon,
           date: partialResultAction.meta.date * 2,
           expiresAt: partialResultAction.meta.expiresAt * 2,
+          fetchedAt: partialResultAction.meta.date * 2,
         },
       };
       const getMeta = (state: any): { date: number; expiresAt: number } =>
@@ -805,10 +808,10 @@ Array [
         },
         entityMeta: {
           [ArticleResource.key]: {
-            '10': { date: 0, expiresAt: 10000 },
-            '20': { date: 0, expiresAt: 10000 },
-            '25': { date: 0, expiresAt: 10000 },
-            '250': { date: 0, expiresAt: 10000 },
+            '10': { date: 0, expiresAt: 10000, fetchedAt: 0 },
+            '20': { date: 0, expiresAt: 10000, fetchedAt: 0 },
+            '25': { date: 0, expiresAt: 10000, fetchedAt: 0 },
+            '250': { date: 0, expiresAt: 10000, fetchedAt: 0 },
           },
         },
         results: { abc: '20' },

--- a/packages/core/src/state/actions/createReceive.ts
+++ b/packages/core/src/state/actions/createReceive.ts
@@ -18,6 +18,7 @@ interface Options<
     'schema' | 'key' | 'type' | 'updaters' | 'update' | 'args'
   > {
   dataExpiryLength: NonNullable<FetchOptions['dataExpiryLength']>;
+  fetchedAt?: number;
 }
 
 /** Update state with data
@@ -39,6 +40,7 @@ export default function createReceive<
     key,
     args,
     updaters,
+    fetchedAt = 0,
     update,
     dataExpiryLength,
   }: Options<Payload, S>,
@@ -53,6 +55,7 @@ export default function createReceive<
     key,
     args,
     date: now,
+    fetchedAt,
     expiresAt: now + dataExpiryLength,
   };
   meta.updaters = updaters;

--- a/packages/core/src/state/actions/createReceiveError.ts
+++ b/packages/core/src/state/actions/createReceiveError.ts
@@ -9,11 +9,12 @@ import { RECEIVE_TYPE } from '@rest-hooks/core/actionTypes';
 interface Options<S extends Schema | undefined = any>
   extends Pick<FetchAction<any, S>['meta'], 'schema' | 'key' | 'options'> {
   errorExpiryLength: NonNullable<FetchOptions['errorExpiryLength']>;
+  fetchedAt?: number;
 }
 
 export default function createReceiveError<S extends Schema | undefined = any>(
   error: Error,
-  { schema, key, options, errorExpiryLength }: Options<S>,
+  { schema, key, options, errorExpiryLength, fetchedAt = 0 }: Options<S>,
 ): ReceiveAction {
   /* istanbul ignore next */
   if (process.env.NODE_ENV === 'development' && errorExpiryLength < 0) {
@@ -27,6 +28,7 @@ export default function createReceiveError<S extends Schema | undefined = any>(
       schema,
       key,
       date: now,
+      fetchedAt,
       expiresAt: now + errorExpiryLength,
       errorPolicy: options?.errorPolicy,
     },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,6 +52,7 @@ export type State<T> = Readonly<{
       readonly [pk: string]: {
         readonly date: number;
         readonly expiresAt: number;
+        readonly fetchedAt: number;
       };
     };
   };

--- a/packages/legacy/src/resource/Entity.ts
+++ b/packages/legacy/src/resource/Entity.ts
@@ -248,6 +248,16 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     return expiresAt;
   }
 
+  /** Return true to merge incoming data; false keeps existing entity */
+  static useIncoming(
+    existingMeta: { date: number; fetchedAt?: number },
+    incomingMeta: { date: number; fetchedAt?: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return existingMeta.date <= incomingMeta.date;
+  }
+
   static infer(
     args: readonly any[],
     indexes: Record<string, any>,

--- a/packages/legacy/src/resource/__tests__/__snapshots__/Delete.test.ts.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/Delete.test.ts.snap
@@ -12,6 +12,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/legacy/src/resource/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/Entity.test.ts.snap
@@ -702,6 +702,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -729,6 +730,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -754,6 +756,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -777,6 +780,7 @@ Object {
       "tacos-user-4": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -805,10 +809,12 @@ Object {
       "4": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "56": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -841,6 +847,7 @@ Object {
       "134351": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -866,6 +873,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -898,12 +906,14 @@ Object {
       "4": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "ParentEntity": Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -935,12 +945,14 @@ Object {
       "456": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "EntriesEntity": Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -984,6 +996,7 @@ Object {
       "hi": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -1038,6 +1051,7 @@ Object {
       "hi": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/legacy/src/resource/__tests__/__snapshots__/SimpleRecord.test.ts.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/SimpleRecord.test.ts.snap
@@ -17,6 +17,7 @@ Object {
       "5": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -46,6 +47,7 @@ Object {
       "5": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -74,6 +76,7 @@ Object {
       "5": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/legacy/src/resource/__tests__/__snapshots__/normalizr.test.js.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/normalizr.test.js.snap
@@ -390,12 +390,14 @@ Object {
       "4": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "Food": Object {
       "1234": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -459,10 +461,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -491,6 +495,7 @@ Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -536,22 +541,26 @@ Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "Comment": Object {
       "comment-123-4738": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "User": Object {
       "10293": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "8472": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -579,10 +588,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -626,10 +637,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -662,10 +675,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -707,10 +722,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -745,6 +762,7 @@ Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -783,12 +801,14 @@ Object {
       "456": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "User": Object {
       "456": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -246,12 +246,14 @@ Object {
       "4": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "Food": Object {
       "1234": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -315,10 +317,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -347,6 +351,7 @@ Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -392,22 +397,26 @@ Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "Comment": Object {
       "comment-123-4738": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "User": Object {
       "10293": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "8472": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -435,10 +444,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -482,10 +493,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -518,10 +531,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -563,10 +578,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -601,6 +618,7 @@ Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -639,12 +657,14 @@ Object {
       "456": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "User": Object {
       "456": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/normalizr/src/entities/Entity.ts
+++ b/packages/normalizr/src/entities/Entity.ts
@@ -78,12 +78,12 @@ export default abstract class Entity {
 
   /** Return true to merge incoming data; false keeps existing entity */
   static useIncoming(
-    existingMeta: { date: number },
-    incomingMeta: { date: number },
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
     existing: any,
     incoming: any,
   ) {
-    return existingMeta.date <= incomingMeta.date;
+    return existingMeta.fetchedAt <= incomingMeta.fetchedAt;
   }
 
   /** Creates new instance copying over defined values of arguments */
@@ -331,7 +331,7 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
   }
 
   static expiresAt(
-    meta: { expiresAt: number; date: number },
+    meta: { expiresAt: number; date: number; fetchedAt: number },
     input: any,
   ): number {
     return meta.expiresAt;

--- a/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/normalizr/src/entities/__tests__/__snapshots__/Entity.test.ts.snap
@@ -336,6 +336,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -363,6 +364,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -397,6 +399,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -420,6 +423,7 @@ Object {
       "tacos-user-4": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -448,10 +452,12 @@ Object {
       "4": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "56": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -484,6 +490,7 @@ Object {
       "134351": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -561,6 +568,7 @@ Object {
       "hi": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -616,6 +624,7 @@ Object {
       "hi": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -74,6 +74,14 @@ export interface EntityInterface<T = any> extends SchemaSimple {
   pk(params: any, parent?: any, key?: string): string | undefined;
   readonly key: string;
   merge(existing: any, incoming: any): any;
+  expiresAt?(meta: any, input: any): number;
+  useIncoming?(
+    existingMeta: any,
+    incomingMeta: any,
+    existing: any,
+    incoming: any,
+  ): boolean;
+  indexes?: any;
   schema: Record<string, Schema>;
   prototype: T;
 }

--- a/packages/normalizr/src/schemas/Delete.ts
+++ b/packages/normalizr/src/schemas/Delete.ts
@@ -93,8 +93,8 @@ export default class Delete<E extends EntityInterface & { process: any }>
   }
 
   useIncoming(
-    existingMeta: { date: number },
-    incomingMeta: { date: number },
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
     existing: any,
     incoming: any,
   ) {

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -375,10 +375,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -770,6 +772,7 @@ Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -797,10 +800,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -829,10 +834,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -869,16 +876,19 @@ Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "456": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "Person": Object {
       "123": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -1126,10 +1136,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -1158,10 +1170,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -1197,12 +1211,14 @@ Object {
       "4": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "Parent": Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Delete.test.ts.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Delete.test.ts.snap
@@ -21,6 +21,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -230,6 +230,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -254,6 +255,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -278,6 +280,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -302,6 +305,7 @@ Object {
       "5": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -328,6 +332,7 @@ Object {
       "5": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Serializable.test.ts.snap
@@ -44,6 +44,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -58,4 +59,4 @@ Object {
 }
 `;
 
-exports[`Serializable normalization normalizes date and custom 2`] = `"{\\"entities\\":{\\"User\\":{\\"1\\":{\\"id\\":\\"1\\",\\"name\\":\\"Nacho\\",\\"createdAt\\":\\"2020-06-07T02:00:15.000Z\\"}}},\\"indexes\\":{},\\"result\\":{\\"user\\":\\"1\\",\\"anotherItem\\":{\\"thing\\":500},\\"time\\":\\"2020-06-07T02:00:15.000Z\\"},\\"entityMeta\\":{\\"User\\":{\\"1\\":{\\"expiresAt\\":null,\\"date\\":1557831718135}}}}"`;
+exports[`Serializable normalization normalizes date and custom 2`] = `"{\\"entities\\":{\\"User\\":{\\"1\\":{\\"id\\":\\"1\\",\\"name\\":\\"Nacho\\",\\"createdAt\\":\\"2020-06-07T02:00:15.000Z\\"}}},\\"indexes\\":{},\\"result\\":{\\"user\\":\\"1\\",\\"anotherItem\\":{\\"thing\\":500},\\"time\\":\\"2020-06-07T02:00:15.000Z\\"},\\"entityMeta\\":{\\"User\\":{\\"1\\":{\\"expiresAt\\":null,\\"date\\":1557831718135,\\"fetchedAt\\":0}}}}"`;

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -131,6 +131,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -157,6 +158,7 @@ Object {
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -195,6 +197,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -221,6 +224,7 @@ Object {
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -410,6 +414,7 @@ Object {
       "22": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -217,12 +217,14 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "Dog": Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -259,6 +261,7 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -293,12 +296,14 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
     "Dog": Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -335,10 +340,12 @@ Object {
       "1": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "2": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },
@@ -429,10 +436,12 @@ Object {
       "BTC": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
       "ETH": Object {
         "date": 1557831718135,
         "expiresAt": Infinity,
+        "fetchedAt": 0,
       },
     },
   },

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -157,6 +157,7 @@ export type NormalizedSchema<E, R> = {
       readonly [pk: string]: {
         readonly date: number;
         readonly expiresAt: number;
+        readonly fetchedAt: number;
       };
     };
   };

--- a/website/src/components/Playground/resources/TodoResource.ts
+++ b/website/src/components/Playground/resources/TodoResource.ts
@@ -17,8 +17,8 @@ export default class TodoResource extends PlaceholderBaseResource {
   static urlRoot = '/api/todos';
 
   static useIncoming(
-    existingMeta: { date: number },
-    incomingMeta: { date: number },
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
     existing: { updatedAt: number },
     incoming: { updatedAt: number },
   ) {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
While adapting API is useful to guarantee correct handling of networking race conditions, the default case should handle the most common assumption. That assumption is that fetches will be resolved in the order they are sent. This makes sense because the only race condition where this is violated is if the server receive time is variable. Whereas there are many parts afterward there could affect response timing.

This assumption makes sense because with an RDS, transactions will lock a given row on first-come basis; and that transaction will only include updates from that request - thus any requests received during processing of that request will *not* be reflected in the response.

#### Events:

Numbered are events; the bullets represent what state is applied

1) fetch1
    - optimistic1
2) fetch2
    - optimistic1
    - optimistic2
3) fetch3
    - optimistic1
    - optimistic2
    - optimistic3
4) resolve1
    - resolve1
    - optimistic2
    - optimistic3
5) resolve2
    - resolve1
    - resolve2
    - optimistic3
6) resolve3
    - resolve1
    - resolve 2
    - resolve 3

In summary, there are three timings for a request - send time, server processing time, and receive time. This default algorithm will handle any problems with the latter 2 - requiring only send time to be in order for data integrity to be maintained.
 
### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Store `fetchedAt` in entityMeta and use it as default useIncoming() implementation.

Additionally:
- Update @rest-hooks/legacy so it includes extra methods
- Update EntityInterface and handle legacy Entities that don't have new methods to support several versions back.

### Is this breaking?

While technically a breaking change in behavior

- The previous behavior was not intended
- Given download tracking it seems unlikely anyone has grown dependent on this as it is only newly introduced in 6.2
- Behavior change only matters in race conditions; and it seems very unlikely people would actually want to rely on the existing behavior since that behavior is problematic.