### PR TITLE
fix: urlRoot type inference handles escapes anywhere in string

### DIFF
--- a/packages/experimental/src/rest/__tests__/types.test.ts
+++ b/packages/experimental/src/rest/__tests__/types.test.ts
@@ -2,13 +2,16 @@ import { PathArgs } from '../types';
 
 describe('PathArgs', () => {
   it('should infer types', () => {
-    type C = 'http\\://test.com/groups/:group?/users/:id?/:next\\?bob/:last';
+    type C =
+      'http\\://test.com/groups/:group?/\\:blah/users/:id?/:next\\?bob/:last';
     function A(args: PathArgs<C>) {}
     // @ts-expect-error
     () => A({});
     () => A({ next: 'hi', last: 'ho' });
     // @ts-expect-error
     () => A({ next: 'hi', last: 'ho', doesnotexist: 'hi' });
+    // @ts-expect-error
+    () => A({ next: 'hi', last: 'ho', blah: 'hi' });
     () => A({ next: 'hi', last: 'ho', id: '5', group: 'whatever' });
   });
 

--- a/packages/experimental/src/rest/types.ts
+++ b/packages/experimental/src/rest/types.ts
@@ -51,13 +51,15 @@ export type Paginatable<
 type OnlyOptional<S extends string> = S extends `${infer K}?` ? K : never;
 type OnlyRequired<S extends string> = S extends `${string}?` ? never : S;
 
-export type PathKeys<S extends string> = S extends `${string}\\:${infer R}`
-  ? PathKeys<R>
+export type PathKeys<S extends string> = string extends S
+  ? string
+  : S extends `${infer A}\\:${infer B}`
+  ? PathKeys<A> | PathKeys<B>
   : S extends `${string}:${infer K}/${infer R}`
   ? RemoveEscapes<K> | PathKeys<R>
   : S extends `${string}:${infer K}`
   ? RemoveEscapes<K>
-  : string;
+  : never;
 
 type RemoveEscapes<S extends string> = S extends `${infer K}\\?${string}`
   ? K


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
If \\: shows up after a real group those groups will be missed.
