### PR TITLE
feat: Simplify Resource.create() & Resource.list() arguments 

### DIFF
--- a/__tests__/common.ts
+++ b/__tests__/common.ts
@@ -256,7 +256,7 @@ export class ArticleResourceWithOtherListUrl extends ArticleResource {
     const list = ArticleResourceWithOtherListUrl.list();
     const otherList = ArticleResourceWithOtherListUrl.otherList();
     return super.create().extend({
-      getOptimisticResponse: (snap, params, body) => body,
+      getOptimisticResponse: (snap, body) => body,
       schema: this,
       update: (newArticleID: string) => ({
         [list.key({})]: (articleIDs: string[] | undefined) => [

--- a/__tests__/legacy-optimistic.ts
+++ b/__tests__/legacy-optimistic.ts
@@ -8,17 +8,10 @@ import {
   SchemaDetail,
   SchemaList,
 } from '@rest-hooks/endpoint';
-import {
-  Resource,
-  RestEndpoint,
-  RestFetch,
-  FetchGet,
-  FetchMutate,
-  HookableResource,
-} from '@rest-hooks/rest';
+import { rest3 } from '@rest-hooks/legacy';
 import React, { createContext, useContext } from 'react';
 
-export class UserResource extends Resource {
+export class UserResource extends rest3.Resource {
   readonly id: number | undefined = undefined;
   readonly username: string = '';
   readonly email: string = '';
@@ -30,7 +23,7 @@ export class UserResource extends Resource {
 
   static urlRoot = 'http://test.com/user/';
 }
-export class ArticleResource extends Resource {
+export class ArticleResource extends rest3.Resource {
   readonly id: number | undefined = undefined;
   readonly title: string = '';
   readonly content: string = '';
@@ -53,13 +46,13 @@ export class ArticleResource extends Resource {
     return super.url(urlParams);
   }
 
-  static longLiving<T extends typeof Resource>(this: T) {
+  static longLiving<T extends typeof rest3.Resource>(this: T) {
     return this.detail().extend({
       dataExpiryLength: 1000 * 60 * 60,
     });
   }
 
-  static neverRetryOnError<T extends typeof Resource>(this: T) {
+  static neverRetryOnError<T extends typeof rest3.Resource>(this: T) {
     return this.detail().extend({
       errorExpiryLength: Infinity,
     });
@@ -79,9 +72,9 @@ export class ArticleResource extends Resource {
     });
   }
 
-  static partialUpdate<T extends typeof Resource>(
+  static partialUpdate<T extends typeof rest3.Resource>(
     this: T,
-  ): RestEndpoint<FetchMutate, T, true> {
+  ): rest3.RestEndpoint<rest3.FetchMutate, T, true> {
     return super.partialUpdate().extend({
       optimisticUpdate: (params: any, body: any) => ({
         id: params.id,
@@ -91,66 +84,12 @@ export class ArticleResource extends Resource {
     });
   }
 
-  static delete<T extends typeof Resource>(this: T) {
+  static delete<T extends typeof rest3.Resource>(this: T) {
     return super.delete().extend({
       optimisticUpdate: (params: any) => params,
       schema: new schema.Delete(this),
     });
   }
-}
-
-export const AuthContext = createContext('');
-
-export class ContextAuthdArticle extends HookableResource {
-  readonly id: number | undefined = undefined;
-  readonly title: string = '';
-  readonly content: string = '';
-  readonly author: UserResource | null = null;
-  readonly tags: string[] = [];
-
-  pk() {
-    return this.id?.toString();
-  }
-
-  static schema = {
-    author: UserResource,
-  };
-
-  static urlRoot = 'http://test.com/article/';
-  static url(urlParams?: any): string {
-    if (urlParams && !urlParams.id) {
-      return `${this.urlRoot}${urlParams.title}`;
-    }
-    return super.url(urlParams);
-  }
-
-  /** Init options for fetch */
-  static useFetchInit(init: RequestInit): RequestInit {
-    /* eslint-disable-next-line */
-    const accessToken = useContext(AuthContext);
-    return {
-      ...init,
-      headers: {
-        ...init.headers,
-        'Access-Token': accessToken,
-      },
-    };
-  }
-}
-
-export class ArticleTimedResource extends ArticleResource {
-  readonly createdAt = new Date(0);
-
-  static schema = {
-    ...ArticleResource.schema,
-    createdAt: Date,
-  };
-
-  static urlRoot = 'http://test.com/article-time/';
-}
-
-export class UrlArticleResource extends ArticleResource {
-  readonly url: string = 'happy.com';
 }
 
 export class ArticleResourceWithOtherListUrl extends ArticleResource {
@@ -160,7 +99,7 @@ export class ArticleResourceWithOtherListUrl extends ArticleResource {
     });
   }
 
-  static create<T extends typeof Resource>(this: T) {
+  static create<T extends typeof rest3.Resource>(this: T) {
     return super.create().extend({
       optimisticUpdate: (
         params: Readonly<object>,
@@ -178,63 +117,6 @@ export class CoolerArticleResource extends ArticleResource {
   }
 }
 
-export class TypedArticleResource extends CoolerArticleResource {
-  get tagString() {
-    return this.tags.join(', ');
-  }
-
-  static update<T extends typeof Resource>(
-    this: T,
-  ): RestEndpoint<
-    FetchMutate<
-      [{ id: number }, Partial<AbstractInstanceType<T>>],
-      Partial<AbstractInstanceType<T>>
-    >,
-    SchemaDetail<AbstractInstanceType<T>>,
-    true
-  > {
-    return super.update();
-  }
-
-  static detail<T extends typeof Resource>(
-    this: T,
-  ): RestEndpoint<
-    FetchGet<[{ id: number }], Partial<AbstractInstanceType<T>>>,
-    SchemaDetail<AbstractInstanceType<T>>,
-    undefined
-  > {
-    return super.detail();
-  }
-
-  static list<T extends typeof Resource>(
-    this: T,
-  ): RestEndpoint<
-    RestFetch<[any], Partial<AbstractInstanceType<T>>[]>,
-    SchemaList<AbstractInstanceType<T>>,
-    undefined
-  > {
-    return super.list();
-  }
-
-  static anyparam<T extends typeof Resource>(
-    this: T,
-  ): RestEndpoint<(a: any) => Promise<any>> {
-    return super.detail() as any;
-  }
-
-  static anybody<T extends typeof Resource>(
-    this: T,
-  ): RestEndpoint<(a: any, b: any) => Promise<any>> {
-    return super.detail() as any;
-  }
-
-  static noparams<T extends typeof Resource>(
-    this: T,
-  ): RestEndpoint<() => Promise<any>, T[], undefined> {
-    return super.list() as any;
-  }
-}
-
 export class FutureArticleResource extends CoolerArticleResource {
   static url(id: any): string {
     if (this.pk({ id }) !== undefined) {
@@ -243,10 +125,10 @@ export class FutureArticleResource extends CoolerArticleResource {
     return this.urlRoot;
   }
 
-  static update<T extends typeof Resource>(
+  static update<T extends typeof rest3.Resource>(
     this: T,
-  ): RestEndpoint<
-    FetchMutate<
+  ): rest3.RestEndpoint<
+    rest3.FetchMutate<
       [{ id: number }, Partial<AbstractInstanceType<T>>],
       Partial<AbstractInstanceType<T>>
     >,
@@ -256,9 +138,9 @@ export class FutureArticleResource extends CoolerArticleResource {
     return super.update();
   }
 
-  static create<T extends typeof Resource>(
+  static create<T extends typeof rest3.Resource>(
     this: T,
-  ): RestEndpoint<
+  ): rest3.RestEndpoint<
     (
       body: Partial<AbstractInstanceType<T>>,
     ) => Promise<Partial<AbstractInstanceType<T>>>,
@@ -281,9 +163,9 @@ export class FutureArticleResource extends CoolerArticleResource {
     });
   }
 
-  static detail<T extends typeof Resource>(
+  static detail<T extends typeof rest3.Resource>(
     this: T,
-  ): RestEndpoint<
+  ): rest3.RestEndpoint<
     (id: number) => Promise<Partial<AbstractInstanceType<T>>>,
     T,
     undefined
@@ -291,9 +173,9 @@ export class FutureArticleResource extends CoolerArticleResource {
     return super.detail().extend({ schema: this });
   }
 
-  /*static list<T extends typeof Resource>(
+  /*static list<T extends typeof rest3.Resource>(
     this: T,
-  ): RestEndpoint<
+  ): rest3.RestEndpoint<
     (
       options?: Record<string, any>,
     ) => Promise<Partial<AbstractInstanceType<T>>[]>,
@@ -302,255 +184,4 @@ export class FutureArticleResource extends CoolerArticleResource {
   > {
     return super.detail().extend({ schema: [this] });
   } - once useResource() takes variable params*/
-}
-
-export class CoauthoredArticleResource extends FutureArticleResource {
-  readonly coAuthors: UserResource[] = [];
-  static schema = {
-    ...FutureArticleResource.schema,
-    coAuthors: [UserResource],
-  };
-}
-
-export const CoolerArticleDetail = new Endpoint(
-  ({ id }: { id: number }) => {
-    return fetch(`http://test.com/article-cooler/${id}`).then(res =>
-      res.json(),
-    ) as Promise<{
-      [k in keyof CoolerArticleResource]: CoolerArticleResource[k];
-    }>;
-  },
-  {
-    key({ id }: { id: number }) {
-      return `article-cooler ${id}`;
-    },
-  },
-);
-
-export class IndexedUserResource extends UserResource {
-  static indexes = ['username' as const];
-
-  static index() {
-    return new Index(this);
-  }
-}
-
-export class InvalidIfStaleArticleResource extends CoolerArticleResource {
-  static getEndpointExtra(): EndpointExtraOptions {
-    return {
-      ...super.getEndpointExtra(),
-      dataExpiryLength: 5000,
-      errorExpiryLength: 5000,
-      invalidIfStale: true,
-    };
-  }
-}
-
-export class PollingArticleResource extends ArticleResource {
-  static getEndpointExtra(): EndpointExtraOptions {
-    return {
-      ...super.getEndpointExtra(),
-      pollFrequency: 5000,
-    };
-  }
-
-  static pusher<T extends typeof PollingArticleResource>(this: T) {
-    return this.detail().extend({
-      extra: {
-        eventType: 'PollingArticleResource:fetch',
-      },
-    });
-  }
-
-  static anotherDetail<T extends typeof PollingArticleResource>(this: T) {
-    return this.detail().extend({
-      method: 'GET',
-      schema: this,
-    });
-  }
-}
-
-export class StaticArticleResource extends ArticleResource {
-  static urlRoot = 'http://test.com/article-static/';
-
-  static EndpointExtraOptions() {
-    return {
-      ...super.getEndpointExtra(),
-      dataExpiryLength: Infinity,
-    };
-  }
-}
-
-class OtherArticleResource extends CoolerArticleResource {}
-
-function makePaginatedRecord<T>(entity: T) {
-  return class PaginatedRecord extends SimpleRecord {
-    readonly prevPage = '';
-    readonly nextPage = '';
-    readonly results: AbstractInstanceType<T>[] = [];
-    static schema = { results: [entity] };
-  };
-}
-
-export class PaginatedArticleResource extends OtherArticleResource {
-  static urlRoot = 'http://test.com/article-paginated/';
-
-  static list<T extends typeof Resource>(
-    this: T,
-  ): RestEndpoint<
-    FetchFunction,
-    { results: T[]; prevPage: string; nextPage: string },
-    undefined
-  > {
-    return super.list().extend({
-      schema: { results: [this], prevPage: '', nextPage: '' },
-    });
-  }
-
-  static listDefaults<T extends typeof Resource>(this: T) {
-    return super.list().extend({
-      schema: makePaginatedRecord(this),
-    });
-  }
-
-  static detail<T extends typeof Resource>(this: T) {
-    return super.detail().extend({
-      schema: { data: this },
-    });
-  }
-}
-
-export const ListPaginatedArticle = new Endpoint(
-  (params: Readonly<Record<string, string | number>>) => {
-    return PaginatedArticleResource.fetch(
-      PaginatedArticleResource.listUrl(params),
-      PaginatedArticleResource.getFetchInit({ method: 'GET' }),
-    );
-  },
-  {
-    schema: makePaginatedRecord(PaginatedArticleResource),
-  },
-);
-
-export class UnionResource extends Resource {
-  readonly id: string = '';
-  readonly body: string = '';
-  readonly type: string = '';
-
-  pk() {
-    return this.id;
-  }
-
-  static urlRoot = '/union/';
-
-  static detail<T extends typeof Resource>(this: T) {
-    return super.detail().extend({
-      schema: new schema.Union(
-        {
-          first: FirstUnionResource,
-          second: SecondUnionResource,
-        },
-        'type',
-      ),
-    });
-  }
-
-  static list<T extends typeof Resource>(this: T) {
-    return super.list().extend({
-      schema: [
-        new schema.Union(
-          {
-            first: FirstUnionResource,
-            second: SecondUnionResource,
-          },
-          (input: FirstUnionResource | SecondUnionResource) => input['type'],
-        ),
-      ],
-    });
-  }
-}
-export class FirstUnionResource extends UnionResource {
-  readonly type = 'first' as const;
-  readonly firstOnlyField: number = 5;
-}
-export class SecondUnionResource extends UnionResource {
-  readonly type = 'second' as const;
-  readonly secondeOnlyField: number = 10;
-}
-
-export class NestedArticleResource extends OtherArticleResource {
-  readonly user: number | null = null;
-
-  static schema = {
-    ...OtherArticleResource.schema,
-    user: UserResource,
-  };
-}
-
-export const GetPhoto = new Endpoint(
-  async function ({ userId }: { userId: string }): Promise<ArrayBuffer> {
-    const response = await fetch(this.key({ userId }));
-    const photoArrayBuffer = await response.arrayBuffer();
-    return photoArrayBuffer;
-  },
-  {
-    key({ userId }: { userId: string }) {
-      return `/users/${userId}/photo`;
-    },
-  },
-);
-
-export const GetPhotoUndefined = GetPhoto.extend({
-  key({ userId }: { userId: string }) {
-    return `/users/${userId}/photo2`;
-  },
-});
-// Currently Endpoint sets schema to null for backwards compat
-// However, we explicitly want to test undefined here to support non-backcompat endpoints
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-GetPhotoUndefined.schema = undefined;
-
-export const GetNoEntities = new Endpoint(
-  async function ({ userId }: { userId: string }) {
-    return await (await fetch(`http://test.com/users/${userId}/simple`)).json();
-  },
-  {
-    key({ userId }: { userId: string }) {
-      return `/users/${userId}/simple`;
-    },
-    schema: { firstThing: '', someItems: [] as { a: number }[] },
-  },
-);
-
-export const Post = new Endpoint(
-  async function ({ userId }: { userId: string }, body: BodyInit) {
-    return await (
-      await fetch(`http://test.com/users/${userId}/simple`, {
-        method: 'POST',
-        body,
-      })
-    ).json();
-  },
-  {
-    key({ userId }: { userId: string }) {
-      return `/users/${userId}/simple`;
-    },
-    schema: { firstThing: '', someItems: [] as { a: number }[] },
-  },
-);
-
-export function makeErrorBoundary(cb: (error: any) => void) {
-  return class ErrorInterceptor extends React.Component<any, { error: any }> {
-    state = { error: null };
-    componentDidCatch(error: any) {
-      this.setState({ error });
-      cb(error);
-    }
-
-    render() {
-      if (this.state.error) return null;
-      return this.props.children;
-    }
-  };
 }

--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -263,7 +263,7 @@ export class ArticleResourceWithOtherListUrl extends ArticleResource {
     const list = ArticleResourceWithOtherListUrl.list();
     const otherList = ArticleResourceWithOtherListUrl.otherList();
     return super.create().extend({
-      getOptimisticResponse: (snap, params, body) => body,
+      getOptimisticResponse: (snap, body) => body,
       schema: this,
       update: (newArticleID: string) => ({
         [list.key({})]: (articleIDs: string[] | undefined) => [

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
@@ -1,23 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useFetcher should dispatch an action that fetches a create 1`] = `
+exports[`useController.fetch should dispatch an action that fetches a create 1`] = `
 Object {
+  "endpoint": [Function],
   "meta": Object {
     "args": Array [
-      Object {},
       Object {
         "content": "hi",
       },
     ],
-    "key": "POST http://test.com/article-cooler/",
-    "options": Object {
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "method": "POST",
-      "signal": undefined,
-      "url": [Function],
-    },
+    "key": "POST http://test.com/article-cooler/?content=hi",
+    "options": [Function],
     "reject": [Function],
     "resolve": [Function],
     "schema": [Function],
@@ -29,8 +22,9 @@ Object {
 }
 `;
 
-exports[`useFetcher should dispatch an action that fetches a full update 1`] = `
+exports[`useController.fetch should dispatch an action that fetches a full update 1`] = `
 Object {
+  "endpoint": [Function],
   "meta": Object {
     "args": Array [
       Object {
@@ -41,14 +35,7 @@ Object {
       },
     ],
     "key": "PUT http://test.com/article-cooler/1",
-    "options": Object {
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "method": "PUT",
-      "signal": undefined,
-      "url": [Function],
-    },
+    "options": [Function],
     "reject": [Function],
     "resolve": [Function],
     "schema": [Function],
@@ -60,8 +47,9 @@ Object {
 }
 `;
 
-exports[`useFetcher should dispatch an action that fetches a partial update 1`] = `
+exports[`useController.fetch should dispatch an action that fetches a partial update 1`] = `
 Object {
+  "endpoint": [Function],
   "meta": Object {
     "args": Array [
       Object {
@@ -72,15 +60,7 @@ Object {
       },
     ],
     "key": "PATCH http://test.com/article-cooler/1",
-    "options": Object {
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "getOptimisticResponse": [Function],
-      "method": "PATCH",
-      "signal": undefined,
-      "url": [Function],
-    },
+    "options": [Function],
     "reject": [Function],
     "resolve": [Function],
     "schema": [Function],
@@ -92,232 +72,39 @@ Object {
 }
 `;
 
-exports[`useFetcher should dispatch an action with multiple updaters in the meta if update shapes params are passed in 1`] = `
+exports[`useController.fetch should dispatch an action with updater in the meta if update shapes params are passed in 1`] = `
 Object {
+  "endpoint": [Function],
   "meta": Object {
     "args": Array [
-      Object {},
       Object {
         "content": "hi",
       },
     ],
-    "key": "POST http://test.com/article/",
-    "options": Object {
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "getOptimisticResponse": [Function],
-      "method": "POST",
-      "signal": undefined,
-      "update": [Function],
-      "url": [Function],
-    },
+    "key": "POST http://test.com/article-cooler/?content=hi",
+    "options": [Function],
     "reject": [Function],
     "resolve": [Function],
     "schema": [Function],
     "throttle": false,
     "type": "mutate",
-    "update": [Function],
   },
   "payload": [Function],
   "type": "rest-hooks/fetch",
 }
 `;
 
-exports[`useFetcher should dispatch an action with updater in the meta if update shapes params are passed in 1`] = `
+exports[`useController.fetch should refresh get details 1`] = `
 Object {
-  "meta": Object {
-    "args": Array [
-      Object {},
-      Object {
-        "content": "hi",
-      },
-    ],
-    "key": "POST http://test.com/article-cooler/",
-    "options": Object {
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "method": "POST",
-      "signal": undefined,
-      "url": [Function],
-    },
-    "reject": [Function],
-    "resolve": [Function],
-    "schema": [Function],
-    "throttle": false,
-    "type": "mutate",
-    "update": [Function],
-  },
-  "payload": [Function],
-  "type": "rest-hooks/fetch",
-}
-`;
-
-exports[`useFetcher should refresh get details 1`] = `
-Object {
+  "endpoint": [Function],
   "meta": Object {
     "args": Array [
       Object {
         "id": 1,
       },
-      undefined,
     ],
     "key": "GET http://test.com/article-cooler/1",
-    "options": Object {
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "method": "GET",
-      "signal": undefined,
-      "url": [Function],
-    },
-    "reject": [Function],
-    "resolve": [Function],
-    "schema": [Function],
-    "throttle": false,
-    "type": "read",
-  },
-  "payload": [Function],
-  "type": "rest-hooks/fetch",
-}
-`;
-
-exports[`useRetrieve should dispatch singles 1`] = `
-Object {
-  "meta": Object {
-    "args": Array [
-      Object {
-        "content": "whatever",
-        "id": 5,
-        "tags": Array [
-          "a",
-          "best",
-          "react",
-        ],
-        "title": "hi ho",
-      },
-      undefined,
-    ],
-    "key": "GET http://test.com/article-cooler/5",
-    "options": Object {
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "method": "GET",
-      "signal": undefined,
-      "url": [Function],
-    },
-    "reject": [Function],
-    "resolve": [Function],
-    "schema": [Function],
-    "throttle": true,
-    "type": "read",
-  },
-  "payload": [Function],
-  "type": "rest-hooks/fetch",
-}
-`;
-
-exports[`useRetrieve should dispatch with fetch shape defined dataExpiryLength 1`] = `
-Object {
-  "meta": Object {
-    "args": Array [
-      Object {
-        "content": "whatever",
-        "id": 5,
-        "tags": Array [
-          "a",
-          "best",
-          "react",
-        ],
-        "title": "hi ho",
-      },
-      undefined,
-    ],
-    "key": "GET http://test.com/article-static/5",
-    "options": Object {
-      "dataExpiryLength": 3600000,
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "method": "GET",
-      "signal": undefined,
-      "url": [Function],
-    },
-    "reject": [Function],
-    "resolve": [Function],
-    "schema": [Function],
-    "throttle": true,
-    "type": "read",
-  },
-  "payload": [Function],
-  "type": "rest-hooks/fetch",
-}
-`;
-
-exports[`useRetrieve should dispatch with fetch shape defined errorExpiryLength 1`] = `
-Object {
-  "meta": Object {
-    "args": Array [
-      Object {
-        "content": "whatever",
-        "id": 5,
-        "tags": Array [
-          "a",
-          "best",
-          "react",
-        ],
-        "title": "hi ho",
-      },
-      undefined,
-    ],
-    "key": "GET http://test.com/article-static/5",
-    "options": Object {
-      "errorExpiryLength": Infinity,
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "method": "GET",
-      "signal": undefined,
-      "url": [Function],
-    },
-    "reject": [Function],
-    "resolve": [Function],
-    "schema": [Function],
-    "throttle": true,
-    "type": "read",
-  },
-  "payload": [Function],
-  "type": "rest-hooks/fetch",
-}
-`;
-
-exports[`useRetrieve should dispatch with resource defined dataExpiryLength 1`] = `
-Object {
-  "meta": Object {
-    "args": Array [
-      Object {
-        "content": "whatever",
-        "id": 5,
-        "tags": Array [
-          "a",
-          "best",
-          "react",
-        ],
-        "title": "hi ho",
-      },
-      undefined,
-    ],
-    "key": "GET http://test.com/article-static/5",
-    "options": Object {
-      "errorPolicy": [Function],
-      "fetchInit": Object {},
-      "getFetchInit": [Function],
-      "method": "GET",
-      "signal": undefined,
-      "url": [Function],
-    },
+    "options": [Function],
     "reject": [Function],
     "resolve": [Function],
     "schema": [Function],

--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CacheProvider Endpoint should gracefully abort in useResource() 1`] = `[AbortError: Aborted]`;
+exports[`CacheProvider Endpoint should gracefully abort in useSuspense() 1`] = `[AbortError: Aborted]`;
 
-exports[`CacheProvider Endpoint should resolve useResource() with SimpleRecords 1`] = `
+exports[`CacheProvider Endpoint should resolve useSuspense() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
     "author": UserResource {
@@ -59,7 +59,7 @@ Value: {
 ]
 `;
 
-exports[`CacheProvider should resolve useResource() with SimpleRecords 1`] = `
+exports[`CacheProvider should resolve useSuspense() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
     "author": UserResource {
@@ -92,7 +92,7 @@ Array [
 ]
 `;
 
-exports[`CacheProvider useResource() should throw errors on malformed response 1`] = `
+exports[`CacheProvider useSuspense() should throw errors on malformed response 1`] = `
 [Error: Error processing GET http://test.com/article-cooler/878
 
 Full Schema: {
@@ -121,9 +121,9 @@ First three members: [
 ]]
 `;
 
-exports[`ExternalCacheProvider Endpoint should gracefully abort in useResource() 1`] = `[AbortError: Aborted]`;
+exports[`ExternalCacheProvider Endpoint should gracefully abort in useSuspense() 1`] = `[AbortError: Aborted]`;
 
-exports[`ExternalCacheProvider Endpoint should resolve useResource() with SimpleRecords 1`] = `
+exports[`ExternalCacheProvider Endpoint should resolve useSuspense() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
     "author": UserResource {
@@ -180,7 +180,7 @@ Value: {
 ]
 `;
 
-exports[`ExternalCacheProvider should resolve useResource() with SimpleRecords 1`] = `
+exports[`ExternalCacheProvider should resolve useSuspense() with SimpleRecords 1`] = `
 Array [
   PaginatedArticleResource {
     "author": UserResource {
@@ -213,7 +213,7 @@ Array [
 ]
 `;
 
-exports[`ExternalCacheProvider useResource() should throw errors on malformed response 1`] = `
+exports[`ExternalCacheProvider useSuspense() should throw errors on malformed response 1`] = `
 [Error: Error processing GET http://test.com/article-cooler/878
 
 Full Schema: {

--- a/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
+++ b/packages/core/src/react-integration/__tests__/endpoint-types.web.tsx
@@ -6,7 +6,7 @@ import {
   makeCacheProvider,
   makeExternalCacheProvider,
 } from '../../../../test';
-import { useResource, useFetcher } from '../hooks';
+import { useResource, useController } from '../hooks';
 import { payload, createPayload, users, nested } from '../test-fixtures';
 
 function onError(e: any) {
@@ -100,49 +100,73 @@ describe('endpoint types', () => {
 
     it('should work with everything correct', async () => {
       const { result } = renderRestHook(() => {
-        return useFetcher(TypedArticleResource.update());
+        return useController().fetch;
       });
-      const a = await result.current({ id: payload.id }, { title: 'hi' });
+      const a = await result.current(
+        TypedArticleResource.update(),
+        { id: payload.id },
+        { title: 'hi' },
+      );
     });
 
     it('types should strictly enforce with parameters that are any', async () => {
       const { result } = renderRestHook(() => {
-        return useFetcher(TypedArticleResource.anyparam());
+        return useController().fetch;
       });
-      // @ts-expect-error
-      () => result.current({ id: payload.id }, { title: 'hi' });
-      () => result.current({ id: payload.id });
+      () =>
+        result.current(
+          TypedArticleResource.anyparam(),
+          { id: payload.id },
+          // @ts-expect-error
+          { title: 'hi' },
+        );
+      () => result.current(TypedArticleResource.anyparam(), { id: payload.id });
     });
 
     it('types should strictly enforce with body that are any', async () => {
       const { result } = renderRestHook(() => {
-        return useFetcher(TypedArticleResource.anybody());
+        return useController().fetch;
       });
-      () => result.current({ id: payload.id }, { title: 'hi' });
-      /* TODO: Re-enable for new fetch dispatcher
-        // @ts-expect-error
-        () => result.current({ id: payload.id });
-        */
+      () =>
+        result.current(
+          TypedArticleResource.anybody(),
+          { id: payload.id },
+          { title: 'hi' },
+        );
+      // @ts-expect-error
+      () => result.current(TypedArticleResource.anybody(), { id: payload.id });
     });
 
     it('should error on invalid payload', async () => {
       const { result } = renderRestHook(() => {
-        return useFetcher(TypedArticleResource.update());
+        return useController().fetch;
       });
-      // @ts-expect-error
-      await result.current({ id: payload.id }, { title2: 'hi' });
-      // @ts-expect-error
-      await result.current({ id: payload.id }, { title: 5 });
+      await result.current(
+        TypedArticleResource.update(),
+        { id: payload.id },
+        // @ts-expect-error
+        { title2: 'hi' },
+      );
+      await result.current(
+        TypedArticleResource.update(),
+        { id: payload.id },
+        // @ts-expect-error
+        { title: 5 },
+      );
     });
 
     it('should error on invalid params', async () => {
-      const { result, waitForNextUpdate } = renderRestHook(() => {
-        return useFetcher(TypedArticleResource.update());
+      const { result } = renderRestHook(() => {
+        return useController().fetch;
       });
 
       await expect(
-        // @ts-expect-error
-        result.current({ id: 'hi' }, { title: 'hi' }),
+        result.current(
+          TypedArticleResource.update(),
+          // @ts-expect-error
+          { id: 'hi' },
+          { title: 'hi' },
+        ),
       ).rejects.toEqual(expect.any(Error));
     });
   });

--- a/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
@@ -159,7 +159,7 @@ describe.each([
       const { result, waitForNextUpdate } = renderRestHook(
         () => {
           const { fetch } = useController();
-          const articles = useCache(CoolerArticleResource.list(), {});
+          const articles = useCache(CoolerArticleResource.list());
           return { fetch, articles };
         },
         {
@@ -223,7 +223,6 @@ describe.each([
       const promise = act(async () => {
         await result.current.fetch(
           ArticleResourceWithOtherListUrl.create(),
-          {},
           body,
         );
       });

--- a/packages/core/src/state/__tests__/reducer.ts
+++ b/packages/core/src/state/__tests__/reducer.ts
@@ -358,7 +358,7 @@ describe('reducer', () => {
           payload,
           meta: {
             schema: ArticleResource,
-            key: ArticleResource.create().key({}, {}),
+            key: ArticleResource.create().key({}),
             updaters,
             date: 0,
             expiresAt: 100000000000,

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -99,6 +99,6 @@
     "@babel/runtime": "^7.7.2"
   },
   "peerDependencies": {
-    "@rest-hooks/endpoint": "^2.0.0"
+    "@rest-hooks/endpoint": "^2.1.0"
   }
 }

--- a/packages/rest/src/HookableResource.ts
+++ b/packages/rest/src/HookableResource.ts
@@ -72,7 +72,7 @@ export default abstract class HookableResource extends BaseResource {
   static useList<T extends typeof HookableResource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any) => Promise<any>,
+    (this: RestEndpoint, params?: any) => Promise<any>,
     SchemaList<AbstractInstanceType<T>>,
     undefined
   > {
@@ -88,16 +88,20 @@ export default abstract class HookableResource extends BaseResource {
   static useCreate<T extends typeof HookableResource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any, body: any) => Promise<any>,
+    (this: RestEndpoint, body: any) => Promise<any>,
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
-    return this.useMemo('#create', () =>
-      this.endpointMutate().extend({
+    return this.useMemo('#create', () => {
+      const instanceFetch = this.fetch.bind(this);
+      return this.endpointMutate().extend({
+        fetch(this: RestEndpoint, body: any) {
+          return instanceFetch(this.url(), this.getFetchInit(body));
+        },
         schema: this,
         url: this.listUrl.bind(this),
-      }),
-    );
+      });
+    });
   }
 
   /** Endpoint to update an existing entity (put) */

--- a/packages/rest/src/Resource.ts
+++ b/packages/rest/src/Resource.ts
@@ -33,7 +33,7 @@ export default abstract class Resource extends BaseResource {
   static list<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any) => Promise<any>,
+    (this: RestEndpoint, params?: any) => Promise<any>,
     SchemaList<AbstractInstanceType<T>>,
     undefined
   > {
@@ -50,18 +50,21 @@ export default abstract class Resource extends BaseResource {
   static create<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any, body: any) => Promise<any>,
+    (this: RestEndpoint, body: any) => Promise<any>,
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
-    //Partial<AbstractInstanceType<T>>
-    const endpoint = this.endpointMutate();
-    return this.memo('#create', () =>
-      endpoint.extend({
+    return this.memo('#create', () => {
+      const endpoint = this.endpointMutate();
+      const instanceFetch = this.fetch.bind(this);
+      return endpoint.extend({
+        fetch(this: RestEndpoint, body: any) {
+          return instanceFetch(this.url(), this.getFetchInit(body));
+        },
         schema: this,
         url: this.listUrl.bind(this),
-      }),
-    );
+      });
+    });
   }
 
   /** Endpoint to update an existing entity (put) */

--- a/packages/rest/src/__tests__/hookableresource-endpoint.ts
+++ b/packages/rest/src/__tests__/hookableresource-endpoint.ts
@@ -183,7 +183,7 @@ describe('HookableResource', () => {
 
     it('useList', async () => {
       const { result, waitForNextUpdate } = renderRestHook(() =>
-        useSuspense(CoolerArticleResource.useList(), {}),
+        useSuspense(CoolerArticleResource.useList()),
       );
       await waitForNextUpdate();
       expect(result.current).toBeDefined();
@@ -197,9 +197,10 @@ describe('HookableResource', () => {
       const payload2 = { id: 20, content: 'better task' };
       const article = await result.current.fetch(
         result.current.endpoint,
-        {},
         payload2,
       );
+      // @ts-expect-error
+      () => result.current.fetch(result.current.endpoint, {}, payload2);
       expect(article).toMatchObject(payload2);
     });
 


### PR DESCRIPTION
BREAKING CHANGE: fetch(Resource.create(), {}, body) -> fetch(Resource.create(), body)

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
More intuitive endpoint definitions

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### Resource.list() arguments are optional

```tsx
const list = useSuspense(MyResource.list());
const filtered = useSuspense(MyResource.list(), { onlyGood: true });
```

#### Resource.create() only takes payload argument

```tsx
const { fetch } = useController()
const handler = () => fetch(MyResource.create(), payload);
```
