### PR TITLE
fix: Hooks with null param maintain basic schema structure

### DIFF
--- a/packages/core/src/react-integration/hooks/useCache.ts
+++ b/packages/core/src/react-integration/hooks/useCache.ts
@@ -27,10 +27,7 @@ export default function useCache<
         ? readonly [...Parameters<E['key']>]
         : readonly [ParamsFromShape<E>])
     | readonly [null],
->(
-  endpoint: E,
-  ...args: Args
-): Args extends [null] ? undefined : DenormalizeNullable<E['schema']> {
+>(endpoint: E, ...args: Args): DenormalizeNullable<E['schema']> {
   const adaptedEndpoint: any = useMemo(() => {
     return shapeToEndpoint(endpoint);
     // we currently don't support shape changes

--- a/packages/core/src/react-integration/newhooks/__tests__/useCache.tsx
+++ b/packages/core/src/react-integration/newhooks/__tests__/useCache.tsx
@@ -73,10 +73,21 @@ describe('useCache()', () => {
     const { result } = renderRestHook(() => {
       return useCache(endpoint, null);
     });
-    const b: undefined = result.current;
+    const b: CoolerArticleResource | undefined = result.current;
     // @ts-expect-error
     const c: object = result.current;
     expect(result.current).toBeUndefined();
+  });
+
+  it(`should maintain schema structure even with null params`, () => {
+    const { result } = renderRestHook(() => {
+      return useCache(PaginatedArticleResource.list(), null);
+    });
+    const b: PaginatedArticleResource[] | undefined = result.current.results;
+    // @ts-expect-error
+    const c: PaginatedArticleResource[] = result.current.results;
+    expect(result.current.results).toBeUndefined();
+    expect(result.current.nextPage).toBe('');
   });
 
   it('should read with id params Endpoint', async () => {

--- a/packages/core/src/react-integration/newhooks/__tests__/useSuspense.web.tsx
+++ b/packages/core/src/react-integration/newhooks/__tests__/useSuspense.web.tsx
@@ -7,6 +7,7 @@ import {
   ArticleTimedResource,
   ContextAuthdArticle,
   AuthContext,
+  PaginatedArticleResource,
 } from '__tests__/new';
 import { createEntityMeta } from '__tests__/utils';
 import {
@@ -33,7 +34,7 @@ import {
   mockInitialState,
 } from '../../../../../test';
 import useSuspense from '../useSuspense';
-import { payload, users, nested } from '../test-fixtures';
+import { articlesPages, payload, users, nested } from '../test-fixtures';
 import { CacheProvider } from '../..';
 
 async function testDispatchFetch(
@@ -421,7 +422,7 @@ describe('useSuspense()', () => {
   });
 
   it('should not suspend with null params to useSuspense()', () => {
-    let article: undefined;
+    let article: CoolerArticleResource | undefined;
     const { result } = renderRestHook(() => {
       const a = useSuspense(CoolerArticleResource.detail(), null);
       article = a;
@@ -431,6 +432,33 @@ describe('useSuspense()', () => {
     });
     expect(result.current).toBe('done');
     expect(article).toBeUndefined();
+  });
+
+  it('should maintain schema structure even with null params', () => {
+    let articles: PaginatedArticleResource[] | undefined;
+    const { result } = renderRestHook(
+      () => {
+        const { results, nextPage } = useSuspense(
+          PaginatedArticleResource.list(),
+          null,
+        );
+        articles = results;
+        // @ts-expect-error
+        const b: PaginatedArticleResource[] = results;
+        return nextPage;
+      },
+      {
+        results: [
+          {
+            request: PaginatedArticleResource.detail(),
+            params: {},
+            result: articlesPages,
+          },
+        ],
+      },
+    );
+    expect(result.current).toBe('');
+    expect(articles).toBeUndefined();
   });
 
   it('should suspend with no params to useSuspense()', async () => {

--- a/packages/core/src/react-integration/newhooks/constants.ts
+++ b/packages/core/src/react-integration/newhooks/constants.ts
@@ -1,7 +1,0 @@
-import { ExpiryStatus } from '@rest-hooks/endpoint';
-
-export const nullResponse = {
-  data: undefined as any,
-  expiryStatus: ExpiryStatus.Invalid,
-  expiresAt: 0,
-};

--- a/packages/core/src/react-integration/newhooks/useCache.ts
+++ b/packages/core/src/react-integration/newhooks/useCache.ts
@@ -9,7 +9,6 @@ import { useContext, useMemo } from 'react';
 import { StateContext } from '@rest-hooks/core/react-integration/context';
 import { ExpiryStatus } from '@rest-hooks/endpoint';
 import useController from '@rest-hooks/core/react-integration/hooks/useController';
-import { nullResponse } from '@rest-hooks/core/react-integration/newhooks/constants';
 
 /**
  * Access a response if it is available.
@@ -23,10 +22,7 @@ export default function useCache<
     'key' | 'schema' | 'invalidIfStale'
   >,
   Args extends readonly [...Parameters<E['key']>] | readonly [null],
->(
-  endpoint: E,
-  ...args: Args
-): Args extends [null] ? undefined : DenormalizeNullable<E['schema']> {
+>(endpoint: E, ...args: Args): DenormalizeNullable<E['schema']> {
   const state = useContext(StateContext);
   const controller = useController();
 
@@ -36,7 +32,6 @@ export default function useCache<
 
   // Compute denormalized value
   const { data, expiryStatus, expiresAt } = useMemo(() => {
-    if (!key) return nullResponse;
     // @ts-ignore
     return controller.getResponse(endpoint, ...args, state) as {
       data: DenormalizeNullable<E['schema']>;

--- a/packages/core/src/react-integration/newhooks/useError.ts
+++ b/packages/core/src/react-integration/newhooks/useError.ts
@@ -21,7 +21,5 @@ export default function useError<
 
   const controller = useController();
 
-  if (args[0] === null) return;
-  // @ts-ignore
-  return controller.getError(endpoint, ...args, state);
+  return controller.getError(endpoint, ...args, state) as any;
 }

--- a/packages/core/src/react-integration/newhooks/useFetch.ts
+++ b/packages/core/src/react-integration/newhooks/useFetch.ts
@@ -9,7 +9,6 @@ import {
   FetchFunction,
 } from '@rest-hooks/endpoint';
 import { useContext, useMemo } from 'react';
-import { nullResponse } from '@rest-hooks/core/react-integration/newhooks/constants';
 
 /**
  * Request a resource if it is not in cache.
@@ -28,7 +27,6 @@ export default function useFetch<
 
   // Compute denormalized value
   const { expiryStatus, expiresAt } = useMemo(() => {
-    if (!key) return nullResponse;
     // @ts-ignore
     return controller.getResponse(endpoint, ...args, state) as {
       data: Denormalize<E['schema']>;

--- a/packages/core/src/state/selectors/useDenormalized.ts
+++ b/packages/core/src/state/selectors/useDenormalized.ts
@@ -47,12 +47,6 @@ export default function useDenormalized<
 
   // Compute denormalized value
   return useMemo(() => {
-    if (key === '')
-      return {
-        data: undefined as any,
-        expiryStatus: ExpiryStatus.Invalid,
-        expiresAt: 0,
-      };
     return controller.getResponse(endpoint, params, state) as {
       data: DenormalizeNullable<Shape['schema']>;
       expiryStatus: ExpiryStatus;

--- a/packages/legacy/src/__tests__/useStatefulResource.tsx
+++ b/packages/legacy/src/__tests__/useStatefulResource.tsx
@@ -1,6 +1,7 @@
 import {
   CoolerArticleResource,
   InvalidIfStaleArticleResource,
+  PaginatedArticleResource,
   TypedArticleResource,
 } from '__tests__/new';
 import { CoolerArticleResource as LegacyArticle } from '__tests__/legacy';
@@ -184,11 +185,23 @@ describe('useStatefulResource()', () => {
     expect(result.current.data).toEqual(CoolerArticleResource.fromJS(payload2));
   });
 
-  it('should not be loading with no params to useResource()', () => {
+  it('should not be loading with null params to useStatefulResource()', () => {
     const { result } = renderRestHook(() => {
       return useStatefulResource(CoolerArticleResource.detail(), null);
     });
     expect(result.current.loading).toBe(false);
+  });
+
+  it('should maintain schema structure even with null params', () => {
+    const { result } = renderRestHook(() => {
+      return useStatefulResource(PaginatedArticleResource.list(), null);
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data.results).toBeUndefined();
+    expect(result.current.data.nextPage).toBe('');
+    // ensure this isn't 'any'
+    // @ts-expect-error
+    const a: PaginatedArticleResource[] = result.current.data.results;
   });
 
   it('should not select when results are stale and invalidIfStale is true', async () => {

--- a/packages/legacy/src/useStatefulResource.ts
+++ b/packages/legacy/src/useStatefulResource.ts
@@ -72,13 +72,6 @@ export default function useStatefulResource<
   // Compute denormalized value
   // eslint-disable-next-line prefer-const
   let { data, expiryStatus, expiresAt } = useMemo(() => {
-    if (!key)
-      return {
-        data: undefined,
-        expiryStatus: ExpiryStatus.Invalid,
-        expiresAt: 0,
-      };
-    // @ts-ignore
     return controller.getResponse(adaptedEndpoint, ...args, state) as {
       data: DenormalizeNullable<E['schema']> | undefined;
       expiryStatus: ExpiryStatus;
@@ -94,9 +87,7 @@ export default function useStatefulResource<
     key,
   ]);
 
-  const error = key
-    ? controller.getError(adaptedEndpoint, ...args, state)
-    : undefined;
+  const error = controller.getError(adaptedEndpoint, ...args, state);
 
   // If we are hard invalid we must fetch regardless of triggering or staleness
   const forceFetch = expiryStatus === ExpiryStatus.Invalid;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Maintaining schema structure simplifies cases where entities are nested in a structure even if null parameter is set. A common need for this is in pagination.

```tsx
const { results, nextPage } = useSuspense(
  PaginatedArticleResource.list(),
  should ? {} : null,
);
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Undo part of https://github.com/coinbase/rest-hooks/pull/1783

However, still not accept null params in snapshot and keep some of the type improvements.

Add a test for pagination that validates types and runtime value.