### PR TITLE
fix: Update github example to use latest experimental Resource

### DIFF
--- a/examples/github-app/src/pages/IssueDetail/CommentsList.tsx
+++ b/examples/github-app/src/pages/IssueDetail/CommentsList.tsx
@@ -8,9 +8,19 @@ import CommentResource from '../../resources/CommentResource';
 
 const { Meta } = Card;
 
-export default function CommentsList({ issueUrl }: { issueUrl: string }) {
+export default function CommentsList({
+  owner,
+  repo,
+  number,
+}: {
+  owner: string;
+  repo: string;
+  number: string | number;
+}) {
   const { results: comments } = useSuspense(CommentResource.list(), {
-    issueUrl,
+    owner,
+    repo,
+    number,
   });
 
   return (

--- a/examples/github-app/src/pages/IssueDetail/index.tsx
+++ b/examples/github-app/src/pages/IssueDetail/index.tsx
@@ -12,8 +12,6 @@ import CommentsList, { CardLoading } from './CommentsList';
 
 const { Meta } = Card;
 
-type Props = Pick<IssueResource, 'repositoryUrl'>;
-
 function ReactionSpan({
   reactions,
   issue,
@@ -38,19 +36,15 @@ function ReactionSpan({
 
 function IssueDetail({ number: s }: { number: string }) {
   const number = Number.parseInt(s, 10);
+  const params = {
+    owner: 'facebook',
+    repo: 'react',
+    number,
+  };
 
-  useFetch(ReactionResource.list(), {
-    repositoryUrl: 'https://api.github.com/repos/facebook/react',
-    number,
-  });
-  const issue = useSuspense(IssueResource.detail(), {
-    repositoryUrl: 'https://api.github.com/repos/facebook/react',
-    number,
-  });
-  const { results: reactions } = useCache(ReactionResource.list(), {
-    repositoryUrl: 'https://api.github.com/repos/facebook/react',
-    number,
-  });
+  useFetch(ReactionResource.list(), params);
+  const issue = useSuspense(IssueResource.detail(), params);
+  const { results: reactions } = useCache(ReactionResource.list(), params);
 
   const actions: JSX.Element[] = useMemo(() => {
     const grouped = groupBy(reactions, (reaction) => reaction.content);
@@ -74,7 +68,7 @@ function IssueDetail({ number: s }: { number: string }) {
       </Card>
       {issue.comments ? (
         <Boundary fallback={<CardLoading />}>
-          <CommentsList issueUrl={issue.url} />
+          <CommentsList {...params} />
         </Boundary>
       ) : null}
     </React.Fragment>

--- a/examples/github-app/src/pages/IssueList.tsx
+++ b/examples/github-app/src/pages/IssueList.tsx
@@ -12,31 +12,29 @@ const REL = new Intl.RelativeTimeFormat(navigator.language || 'en-US', {
   style: 'long',
 });
 
-type Props = Pick<IssueResource, 'repositoryUrl'> &
-  (
-    | {
-        page: number;
-      }
-    | {
-        state?: IssueResource['state'];
-      }
-  );
+type Props = { owner: string; repo: string } & (
+  | {
+      page: number;
+    }
+  | {
+      state?: IssueResource['state'];
+    }
+);
 
-export default function IssueList({ repositoryUrl }: Props) {
+export default function IssueList({ owner, repo }: Props) {
   const location = useLocation();
   const page = Number.parseInt(
     new URLSearchParams(location && location.search.substring(1)).get('page') ||
       '1',
     10,
   );
-  const { results: issues, link } = useSuspense(IssueResource.list(), {
-    repositoryUrl,
+  const params = {
+    owner,
+    repo,
     page,
-  });
-  useSubscription(IssueResource.list(), {
-    repositoryUrl,
-    page,
-  });
+  };
+  const { results: issues, link } = useSuspense(IssueResource.list(), params);
+  useSubscription(IssueResource.list(), params);
 
   return (
     <>
@@ -53,16 +51,18 @@ export default function IssueList({ repositoryUrl }: Props) {
 }
 
 function NextPage({
-  repositoryUrl,
+  repo,
+  owner,
   page,
 }: {
-  repositoryUrl: string;
+  repo: string;
+  owner: string;
   page: number;
 }) {
   const { fetch } = useController();
   const [count, setCount] = useState(0);
   const loadMore = () => {
-    fetch(IssueResource.listPage(), { page: page + count + 1, repositoryUrl });
+    fetch(IssueResource.listPage(), { page: page + count + 1, repo, owner });
     setCount((count) => count + 1);
   };
   return (

--- a/examples/github-app/src/resources/BaseResource.ts
+++ b/examples/github-app/src/resources/BaseResource.ts
@@ -4,6 +4,7 @@ import {
   RestEndpoint,
   Paginatable,
   FetchGet,
+  PathArgsAndSearch,
 } from '@rest-hooks/experimental';
 
 function deeplyApplyKeyTransform(obj: any, transform: (key: string) => string) {
@@ -41,12 +42,19 @@ export default abstract class BaseResource extends Resource {
   static list<T extends typeof Resource>(
     this: T,
   ): Paginatable<
-    RestEndpoint<FetchGet, { results: T[]; link: string }, undefined>
+    RestEndpoint<
+      (
+        this: RestEndpoint,
+        params?: PathArgsAndSearch<T['urlRoot']>,
+      ) => Promise<any>,
+      { results: T[]; link: string },
+      undefined
+    >
   > {
     const instanceFetchResponse = this.fetchResponse.bind(this);
 
     return super.list().extend({
-      fetch: async function (params: Readonly<object>) {
+      fetch: async function (params: any) {
         const response = await instanceFetchResponse(
           this.url(params),
           this.getFetchInit(),
@@ -70,7 +78,7 @@ export default abstract class BaseResource extends Resource {
     this: T,
   ): Paginatable<
     RestEndpoint<
-      FetchGet<[{ page: number } & Parameters<ReturnType<T['list']>>[0]]>,
+      FetchGet<[{ page: number } & PathArgsAndSearch<T['urlRoot']>]>,
       { results: T[]; link: string },
       undefined
     >

--- a/examples/github-app/src/resources/CommentResource.ts
+++ b/examples/github-app/src/resources/CommentResource.ts
@@ -1,5 +1,3 @@
-import { Resource } from '@rest-hooks/experimental';
-
 import BaseResource from './BaseResource';
 import UserResource from './UserResource';
 
@@ -16,22 +14,8 @@ export default class CommentResource extends BaseResource {
     return this.id?.toString();
   }
 
-  static urlRoot = 'https://api.github.com/repos/issues/comments';
-
-  static url<T extends typeof Resource>(
-    this: T,
-    urlParams?: Readonly<any>,
-  ): string {
-    throw new Error('retrieving single comment not supported');
-  }
-
-  static listUrl<T extends typeof Resource>(
-    this: T,
-    searchParams?: Readonly<any>,
-  ): string {
-    if (!searchParams) throw new Error('requires searchparams');
-    return `${searchParams.issueUrl}/comments`;
-  }
+  static urlRoot =
+    'https\\://api.github.com/repos/:owner/:repo/issues/:number/comments' as const;
 
   static schema = {
     user: UserResource,

--- a/examples/github-app/src/resources/IssueResource.tsx
+++ b/examples/github-app/src/resources/IssueResource.tsx
@@ -1,12 +1,6 @@
-import {
-  EndpointExtraOptions,
-  FetchGet,
-  Resource,
-  RestEndpoint,
-} from '@rest-hooks/experimental';
+import { EndpointExtraOptions } from '@rest-hooks/experimental';
 import React from 'react';
 import { InfoCircleOutlined, IssuesCloseOutlined } from '@ant-design/icons';
-import { Paginatable } from '@rest-hooks/experimental';
 
 import BaseResource from './BaseResource';
 import UserResource from './UserResource';
@@ -46,42 +40,10 @@ export default class IssueResource extends BaseResource {
     return [this.repositoryUrl, this.number].join(',');
   }
 
-  static urlRoot = 'https://api.github.com/repos/issues';
+  static urlRoot =
+    'https\\://api.github.com/repos/:owner/:repo/issues/:number?' as const;
 
   static getEndpointExtra(): EndpointExtraOptions {
     return { ...super.getEndpointExtra(), pollFrequency: 60000 };
-  }
-
-  static url(urlParams: Readonly<any>): string {
-    if (urlParams) {
-      return `${urlParams.repositoryUrl}/issues/${urlParams.number}`;
-    }
-    return this.urlRoot;
-  }
-
-  static listUrl(
-    searchParams: Readonly<Record<string, string | number>>,
-  ): string {
-    const queryParams: any = {
-      ...searchParams,
-      per_page: 50,
-    };
-    delete queryParams.repositoryUrl;
-
-    const params = new URLSearchParams(queryParams);
-    params.sort();
-    return `${searchParams.repositoryUrl}/issues?${params.toString()}`;
-  }
-
-  static list<T extends typeof Resource>(
-    this: T,
-  ): Paginatable<
-    RestEndpoint<
-      FetchGet<[{ repositoryUrl: string; state?: string; page?: number }]>,
-      { results: T[]; link: string },
-      undefined
-    >
-  > {
-    return super.list() as any;
   }
 }

--- a/examples/github-app/src/resources/ReactionResource.tsx
+++ b/examples/github-app/src/resources/ReactionResource.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import { Resource } from '@rest-hooks/experimental';
 import { HeartOutlined } from '@ant-design/icons';
 
 import PreviewResource from './PreviewResource';
@@ -42,25 +40,8 @@ export default class ReactionResource extends PreviewResource {
     return this.id?.toString();
   }
 
-  static urlRoot = 'https://api.github.com/reactions/';
-
-  static listUrl<T extends typeof Resource>(
-    this: T,
-    searchParams?: Readonly<Record<string, string | number>>,
-  ): string {
-    if (!searchParams) throw new Error('need search params');
-    const queryParams: any = {
-      ...searchParams,
-    };
-    delete queryParams.repositoryUrl;
-    delete queryParams.number;
-
-    const params = new URLSearchParams(queryParams as any);
-    params.sort();
-    return `${searchParams.repositoryUrl}/issues/${
-      searchParams.number
-    }/reactions?${params.toString()}`;
-  }
+  static urlRoot =
+    'https\\://api.github.com/repos/:owner/:repo/issues/:number/reactions' as const;
 
   static schema = {
     user: UserResource,

--- a/examples/github-app/src/resources/UserResource.ts
+++ b/examples/github-app/src/resources/UserResource.ts
@@ -1,5 +1,3 @@
-import { FetchGet, Resource, RestEndpoint } from '@rest-hooks/experimental';
-
 import BaseResource from './BaseResource';
 
 export default class UserResource extends BaseResource {
@@ -48,21 +46,15 @@ export default class UserResource extends BaseResource {
     return this.login;
   }
 
-  static urlRoot = 'https://api.github.com/users/';
+  static urlRoot = 'https\\://api.github.com/users/:login?' as const;
 
   /** Retrieves current logged in user */
-  static current<T extends typeof Resource>(this: T) {
-    return super.endpoint().extend({
+  static current<T extends typeof UserResource>(this: T) {
+    return this.endpoint().extend({
       url() {
         return 'https://api.github.com/user/';
       },
       schema: this,
     });
-  }
-
-  static detail<T extends typeof Resource>(
-    this: T,
-  ): RestEndpoint<FetchGet<[{ login: string }]>, T, undefined> {
-    return super.detail().extend({ schema: this });
   }
 }

--- a/examples/github-app/src/routing/routes.tsx
+++ b/examples/github-app/src/routing/routes.tsx
@@ -24,10 +24,11 @@ export const routes = [
   {
     name: 'Home',
     component: lazyPage('IssueList'),
-    repositoryUrl: 'https://api.github.com/repos/facebook/react',
+    owner: 'facebook',
+    repo: 'react',
     resolveData: async (
       controller: Controller,
-      match: { repositoryUrl: string },
+      match: { owner: string; repo: string },
     ) => {
       controller.fetch(IssueResource.list(), match);
     },
@@ -36,17 +37,14 @@ export const routes = [
     name: 'IssueDetail',
     component: lazyPage('IssueDetail'),
     resolveData: async (controller: Controller, match: { number: string }) => {
-      controller.fetch(ReactionResource.list(), {
-        repositoryUrl: 'https://api.github.com/repos/facebook/react',
+      const params = {
+        owner: 'facebook',
+        repo: 'react',
         number: match.number,
-      });
-      const issue = await controller.fetch(IssueResource.detail(), {
-        repositoryUrl: 'https://api.github.com/repos/facebook/react',
-        number: match.number,
-      });
-      controller.fetch(CommentResource.list(), {
-        issueUrl: issue.url,
-      });
+      };
+      controller.fetch(ReactionResource.list(), params);
+      controller.fetch(CommentResource.list(), params);
+      await controller.fetch(IssueResource.detail(), params);
     },
   },
   {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Already using it but forgot that was the case.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Beautiful clean definitions:

```ts
import BaseResource from './BaseResource';
import UserResource from './UserResource';

export default class CommentResource extends BaseResource {
  readonly id: number | undefined = undefined;
  readonly issueUrl: string = '';
  readonly htmlUrl: string = '';
  readonly body: string = '';
  readonly user: UserResource = UserResource.fromJS({});
  readonly createdAt: Date = new Date(0);
  readonly updatedAt: Date = new Date(0);

  pk() {
    return this.id?.toString();
  }

  static urlRoot =
    'https\\://api.github.com/repos/:owner/:repo/issues/:number/comments' as const;

  static schema = {
    user: UserResource,
    createdAt: Date,
    updatedAt: Date,
  };
}
```