### PR TITLE
enhance: Resource extends from Entity rather than EntityRecord

### DIFF
--- a/packages/experimental/src/rest/BaseResource.ts
+++ b/packages/experimental/src/rest/BaseResource.ts
@@ -1,6 +1,6 @@
 import { Endpoint } from '@rest-hooks/endpoint';
 import type { EndpointExtraOptions, Schema } from '@rest-hooks/endpoint';
-import { EntityRecord } from '@rest-hooks/rest';
+import { Entity } from '@rest-hooks/endpoint';
 
 import paramsToString from './paramsToString';
 import { RestEndpoint } from './types';
@@ -25,7 +25,7 @@ class NetworkError extends Error {
  * This can be a useful organization for many REST-like API patterns.
  * @see https://resthooks.io/docs/api/resource
  */
-export default abstract class BaseResource extends EntityRecord {
+export default abstract class BaseResource extends Entity {
   // typescript todo: require subclasses to implement
   /** Used as base of url construction */
   static readonly urlRoot: string;


### PR DESCRIPTION
BREAKING CHANGE: Resource loses hasDefined, mergeRecord,
toObjectDefined, keysDefined, set

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
These weren't super useful in practice

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
No longer rely on rest package which shouldn't have been the case to begin with.