### PR TITLE
docs: Ensure mocking service worker is installed

### DIFF
--- a/website/src/mocks/init.js
+++ b/website/src/mocks/init.js
@@ -1,12 +1,26 @@
 if (typeof window !== 'undefined') {
   const { worker } = require('./browser');
-  worker.start({
-    onUnhandledRequest: ({ method, url }) => {
-      if (url.pathname.startsWith('/api')) {
-        console.warn(`Unhandled ${method} request to ${url}`);
+  worker
+    .start({
+      onUnhandledRequest: ({ method, url }) => {
+        if (url.pathname.startsWith('/api')) {
+          console.warn(`Unhandled ${method} request to ${url}`);
+        }
+      },
+    })
+    .then(reg => {
+      if (reg.installing) {
+        const sw = reg.installing || reg.waiting;
+        sw.onstatechange = function () {
+          if (sw.state === 'installed') {
+            // SW installed.  Refresh page so SW can respond with SW-enabled page.
+            window.location.reload();
+          }
+        };
+      } else if (reg.active) {
+        console.info('MSW service worker already installed');
       }
-    },
-  });
+    });
 } else {
   const { server } = require('./server');
   server.listen({


### PR DESCRIPTION

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Without the service worker installed; the live demos on the homepage will look broken as the network will error.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
This seems to be the only way to ensure service worker is loaded - reloading page if it is not.

Taken from: https://stackoverflow.com/a/61432538