### PR TITLE
internal: Pin linaria sub-packages to make demos work in stackblitz

### DIFF
--- a/examples/github-app/package.json
+++ b/examples/github-app/package.json
@@ -49,5 +49,10 @@
     "react-error-boundary": "^3.1.3",
     "react-markdown": "8.0.3",
     "rest-hooks": "^6.3.4"
+  },
+  "resolutions": {
+    "@linaria/babel-preset": "3.0.0-beta.18",
+    "@linaria/preeval": "3.0.0-beta.18",
+    "@linaria/utils": "3.0.0-beta.18"
   }
 }

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -42,5 +42,10 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "rest-hooks": "^6.3.4"
+  },
+  "resolutions": {
+    "@linaria/babel-preset": "3.0.0-beta.18",
+    "@linaria/preeval": "3.0.0-beta.18",
+    "@linaria/utils": "3.0.0-beta.18"
   }
 }


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
stackblitz installs from sub directory thus ignoring yarn.lock. newer linaria is broken as well as incompatible with previous versions.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
add resolutions that only run when installed from that directory