### PR TITLE
enhance: Infer parameter types from urlRoot

### DIFF
--- a/packages/experimental/src/rest/Resource.ts
+++ b/packages/experimental/src/rest/Resource.ts
@@ -7,7 +7,12 @@ import { schema } from '@rest-hooks/endpoint';
 
 import getArrayPath from './getArrayPath';
 import BaseResource from './BaseResource';
-import type { RestEndpoint, Paginatable } from './types';
+import type {
+  RestEndpoint,
+  Paginatable,
+  PathArgs,
+  PathArgsAndSearch,
+} from './types';
 
 /**
  * Represents an entity to be retrieved from a server.
@@ -19,7 +24,7 @@ export default abstract class Resource extends BaseResource {
   static detail<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any) => Promise<any>,
+    (this: RestEndpoint, params: PathArgs<T['urlRoot']>) => Promise<any>,
     SchemaDetail<AbstractInstanceType<T>>,
     undefined
   > {
@@ -36,7 +41,10 @@ export default abstract class Resource extends BaseResource {
     this: T,
   ): Paginatable<
     RestEndpoint<
-      (this: RestEndpoint, params?: any) => Promise<any>,
+      (
+        this: RestEndpoint,
+        params?: PathArgsAndSearch<T['urlRoot']>,
+      ) => Promise<any>,
       SchemaList<AbstractInstanceType<T>>,
       undefined
     >
@@ -71,7 +79,7 @@ export default abstract class Resource extends BaseResource {
           });
         },
       }),
-    );
+    ) as any;
   }
 
   /** Endpoint to create a new entity (post) */
@@ -104,7 +112,11 @@ export default abstract class Resource extends BaseResource {
   static update<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any, body: any) => Promise<any>,
+    (
+      this: RestEndpoint,
+      params: PathArgs<T['urlRoot']>,
+      body: any,
+    ) => Promise<any>,
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
@@ -121,7 +133,11 @@ export default abstract class Resource extends BaseResource {
   static partialUpdate<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any, body: any) => Promise<any>,
+    (
+      this: RestEndpoint,
+      params: PathArgs<T['urlRoot']>,
+      body: any,
+    ) => Promise<any>,
     SchemaDetail<AbstractInstanceType<T>>,
     true
   > {
@@ -138,7 +154,7 @@ export default abstract class Resource extends BaseResource {
   static delete<T extends typeof Resource>(
     this: T,
   ): RestEndpoint<
-    (this: RestEndpoint, params: any) => Promise<any>,
+    (this: RestEndpoint, params: PathArgs<T['urlRoot']>) => Promise<any>,
     schema.Delete<T>,
     true
   > {

--- a/packages/experimental/src/rest/__tests__/types.test.ts
+++ b/packages/experimental/src/rest/__tests__/types.test.ts
@@ -1,0 +1,14 @@
+import { PathArgs } from '../types';
+
+describe('types', () => {
+  it('should infer types', () => {
+    type C = 'http\\://test.com/groups/:group?/users/:id?/:next\\?bob/:last';
+    function A(args: PathArgs<C>) {}
+    // @ts-expect-error
+    () => A({});
+    () => A({ next: 'hi', last: 'ho' });
+    // @ts-expect-error
+    () => A({ next: 'hi', last: 'ho', doesnotexist: 'hi' });
+    () => A({ next: 'hi', last: 'ho', id: '5', group: 'whatever' });
+  });
+});

--- a/packages/experimental/src/rest/types.ts
+++ b/packages/experimental/src/rest/types.ts
@@ -45,8 +45,30 @@ export interface RestEndpoint<
 export type Paginatable<
   E extends EndpointInterface<RestFetch, Schema | undefined, true | undefined>,
 > = E & {
-  paginated<T extends E>(
-    this: T,
-    removeCursor: (...args: Parameters<E>) => any[],
-  ): T;
+  paginated<T extends E>(this: T, removeCursor: (...args: any) => any[]): T;
 };
+
+type OnlyOptional<S extends string> = S extends `${infer K}?` ? K : never;
+type OnlyRequired<S extends string> = S extends `${string}?` ? never : S;
+
+export type PathKeys<S extends string> = S extends `${string}\\:${infer R}`
+  ? PathKeys<R>
+  : S extends `${string}:${infer K}/${infer R}`
+  ? RemoveEscapes<K> | PathKeys<R>
+  : S extends `${string}:${infer K}`
+  ? RemoveEscapes<K>
+  : never;
+
+type RemoveEscapes<S extends string> = S extends `${infer K}\\?${string}`
+  ? K
+  : S;
+
+export type PathArgs<S extends string> = {
+  [K in PathKeys<S> as OnlyOptional<K>]?: string | number;
+} & {
+  [K in PathKeys<S> as OnlyRequired<K>]: string | number;
+};
+
+export type PathArgsAndSearch<S extends string> = {
+  [K in PathKeys<S> as OnlyRequired<K>]: string | number;
+} & Record<string, number | string>;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Writing custom endpoints is cumbersome....what if types could also be generated from urlRoot alone?

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

As long as urlRoot includes `as const`, our recursion type algorithm will automatically extract the relevant types and apply appropriately to all endpoints.

Note this relies on [template literal types](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html) which were introduced in [typescript 4.1](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html)

```tsx
class UserResource extends Resource {
  readonly id: number | undefined = undefined;
  readonly username: string = '';
  readonly email: string = '';
  readonly isAdmin: boolean = false;

  pk() {
    return this.id?.toString();
  }

  static urlRoot = 'http\\://test.com/groups/:group/users/:id?' as const;
}
expect(UserResource.detail().url({ group: 'big', id: '5' })).toBe(
  'http://test.com/groups/big/users/5',
);
expect(UserResource.detail().url({ group: 'big', id: '100' })).toBe(
  'http://test.com/groups/big/users/100',
);
expect(UserResource.list().url({ group: 'big', bob: '100' })).toBe(
  'http://test.com/groups/big/users?bob=100',
);
expect(UserResource.create().url({ group: 'big' }, { bob: '100' })).toBe(
  'http://test.com/groups/big/users',
);
expect(
  UserResource.update().url(
    { group: 'big', id: '100' },
    { id: '100', username: 'bob' },
  ),
).toBe('http://test.com/groups/big/users/100');

// missing required
expect(() =>
  // @ts-expect-error
  UserResource.detail().url({ id: '5' }),
).toThrow();
// extra fields
() =>
  UserResource.detail().url({
    group: 'mygroup',
    id: '5',
    // @ts-expect-error
    notexisting: 'hi',
  });
```

#### Type Algorithm

```ts
type OnlyOptional<S extends string> = S extends `${infer K}?` ? K : never;
type OnlyRequired<S extends string> = S extends `${string}?` ? never : S;

export type PathKeys<S extends string> = S extends `${string}\\:${infer R}`
  ? PathKeys<R>
  : S extends `${string}:${infer K}/${infer R}`
  ? K | PathKeys<R>
  : S extends `${string}:${infer K}`
  ? K
  : never;

export type PathArgs<S extends string> = {
  [K in PathKeys<S> as OnlyOptional<K>]?: string | number;
} & {
  [K in PathKeys<S> as OnlyRequired<K>]: string | number;
};
```
