### PR TITLE
fix: Use imported State interface rather than a copy

### DIFF
--- a/packages/test/src/mockState.ts
+++ b/packages/test/src/mockState.ts
@@ -110,7 +110,7 @@ export function actionFromFixture(fixture: Fixture) {
   return { key, action };
 }
 
-export default function mockInitialState(results: Fixture[]) {
+export default function mockInitialState(results: Fixture[]): State<unknown> {
   let reducer: (
     state: State<unknown> | undefined,
     action: ActionTypes,

--- a/packages/test/src/providers.tsx
+++ b/packages/test/src/providers.tsx
@@ -89,21 +89,25 @@ try {
   };
 }
 
-const makeCacheProvider = (
+function makeCacheProvider(
   managers: Manager[],
   initialState?: State<unknown>,
-) => {
+): (props: { children: React.ReactNode }) => JSX.Element {
   return function ConfiguredCacheProvider({
     children,
   }: {
     children: React.ReactNode;
   }) {
-    return (
-      <CacheProvider managers={managers} initialState={initialState}>
-        {children}
-      </CacheProvider>
-    );
+    if (initialState) {
+      return (
+        <CacheProvider managers={managers} initialState={initialState}>
+          {children}
+        </CacheProvider>
+      );
+    } else {
+      return <CacheProvider managers={managers}>{children}</CacheProvider>;
+    }
   };
-};
+}
 
 export { makeExternalCacheProvider, makeCacheProvider };

--- a/packages/test/tsconfig.compile.json
+++ b/packages/test/tsconfig.compile.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "paths": {
       "@rest-hooks/test/*": ["packages/test/src/*"]
     }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Test package should be compatible with a wide range of rest hooks versions. To make this possible it should rely on the interfaces of whatever provided package exists.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Previously TypeScript compilation ended up duplicating State instead of referencing it which meant it was whatever State happened to be at the time of compilation. By explicitly setting the return value and using 'function' vs 'const' TypeScript will retain the reference to the imported type. This leads me to believe const functions should be avoided at all costs if not necessary (like when using them for the desired behavior of `this` scoping)

Also added `exactOptionalPropertyTypes` compiler flag; but this wasn't necessary for this fix. I kept it because it seems like a better way forward.

#### Before .d.ts

```ts
export default function mockInitialState(results: Fixture[]): Readonly<{
    entities: {
        readonly [entityKey: string]: {
            readonly [pk: string]: unknown;
        } | undefined;
    };
    indexes: import("../../normalizr/lib").NormalizedIndex;
    results: {
        readonly [key: string]: unknown;
    };
    meta: {
        readonly [key: string]: {
            readonly date: number;
            readonly error?: import("../../endpoint/lib").ErrorTypes | undefined;
            readonly expiresAt: number;
            readonly prevExpiresAt?: number | undefined;
            readonly invalidated?: boolean | undefined;
            readonly errorPolicy?: "soft" | undefined;
        };
    };
    entityMeta: {
        readonly [entityKey: string]: {
            readonly [pk: string]: {
                readonly date: number;
                readonly expiresAt: number;
                readonly fetchedAt: number;
            };
        };
    };
    optimistic: (ReceiveAction<string | number | object | null, any> | RestHooks.OptimisticAction<EndpointInterface<RestHooks.FetchFunction<any, any, any>, Schema | undefined, true | undefined> & {
        update?: RestHooks.EndpointUpdateFunction<EndpointInterface<RestHooks.FetchFunction<any, any, any>, Schema | undefined, true | undefined>, Record<string, any>> | undefined;
    }>)[];
    lastReset: number | Date;
}>;

declare const makeCacheProvider: (managers: Manager[], initialState?: Readonly<{
    entities: {
        readonly [entityKey: string]: {
            readonly [pk: string]: unknown;
        } | undefined;
    };
    indexes: import("../../normalizr/lib").NormalizedIndex;
    results: {
        readonly [key: string]: unknown;
    };
    meta: {
        readonly [key: string]: {
            readonly date: number;
            readonly error?: import("../../endpoint/lib").ErrorTypes | undefined;
            readonly expiresAt: number;
            readonly prevExpiresAt?: number | undefined;
            readonly invalidated?: boolean | undefined;
            readonly errorPolicy?: "soft" | undefined;
        };
    };
    entityMeta: {
        readonly [entityKey: string]: {
            readonly [pk: string]: {
                readonly date: number;
                readonly expiresAt: number;
                readonly fetchedAt: number;
            };
        };
    };
    optimistic: (import("rest-hooks").ReceiveAction<string | number | object | null, any> | import("@rest-hooks/core").OptimisticAction<import("rest-hooks").EndpointInterface<import("rest-hooks").FetchFunction<any, any, any>, import("rest-hooks").Schema | undefined, true | undefined> & {
        update?: import("@rest-hooks/core").EndpointUpdateFunction<import("rest-hooks").EndpointInterface<import("rest-hooks").FetchFunction<any, any, any>, import("rest-hooks").Schema | undefined, true | undefined>, Record<string, any>> | undefined;
    }>)[];
    lastReset: number | Date;
}> | undefined) => ({ children, }: {
    children: React.ReactNode;
}) => JSX.Element;
```

#### After .d.ts

```ts
export default function mockInitialState(results: Fixture[]): State<unknown>;

declare function makeCacheProvider(managers: Manager[], initialState?: State<unknown>): (props: {
    children: React.ReactNode;
}) => JSX.Element;
```