### PR TITLE
feat: Add useDLE() to core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export {
 export {
   useSuspense,
   useFetch,
+  useDLE,
 } from '@rest-hooks/core/react-integration/newhooks/index';
 export type { ErrorTypes } from '@rest-hooks/core/react-integration/index';
 export {

--- a/packages/core/src/react-integration/newhooks/__tests__/fixtures.ts
+++ b/packages/core/src/react-integration/newhooks/__tests__/fixtures.ts
@@ -1,0 +1,122 @@
+export const payload = {
+  id: 5,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+export const payload2 = {
+  id: 6,
+  title: 'next',
+  content: 'my best content yet',
+  tags: ['b'],
+};
+
+export const createPayload = {
+  id: 1,
+  title: 'hi ho',
+  content: 'whatever',
+  tags: ['a', 'best', 'react'],
+};
+
+export const articlesPages = {
+  prevPage: '23asdl',
+  nextPage: 's3f3',
+  results: [
+    {
+      id: 23,
+      title: 'the first draft',
+      content: 'the best things in life com efree',
+      tags: ['one', 'two'],
+    },
+    {
+      id: 44,
+      title: 'the second book',
+      content: 'the best things in life com efree',
+      tags: ['hbh', 'wew'],
+    },
+    {
+      id: 2,
+      title: 'the third novel',
+      content: 'the best things in life com efree',
+      tags: ['free', 'honey'],
+    },
+    {
+      id: 643,
+      title: 'a long time ago',
+      content: 'the best things in life com efree',
+    },
+  ],
+};
+
+export const users = [
+  {
+    id: 23,
+    username: 'bob',
+    email: 'bob@bob.com',
+    isAdmin: false,
+  },
+  {
+    id: 7342,
+    username: 'lindsey',
+    email: 'lindsey@bob.com',
+    isAdmin: true,
+  },
+];
+
+export const nested = [
+  {
+    id: 5,
+    title: 'hi ho',
+    content: 'whatever',
+    tags: ['a', 'best', 'react'],
+    author: {
+      id: 23,
+      username: 'bob',
+    },
+  },
+  {
+    id: 3,
+    title: 'the next time',
+    content: 'whatever',
+    author: {
+      id: 23,
+      username: 'charles',
+      email: 'bob@bob.com',
+    },
+  },
+];
+
+const moreNested = [
+  {
+    id: 7,
+    title: 'article 7',
+    content: 'whatever',
+    tags: ['blah'],
+    author: {
+      id: 23,
+      username: 'bob',
+    },
+  },
+  {
+    id: 8,
+    title: 'article 8',
+    content: 'whatever',
+    author: {
+      id: 27,
+      username: 'zac',
+      email: 'zac@bob.com',
+    },
+  },
+];
+
+export const paginatedFirstPage = {
+  results: nested,
+};
+
+export const paginatedSecondPage = {
+  results: moreNested,
+};
+
+describe('fixtures', () => {
+  it('should pass', () => {});
+});

--- a/packages/core/src/react-integration/newhooks/__tests__/useDLE.tsx
+++ b/packages/core/src/react-integration/newhooks/__tests__/useDLE.tsx
@@ -1,0 +1,216 @@
+import {
+  CoolerArticleResource,
+  InvalidIfStaleArticleResource,
+  PaginatedArticleResource,
+  TypedArticleResource,
+} from '__tests__/new';
+import { makeRenderRestHook, makeCacheProvider } from '@rest-hooks/test';
+import nock from 'nock';
+
+import { payload, payload2, users, nested } from './fixtures';
+import useDLE from '../useDLE';
+
+function onError(e: any) {
+  e.preventDefault();
+}
+beforeAll(() => {
+  if (typeof addEventListener === 'function')
+    addEventListener('error', onError);
+});
+afterAll(() => {
+  if (typeof removeEventListener === 'function')
+    removeEventListener('error', onError);
+});
+
+describe('useDLE()', () => {
+  let renderRestHook: ReturnType<typeof makeRenderRestHook>;
+
+  beforeAll(() => {
+    nock(/.*/)
+      .persist()
+      .defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*',
+        'Content-Type': 'application/json',
+      })
+      .options(/.*/)
+      .reply(200)
+      .get(`/article-cooler/${payload.id}`)
+      .reply(200, payload)
+      .get(`/article-cooler/${payload2.id}`)
+      .reply(200, payload2)
+      .delete(`/article-cooler/${payload.id}`)
+      .reply(204, '')
+      .delete(`/article/${payload.id}`)
+      .reply(200, {})
+      .get(`/article-cooler/0`)
+      .reply(403, {})
+      .get(`/article-cooler/666`)
+      .reply(200, '')
+      .get(`/article-cooler/`)
+      .reply(200, nested)
+      .get(/article-cooler\/.*/)
+      .reply(404, 'not found')
+      .put(/article-cooler\/[^5].*/)
+      .reply(404, 'not found')
+      .get(`/user/`)
+      .reply(200, users);
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+  });
+
+  beforeEach(() => {
+    renderRestHook = makeRenderRestHook(makeCacheProvider);
+  });
+
+  it('should work on good network', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useDLE(CoolerArticleResource.detail(), {
+        id: payload.id,
+      });
+    });
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.error).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.data).toEqual(CoolerArticleResource.fromJS(payload));
+  });
+
+  it('should work on good network with endpoint', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useDLE(TypedArticleResource.detail(), {
+        id: payload.id,
+      });
+    });
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.error).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.data).toEqual(CoolerArticleResource.fromJS(payload));
+  });
+
+  it('should return errors on bad network', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useDLE(CoolerArticleResource.detail(), {
+        title: '0',
+      });
+    });
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.error).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeDefined();
+    expect((result.current.error as any).status).toBe(403);
+  });
+
+  it('should pass with exact params', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      return useDLE(TypedArticleResource.detail(), {
+        id: payload.id,
+      });
+    });
+    expect(result.current.data).toBeUndefined();
+    await waitForNextUpdate();
+    // type discrimination forces it to be resolved
+    if (!result.current.loading && result.current.error === undefined) {
+      expect(result.current.data.title).toBe(payload.title);
+      // @ts-expect-error ensure this isn't "any"
+      result.current.data.doesnotexist;
+    }
+  });
+
+  it('should fail with improperly typed param', async () => {
+    const { result, waitForNextUpdate } = renderRestHook(() => {
+      // @ts-expect-error
+      return useDLE(TypedArticleResource.detail(), {
+        id: { a: 'five' },
+      });
+    });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeDefined();
+    if (result.current.error) {
+      expect(result.current.error.status).toBe(404);
+    }
+  });
+
+  it('should fetch anew with param changes', async () => {
+    const { result, waitForNextUpdate, rerender } = renderRestHook(
+      ({ id }: { id: number }) => {
+        return useDLE(CoolerArticleResource.detail(), {
+          id,
+        });
+      },
+      { initialProps: { id: payload.id } },
+    );
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.error).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.data).toEqual(CoolerArticleResource.fromJS(payload));
+    await rerender({ id: payload2.id });
+    expect(result.current.data).toBe(undefined);
+    expect(result.current.error).toBe(undefined);
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.data).toEqual(CoolerArticleResource.fromJS(payload2));
+  });
+
+  it('should not be loading with null params to useStatefulResource()', () => {
+    const { result } = renderRestHook(() => {
+      return useDLE(CoolerArticleResource.detail(), null);
+    });
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('should maintain schema structure even with null params', () => {
+    const { result } = renderRestHook(() => {
+      return useDLE(PaginatedArticleResource.list(), null);
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data.results).toBeUndefined();
+    expect(result.current.data.nextPage).toBe('');
+    // ensure this isn't 'any'
+    // @ts-expect-error
+    const a: PaginatedArticleResource[] = result.current.data.results;
+  });
+
+  it('should not select when results are stale and invalidIfStale is true', async () => {
+    const realDate = global.Date.now;
+    Date.now = jest.fn(() => 999999999);
+    const { result, rerender, waitForNextUpdate } = renderRestHook(
+      props => {
+        return useDLE(InvalidIfStaleArticleResource.detail(), props);
+      },
+      { initialProps: { id: payload.id } as any },
+    );
+
+    await waitForNextUpdate();
+    expect(result.current.data).toBeDefined();
+    Date.now = jest.fn(() => 999999999 * 3);
+
+    rerender(null);
+    expect(result.current.data).toBeUndefined();
+    rerender({ id: payload.id });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.loading).toBe(true);
+    await waitForNextUpdate();
+    expect(result.current.data).toBeDefined();
+    expect(result.current.loading).toBe(false);
+
+    global.Date.now = realDate;
+  });
+});

