### PR TITLE
fix: Accept undefined or null responses for schema entries

### DIFF
--- a/packages/core/src/controller/__tests__/__snapshots__/getResponse.ts.snap
+++ b/packages/core/src/controller/__tests__/__snapshots__/getResponse.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Controller.getResponse() denormalizes schema with extra members but not set 1`] = `
+Object {
+  "data": Array [
+    Tacos {
+      "id": "1",
+      "type": "foo",
+    },
+    Tacos {
+      "id": "2",
+      "type": "bar",
+    },
+  ],
+}
+`;
+
+exports[`Controller.getResponse() infers schema with extra members but not set 1`] = `
+Object {
+  "data": Tacos {
+    "id": "1",
+    "type": "foo",
+  },
+  "extra": "",
+  "page": Object {
+    "complex": Object {
+      "complex": true,
+      "next": false,
+    },
+    "first": null,
+    "second": undefined,
+    "third": 0,
+  },
+}
+`;

--- a/packages/core/src/controller/__tests__/getResponse.ts
+++ b/packages/core/src/controller/__tests__/getResponse.ts
@@ -1,0 +1,94 @@
+import { Endpoint, Entity, ExpiryStatus } from '../..';
+import Contoller from '../Controller';
+import { initialState } from '../../state/createReducer';
+
+describe('Controller.getResponse()', () => {
+  it('denormalizes schema with extra members but not set', () => {
+    const controller = new Contoller();
+    class Tacos extends Entity {
+      type = '';
+      id = '';
+      pk() {
+        return this.id;
+      }
+    }
+    const ep = new Endpoint(() => Promise.resolve(), {
+      key() {
+        return 'mytest';
+      },
+      schema: {
+        data: [Tacos],
+        extra: '',
+        page: {
+          first: null,
+          second: undefined,
+          third: 0,
+          complex: { complex: true, next: false },
+        },
+      },
+    });
+    const entities = {
+      Tacos: {
+        1: { id: '1', type: 'foo' },
+        2: { id: '2', type: 'bar' },
+      },
+    };
+
+    const state = {
+      ...initialState,
+      entities,
+      results: {
+        [ep.key()]: {
+          data: ['1', '2'],
+        },
+      },
+    };
+    const { data, expiryStatus } = controller.getResponse(ep, state);
+    expect(expiryStatus).toBe(ExpiryStatus.Valid);
+    expect(data).toMatchSnapshot();
+  });
+
+  it('infers schema with extra members but not set', () => {
+    const controller = new Contoller();
+    class Tacos extends Entity {
+      type = '';
+      id = '';
+      pk() {
+        return this.id;
+      }
+    }
+    const ep = new Endpoint(({ id }: { id: string }) => Promise.resolve(), {
+      key({ id }) {
+        return `mytest ${id}`;
+      },
+      schema: {
+        data: Tacos,
+        extra: '',
+        page: {
+          first: null,
+          second: undefined,
+          third: 0,
+          complex: { complex: true, next: false },
+        },
+      },
+    });
+    const entities = {
+      Tacos: {
+        1: { id: '1', type: 'foo' },
+        2: { id: '2', type: 'bar' },
+      },
+    };
+
+    const state = {
+      ...initialState,
+      entities,
+    };
+    const { data, expiryStatus } = controller.getResponse(
+      ep,
+      { id: '1' },
+      state,
+    );
+    expect(expiryStatus).toBe(ExpiryStatus.Valid);
+    expect(data).toMatchSnapshot();
+  });
+});

--- a/packages/legacy/src/resource/__tests__/__snapshots__/normalizr.test.js.snap
+++ b/packages/legacy/src/resource/__tests__/__snapshots__/normalizr.test.js.snap
@@ -241,7 +241,7 @@ Array [
       },
     ],
   },
-  true,
+  false,
   false,
   Object {
     "Tacos": Object {

--- a/packages/legacy/src/resource/__tests__/normalizr.test.js
+++ b/packages/legacy/src/resource/__tests__/normalizr.test.js
@@ -923,7 +923,23 @@ describe('denormalize with global cache', () => {
         entityCache,
         resultCache,
       );
-      expect(denorm).toEqual({});
+      expect(denorm).toEqual(null);
+      expect(found).toBe(true);
+      expect(deleted).toBe(false);
+    });
+
+    test('handles undefined at top level', () => {
+      const entityCache = {};
+      const resultCache = new WeakListMap();
+
+      const [denorm, found, deleted] = denormalize(
+        undefined,
+        { data: Article },
+        {},
+        entityCache,
+        resultCache,
+      );
+      expect(denorm).toEqual(undefined);
       expect(found).toBe(false);
       expect(deleted).toBe(false);
     });

--- a/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/normalizr/src/__tests__/__snapshots__/index.test.js.snap
@@ -154,7 +154,7 @@ Array [
       },
     ],
   },
-  true,
+  false,
   false,
 ]
 `;

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -1031,7 +1031,23 @@ describe('denormalize with global cache', () => {
         entityCache,
         resultCache,
       );
-      expect(denorm).toEqual({});
+      expect(denorm).toEqual(null);
+      expect(found).toBe(true);
+      expect(deleted).toBe(false);
+    });
+
+    test('handles undefined at top level', () => {
+      const entityCache = {};
+      const resultCache = new WeakListMap();
+
+      const [denorm, found, deleted] = denormalize(
+        undefined,
+        { data: Article },
+        {},
+        entityCache,
+        resultCache,
+      );
+      expect(denorm).toEqual(undefined);
       expect(found).toBe(false);
       expect(deleted).toBe(false);
     });

