### PR TITLE
internal: Upgrade unit test machine size to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
       react-version:
         type: string
     docker: *docker
+    resource_class: large
     steps:
       - attach_workspace:
           at: ~/


### PR DESCRIPTION
Unit tests are hitting memory limit resulting in 75% flake rate: https://app.circleci.com/pipelines/github/coinbase/rest-hooks/7726/workflows/70fb2deb-2e1e-448e-a85f-efc91cc636be/jobs/47702/resources is a successful run after failure https://app.circleci.com/pipelines/github/coinbase/rest-hooks/7726/workflows/4d658d3e-72ca-48fd-8e3b-feb16a34b9c8/jobs/47701