### PR TITLE
enhance: Improve type inference for getFetchKey

### DIFF
--- a/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/hooks-endpoint.web.tsx
@@ -11,7 +11,7 @@ import {
   mockInitialState,
 } from '../../../../test';
 import { ControllerContext, DispatchContext, StateContext } from '../context';
-import { useController } from '../hooks';
+import { useController, useFetcher } from '../hooks';
 import { State, ActionTypes } from '../../types';
 import { INVALIDATE_TYPE, RESET_TYPE } from '../../actionTypes';
 import { articlesPages } from '../test-fixtures';
@@ -105,6 +105,27 @@ describe('useController.fetch', () => {
       return null;
     }
     await testDispatchFetch(DispatchTester, [payload]);
+  });
+
+  it('useFetcher() handle zero argument Endpoints', async () => {
+    const endpoint = CoolerArticleResource.list().extend({
+      fetch() {
+        return CoolerArticleResource.list().call(this as any, {});
+      },
+      url() {
+        return '';
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    function DispatchTester() {
+      const a = useFetcher(endpoint);
+      a(undefined).then(v => {
+        v[0].author;
+        //@ts-expect-error
+        v.jasfdasdf;
+      });
+      return null;
+    }
   });
 
   it('should handle zero argument Endpoints', async () => {

--- a/packages/endpoint/src/endpoint.d.ts
+++ b/packages/endpoint/src/endpoint.d.ts
@@ -148,11 +148,7 @@ export interface EndpointInstance<
     : IfAny<M, any, IfTypeScriptLooseNull<'read', 'mutate'>>;
 
   /** @deprecated */
-  getFetchKey(
-    ...args: Parameters<F>[0] extends undefined
-      ? []
-      : [params: Parameters<F>[0]]
-  ): string;
+  getFetchKey(...args: OnlyFirst<Parameters<F>>): string;
   /** @deprecated */
   options?: EndpointExtraOptions<F>;
 }
@@ -179,3 +175,5 @@ export default Endpoint;
 
 type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
 type IfTypeScriptLooseNull<Y, N> = 1 | undefined extends 1 ? Y : N;
+
+type OnlyFirst<A extends unknown[]> = A extends [] ? [] : [A[0]];


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://github.com/coinbase/rest-hooks/pull/1514 wasn't good enough. This ends up doing weird things when the first param is optional because undefined is a distinct track.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Using tuple comparisons eliminates undefined as actual option from being problematic.