--- a/packages/core/src/react-integration/newhooks/index.ts
+++ b/packages/core/src/react-integration/newhooks/index.ts
@@ -3,3 +3,4 @@ export { default as useCache } from '@rest-hooks/core/react-integration/newhooks
 export { default as useError } from '@rest-hooks/core/react-integration/newhooks/useError';
 export { default as useFetch } from '@rest-hooks/core/react-integration/newhooks/useFetch';
 export { default as useSubscription } from '@rest-hooks/core/react-integration/newhooks/useSubscription';
+export { default as useDLE } from '@rest-hooks/core/react-integration/newhooks/useDLE';

--- a/packages/core/src/react-integration/newhooks/useCache.ts
+++ b/packages/core/src/react-integration/newhooks/useCache.ts
@@ -64,7 +64,7 @@ export default function useCache<
   const wouldSuspend = expiryStatus !== ExpiryStatus.Valid && expired;
 
   return useMemo(() => {
-    // if useResource() would suspend, don't include entities from cache
+    // if useSuspense() would suspend, don't include entities from cache
     if (wouldSuspend) {
       if (!endpoint.schema) return undefined;
       // @ts-ignore

--- a/packages/core/src/react-integration/newhooks/useDLE.ts
+++ b/packages/core/src/react-integration/newhooks/useDLE.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import type {
+  Denormalize,
+  DenormalizeNullable,
+  ErrorTypes,
+  EndpointInterface,
+  FetchFunction,
+  Schema,
+} from '@rest-hooks/endpoint';
+import useController from '@rest-hooks/core/react-integration/hooks/useController';
+import { ExpiryStatus } from '@rest-hooks/endpoint';
+import { StateContext } from '@rest-hooks/core/react-integration/context';
+import { useContext, useMemo } from 'react';
+
+type CondNull<P, A, B> = P extends null ? A : B;
+
+type StatefulReturn<S extends Schema | undefined, P> = CondNull<
+  P,
+  {
+    data: DenormalizeNullable<S>;
+    loading: false;
+    error: undefined;
+  },
+  | {
+      data: Denormalize<S>;
+      loading: false;
+      error: undefined;
+    }
+  | { data: DenormalizeNullable<S>; loading: true; error: undefined }
+  | { data: DenormalizeNullable<S>; loading: false; error: ErrorTypes }
+>;
+
+/**
+ * Use async date with { data, loading, error } (DLE)
+ * @see https://resthooks.io/docs/guides/no-suspense
+ */
+export default function useDLE<
+  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  Args extends readonly [...Parameters<E>] | readonly [null],
+>(endpoint: E, ...args: Args): StatefulReturn<E['schema'], Args[0]> {
+  const state = useContext(StateContext);
+  const controller = useController();
+
+  const key = args[0] !== null ? endpoint.key(...args) : '';
+  const cacheResults = args[0] !== null && state.results[key];
+
+  // Compute denormalized value
+  // eslint-disable-next-line prefer-const
+  let { data, expiryStatus, expiresAt } = useMemo(() => {
+    // @ts-ignore
+    return controller.getResponse(endpoint, ...args, state) as {
+      data: DenormalizeNullable<E['schema']> | undefined;
+      expiryStatus: ExpiryStatus;
+      expiresAt: number;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    cacheResults,
+    state.indexes,
+    state.entities,
+    state.entityMeta,
+    state.meta,
+    key,
+  ]);
+
+  // @ts-ignore
+  const error = controller.getError(endpoint, ...args, state);
+
+  // If we are hard invalid we must fetch regardless of triggering or staleness
+  const forceFetch = expiryStatus === ExpiryStatus.Invalid;
+
+  const maybePromise = useMemo(() => {
+    // null params mean don't do anything
+    if ((Date.now() <= expiresAt && !forceFetch) || !key) return;
+
+    return controller.fetch(endpoint, ...(args as any)).catch(() => {});
+    // we need to check against serialized params, since params can change frequently
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expiresAt, controller, key, forceFetch, state.lastReset]);
+
+  // fully "valid" data will not suspend/loading even if it is not fresh
+  const loading = expiryStatus !== ExpiryStatus.Valid && !!maybePromise;
+
+  data = useMemo(() => {
+    // if useSuspense() would suspend, don't include entities from cache
+    if (loading) {
+      if (!endpoint.schema) return undefined;
+      // @ts-ignore
+      return controller.getResponse(endpoint, ...args, {
+        ...state,
+        entities: {},
+      }).data as any;
+    }
+    return data;
+    // key substitutes args + endpoint
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, controller, data, loading, state]);
+
+  return {
+    data,
+    loading,
+    error,
+  } as any;
+}


### PR DESCRIPTION
Fixes #1467

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Keep legacy just for back compat support.
- Avoid cross-package peerDeps issues with weird package managers

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
useDLE (data-loading-error) is like useStatefulResource except:

- Accepts [Endpoints](https://resthooks.io/docs/getting-started/endpoint) only
- Inside core package so additional package not needed.
- Doesn't awkwardly rely on denormalize export from normalizr
- Everything else is copy/paste of useStatefulResource()

Note: Keeping useStatefulResource() in legacy for use with FetchShape