### PR TITLE
feat: Add CacheProvider Controller prop to allow controller customization

### DIFF
--- a/packages/core/src/react-integration/provider/CacheProvider.tsx
+++ b/packages/core/src/react-integration/provider/CacheProvider.tsx
@@ -15,16 +15,18 @@ interface ProviderProps {
   children: ReactNode;
   managers: Manager[];
   initialState: State<unknown>;
+  Controller: typeof Controller;
 }
 
 /**
- * Controller managing state of the REST cache and coordinating network requests.
+ * Controller managing state of the cache and coordinating network requests.
  * @see https://resthooks.io/docs/api/CacheProvider
  */
 export default function CacheProvider({
   children,
   managers,
   initialState,
+  Controller,
 }: ProviderProps) {
   // contents of this component expected to be relatively stable
 
@@ -60,4 +62,5 @@ export default function CacheProvider({
 CacheProvider.defaultProps = {
   managers: [new NetworkManager()] as Manager[],
   initialState: defaultState as State<unknown>,
+  Controller,
 };


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Users can extends Controller to augment or add extra methods

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```tsx
class MyController extends Controller {
}

<CacheProvider Controller=MyController/>
```