### PR TITLE
docs(fix): Update imports to reflect breaking changes in beta.22

### DIFF
--- a/website/src/components/Demo/CodeProvider.tsx
+++ b/website/src/components/Demo/CodeProvider.tsx
@@ -2,7 +2,7 @@ import React, { memo, useState } from 'react';
 import {
   useScrollPositionBlocker,
   useTabGroupChoice,
-} from '@docusaurus/theme-common';
+} from '@docusaurus/theme-common/internal';
 
 import CodeTabContext from './CodeTabContext';
 

--- a/website/src/components/Playground/Result.tsx
+++ b/website/src/components/Playground/Result.tsx
@@ -10,7 +10,7 @@ import clsx from 'clsx';
 import {
   useScrollPositionBlocker,
   useTabGroupChoice,
-} from '@docusaurus/theme-common';
+} from '@docusaurus/theme-common/internal';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 
 import styles from './styles.module.css';


### PR DESCRIPTION
https://github.com/facebook/docusaurus/pull/7660 Moved some exports we were using for our Playground component.

In the future we'll have to consider reworking this since these APIs are considered 'unstable'.

Larger docusaurus context: https://github.com/facebook/docusaurus/issues/6113