### PR TITLE
enhance: Improve robustness when using distinct schemas to normalize/denormalize

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -306,6 +306,15 @@ export class CoolerArticleResource extends ArticleResource {
   }
 }
 
+export class EditorArticleResource extends CoolerArticleResource {
+  readonly editor: UserResource | null = null;
+
+  static schema = {
+    ...ArticleResource.schema,
+    editor: UserResource,
+  };
+}
+
 export class TypedArticleResource extends CoolerArticleResource {
   get tagString() {
     return this.tags.join(', ');

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -318,7 +318,7 @@ export default class Controller {
           Object.keys(entities).forEach(pk => {
             expiresAt = Math.min(
               expiresAt,
-              state.entityMeta[key][pk].expiresAt,
+              state.entityMeta[key]?.[pk]?.expiresAt ?? Infinity,
             );
           }),
         );

--- a/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/integration-endpoint.web.tsx.snap
@@ -56,6 +56,21 @@ Value: {
   \\"body\\": \\"hi\\"
 }",
   ],
+  Array [
+    "TypeError: Unable to infer schema for UnionSchema
+Value: {
+  \\"id\\": \\"5\\",
+  \\"body\\": \\"hi\\",
+  \\"type\\": \\"another\\"
+}.",
+  ],
+  Array [
+    "TypeError: Unable to infer schema for UnionSchema
+Value: {
+  \\"id\\": \\"5\\",
+  \\"body\\": \\"hi\\"
+}.",
+  ],
 ]
 `;
 
@@ -176,6 +191,21 @@ Value: {
   \\"id\\": \\"5\\",
   \\"body\\": \\"hi\\"
 }",
+  ],
+  Array [
+    "TypeError: Unable to infer schema for UnionSchema
+Value: {
+  \\"id\\": \\"5\\",
+  \\"body\\": \\"hi\\",
+  \\"type\\": \\"another\\"
+}.",
+  ],
+  Array [
+    "TypeError: Unable to infer schema for UnionSchema
+Value: {
+  \\"id\\": \\"5\\",
+  \\"body\\": \\"hi\\"
+}.",
   ],
 ]
 `;

--- a/packages/core/src/react-integration/test-fixtures.ts
+++ b/packages/core/src/react-integration/test-fixtures.ts
@@ -57,6 +57,11 @@ export const users = [
   },
 ];
 
