### PR TITLE
Integration test for parent fetch of an attribute not present in its schema, but in one of its childen's schemas

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -306,6 +306,15 @@ export class CoolerArticleResource extends ArticleResource {
   }
 }
 
+export class EditorArticleResource extends CoolerArticleResource {
+  readonly editor: UserResource | null = null;
+
+  static schema = {
+    ...ArticleResource.schema,
+    editor: UserResource,
+  };
+}
+
 export class TypedArticleResource extends CoolerArticleResource {
   get tagString() {
     return this.tags.join(', ');

--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -83,8 +83,6 @@ describe.each([
       .reply(200, valuesFixture)
       .post(`/article-cooler/`)
       .reply(200, createPayload)
-      .patch(`/article-cooler/${payload.id}`)
-      .reply(200, payload)
       .get(`/user/`)
       .reply(200, users)
       .get(`/article-cooler/withEditor`)

--- a/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-endpoint.web.tsx
@@ -1,5 +1,6 @@
 import {
   CoolerArticleResource,
+  EditorArticleResource,
   ArticleResource,
   PaginatedArticleResource,
   UserResource,
@@ -30,6 +31,7 @@ import {
   paginatedFirstPage,
   paginatedSecondPage,
   valuesFixture,
+  editorPayload,
 } from '../test-fixtures';
 
 function onError(e: any) {
@@ -81,8 +83,12 @@ describe.each([
       .reply(200, valuesFixture)
       .post(`/article-cooler/`)
       .reply(200, createPayload)
+      .patch(`/article-cooler/${payload.id}`)
+      .reply(200, payload)
       .get(`/user/`)
-      .reply(200, users);
+      .reply(200, users)
+      .get(`/article-cooler/withEditor`)
+      .reply(200, editorPayload);
 
     mynock = nock(/.*/).defaultReplyHeaders({
       'Access-Control-Allow-Origin': '*',
@@ -655,5 +661,31 @@ describe.each([
         ({ id }: Partial<PaginatedArticleResource>) => id,
       ),
     ).toEqual([5, 3, 7, 8]);
+  });
+  describe("a parent resource endpoint returns an attribute NOT in its own schema but used in a child's schemas", () => {
+    it('should not error when fetching the child entity from cache', async () => {
+      const { result, waitForNextUpdate } = renderRestHook(() => {
+        // CoolerArticleResource does NOT have editor in its schema, but return editor from the server
+        const articleWithoutEditorSchema = useSuspense(
+          CoolerArticleResource.detail(),
+          {
+            title: 'withEditor',
+          },
+        );
+        // EditorArticleResource does have editor in its schema, get it from cache
+        const articleWithEditorSchema = useCache(
+          EditorArticleResource.detail(),
+          {
+            id: payload.id,
+          },
+        );
+        return { articleWithoutEditorSchema, articleWithEditorSchema };
+      });
+      await waitForNextUpdate();
+      // This throws TypeError: Cannot read properties of undefined (reading '[object Object]')
+      expect(result.current.articleWithEditorSchema?.editor?.id).toEqual(
+        editorPayload.editor.id,
+      );
+    });
   });
 });

--- a/packages/core/src/react-integration/test-fixtures.ts
+++ b/packages/core/src/react-integration/test-fixtures.ts
@@ -57,6 +57,11 @@ export const users = [
   },
 ];
 
+export const editorPayload = {
+  ...payload,
+  editor: users[0],
+};
+
 export const nested = [
   {
     id: 5,


### PR DESCRIPTION
## Today
- Have one resource `CoolerArticleResource` and a resource that extends it (child) `EditorArticleResource`. 
- `EditorArticleResource` has schema ` { editor: UserResource }`
- `CoolerArticleResource.detail() receives `editor` unexpectedly as part of the server response for a given `id`
- Getting `EditorArticleResource.detail()` from cache errors.
```
TypeError: Cannot read properties of undefined (reading '[object Object]')

      319 |             expiresAt = Math.min(
      320 |               expiresAt,
    > 321 |               state.entityMeta[key][pk].expiresAt,
          |               ^
      322 |             );
      323 |           }),
      324 |         );
```

## Expected
- Upon fetching `EditorArticleResource.detail()`, from cache, existing entity should be normalized and returned without error. (@ntucker I'm confident on the error repro. I'm someone sure, but not 100%, what I've described is the desired behavior).