### PR TITLE
fix: createPersistedStore import

### DIFF
--- a/packages/ssr/src/createPersistedStore.tsx
+++ b/packages/ssr/src/createPersistedStore.tsx
@@ -8,8 +8,7 @@ import {
   NetworkManager,
 } from '@rest-hooks/core';
 import { createStore, applyMiddleware } from 'redux';
-
-import ServerDataComponent from './ServerDataComponent';
+import { ServerDataComponent } from '@rest-hooks/ssr/ServerDataComponent';
 
 export default function createPersistedStore(managers?: Manager[]) {
   const controller = new Controller();


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
`ModuleNotFoundError: Module not found: Error: Can't resolve './ServerDataComponent' in '/home/ntucker/src/anansi/node_modules/@rest-hooks/ssr/lib'`

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Our tooling with rename to include .js in import when using absolute paths.