--- a/packages/normalizr/src/entities/__tests__/Entity.test.ts
+++ b/packages/normalizr/src/entities/__tests__/Entity.test.ts
@@ -104,6 +104,47 @@ describe(`${Entity.name} normalization`, () => {
     expect(normalizeBad).toThrowErrorMatchingSnapshot();
   });
 
+  it('should handle optional schema entries Entity', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly blarb: Date | undefined = undefined;
+      pk() {
+        return this.name;
+      }
+
+      static schema = {
+        blarb: Date,
+      };
+    }
+    const schema = MyEntity;
+
+    expect(normalize({ name: 'bob', secondthing: 'hi' }, schema))
+      .toMatchInlineSnapshot(`
+      Object {
+        "entities": Object {
+          "MyEntity": Object {
+            "bob": Object {
+              "name": "bob",
+              "secondthing": "hi",
+            },
+          },
+        },
+        "entityMeta": Object {
+          "MyEntity": Object {
+            "bob": Object {
+              "date": 1557831718135,
+              "expiresAt": Infinity,
+              "fetchedAt": 0,
+            },
+          },
+        },
+        "indexes": Object {},
+        "result": "bob",
+      }
+    `);
+  });
+
   it('should throw a custom error if data loads with no matching props', () => {
     class MyEntity extends Entity {
       readonly name: string = '';
@@ -736,6 +777,70 @@ describe(`${Entity.name} denormalization`, () => {
 
     expect(denormalize('2', Menu, entities)).toMatchSnapshot();
     expect(denormalize('2', Menu, fromJS(entities))).toMatchSnapshot();
+  });
+
+  it('should handle optional schema entries Entity', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly blarb: Date | undefined = undefined;
+      pk() {
+        return this.name;
+      }
+
+      static schema = {
+        blarb: Date,
+      };
+    }
+    const schema = MyEntity;
+
+    expect(
+      denormalize('bob', schema, {
+        MyEntity: { bob: { name: 'bob', secondthing: 'hi' } },
+      }),
+    ).toMatchInlineSnapshot(`
+      Array [
+        MyEntity {
+          "blarb": undefined,
+          "name": "bob",
+          "secondthing": "hi",
+        },
+        true,
+        false,
+      ]
+    `);
+  });
+
+  it('should handle null schema entries Entity', () => {
+    class MyEntity extends Entity {
+      readonly name: string = '';
+      readonly secondthing: string = '';
+      readonly blarb: Date | null = null;
+      pk() {
+        return this.name;
+      }
+
+      static schema = {
+        blarb: Date,
+      };
+    }
+    const schema = MyEntity;
+
+    expect(
+      denormalize('bob', schema, {
+        MyEntity: { bob: { name: 'bob', secondthing: 'hi', blarb: null } },
+      }),
+    ).toMatchInlineSnapshot(`
+      Array [
+        MyEntity {
+          "blarb": null,
+          "name": "bob",
+          "secondthing": "hi",
+        },
+        true,
+        false,
+      ]
+    `);
   });
 
   test('denormalizes to undefined for deleted data', () => {

--- a/packages/normalizr/src/schema.d.ts
+++ b/packages/normalizr/src/schema.d.ts
@@ -52,7 +52,7 @@ export interface SchemaSimple<T = any> {
   ): any;
   denormalize(
     // eslint-disable-next-line @typescript-eslint/ban-types
-    input: {} | undefined,
+    input: {},
     unvisit: UnvisitFunction,
   ): [denormalized: T, found: boolean, suspend: boolean];
   infer(
@@ -103,7 +103,7 @@ export class Array<S extends Schema = Schema> implements SchemaClass {
 
   denormalize(
     // eslint-disable-next-line @typescript-eslint/ban-types
-    input: {} | undefined,
+    input: {},
     unvisit: UnvisitFunction,
   ): [denormalized: Denormalize<S>[], found: boolean, suspend: boolean];
 
@@ -135,7 +135,7 @@ export class Object<O extends Record<string, any> = Record<string, Schema>>
 
   denormalize(
     // eslint-disable-next-line @typescript-eslint/ban-types
-    input: {} | undefined,
+    input: {},
     unvisit: UnvisitFunction,
   ): [denormalized: DenormalizeObject<O>, found: boolean, suspend: boolean];
 
@@ -173,7 +173,7 @@ export class Union<Choices extends EntityMap = any> implements SchemaClass {
 
   denormalize(
     // eslint-disable-next-line @typescript-eslint/ban-types
-    input: {} | undefined,
+    input: {},
     unvisit: UnvisitFunction,
   ): [
     denormalized: AbstractInstanceType<Choices[keyof Choices]>,
@@ -236,7 +236,7 @@ export class Values<Choices extends Schema = any> implements SchemaClass {
 
   denormalize(
     // eslint-disable-next-line @typescript-eslint/ban-types
-    input: {} | undefined,
+    input: {},
     unvisit: UnvisitFunction,
   ): [
     denormalized: Record<

--- a/packages/normalizr/src/schemas/Array.ts
+++ b/packages/normalizr/src/schemas/Array.ts
@@ -43,20 +43,15 @@ export const denormalize = (
   unvisit: any,
 ): [denormalized: any, found: boolean, suspend: boolean] => {
   schema = validateSchema(schema);
-  let deleted = false;
-  let found = true;
-  if (input === undefined && schema) {
-    [, found, deleted] = unvisit(undefined, schema);
-  }
   return [
-    input && input.map
+    input.map
       ? input
           .map(entityOrId => unvisit(entityOrId, schema))
           .filter(filterEmpty)
           .map(([value]) => value)
       : input,
-    found,
-    deleted,
+    true,
+    false,
   ];
 };
 
@@ -94,20 +89,15 @@ export default class ArraySchema extends PolymorphicSchema {
   }
 
   denormalize(input: any, unvisit: any) {
-    let deleted = false;
-    let found = true;
-    if (input === undefined && this.schema) {
-      [, found, deleted] = unvisit(undefined, this.schema);
-    }
     return [
-      input && input.map
+      input.map
         ? input
             .map(entityOrId => this.denormalizeValue(entityOrId, unvisit))
             .filter(filterEmpty)
             .map(([value]) => value)
         : input,
-      found,
-      deleted,
+      true,
+      false,
     ];
   }
 

--- a/packages/normalizr/src/schemas/ImmutableUtils.ts
+++ b/packages/normalizr/src/schemas/ImmutableUtils.ts
@@ -3,6 +3,8 @@
  * the 'immutable' package as a dependency.
  */
 
+import Immutable from 'immutable';
+
 /**
  * Check if an object is immutable by checking if it has a key specific
  * to the immutable library.
@@ -10,12 +12,16 @@
  * @param  {any} object
  * @return {bool}
  */
-export function isImmutable(object: any) {
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function isImmutable(object: {}): object is {
+  get(k: string): any;
+  [k: string]: any;
+} {
   return !!(
-    object &&
     typeof object.hasOwnProperty === 'function' &&
     (Object.hasOwnProperty.call(object, '__ownerID') || // Immutable.Map
-      (object._map && Object.hasOwnProperty.call(object._map, '__ownerID')))
+      ((object as any)._map &&
+        Object.hasOwnProperty.call((object as any)._map, '__ownerID')))
   ); // Immutable.Record
 }
 

--- a/packages/normalizr/src/schemas/Object.ts
+++ b/packages/normalizr/src/schemas/Object.ts
@@ -31,7 +31,8 @@ export const normalize = (
 
 export const denormalize = (
   schema: any,
-  input: any,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  input: {},
   unvisit: any,
 ): [denormalized: any, found: boolean, deleted: boolean] => {
   if (isImmutable(input)) {
@@ -100,7 +101,8 @@ export default class ObjectSchema {
     return normalize(this.schema, ...args);
   }
 
-  denormalize(...args: readonly [input: any, unvisit: any]) {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  denormalize(...args: readonly [input: {}, unvisit: any]) {
     return denormalize(this.schema, ...args);
   }
 

--- a/packages/normalizr/src/schemas/Polymorphic.ts
+++ b/packages/normalizr/src/schemas/Polymorphic.ts
@@ -83,9 +83,6 @@ Value: ${JSON.stringify(value, undefined, 2)}`,
 
   // value is guaranteed by caller to not be null
   denormalizeValue(value: any, unvisit: any) {
-    if (value === undefined) {
-      return [value, false, false];
-    }
     const schemaKey = isImmutable(value) ? value.get('schema') : value.schema;
     if (!this.isSingleSchema && !schemaKey) {
       /* istanbul ignore else */

--- a/packages/normalizr/src/schemas/Union.ts
+++ b/packages/normalizr/src/schemas/Union.ts
@@ -25,7 +25,8 @@ export default class UnionSchema extends PolymorphicSchema {
     );
   }
 
-  denormalize(input, unvisit) {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  denormalize(input: {}, unvisit: any) {
     return this.denormalizeValue(input, unvisit);
   }
 

--- a/packages/normalizr/src/schemas/Values.ts
+++ b/packages/normalizr/src/schemas/Values.ts
@@ -24,7 +24,8 @@ export default class ValuesSchema extends PolymorphicSchema {
     }, {});
   }
 
-  denormalize(input, unvisit) {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  denormalize(input: {}, unvisit: any) {
     let found = true;
     let deleted = false;
     return [

--- a/packages/normalizr/src/schemas/__tests__/Array.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Array.test.js
@@ -295,6 +295,31 @@ describe(`${schema.Array.name} denormalization`, () => {
       expect(found).toBe(true);
     });
 
+    test('denormalizes removes undefined', () => {
+      class Cat extends IDEntity {}
+      const catSchema = { results: [Cat], nextPage: '' };
+      const entities = {
+        Cat: {
+          1: { id: '1', name: 'Milo' },
+          2: { id: '2', name: 'Jake' },
+        },
+      };
+      let [value, found] = denormalize(
+        { results: ['1', undefined, '2'] },
+        catSchema,
+        entities,
+      );
+      expect(value).toMatchSnapshot();
+      expect(found).toBe(true);
+      [value, found] = denormalize(
+        { results: ['1', '2'] },
+        catSchema,
+        fromJS(entities),
+      );
+      expect(value).toMatchSnapshot();
+      expect(found).toBe(true);
+    });
+
     test('denormalizes should not be found when result array is undefined', () => {
       class Cat extends IDEntity {}
       const catSchema = { results: [Cat] };

--- a/packages/normalizr/src/schemas/__tests__/Object.test.js
+++ b/packages/normalizr/src/schemas/__tests__/Object.test.js
@@ -127,9 +127,9 @@ describe(`${schema.Object.name} denormalization`, () => {
   test('should have found = true with null member even when schema has nested entity', () => {
     class User extends IDEntity {}
     const object = {
-      item: new schema.Object({
+      item: {
         user: User,
-      }),
+      },
     };
     const entities = {
       User: {

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -158,7 +158,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -171,7 +171,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -184,7 +184,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -239,7 +239,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -252,7 +252,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -265,7 +265,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -530,7 +530,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -543,7 +543,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -556,7 +556,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -611,7 +611,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -624,7 +624,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -637,7 +637,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -682,6 +682,36 @@ Array [
   true,
   false,
 ]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes removes undefined 1`] = `
+Object {
+  "results": Array [
+    Cat {
+      "id": "1",
+      "name": "Milo",
+    },
+    Cat {
+      "id": "2",
+      "name": "Jake",
+    },
+  ],
+}
+`;
+
+exports[`ArraySchema denormalization Object denormalizes removes undefined 2`] = `
+Object {
+  "results": Array [
+    Cat {
+      "id": "1",
+      "name": "Milo",
+    },
+    Cat {
+      "id": "2",
+      "name": "Jake",
+    },
+  ],
+}
 `;
 
 exports[`ArraySchema denormalization Object denormalizes should not be found when result array is undefined 1`] = `

--- a/packages/normalizr/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/packages/normalizr/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -125,7 +125,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -138,7 +138,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;
@@ -151,7 +151,7 @@ Array [
       "name": "Jane",
     },
   },
-  true,
+  false,
   false,
 ]
 `;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
```tsx
class MyItem extends Entity {
  readonly createdAt: Date | undefined;
  static schema = {
    createAt: Date,
  }
}
```

@WayneYe

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- `null` and `undefined` are always considered valid from a network response
- 'required' fields should not default to either or users should specify a validate() method
- Greatly simplified logic as handling null and undefined in root denormalize
- `undefined` inputs short-circuit 'found' tracking since they should infer something other than undefined if we should recurse. Therefore any `undefined` value is considered not 'found'

### Is this a breaking change?

While this technically changes behavior; We meticulously validated each change to prevent regressions. We are strongly certain that if the new behavior is different it means it is more of what a user wants. I.e., they get a result when it would have errored before. 