### PR TITLE
enhance: Warn about CacheProvider usage for SSR

### DIFF
--- a/packages/core/src/react-integration/provider/BackupBoundary.tsx
+++ b/packages/core/src/react-integration/provider/BackupBoundary.tsx
@@ -3,24 +3,13 @@ import React, { Suspense, memo, useMemo, version } from 'react';
 /* istanbul ignore next  */
 const LegacyReact = version.startsWith('16') || version.startsWith('17');
 /* istanbul ignore next  */
-const SSR = typeof document === 'undefined';
-const SSR_ID = 'rest-hooks-SSR';
-/* istanbul ignore next  */
-const HYDRATED = !SSR && document.getElementById(SSR_ID);
+const SSR = typeof window === 'undefined';
 
 // since Suspense does not introduce DOM elements, this should not affect rehydration.
 const BackupBoundary: React.FunctionComponent<{ children: React.ReactNode }> =
   /* istanbul ignore if */
   LegacyReact && SSR
-    ? /* istanbul ignore next  */ ({ children }) => (
-        <div id={SSR_ID}>{children}</div>
-      )
-    : /* istanbul ignore if */ HYDRATED
-    ? /* istanbul ignore next  */ ({ children }) => (
-        <Suspense fallback={<div id={SSR_ID}></div>}>
-          <div id={SSR_ID}>{children}</div>
-        </Suspense>
-      )
+    ? /* istanbul ignore next  */ ({ children }) => children as JSX.Element
     : ({ children }) => <Suspense fallback={<Loading />}>{children}</Suspense>;
 
 export default memo(BackupBoundary);

--- a/packages/core/src/react-integration/provider/CacheProvider.tsx
+++ b/packages/core/src/react-integration/provider/CacheProvider.tsx
@@ -29,6 +29,7 @@ export default function CacheProvider({
   initialState,
   Controller,
 }: ProviderProps) {
+  /* istanbul ignore else */
   if (process.env.NODE_ENV !== 'production' && SSR) {
     console.warn(
       `CacheProvider does not update while doing SSR.

--- a/packages/core/src/react-integration/provider/CacheProvider.tsx
+++ b/packages/core/src/react-integration/provider/CacheProvider.tsx
@@ -9,6 +9,9 @@ import applyManager from '../../state/applyManager.js';
 import CacheStore from './CacheStore.js';
 import Controller from '../../controller/Controller.js';
 
+/* istanbul ignore next  */
+const SSR = typeof window === 'undefined';
+
 interface ProviderProps {
   children: ReactNode;
   managers: Manager[];
@@ -26,6 +29,12 @@ export default function CacheProvider({
   initialState,
   Controller,
 }: ProviderProps) {
+  if (process.env.NODE_ENV !== 'production' && SSR) {
+    console.warn(
+      `CacheProvider does not update while doing SSR.
+Try using https://resthooks.io/docs/api/ExternalCacheProvider for server entry points.`,
+    );
+  }
   // contents of this component expected to be relatively stable
 
   const controllerRef: React.MutableRefObject<Controller> = useRef<any>();

--- a/packages/core/src/react-integration/provider/__tests__/backupboundary.node.tsx
+++ b/packages/core/src/react-integration/provider/__tests__/backupboundary.node.tsx
@@ -23,9 +23,7 @@ describe('<BackupBoundary />', () => {
     const msg = renderToString(tree);
     if (LegacyReact) {
       expect(msg).toBeDefined();
-      expect(msg).toMatchInlineSnapshot(
-        `"<div id=\\"rest-hooks-SSR\\"><div>hi</div></div>"`,
-      );
+      expect(msg).toMatchInlineSnapshot(`"<div>hi</div>"`);
     } else {
       expect(msg).toMatchInlineSnapshot(`"<!--$--><div>hi</div><!--/$-->"`);
     }

--- a/packages/core/src/react-integration/provider/__tests__/provider.node.tsx
+++ b/packages/core/src/react-integration/provider/__tests__/provider.node.tsx
@@ -2,7 +2,7 @@
 import React, { version } from 'react';
 import { renderToString } from 'react-dom/server';
 
-import BackupBoundary from '../BackupBoundary';
+import CacheProvider from '../CacheProvider';
 
 describe('<BackupBoundary />', () => {
   let warnspy: jest.SpyInstance;
@@ -13,20 +13,27 @@ describe('<BackupBoundary />', () => {
     warnspy.mockRestore();
   });
 
-  it('should warn users about missing Suspense', () => {
+  it('should warn users about SSR with CacheProvider', () => {
     const tree = (
-      <BackupBoundary>
+      <CacheProvider>
         <div>hi</div>
-      </BackupBoundary>
+      </CacheProvider>
     );
     const LegacyReact = version.startsWith('16') || version.startsWith('17');
+
     const msg = renderToString(tree);
 
-    if (LegacyReact) {
-      expect(msg).toBeDefined();
-      expect(msg).toMatchInlineSnapshot(`"<div>hi</div>"`);
-    } else {
+    expect(warnspy.mock.lastCall).toMatchInlineSnapshot(`
+      Array [
+        "CacheProvider does not update while doing SSR.
+      Try using https://resthooks.io/docs/api/ExternalCacheProvider for server entry points.",
+      ]
+    `);
+
+    if (!LegacyReact) {
       expect(msg).toMatchInlineSnapshot(`"<!--$--><div>hi</div><!--/$-->"`);
+    } else {
+      expect(msg).toMatchInlineSnapshot(`"<div>hi</div>"`);
     }
   });
 });


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
There is no case where context is updated in react 16/17 during an SSR cycle. So it doesn't make sense to use CacheProvider here - even when no suspense is used.

Also, adding actual elements in a provider is quite unexpected, which for instance led to the docs site having layout issues due to the nature of flexbox layout.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Log that they should use ExternalCacheProvider for the server-side rendering and remove special SSR handling. BackupBoundary is still used in ExternalCacheProvider but the hydration mismatch doesn't make any sense since server and client side have same DOM so I suspect it's a bug somewhere.

This is not a pure revert of #2039 as we maintain the test and used an alternative solution of warning about best usage patterns