### PR TITLE
fix: Hydration mismatch in React 17

### DIFF
--- a/packages/core/src/react-integration/provider/BackupBoundary.tsx
+++ b/packages/core/src/react-integration/provider/BackupBoundary.tsx
@@ -1,15 +1,26 @@
 import React, { Suspense, memo, useMemo, version } from 'react';
 
 /* istanbul ignore next  */
-const NoSuspense =
-  (version.startsWith('16') || version.startsWith('17')) &&
-  typeof window === 'undefined';
+const LegacyReact = version.startsWith('16') || version.startsWith('17');
+/* istanbul ignore next  */
+const SSR = typeof document === 'undefined';
+const SSR_ID = 'rest-hooks-SSR';
+/* istanbul ignore next  */
+const HYDRATED = !SSR && document.getElementById(SSR_ID);
 
 // since Suspense does not introduce DOM elements, this should not affect rehydration.
 const BackupBoundary: React.FunctionComponent<{ children: React.ReactNode }> =
   /* istanbul ignore if */
-  NoSuspense
-    ? /* istanbul ignore next  */ ({ children }) => children as JSX.Element
+  LegacyReact && SSR
+    ? /* istanbul ignore next  */ ({ children }) => (
+        <div id={SSR_ID}>{children}</div>
+      )
+    : /* istanbul ignore if */ HYDRATED
+    ? /* istanbul ignore next  */ ({ children }) => (
+        <Suspense fallback={<div id={SSR_ID}></div>}>
+          <div id={SSR_ID}>{children}</div>
+        </Suspense>
+      )
     : ({ children }) => <Suspense fallback={<Loading />}>{children}</Suspense>;
 
 export default memo(BackupBoundary);

--- a/packages/core/src/react-integration/provider/__tests__/backupboundary.node.tsx
+++ b/packages/core/src/react-integration/provider/__tests__/backupboundary.node.tsx
@@ -1,0 +1,33 @@
+// eslint-env jest
+import React, { version } from 'react';
+import { renderToString } from 'react-dom/server';
+
+import BackupBoundary from '../BackupBoundary';
+
+describe('<BackupBoundary />', () => {
+  let warnspy: jest.SpyInstance;
+  beforeEach(() => {
+    warnspy = jest.spyOn(global.console, 'warn');
+  });
+  afterEach(() => {
+    warnspy.mockRestore();
+  });
+
+  it('should warn users about missing Suspense', () => {
+    const tree = (
+      <BackupBoundary>
+        <div>hi</div>
+      </BackupBoundary>
+    );
+    const LegacyReact = version.startsWith('16') || version.startsWith('17');
+    const msg = renderToString(tree);
+    if (LegacyReact) {
+      expect(msg).toBeDefined();
+      expect(msg).toMatchInlineSnapshot(
+        `"<div id=\\"rest-hooks-SSR\\"><div>hi</div></div>"`,
+      );
+    } else {
+      expect(msg).toMatchInlineSnapshot(`"<!--$--><div>hi</div><!--/$-->"`);
+    }
+  });
+});


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #2037

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
To deal with Legacy react not rendering below suspense boundaries during SSR - we won't render them. However, this creates a hydration mismatch warning, so we need to identify this case client-side and change behavior appropriately.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Injecting scripts introduces all sorts of troubles with CSP; so we're just adding an element with a specific ID to detect the path.

I couldn't easily find a solution to actually test hydration - so I just tested the SSR node-side.