### PR TITLE
fix: package exports support for latest resolve pkg

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
         "import": "./node.mjs",
         "require": "./dist/index.js"
       },
+      "require": "./dist/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -31,6 +31,7 @@
         "import": "./node.mjs",
         "require": "./dist/index.js"
       },
+      "require": "./dist/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -31,6 +31,7 @@
         "import": "./node.mjs",
         "require": "./dist/index.js"
       },
+      "require": "./dist/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -31,6 +31,7 @@
         "import": "./node.mjs",
         "require": "./dist/index.js"
       },
+      "require": "./dist/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -57,6 +57,7 @@
         "import": "./node.mjs",
         "require": "./dist/normalizr.js"
       },
+      "require": "./dist/normalizr.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -31,6 +31,7 @@
         "import": "./node.mjs",
         "require": "./dist/index.js"
       },
+      "require": "./dist/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -31,6 +31,7 @@
         "import": "./node.mjs",
         "require": "./dist/index.js"
       },
+      "require": "./dist/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -31,6 +31,7 @@
         "import": "./node.mjs",
         "require": "./dist/index.js"
       },
+      "require": "./dist/index.js",
       "default": "./lib/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -30,6 +30,7 @@
         "import": "./node.mjs",
         "require": "./dist/index.js"
       },
+      "require": "./dist/index.js",
       "default": "./lib/browser.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #2060 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Some recent version of something (maybe resolve package?) started not using node conditional and instead using the browser condition when jest tests are running.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add require conditional as fallback after node to hit before reaching 'default'.