### PR TITLE
fix: optimisticUpdate when used with controller.fetch or useSuspense

### DIFF
--- a/packages/core/src/controller/createReceive.ts
+++ b/packages/core/src/controller/createReceive.ts
@@ -39,7 +39,7 @@ export default function createReceive<
   endpoint: E,
   {
     args,
-    fetchedAt = 0,
+    fetchedAt,
     response,
     error = false,
   }: {
@@ -59,7 +59,7 @@ export default function createReceive<
   const now = Date.now();
   const meta: ReceiveAction['meta'] = {
     args,
-    fetchedAt,
+    fetchedAt: fetchedAt ?? now,
     date: now,
     expiresAt: now + expiryLength,
     // For legacy support; TODO: remove

--- a/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
@@ -284,7 +284,7 @@ describe.each([
           return { fetch, article };
         },
         {
-          results: [
+          initialFixtures: [
             {
               endpoint: CoolerArticleResource.detail(),
               args: [params],

--- a/packages/core/src/react-integration/__tests__/integration-optimistic-legacy-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-optimistic-legacy-endpoint.web.tsx
@@ -271,11 +271,11 @@ describe.each([
           return { put, article };
         },
         {
-          results: [
+          initialFixtures: [
             {
-              request: CoolerArticleResource.detail(),
-              params,
-              result: payload,
+              endpoint: CoolerArticleResource.detail(),
+              args: [params],
+              response: payload,
             },
           ],
         },

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -90,7 +90,8 @@ const addEntities =
         const useIncoming =
           // we may have in store but not in meta; so this existance check is still important
           !inStoreMeta ||
-          (schema.useIncoming
+          // useIncoming should not be used with legacy optimistic
+          (schema.useIncoming && meta.fetchedAt
             ? schema.useIncoming(
                 inStoreMeta,
                 meta,

--- a/packages/test/src/mockState.ts
+++ b/packages/test/src/mockState.ts
@@ -57,76 +57,82 @@ export interface ErrorFixture {
 export type FixtureEndpoint = SuccessFixtureEndpoint | ErrorFixtureEndpoint;
 export type Fixture = SuccessFixture | ErrorFixture | FixtureEndpoint;
 
-export function actionFromFixture(fixture: Fixture) {
+export function actionFromFixture(fixture: SuccessFixture | ErrorFixture) {
   let action: ReceiveAction;
-  let key: string;
 
-  // Endpoint path
-  if ('endpoint' in fixture) {
-    const { endpoint, args, response, error } = fixture;
-    key = endpoint.key(...args);
-    if (error === true) {
-      action = createReceiveError(response, {
-        errorExpiryLength: 10000000,
-        schema: endpoint.schema,
-        //args,
-        key,
-      });
-    } else {
-      action = createReceive(response, {
-        dataExpiryLength: 10000000,
-        type: 'read' as const,
-        schema: endpoint.schema,
-        update: (endpoint as any).update,
-        args,
-        key,
-      });
-    }
-    // FetchShape path
+  const { request, params, body, result, error } = fixture;
+  const { schema, getFetchKey, options } = request;
+  const args = [params, body] as const;
+  const key = getFetchKey(params);
+  if (error === true) {
+    action = createReceiveError(result as Error, {
+      errorExpiryLength: options?.errorExpiryLength ?? 1000,
+      ...options,
+      schema,
+      key,
+    });
   } else {
-    const { request, params, body, result, error } = fixture;
-    const { schema, getFetchKey, options } = request;
-    const args = [params, body] as const;
-    key = getFetchKey(params);
-    if (error === true) {
-      action = createReceiveError(result as Error, {
-        errorExpiryLength: 10000000,
-        ...options,
-        schema,
-        key,
-      });
-    } else {
-      action = createReceive(result, {
-        dataExpiryLength: 10000000,
-        type: 'read' as const,
-        ...options,
-        args,
-        schema,
-        key,
-      });
-    }
+    action = createReceive(result, {
+      dataExpiryLength: options?.dataExpiryLength ?? 60000,
+      type: 'read' as const,
+      ...options,
+      args,
+      schema,
+      key,
+    });
   }
 
-  return { key, action };
+  return action;
 }
 
-export default function mockInitialState(results: Fixture[]): State<unknown> {
+export default function mockInitialState(fixtures: Fixture[]): State<unknown> {
   let reducer: (
     state: State<unknown> | undefined,
     action: ActionTypes,
   ) => State<unknown>;
+  const actions: ReceiveAction[] = [];
+  const dispatch = (action: any) => {
+    actions.push(action);
+    return Promise.resolve();
+  };
+  const controller = new RestHooks.Controller({ dispatch });
   // >=6.1 of Rest Hooks / >=3.1 of RH/core
   if ('createReducer' in RestHooks) {
     // `{...RestHooks}` blocks webpack from barfing during compilation if createReducer export isn't available
-    reducer = { ...RestHooks }.createReducer(new RestHooks.Controller());
+    reducer = { ...RestHooks }.createReducer(controller);
     // previous versions
   } else {
     reducer = (RestHooks as any).reducer;
   }
 
-  const mockState = results.reduce((acc, fixture) => {
-    const { action } = actionFromFixture(fixture);
-    return reducer(acc, action);
-  }, initialState);
-  return mockState;
+  fixtures.forEach(fixture => {
+    if ('endpoint' in fixture) {
+      dispatchFixture(fixture, controller);
+    } else {
+      actions.push(actionFromFixture(fixture));
+    }
+  });
+  return actions.reduce(reducer, initialState);
+}
+
+export function dispatchFixture(
+  fixture: FixtureEndpoint,
+  controller: RestHooks.Controller,
+  fetchedAt?: number,
+) {
+  const { endpoint, args, response, error } = fixture;
+  if (controller.resolve) {
+    controller.resolve(endpoint, {
+      args,
+      response,
+      error,
+      fetchedAt: fetchedAt ?? Date.now(),
+    });
+  } else {
+    if (error === true) {
+      controller.receiveError(endpoint, ...args, response);
+    } else {
+      controller.receive(endpoint, ...args, response);
+    }
+  }
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
When using modern fetch methods like useSuspense and Controller.fetch, the legacy optimisticUpdate computing a fetchedAt of 0 which cannot compare to previously stored data. This was missed in our legacy optimisticUpdate tests due to our mocking code not reflecting the new behavior of those new fetches.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

- Update mock state to detect new fetches and appropriately reflect their behavior.
- Only useIncoming() when fetchedAt is defined (to fallback to previous behavior if not existing)
- Ensure legacy test fails when fix is not in place
