### PR TITLE
fix: Missing import extension in legacy package

### DIFF
--- a/packages/legacy/src/index.ts
+++ b/packages/legacy/src/index.ts
@@ -9,4 +9,4 @@ export type {
   SetShapeParams,
   ParamsFromShape,
 } from '@rest-hooks/core';
-export * as rest3 from './rest-3/index';
+export * as rest3 from './rest-3/index.js';


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #1976 
