### PR TITLE
docs: Update yarn.lock for docs site

### DIFF
--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3114,23 +3114,23 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.19.tgz#2c94db828794aa53e7a420809dac870348819233"
   integrity sha512-kHR9OHwP9WLpyC0i/WCAQCgf5hXkR9C+/21qxmrn+YwRlDRnBlqrcrFpXxhJTA9LDHJWa/FjoO2LJ12q8iWlEQ==
 
-"@rest-hooks/core@^3.1.0", "@rest-hooks/core@file:../packages/core":
-  version "3.1.0"
+"@rest-hooks/core@^3.1.2", "@rest-hooks/core@file:../packages/core":
+  version "3.1.2"
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@rest-hooks/endpoint" "^2.2.0"
-    "@rest-hooks/normalizr" "^8.2.0"
+    "@rest-hooks/endpoint" "^2.2.2"
+    "@rest-hooks/normalizr" "^8.2.2"
     "@rest-hooks/use-enhanced-reducer" "^1.1.1"
     flux-standard-action "^2.1.1"
 
-"@rest-hooks/endpoint@^2.2.0", "@rest-hooks/endpoint@file:../packages/endpoint":
-  version "2.2.0"
+"@rest-hooks/endpoint@^2.2.2", "@rest-hooks/endpoint@file:../packages/endpoint":
+  version "2.2.2"
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@rest-hooks/normalizr" "^8.2.0"
+    "@rest-hooks/normalizr" "^8.2.2"
 
 "@rest-hooks/graphql@file:../packages/graphql":
-  version "0.1.2"
+  version "0.1.4"
   dependencies:
     "@babel/runtime" "^7.7.2"
 
@@ -3139,8 +3139,8 @@
   dependencies:
     "@babel/runtime" "^7.7.2"
 
-"@rest-hooks/normalizr@^8.2.0", "@rest-hooks/normalizr@file:../packages/normalizr":
-  version "8.2.0"
+"@rest-hooks/normalizr@^8.2.2", "@rest-hooks/normalizr@file:../packages/normalizr":
+  version "8.2.2"
   dependencies:
     "@babel/runtime" "^7.7.2"
 
@@ -10630,11 +10630,11 @@ responselike@^1.0.2:
     lowercase-keys "^1.0.0"
 
 "rest-hooks@file:../packages/rest-hooks":
-  version "6.2.0"
+  version "6.2.2"
   dependencies:
     "@babel/runtime" "^7.7.2"
-    "@rest-hooks/core" "^3.1.0"
-    "@rest-hooks/endpoint" "^2.2.0"
+    "@rest-hooks/core" "^3.1.2"
+    "@rest-hooks/endpoint" "^2.2.2"
 
 restore-cursor@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Since we use relative paths (waiting on yarn 3, which is waiting on renovate), yarn.lock has to be updated every publish to get new versions.