+export const editorPayload = {
+  ...payload,
+  editor: users[0],
+};
+
 export const nested = [
   {
     id: 5,

--- a/packages/legacy/src/resource/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/Entity.test.ts.snap
@@ -12,7 +12,7 @@ Array [
   false,
   Object {
     "Food": Object {
-      "[object Object]": Food {
+      "1": Food {
         "id": "1",
       },
     },
@@ -40,7 +40,7 @@ Array [
   false,
   Object {
     "Food": Object {
-      "Map { \\"id\\": \\"1\\" }": Food {
+      "1": Food {
         "id": "1",
       },
     },

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -56,7 +56,7 @@ Make sure you do not have multiple versions of @rest-hooks/normalizr installed.`
   }
 
   if (localCache[schema.key] === undefined) {
-    localCache[schema.key] = {};
+    localCache[schema.key] = Object.create(null);
   }
 
   let found = true;

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -787,7 +787,8 @@ describe(`${Entity.name} denormalization`, () => {
         '1': { id: '1', food: { id: '1' } },
       },
       Food: {
-        '1': { id: '1' },
+        // TODO: BREAKING CHANGE: Update this to use main entity and only return nested as 'fallback' in case main entity is not set
+        '1': { id: '1', extra: 'hi' },
       },
     };
 

--- a/packages/normalizr/src/schemas/Polymorphic.ts
+++ b/packages/normalizr/src/schemas/Polymorphic.ts
@@ -81,12 +81,20 @@ Value: ${JSON.stringify(value, undefined, 2)}`,
         };
   }
 
+  // value is guaranteed by caller to not be null
   denormalizeValue(value: any, unvisit: any) {
     if (value === undefined) {
       return [value, false, false];
     }
     const schemaKey = isImmutable(value) ? value.get('schema') : value.schema;
     if (!this.isSingleSchema && !schemaKey) {
+      /* istanbul ignore else */
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          `TypeError: Unable to infer schema for ${this.constructor.name}
+Value: ${JSON.stringify(value, undefined, 2)}.`,
+        );
+      }
       return [value, true, false];
     }
     const id = this.isSingleSchema

--- a/packages/normalizr/src/schemas/__tests__/Union.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Union.test.js
@@ -319,7 +319,7 @@ describe(`${schema.Union.name} denormalization`, () => {
     ).toMatchSnapshot();
   });
 
-  test('returns the original value no schema is given', () => {
+  test('returns the original value when no schema is given', () => {
     const union = new schema.Union(
       {
         users: User,
@@ -334,5 +334,19 @@ describe(`${schema.Union.name} denormalization`, () => {
     expect(
       denormalize(fromJS({ id: '1' }), union, fromJS(entities)),
     ).toMatchSnapshot();
+  });
+
+  test('returns the original value when string is given', () => {
+    const union = new schema.Union(
+      {
+        users: User,
+        groups: Group,
+      },
+      input => {
+        return input.username ? 'users' : 'groups';
+      },
+    );
+
+    expect(denormalize('1', union, entities)).toMatchSnapshot();
   });
 });

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -96,7 +96,7 @@ Array [
 ]
 `;
 
-exports[`UnionSchema denormalization returns the original value no schema is given 1`] = `
+exports[`UnionSchema denormalization returns the original value when no schema is given 1`] = `
 Array [
   Object {
     "id": "1",
@@ -106,11 +106,19 @@ Array [
 ]
 `;
 
-exports[`UnionSchema denormalization returns the original value no schema is given 2`] = `
+exports[`UnionSchema denormalization returns the original value when no schema is given 2`] = `
 Array [
   Immutable.Map {
     "id": "1",
   },
+  true,
+  false,
+]
+`;
+
+exports[`UnionSchema denormalization returns the original value when string is given 1`] = `
+Array [
+  "1",
   true,
   false,
 ]


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
New [validation cycle](https://resthooks.io/docs/getting-started/validation#partial-results) means users are encouraged to use multiple distinct schemas for the same entity depending on endpoint.

This breaks previous invariant that denormalize path always applied to same normalize path, which could result in confusing bugs if not defined correctly. For instance, if a nested schema is not defined for a normalization path, but it ends up actually getting that field, then the denormalization will end up getting a value from the response - rather than processed id.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

"partial denormalization" is already intended for support (as there are tests for it). However, this broke with the assumption id was a string in `unvisitEntity`. This is used for the global referential equality guarantee.

First step is to update types correctly to ensure good processing.

Next we compute `PK` in unvisitEntity in case id is the object itself. This allows us to correctly index the global equality store. In case this fails, we simply short-circuit just like if entity were an unexpected type (`[entity, false, false]`).

The end result is that if normalization wasn't run, it can still denormalize to an expected value. This means consistent schema definitions for Entities are not required.

This bug was hidden in a previous snapshot test that was clearly showing invalid results. So that test is now updated with a good snapshot.

From the tests:

```ts
  test('can denormalize already partially denormalized data', () => {
    const entities = {
      Menu: {
        '1': { id: '1', food: { id: '1' } },
      },
      Food: {
        '1': { id: '1' },
      },
    };

    expect(denormalize('1', Menu, entities)).toMatchSnapshot();
    expect(denormalize('1', Menu, fromJS(entities))).toMatchSnapshot();
  });
```

Here 'food' is set as an object rather than the pk itself. However, since that object can be used to create a PK it will still work.