### PR TITLE
fix: Ensure dual package hazard solved for non-node

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,10 +27,8 @@
   },
   "exports": {
     ".": {
-      "node": {
-        "import": "./node.mjs",
-        "require": "./dist/index.js"
-      },
+      "module": "./lib/index.js",
+      "import": "./node.mjs",
       "require": "./dist/index.js",
       "default": "./lib/index.js"
     },

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -27,10 +27,8 @@
   },
   "exports": {
     ".": {
-      "node": {
-        "import": "./node.mjs",
-        "require": "./dist/index.js"
-      },
+      "module": "./lib/index.js",
+      "import": "./node.mjs",
       "require": "./dist/index.js",
       "default": "./lib/index.js"
     },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -27,10 +27,8 @@
   },
   "exports": {
     ".": {
-      "node": {
-        "import": "./node.mjs",
-        "require": "./dist/index.js"
-      },
+      "module": "./lib/index.js",
+      "import": "./node.mjs",
       "require": "./dist/index.js",
       "default": "./lib/index.js"
     },

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -27,10 +27,8 @@
   },
   "exports": {
     ".": {
-      "node": {
-        "import": "./node.mjs",
-        "require": "./dist/index.js"
-      },
+      "module": "./lib/index.js",
+      "import": "./node.mjs",
       "require": "./dist/index.js",
       "default": "./lib/index.js"
     },

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -53,10 +53,8 @@
   },
   "exports": {
     ".": {
-      "node": {
-        "import": "./node.mjs",
-        "require": "./dist/normalizr.js"
-      },
+      "module": "./lib/index.js",
+      "import": "./node.mjs",
       "require": "./dist/normalizr.js",
       "default": "./lib/index.js"
     },

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -27,10 +27,8 @@
   },
   "exports": {
     ".": {
-      "node": {
-        "import": "./node.mjs",
-        "require": "./dist/index.js"
-      },
+      "module": "./lib/index.js",
+      "import": "./node.mjs",
       "require": "./dist/index.js",
       "default": "./lib/index.js"
     },

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -27,10 +27,8 @@
   },
   "exports": {
     ".": {
-      "node": {
-        "import": "./node.mjs",
-        "require": "./dist/index.js"
-      },
+      "module": "./lib/index.js",
+      "import": "./node.mjs",
       "require": "./dist/index.js",
       "default": "./lib/index.js"
     },

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -27,10 +27,8 @@
   },
   "exports": {
     ".": {
-      "node": {
-        "import": "./node.mjs",
-        "require": "./dist/index.js"
-      },
+      "module": "./lib/index.js",
+      "import": "./node.mjs",
       "require": "./dist/index.js",
       "default": "./lib/index.js"
     },

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -27,11 +27,14 @@
   "exports": {
     ".": {
       "node": {
+        "module": "./lib/index.js",
         "import": "./node.mjs",
         "require": "./dist/index.js"
       },
+      "module": "./lib/browser.js",
+      "import": "./node.mjs",
       "require": "./dist/index.js",
-      "default": "./lib/browser.js"
+      "default": "./lib/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard) can cause issue if multiple imports occur that provide singletons like Symbols or React Context variables.

We currently solve this by pointing to commonjs from an ESM module. This works fine in node contexts because it is not considered that tree shaking is needed in this case.

However, [jest does not currently support ESM - only commonjs](https://github.com/coinbase/rest-hooks/issues/2060). Additionally in a recent update their jsdom environment will report only 'browser' condition to 'exports' fields. This means we must provide it with a commonjs module.

Previously we had simply adding a require condition to capture this case - but that introduced the dual package hazard for any non-node condition.

This resulted in Rest Hooks reporting the CacheProvider was not installed in any case where there was both a CJS and ESM import. This happened for me with a hot-reloading script that triggered a require() call.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Webpack now provides a 'module' condition, which we can use to ensure that we provide the ESM version to anything that 'speaks' ESM even if they don't want ESM in their final form. This results in the following:

```json
{
      "module": "./lib/index.js",
      "import": "./node.mjs",
      "require": "./dist/index.js",
      "default": "./lib/index.js"
}
```
