### PR TITLE
internal: publish

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.2.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.4...@rest-hooks/core@3.2.7) (2022-07-20)
+
+
+### 💅 Enhancement
+
+* Warn about CacheProvider usage for SSR ([#2044](https://github.com/coinbase/rest-hooks/issues/2044)) ([6b62bc6](https://github.com/coinbase/rest-hooks/commit/6b62bc61fbec06bb4f8eb30c8f2eb8e341e32a21))
+
+
+### 🐛 Bug Fix
+
+* 18.2 StrictMode compatibility ([#2096](https://github.com/coinbase/rest-hooks/issues/2096)) ([ca7d9de](https://github.com/coinbase/rest-hooks/commit/ca7d9deb2e5bcb542dfa33bc7ab3ef1b6aff7b8b))
+* Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
+* Hydration mismatch in React 17 ([#2039](https://github.com/coinbase/rest-hooks/issues/2039)) ([e8aff22](https://github.com/coinbase/rest-hooks/commit/e8aff22fe754bf47691b8f6c1b27d45335445def))
+
+
+
 ### [3.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.3...@rest-hooks/core@3.2.4) (2022-05-30)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -107,8 +107,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^2.2.7",
-    "@rest-hooks/normalizr": "^8.2.6",
+    "@rest-hooks/endpoint": "^2.2.10",
+    "@rest-hooks/normalizr": "^8.2.9",
     "@rest-hooks/use-enhanced-reducer": "^1.1.1",
     "flux-standard-action": "^2.1.1"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "3.2.4",
+  "version": "3.2.6",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.2.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.7...@rest-hooks/endpoint@2.2.10) (2022-07-20)
+
+
+### 🐛 Bug Fix
+
+* Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
+
+
+
 ### [2.2.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.6...@rest-hooks/endpoint@2.2.7) (2022-05-30)
 
 

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -98,6 +98,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/normalizr": "^8.2.6"
+    "@rest-hooks/normalizr": "^8.2.9"
   }
 }

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "2.2.7",
+  "version": "2.2.9",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.3...@rest-hooks/experimental@5.0.5) (2022-07-20)
+
+
+### 📦 Package
+
+* build, eslint, webpack, typescript ([#2050](https://github.com/coinbase/rest-hooks/issues/2050)) ([9e2d363](https://github.com/coinbase/rest-hooks/commit/9e2d3636879d0c3c51763b9e74424640c4976e3a))
+
+
+
 ### [5.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.2...@rest-hooks/experimental@5.0.3) (2022-05-30)
 
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.6...@rest-hooks/graphql@0.1.8) (2022-07-20)
+
+
+### 🐛 Bug Fix
+
+* Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
+
+
+
 ### [0.1.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.5...@rest-hooks/graphql@0.1.6) (2022-05-30)
 
 

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.3.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.3...@rest-hooks/legacy@4.3.5) (2022-07-20)
+
+
+### 🐛 Bug Fix
+
+* Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
+
+
+
 ### [4.3.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.2...@rest-hooks/legacy@4.3.3) (2022-05-30)
 
 

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [8.2.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.6...@rest-hooks/normalizr@8.2.9) (2022-07-20)
+
+
+### 🐛 Bug Fix
+
+* Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
+
+
+
 ### [8.2.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.5...@rest-hooks/normalizr@8.2.6) (2022-05-30)
 
 

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "8.2.6",
+  "version": "8.2.8",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "8.2.8",
+  "version": "8.2.9",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.3.7](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.4...rest-hooks@6.3.7) (2022-07-20)
+
+
+### 🐛 Bug Fix
+
+* Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
+
+
+
 ### [6.3.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.3...rest-hooks@6.3.4) (2022-05-30)
 
 

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "6.3.6",
+  "version": "6.3.7",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -107,8 +107,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/core": "^3.2.4",
-    "@rest-hooks/endpoint": "^2.2.7"
+    "@rest-hooks/core": "^3.2.7",
+    "@rest-hooks/endpoint": "^2.2.10"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "6.3.4",
+  "version": "6.3.6",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.2...@rest-hooks/rest@5.0.4) (2022-07-20)
+
+
+### 🐛 Bug Fix
+
+* Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
+
+
+
 ### [5.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.1...@rest-hooks/rest@5.0.2) (2022-05-30)
 
 

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.0...@rest-hooks/ssr@0.2.2) (2022-07-20)
+
+
+### 🐛 Bug Fix
+
+* Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
+
+
+
 ## [0.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.1.4...@rest-hooks/ssr@0.2.0) (2022-05-30)
 
 

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/ssr",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/ssr",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.3.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.1...@rest-hooks/test@7.3.3) (2022-07-20)
+
+
+### 🐛 Bug Fix
+
+* Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
+
+
+### 📦 Package
+
+* Update `@testing-library/react-hooks` to v8 ([#2070](https://github.com/coinbase/rest-hooks/issues/2070)) ([174d896](https://github.com/coinbase/rest-hooks/commit/174d896af4fe77443037409b336a12efd86ce5ad))
+
+
+
 ### [7.3.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.0...@rest-hooks/test@7.3.1) (2022-04-30)
 
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "7.3.2",
+  "version": "7.3.3",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",


### PR DESCRIPTION
 - @rest-hooks/core: 3.2.6 => 3.2.7
 - @rest-hooks/endpoint: 2.2.9 => 2.2.10
 - @rest-hooks/experimental: 5.0.4 => 5.0.5
 - @rest-hooks/graphql: 0.1.7 => 0.1.8
 - @rest-hooks/legacy: 4.3.4 => 4.3.5
 - @rest-hooks/normalizr: 8.2.8 => 8.2.9
 - rest-hooks: 6.3.6 => 6.3.7
 - @rest-hooks/rest: 5.0.3 => 5.0.4
 - @rest-hooks/ssr: 0.2.1 => 0.2.2
 - @rest-hooks/test: 7.3.2 => 7.3.3