### PR TITLE
docs(example): Use single arg create from rest@5

### DIFF
--- a/examples/todo-app/src/pages/Home/NewTodo.tsx
+++ b/examples/todo-app/src/pages/Home/NewTodo.tsx
@@ -6,9 +6,12 @@ import TodoResource from 'resources/TodoResource';
 export default function NewTodo({ lastId }: { lastId: number }) {
   const { fetch } = useController();
   const [title, setTitle] = useState('');
-  const handleChange = useCallback((e) => {
-    setTitle(e.currentTarget.value);
-  }, []);
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      setTitle(e.currentTarget.value);
+    },
+    [],
+  );
 
   // this allows handlePress to never change referential equality
   const payload = useRef({ id: lastId + 1, title: title });
@@ -17,7 +20,7 @@ export default function NewTodo({ lastId }: { lastId: number }) {
   const handlePress = useCallback(
     async (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
-        fetch(TodoResource.create(), {}, payload.current);
+        fetch(TodoResource.create(), payload.current);
         setTitle('');
       }
     },

--- a/examples/todo-app/src/resources/PlaceholderBaseResource.ts
+++ b/examples/todo-app/src/resources/PlaceholderBaseResource.ts
@@ -28,9 +28,9 @@ export default abstract class PlaceholderBaseResource extends Resource {
   static create<T extends typeof Resource>(this: T) {
     const endpoint = super.create();
     return endpoint.extend({
-      fetch: async (params: any, body: any) => {
+      fetch: async (body: any) => {
         // create has no parameters, but has a body with the id
-        return { ...(await endpoint(params, body)), id: body.id };
+        return { ...(await endpoint(body)), id: body.id };
       },
     });
   }

--- a/examples/todo-app/src/resources/TodoResource.ts
+++ b/examples/todo-app/src/resources/TodoResource.ts
@@ -40,4 +40,4 @@ const optimisticPartial = (
   ...body,
 });
 
-const optimisticCreate = (snap: SnapshotInterface, _: any, body: any) => body;
+const optimisticCreate = (snap: SnapshotInterface, body: any) => body;


### PR DESCRIPTION
Best practices from latest @rest-hooks/rest version. Single arg create.