### PR TITLE
enhance: Better handle non-const urlRoot types

### DIFF
--- a/packages/experimental/src/rest/__tests__/types.test.ts
+++ b/packages/experimental/src/rest/__tests__/types.test.ts
@@ -1,6 +1,6 @@
 import { PathArgs } from '../types';
 
-describe('types', () => {
+describe('PathArgs', () => {
   it('should infer types', () => {
     type C = 'http\\://test.com/groups/:group?/users/:id?/:next\\?bob/:last';
     function A(args: PathArgs<C>) {}
@@ -10,5 +10,24 @@ describe('types', () => {
     // @ts-expect-error
     () => A({ next: 'hi', last: 'ho', doesnotexist: 'hi' });
     () => A({ next: 'hi', last: 'ho', id: '5', group: 'whatever' });
+  });
+
+  it('should be flexible for string type', () => {
+    class Parent {
+      constructor() {}
+      A(args: PathArgs<string>) {
+        const b = args['hi'];
+      }
+    }
+    class Child extends Parent {
+      A(args: { item: string }) {}
+    }
+    const thing = new Parent();
+    () => thing.A({});
+    () => thing.A({ next: 'hi', last: 'ho' });
+    const thing2 = new Child();
+    //@ts-expect-error
+    () => thing2.A({});
+    () => thing2.A({ item: 'win' });
   });
 });

--- a/packages/experimental/src/rest/types.ts
+++ b/packages/experimental/src/rest/types.ts
@@ -57,7 +57,7 @@ export type PathKeys<S extends string> = S extends `${string}\\:${infer R}`
   ? RemoveEscapes<K> | PathKeys<R>
   : S extends `${string}:${infer K}`
   ? RemoveEscapes<K>
-  : never;
+  : string;
 
 type RemoveEscapes<S extends string> = S extends `${infer K}\\?${string}`
   ? K


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
In case `as const` is missed we want to simply fallback to 'any' rather than breaking the types.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
string fallback for ternary.
