### PR TITLE
enhance: autopause devtools by default

### DIFF
--- a/packages/rest-hooks/src/manager/DevtoolsManager.ts
+++ b/packages/rest-hooks/src/manager/DevtoolsManager.ts
@@ -26,6 +26,7 @@ export default class DevToolsManager implements Manager {
   constructor(
     config: DevToolsConfig = {
       name: `Rest Hooks: ${globalThis.document?.title}`,
+      autoPause: true,
       serialize: {
         // the default options are only used if serialize isn't specified, so we include the default here
         options: {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
While incredibly helpful, the addition of datetime serialization to devtools integration has added a noticeable performance cost in development mode. This cost is still small when devtools are desired but otherwise hinders developer's productivity.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#autopause

`autoPause` is a quick simple way to avoid this cost. In the future, we will want to integrate a solution that still *logs* the actions, without the cost of serializing and updating devtools itself.