### PR TITLE
internal: publish

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,22 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [3.2.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.7...@rest-hooks/core@3.2.8) (2022-07-23)
+### [3.2.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.8...@rest-hooks/core@3.2.9) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [3.2.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.7...@rest-hooks/core@3.2.8) (2022-07-23)
 
 ### 🐛 Bug Fix
 
 * Ensure dual package hazard solved for non-node ([#2099](https://github.com/coinbase/rest-hooks/issues/2099)) ([6206e64](https://github.com/coinbase/rest-hooks/commit/6206e6463a7c3699d5c1d1b248e4d5418b1327f1))
 
-
-
 ### [3.2.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.4...@rest-hooks/core@3.2.7) (2022-07-20)
-
 
 ### 💅 Enhancement
 
 * Warn about CacheProvider usage for SSR ([#2044](https://github.com/coinbase/rest-hooks/issues/2044)) ([6b62bc6](https://github.com/coinbase/rest-hooks/commit/6b62bc61fbec06bb4f8eb30c8f2eb8e341e32a21))
-
 
 ### 🐛 Bug Fix
 
@@ -26,38 +27,26 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
 * Hydration mismatch in React 17 ([#2039](https://github.com/coinbase/rest-hooks/issues/2039)) ([e8aff22](https://github.com/coinbase/rest-hooks/commit/e8aff22fe754bf47691b8f6c1b27d45335445def))
 
-
-
 ### [3.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.3...@rest-hooks/core@3.2.4) (2022-05-30)
-
 
 ### 📦 Package
 
 * [@anansi](https://github.com/anansi), types, antd, eslint, node, redux, typescript, webpack ([#2015](https://github.com/coinbase/rest-hooks/issues/2015)) ([972d646](https://github.com/coinbase/rest-hooks/commit/972d6463c6d1946254673bb7029898b19ce4ffdd))
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
 
-
-
 ### [3.2.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.2...@rest-hooks/core@3.2.3) (2022-04-30)
-
 
 ### 🐛 Bug Fix
 
 * Accept undefined or null responses for schema entries ([#1963](https://github.com/coinbase/rest-hooks/issues/1963)) ([2d4214a](https://github.com/coinbase/rest-hooks/commit/2d4214a4c6b74725c9a6a92e36817bd26aa3c366))
 
-
-
 ### [3.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.1...@rest-hooks/core@3.2.2) (2022-04-16)
-
 
 ### 💅 Enhancement
 
 * Improve robustness when using distinct schemas to normalize/denormalize ([#1908](https://github.com/coinbase/rest-hooks/issues/1908)) ([c8fdca9](https://github.com/coinbase/rest-hooks/commit/c8fdca9e0cd65622d41692b66c3e2744b20bef23)), closes [#1912](https://github.com/coinbase/rest-hooks/issues/1912)
 
-
-
 ### [3.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.0...@rest-hooks/core@3.2.1) (2022-04-11)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -69,59 +58,43 @@ instead
 * HookableResource - endpoints as hooks ([#1891](https://github.com/coinbase/rest-hooks/issues/1891)) ([dcd9fbb](https://github.com/coinbase/rest-hooks/commit/dcd9fbb4f4ce5583503187317ea0e065f5d31f1a))
 * Resource.create() can take 1-2 args ([ed4f55c](https://github.com/coinbase/rest-hooks/commit/ed4f55c8b4b80eb93f3c01108c2177b97f5dc4e8))
 
-
 ### 💅 Enhancement
 
 * Improve type inference for getFetchKey ([#1896](https://github.com/coinbase/rest-hooks/issues/1896)) ([36b11af](https://github.com/coinbase/rest-hooks/commit/36b11af67b08183288ad295ff0303eaf78f01dba))
 
-
-
 ## [3.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.2...@rest-hooks/core@3.2.0) (2022-04-08)
-
 
 ### 🚀 Features
 
 * Add CacheProvider Controller prop to allow controller customization ([#1868](https://github.com/coinbase/rest-hooks/issues/1868)) ([2b3f70e](https://github.com/coinbase/rest-hooks/commit/2b3f70e318f168d3788303a4be6e7992fb2678e8))
 * Add useDLE() to core ([#1866](https://github.com/coinbase/rest-hooks/issues/1866)) ([9efc216](https://github.com/coinbase/rest-hooks/commit/9efc21650bbe0c445ea61e0acb334391b996dd40))
 
-
 ### 💅 Enhancement
 
 * Improve update types ([b6b0334](https://github.com/coinbase/rest-hooks/commit/b6b033470c14bf9bed0e6b161570dde97b6390b4))
-
 
 ### 🐛 Bug Fix
 
 * optimisticUpdate when used with controller.fetch or useSuspense ([e40f5ea](https://github.com/coinbase/rest-hooks/commit/e40f5ea75191ff5b4e170922744f1eaa95c09275))
 
-
-
 ### [3.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.1...@rest-hooks/core@3.1.2) (2022-04-02)
-
 
 ### 💅 Enhancement
 
 * More exact optional type handling ([#1858](https://github.com/coinbase/rest-hooks/issues/1858)) ([0459dbd](https://github.com/coinbase/rest-hooks/commit/0459dbdc3fe1555c5e6dc80290187ec8297d1aa6))
 
-
-
 ### [3.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.0-beta.9...@rest-hooks/core@3.1.1) (2022-04-01)
-
 
 ### 💅 Enhancement
 
 * Hooks should type return value based on 'null' arg ([#1783](https://github.com/coinbase/rest-hooks/issues/1783)) ([d14673e](https://github.com/coinbase/rest-hooks/commit/d14673eab0dad3f02edb54f7bf37e6fed1c47a62))
-
 
 ### 🐛 Bug Fix
 
 * Default optimistic race condition handling should assume in-order server response ([#1852](https://github.com/coinbase/rest-hooks/issues/1852)) ([cf38c3f](https://github.com/coinbase/rest-hooks/commit/cf38c3f67ff0041b528e9d8cf21d31704b76fc01))
 * Hooks with null param maintain basic schema structure ([#1853](https://github.com/coinbase/rest-hooks/issues/1853)) ([0707e1a](https://github.com/coinbase/rest-hooks/commit/0707e1a6ee8233b2d1b6590db137e298e264635c))
 
-
-
 ## [3.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.0.2...@rest-hooks/core@3.1.0) (2022-03-17)
-
 
 ### 🚀 Features
 
@@ -130,14 +103,12 @@ instead
 * export BackupBoundary ([7a7c398](https://github.com/coinbase/rest-hooks/commit/7a7c398d2db852ab6d3523f1a7ca20ef46e9d5f4))
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
 
-
 ### 💅 Enhancement
 
 * Dispatch new receive action if new fetch triggered it ([#1455](https://github.com/coinbase/rest-hooks/issues/1455)) ([99f9a6d](https://github.com/coinbase/rest-hooks/commit/99f9a6d13b970eba398d869acf60f6776e62939e))
 * Fetch resolution only removes the optimistic update corresponding to that fetch ([#1653](https://github.com/coinbase/rest-hooks/issues/1653)) ([2fd93f2](https://github.com/coinbase/rest-hooks/commit/2fd93f235074d134200e81ddb16792647b3cffad))
 * Hooks should type return value based on 'null' arg ([#1783](https://github.com/coinbase/rest-hooks/issues/1783)) ([d14673e](https://github.com/coinbase/rest-hooks/commit/d14673eab0dad3f02edb54f7bf37e6fed1c47a62))
 * optimisticUpdater -> getOptimisticResponse ([#1769](https://github.com/coinbase/rest-hooks/issues/1769)) ([4d1cd66](https://github.com/coinbase/rest-hooks/commit/4d1cd66ea2677868aba402d362b9896dffc24462))
-
 
 ### 🐛 Bug Fix
 
@@ -147,24 +118,17 @@ instead
 * Union schemas with null args[0] hooks ([#1779](https://github.com/coinbase/rest-hooks/issues/1779)) ([fcf70a9](https://github.com/coinbase/rest-hooks/commit/fcf70a92ef15531b7fd12feb117f29ad8c3de3d8))
 * useFetcher() work with zero argument Endpoint ([#1514](https://github.com/coinbase/rest-hooks/issues/1514)) ([c5ac9e7](https://github.com/coinbase/rest-hooks/commit/c5ac9e7a1d66f57ddcee5c343b239cf2d6d5f782))
 
-
 ### 📝 Documentation
 
 * Use stackblitz for demos ([#1699](https://github.com/coinbase/rest-hooks/issues/1699)) ([ee7b4ca](https://github.com/coinbase/rest-hooks/commit/ee7b4ca6fbe5ccea4ea32a52885bf9fe64cbb947))
 
-
-
 ## [3.1.0-beta.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.0-beta.8...@rest-hooks/core@3.1.0-beta.9) (2022-03-10)
-
 
 ### 🐛 Bug Fix
 
 * Union schemas with null args[0] hooks ([#1779](https://github.com/coinbase/rest-hooks/issues/1779)) ([fcf70a9](https://github.com/coinbase/rest-hooks/commit/fcf70a92ef15531b7fd12feb117f29ad8c3de3d8))
 
-
-
 ## [3.1.0-beta.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.0-beta.6...@rest-hooks/core@3.1.0-beta.8) (2022-03-08)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -175,82 +139,58 @@ instead
 * Entity.useIncoming() for race condition handling ([#1771](https://github.com/coinbase/rest-hooks/issues/1771)) ([ffd70fe](https://github.com/coinbase/rest-hooks/commit/ffd70fe0aa12634d06d2e0d43a5b89d420e2220c))
 * export BackupBoundary ([7a7c398](https://github.com/coinbase/rest-hooks/commit/7a7c398d2db852ab6d3523f1a7ca20ef46e9d5f4))
 
-
 ### 💅 Enhancement
 
 * optimisticUpdater -> getOptimisticResponse ([#1769](https://github.com/coinbase/rest-hooks/issues/1769)) ([4d1cd66](https://github.com/coinbase/rest-hooks/commit/4d1cd66ea2677868aba402d362b9896dffc24462))
-
 
 ### 🐛 Bug Fix
 
 * lastReset should serialize ([#1745](https://github.com/coinbase/rest-hooks/issues/1745)) ([e25158a](https://github.com/coinbase/rest-hooks/commit/e25158a28c5bdc90aeb7fa6e7ca2c43580f6f88f))
 
-
-
 ## [3.1.0-beta.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.0-beta.6...@rest-hooks/core@3.1.0-beta.7) (2022-03-01)
-
 
 ### 🚀 Features
 
 * export BackupBoundary ([7a7c398](https://github.com/coinbase/rest-hooks/commit/7a7c398d2db852ab6d3523f1a7ca20ef46e9d5f4))
 
-
 ### 🐛 Bug Fix
 
 * lastReset should serialize ([#1745](https://github.com/coinbase/rest-hooks/issues/1745)) ([e25158a](https://github.com/coinbase/rest-hooks/commit/e25158a28c5bdc90aeb7fa6e7ca2c43580f6f88f))
 
-
-
 ## [3.1.0-beta.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.0-beta.5...@rest-hooks/core@3.1.0-beta.6) (2022-02-26)
-
 
 ### 🐛 Bug Fix
 
 * Expiry defaults for useSuspense() should match useResource() ([#1738](https://github.com/coinbase/rest-hooks/issues/1738)) ([b98dcfd](https://github.com/coinbase/rest-hooks/commit/b98dcfdb56bfc947829e2eead4b6a785dfe3965d))
 * InvalidIfStale should be respected in no-schema endpoints ([#1724](https://github.com/coinbase/rest-hooks/issues/1724)) ([28fab73](https://github.com/coinbase/rest-hooks/commit/28fab739952aae6819ddfcaafe9fcb3c893f8d2f))
 
-
-
 ## [3.1.0-beta.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.0-beta.3...@rest-hooks/core@3.1.0-beta.5) (2022-02-15)
-
 
 ### 💅 Enhancement
 
 * Fetch resolution only removes the optimistic update corresponding to that fetch ([#1653](https://github.com/coinbase/rest-hooks/issues/1653)) ([2fd93f2](https://github.com/coinbase/rest-hooks/commit/2fd93f235074d134200e81ddb16792647b3cffad))
-
 
 ### 📝 Documentation
 
 * Use stackblitz for demos ([#1699](https://github.com/coinbase/rest-hooks/issues/1699)) ([ee7b4ca](https://github.com/coinbase/rest-hooks/commit/ee7b4ca6fbe5ccea4ea32a52885bf9fe64cbb947))
 
-
-
 ## [3.1.0-beta.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.0-beta.3...@rest-hooks/core@3.1.0-beta.4) (2022-01-31)
-
 
 ### 💅 Enhancement
 
 * Fetch resolution only removes the optimistic update corresponding to that fetch ([#1653](https://github.com/coinbase/rest-hooks/issues/1653)) ([2fd93f2](https://github.com/coinbase/rest-hooks/commit/2fd93f235074d134200e81ddb16792647b3cffad))
 
-
-
 ## [3.1.0-beta.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.0-beta.2...@rest-hooks/core@3.1.0-beta.3) (2022-01-23)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 
-
-
 ## [3.1.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.1.0-beta.1...@rest-hooks/core@3.1.0-beta.2) (2021-11-26)
-
 
 ### 🐛 Bug Fix
 
 * useFetcher() work with zero argument Endpoint ([#1514](https://github.com/coinbase/rest-hooks/issues/1514)) ([c5ac9e7](https://github.com/coinbase/rest-hooks/commit/c5ac9e7a1d66f57ddcee5c343b239cf2d6d5f782))
-
-
 
 ## [3.1.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.0.2...@rest-hooks/core@3.1.0-beta.1) (2021-10-29)
 
@@ -258,37 +198,25 @@ instead
 
 * Dispatch new receive action if new fetch triggered it ([#1455](https://github.com/coinbase/rest-hooks/issues/1455)) ([99f9a6d](https://github.com/coinbase/rest-hooks/commit/99f9a6d13b970eba398d869acf60f6776e62939e))
 
-
-
 ## [3.1.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.0.2...@rest-hooks/core@3.1.0-beta.0) (2021-10-24)
-
 
 ### 🚀 Features
 
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
 
-
-
 ### [3.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.0.1...@rest-hooks/core@3.0.2) (2021-10-20)
-
 
 ### 💅 Enhancement
 
 * Use const enums for ExpiryStatus ([#1417](https://github.com/coinbase/rest-hooks/issues/1417)) ([8d3f7f9](https://github.com/coinbase/rest-hooks/commit/8d3f7f973155680b2d52ed3f2e2758327b76d356))
 
-
-
 ### [3.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.0.0...@rest-hooks/core@3.0.1) (2021-10-18)
-
 
 ### 💅 Enhancement
 
 * Improve types of controller.sub/unsub ([#1401](https://github.com/coinbase/rest-hooks/issues/1401)) ([85f18b0](https://github.com/coinbase/rest-hooks/commit/85f18b0af0f11efcb240ac44c2d04ec6d115f72f))
 
-
-
 ## [3.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.2.2...@rest-hooks/core@3.0.0) (2021-10-17)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -303,20 +231,15 @@ instead
 
 * Improve Controller.getResponse() interface ([#1396](https://github.com/coinbase/rest-hooks/issues/1396)) ([f57a909](https://github.com/coinbase/rest-hooks/commit/f57a909b98aa1c385a95f1dde437a0d6aa7ff916))
 
-
 ### 🐛 Bug Fix
 
 * Correct controller override ([#1386](https://github.com/coinbase/rest-hooks/issues/1386)) ([c1d4a70](https://github.com/coinbase/rest-hooks/commit/c1d4a70d09f0bd501ea5c0112a48b377d553ca45))
 
-
-
 ### [2.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.2.1...@rest-hooks/core@2.2.2) (2021-10-11)
-
 
 ### 💅 Enhancement
 
 * Unified unset dispatch function ([#1362](https://github.com/coinbase/rest-hooks/issues/1362)) ([1b6d718](https://github.com/coinbase/rest-hooks/commit/1b6d71850d5adf38de879181ba62115db73e4e45))
-
 
 ### 📝 Documentation
 
@@ -326,76 +249,53 @@ instead
 * Rearrange homepage ([#1352](https://github.com/coinbase/rest-hooks/issues/1352)) ([404b2b0](https://github.com/coinbase/rest-hooks/commit/404b2b0eaeea9be71594e031f9763b09c6c8fee7))
 * Reorganize docs ([#1345](https://github.com/coinbase/rest-hooks/issues/1345)) ([fa49b6b](https://github.com/coinbase/rest-hooks/commit/fa49b6bcf1d6838b85ce21e728f0630e2746e68f))
 
-
-
 ### [2.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.2.0...@rest-hooks/core@2.2.1) (2021-09-29)
-
 
 ### 💅 Enhancement
 
 * Hoist conditional for Boundary SSR ([#1313](https://github.com/coinbase/rest-hooks/issues/1313)) ([7cfd9fa](https://github.com/coinbase/rest-hooks/commit/7cfd9fa2ff534233442e8135228d6e5c165fa20d))
 
-
-
 ## [2.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.1.0...@rest-hooks/core@2.2.0) (2021-09-29)
-
 
 ### 🚀 Features
 
 * Add controller.getResponse() & controller.getError() ([#1290](https://github.com/coinbase/rest-hooks/issues/1290)) ([2434d95](https://github.com/coinbase/rest-hooks/commit/2434d95d6d3a546b448790058c3fd8e779a1da4d))
 
-
 ### 💅 Enhancement
 
 * Improve compatibility with SSR and React Native ([#1308](https://github.com/coinbase/rest-hooks/issues/1308)) ([de4c1a4](https://github.com/coinbase/rest-hooks/commit/de4c1a4def0bf05236ce4138e3ab96cc24ace568))
-
 
 ### 🐛 Bug Fix
 
 * Compatibility with React Native in CacheProvider ([#1307](https://github.com/coinbase/rest-hooks/issues/1307)) ([f021905](https://github.com/coinbase/rest-hooks/commit/f021905e3f31fadc68f6b27a6219db8b232a74f8)), closes [#1306](https://github.com/coinbase/rest-hooks/issues/1306)
 
-
-
 ## [2.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.1...@rest-hooks/core@2.1.0) (2021-09-19)
-
 
 ### 🚀 Features
 
 * Add Controller ([#1239](https://github.com/coinbase/rest-hooks/issues/1239)) ([321dbaa](https://github.com/coinbase/rest-hooks/commit/321dbaa905744b5d331a163d4a0f219809f740ee))
 * Send controller to middlewares ([#1271](https://github.com/coinbase/rest-hooks/issues/1271)) ([29db53c](https://github.com/coinbase/rest-hooks/commit/29db53c8ee7f5d770dd43b6e3d97346bc77f76d7))
 
-
 ### 📝 Documentation
 
 * Random fixes ([#1261](https://github.com/coinbase/rest-hooks/issues/1261)) ([ec90154](https://github.com/coinbase/rest-hooks/commit/ec901542a5157b35e20a346b7794f986f775138c))
-
-
 
 ### [2.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.0...@rest-hooks/core@2.0.1) (2021-09-14)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ## [2.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.0-beta.6...@rest-hooks/core@2.0.0) (2021-09-08)
-
 
 ### 🐛 Bug Fix
 
 * Updating nesting under arrays ([#1047](https://github.com/coinbase/rest-hooks/issues/1047)) ([a78a1a4](https://github.com/coinbase/rest-hooks/commit/a78a1a41149dbb0646660fdeef38918b2e16cc14))
-
 
 ### 📝 Documentation
 
 * Add links to protocol specific docs ([#1218](https://github.com/coinbase/rest-hooks/issues/1218)) ([1570881](https://github.com/coinbase/rest-hooks/commit/1570881372bb1cc0a3d4034c24543bb8ea5d99c1))
 * Add more tags to packages ([#1223](https://github.com/coinbase/rest-hooks/issues/1223)) ([ef76efc](https://github.com/coinbase/rest-hooks/commit/ef76efc70f7c6acb73d22135a227f84e522729b4))
 
-
-
 ## [2.0.0-beta.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.0-beta.5...@rest-hooks/core@2.0.0-beta.6) (2021-09-06)
-
 
 ### 💅 Enhancement
 
@@ -404,28 +304,19 @@ instead
 * validate during denormalization ([#1183](https://github.com/coinbase/rest-hooks/issues/1183)) ([bca1e4a](https://github.com/coinbase/rest-hooks/commit/bca1e4a9158a294ee82745107e04e43564ccd5a0))
 * Warn users if they are missing Suspense boundary ([#1169](https://github.com/coinbase/rest-hooks/issues/1169)) ([ccf819a](https://github.com/coinbase/rest-hooks/commit/ccf819ab65163aa056a3317e1c1eca17c003ecf6))
 
-
-
 ## [2.0.0-beta.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.0-beta.4...@rest-hooks/core@2.0.0-beta.5) (2021-08-25)
-
 
 ### 💅 Enhancement
 
 * Back to avoiding reducer for fetch ([#1149](https://github.com/coinbase/rest-hooks/issues/1149)) ([06ae6a4](https://github.com/coinbase/rest-hooks/commit/06ae6a450f65f0344a44e2c8d162b62e7461bfe8))
 
-
-
 ## [2.0.0-beta.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.0-beta.3...@rest-hooks/core@2.0.0-beta.4) (2021-08-22)
-
 
 ### 🐛 Bug Fix
 
 * Cannot update a component while rendering a different component ([#1130](https://github.com/coinbase/rest-hooks/issues/1130)) ([0003388](https://github.com/coinbase/rest-hooks/commit/00033882ec88338b94bd78c8a7a5ad2954af40d6))
 
-
-
 ## [2.0.0-beta.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.0-beta.2...@rest-hooks/core@2.0.0-beta.3) (2021-08-21)
-
 
 ### 💅 Enhancement
 
@@ -433,16 +324,12 @@ instead
 * Hide throttled fetches from devtools ([#1083](https://github.com/coinbase/rest-hooks/issues/1083)) ([2f09c22](https://github.com/coinbase/rest-hooks/commit/2f09c227ef9dcc056a4e9f1c76b725aa063964d6))
 * Improve reducer error visibility ([#1084](https://github.com/coinbase/rest-hooks/issues/1084)) ([b69a50d](https://github.com/coinbase/rest-hooks/commit/b69a50d7b3d658c0b4c7f6c198fe8e2a76ec8aa9))
 
-
 ### 🐛 Bug Fix
 
 * RESET clears inflight fetches ([#1085](https://github.com/coinbase/rest-hooks/issues/1085)) ([02fa0d5](https://github.com/coinbase/rest-hooks/commit/02fa0d527ef138961ba6dc2509648337c01e604d))
 * useFetchInit() hook calls same amount every render ([#1123](https://github.com/coinbase/rest-hooks/issues/1123)) ([6cd0b7c](https://github.com/coinbase/rest-hooks/commit/6cd0b7cc57de59b5f394942dfa9a3a08d9f2e912))
 
-
-
 ## [2.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.5.3...@rest-hooks/core@2.0.0-beta.2) (2021-07-12)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -470,7 +357,6 @@ errors for missing entities
 * FixtureEndpoint & renderRestHook resolverFixtures ([#1027](https://github.com/coinbase/rest-hooks/issues/1027)) ([bbb69e9](https://github.com/coinbase/rest-hooks/commit/bbb69e9faaa523c46a0e309a44e0fd52f0ce91aa))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Different babel targets for cjs and umd builds ([#989](https://github.com/coinbase/rest-hooks/issues/989)) ([f054814](https://github.com/coinbase/rest-hooks/commit/f05481410cf8daa2101d4dbda826e56ad10ec723))
@@ -483,29 +369,21 @@ errors for missing entities
 * Use optional chaining ([#1003](https://github.com/coinbase/rest-hooks/issues/1003)) ([6e45937](https://github.com/coinbase/rest-hooks/commit/6e459377e3f0d90d1832c0173358c3c73f253831))
 * useError() only checks meta error ([#938](https://github.com/coinbase/rest-hooks/issues/938)) ([b08d708](https://github.com/coinbase/rest-hooks/commit/b08d708ea50170de0dd25340aec84b86a7687f48))
 
-
 ### 🐛 Bug Fix
 
 * module build import path ([#994](https://github.com/coinbase/rest-hooks/issues/994)) ([1f84f51](https://github.com/coinbase/rest-hooks/commit/1f84f51e0f3b62832945e75d0e241dba59b6623c))
-
 
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
 
-
-
 ## [2.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@2.0.0-beta.0...@rest-hooks/core@2.0.0-beta.1) (2021-06-30)
-
 
 ### 🐛 Bug Fix
 
 * module build import path ([#994](https://github.com/coinbase/rest-hooks/issues/994)) ([1f84f51](https://github.com/coinbase/rest-hooks/commit/1f84f51e0f3b62832945e75d0e241dba59b6623c))
 
-
-
 ## [2.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.5.2...@rest-hooks/core@2.0.0-beta.0) (2021-06-30)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -532,7 +410,6 @@ errors for missing entities
 * Add errorPolicy to endpoint options ([#971](https://github.com/coinbase/rest-hooks/issues/971)) ([836f05b](https://github.com/coinbase/rest-hooks/commit/836f05b407b5ac96c8f094e652221aa5a95300b0))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Different babel targets for cjs and umd builds ([#989](https://github.com/coinbase/rest-hooks/issues/989)) ([f054814](https://github.com/coinbase/rest-hooks/commit/f05481410cf8daa2101d4dbda826e56ad10ec723))
@@ -543,7 +420,6 @@ errors for missing entities
 * Remove Resource export from 'rest-hooks' package ([#939](https://github.com/coinbase/rest-hooks/issues/939)) ([0707920](https://github.com/coinbase/rest-hooks/commit/0707920bd9de70112b5287d101dcd4f6962f21d1))
 * useError() only checks meta error ([#938](https://github.com/coinbase/rest-hooks/issues/938)) ([b08d708](https://github.com/coinbase/rest-hooks/commit/b08d708ea50170de0dd25340aec84b86a7687f48))
 
-
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
@@ -552,75 +428,48 @@ errors for missing entities
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ### [1.5.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.5.1...@rest-hooks/core@1.5.2) (2021-06-19)
 
 **Note:** Version bump only for package @rest-hooks/core
-
-
-
-
 
 ### [1.5.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.5.0...@rest-hooks/core@1.5.1) (2021-06-16)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ## [1.5.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.4.1...@rest-hooks/core@1.5.0) (2021-06-13)
-
 
 ### 🚀 Features
 
 * Normalize merges entities, entitymeta, indexes ([#915](https://github.com/coinbase/rest-hooks/issues/915)) ([bd21d8c](https://github.com/coinbase/rest-hooks/commit/bd21d8ce0d004a56e6853918d9fb9ecaa2c730a8))
 * Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
 
-
 ### 💅 Enhancement
 
 * Use inferResults() from normalizr ([#901](https://github.com/coinbase/rest-hooks/issues/901)) ([875cb6a](https://github.com/coinbase/rest-hooks/commit/875cb6acf31055e37e2d1faf4414bcbf31f5700f))
 
-
-
 ### [1.4.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.4.0...@rest-hooks/core@1.4.1) (2021-06-09)
-
 
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ## [1.4.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.2.1...@rest-hooks/core@1.4.0) (2021-06-02)
-
 
 ### 🚀 Features
 
 * Add garbage collection action ([#865](https://github.com/coinbase/rest-hooks/issues/865)) ([aab7ad6](https://github.com/coinbase/rest-hooks/commit/aab7ad6045a08417f53b778a7ea4d2611f6cac06))
-
 
 ### 💅 Enhancement
 
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
-
 ## [1.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.2.1...@rest-hooks/core@1.3.0) (2021-05-30)
-
 
 ### 🚀 Features
 
 * Add garbage collection action ([#865](https://github.com/coinbase/rest-hooks/issues/865)) ([aab7ad6](https://github.com/coinbase/rest-hooks/commit/aab7ad6045a08417f53b778a7ea4d2611f6cac06))
 
-
-
 ### [1.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.2.0...@rest-hooks/core@1.2.1) (2021-05-24)
-
 
 ### 💅 Enhancement
 
@@ -628,88 +477,61 @@ errors for missing entities
 * Support endpoint.update in existing useFetcher ([#853](https://github.com/coinbase/rest-hooks/issues/853)) ([2436f3b](https://github.com/coinbase/rest-hooks/commit/2436f3b9e6f91fc73178476d3ca88605349bba33))
 * Transform updateParams to 'update' function ([#854](https://github.com/coinbase/rest-hooks/issues/854)) ([7ef3e2a](https://github.com/coinbase/rest-hooks/commit/7ef3e2a646421356029294e440e1a2e000b05f05))
 
-
-
 ## [1.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.1.2...@rest-hooks/core@1.2.0) (2021-05-24)
-
 
 ### 🚀 Features
 
 * Endpoint.update programmable sideeffects ([#843](https://github.com/coinbase/rest-hooks/issues/843)) ([3b011b2](https://github.com/coinbase/rest-hooks/commit/3b011b2ab7d3f2fd6588bd26c566bf542beeba49))
 
-
 ### 💅 Enhancement
 
 * Do not throw on unmount of CacheProvider ([#837](https://github.com/coinbase/rest-hooks/issues/837)) ([f7dcf24](https://github.com/coinbase/rest-hooks/commit/f7dcf24d2b6123ab84470263d505a975591bd9b4))
 
-
-
 ### [1.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.1.1...@rest-hooks/core@1.1.2) (2021-04-26)
-
 
 ### 🐛 Bug Fix
 
 * useMeta() parameters type ([#775](https://github.com/coinbase/rest-hooks/issues/775)) ([9f7fae4](https://github.com/coinbase/rest-hooks/commit/9f7fae4dba0d797fdfac114e52cdd5ea90f4d61f))
 
-
-
 ### [1.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.1.0...@rest-hooks/core@1.1.1) (2021-04-25)
-
 
 ### 💅 Enhancement
 
 * Make hook generics use consist params ([#769](https://github.com/coinbase/rest-hooks/issues/769)) ([5a68f2a](https://github.com/coinbase/rest-hooks/commit/5a68f2a5d9d942436f08c513b8b56c78718f14aa))
 
-
 ### 🐛 Bug Fix
 
 * Delete should only be triggered on finding DELETE symbol ([#770](https://github.com/coinbase/rest-hooks/issues/770)) ([20886f6](https://github.com/coinbase/rest-hooks/commit/20886f65cba2e741e1496990123f97f38852aaf4))
 
-
-
 ## [1.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.16...@rest-hooks/core@1.1.0) (2021-04-24)
-
 
 ### 🚀 Features
 
 * Endpoint parameters can be of any length ([#767](https://github.com/coinbase/rest-hooks/issues/767)) ([552f837](https://github.com/coinbase/rest-hooks/commit/552f83740279376288879a661ff487c5c6f1d469))
 
-
-
 ### [1.0.16](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.15...@rest-hooks/core@1.0.16) (2021-04-13)
-
 
 ### 💅 Enhancement
 
 * Remove extraneous outdated hack ([#750](https://github.com/coinbase/rest-hooks/issues/750)) ([da7e7cb](https://github.com/coinbase/rest-hooks/commit/da7e7cbedd6264b26f6158079d9224f52fe2f829))
 
-
 ### 🐛 Bug Fix
 
 * Generate types that do not refer internally to other packages ([#749](https://github.com/coinbase/rest-hooks/issues/749)) ([2e55e32](https://github.com/coinbase/rest-hooks/commit/2e55e3229f23ba1d0d6eb15faf3dd5ba3de838c4))
 
-
-
 ### [1.0.15](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.14...@rest-hooks/core@1.0.15) (2021-04-12)
-
 
 ### 🐛 Bug Fix
 
 * Relax DeleteShape def to be back-compat ([#743](https://github.com/coinbase/rest-hooks/issues/743)) ([20aa3a0](https://github.com/coinbase/rest-hooks/commit/20aa3a09bbe4419c23e37b331ca3208349f0e07c))
 
-
-
 ### [1.0.14](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.13...@rest-hooks/core@1.0.14) (2021-04-12)
-
 
 ### 🐛 Bug Fix
 
 * Publish legacy type files ([#741](https://github.com/coinbase/rest-hooks/issues/741)) ([bbae8bd](https://github.com/coinbase/rest-hooks/commit/bbae8bd44d9870e7f6ed599b0751ad264f9f2313))
 
-
-
 ### [1.0.13](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.12...@rest-hooks/core@1.0.13) (2021-04-12)
-
 
 ### 💅 Enhancement
 
@@ -718,144 +540,97 @@ errors for missing entities
 * Support TypeScript 3, while using TypeScript 4 features ([#726](https://github.com/coinbase/rest-hooks/issues/726)) ([4db2522](https://github.com/coinbase/rest-hooks/commit/4db2522b9060a7f7aaba4a93c3cf1694eb3d5364))
 * Use namedtuples for denormalize ([#733](https://github.com/coinbase/rest-hooks/issues/733)) ([83382cc](https://github.com/coinbase/rest-hooks/commit/83382cce716ec22949127cc0f190bbeddf5a3722))
 
-
 ### 🐛 Bug Fix
 
 * Inferring schema.Values() ([#732](https://github.com/coinbase/rest-hooks/issues/732)) ([1a77a03](https://github.com/coinbase/rest-hooks/commit/1a77a03a5c06b352feb467958be2e6e3f8f91003))
 * schema.Values singleSchema denormalization ([#723](https://github.com/coinbase/rest-hooks/issues/723)) ([99317d1](https://github.com/coinbase/rest-hooks/commit/99317d17db8293d6bf987d1cbfa99691cf58903e))
 
-
-
 ### [1.0.12](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.11...@rest-hooks/core@1.0.12) (2021-04-04)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ### [1.0.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.10...@rest-hooks/core@1.0.11) (2021-03-26)
-
 
 ### 🐛 Bug Fix
 
 * Compatibility with TypeScript strict: false ([#683](https://github.com/coinbase/rest-hooks/issues/683)) ([8a6e7ed](https://github.com/coinbase/rest-hooks/commit/8a6e7ed4d179555c4ba5cb8957b1c63697a1ce1a))
 
-
 ### 📝 Documentation
 
 * Update package description ([#684](https://github.com/coinbase/rest-hooks/issues/684)) ([c2b6915](https://github.com/coinbase/rest-hooks/commit/c2b6915c3a055816f345634416aeae9196de7051))
-
-
 
 ### [1.0.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.9...@rest-hooks/core@1.0.10) (2021-03-24)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ### [1.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.8...@rest-hooks/core@1.0.9) (2021-03-14)
-
 
 ### 📝 Documentation
 
 * Update package tags ([#650](https://github.com/coinbase/rest-hooks/issues/650)) ([4ef465a](https://github.com/coinbase/rest-hooks/commit/4ef465a129cd59668cd9c3542bb9ec03c84d2a4d))
 
-
-
 ### [1.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.7...@rest-hooks/core@1.0.8) (2021-03-08)
-
 
 ### 💅 Enhancement
 
 * Don't use global for rIC def ([#617](https://github.com/coinbase/rest-hooks/issues/617)) ([ed33203](https://github.com/coinbase/rest-hooks/commit/ed33203aa8685953e0d09c831343480e0e2e6051))
 
-
-
 ### [1.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.6...@rest-hooks/core@1.0.7) (2021-03-03)
-
 
 ### 🐛 Bug Fix
 
 * useStatefulResource() return type ([#613](https://github.com/coinbase/rest-hooks/issues/613)) ([05a4995](https://github.com/coinbase/rest-hooks/commit/05a49954c61f47deef18bc5d58d045ac79efd78e))
 
-
-
 ### [1.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.5...@rest-hooks/core@1.0.6) (2021-03-01)
-
 
 ### 💅 Enhancement
 
 * Support 'undefined' as schema ([#583](https://github.com/coinbase/rest-hooks/issues/583)) ([1e81470](https://github.com/coinbase/rest-hooks/commit/7ef172a3d8469b182cc7a19055920a308841b59e))
 
-
-
 ### [1.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.4...@rest-hooks/core@1.0.5) (2021-02-27)
-
 
 ### 💅 Enhancement
 
 * Make type discrimination easier in error types ([#581](https://github.com/coinbase/rest-hooks/issues/581)) ([cd105f3](https://github.com/coinbase/rest-hooks/commit/cd105f378e3c97b6accd127a61759287fb8bb3b5))
 
-
-
 ### [1.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.3...@rest-hooks/core@1.0.4) (2021-02-24)
-
 
 ### 💅 Enhancement
 
 * Improve error type preciseness ([#571](https://github.com/coinbase/rest-hooks/issues/571)) ([6f760be](https://github.com/coinbase/rest-hooks/commit/6f760be7149f04eb26727730e0ec0d67f2215ed5))
 * legacy Resource should only warn on validation problems ([#540](https://github.com/coinbase/rest-hooks/issues/540)) ([eb83a51](https://github.com/coinbase/rest-hooks/commit/eb83a511d41c0b18ea3f5ecd6696e1013ed8e1c3))
 
-
-
 ### [1.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.2...@rest-hooks/core@1.0.3) (2021-02-04)
-
 
 ### 📦 Package
 
 * Relax @babel/runtime requirement to ^7.7.2 ([#513](https://github.com/coinbase/rest-hooks/issues/513)) ([cc95b21](https://github.com/coinbase/rest-hooks/commit/cc95b219fbddebfbf334728887ca6d2fa070fce1))
 
-
 ### 📝 Documentation
 
 * Link improvements, flesh out test readme ([#511](https://github.com/coinbase/rest-hooks/issues/511)) ([9cab431](https://github.com/coinbase/rest-hooks/commit/9cab431803a8b7d9c18e02b3e9cb7e336215ccdb))
-
-
 
 ### [1.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.1...@rest-hooks/core@1.0.2) (2021-01-30)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0...@rest-hooks/core@1.0.1) (2021-01-24)
-
 
 ### 💅 Enhancement
 
 * Add `static automaticValidation` to Entity ([#495](https://github.com/coinbase/rest-hooks/issues/495)) ([034450d](https://github.com/coinbase/rest-hooks/commit/034450d2eb00fab636ca4db5138b6a0573620db6))
 * Improve malformed entity detection ([#494](https://github.com/coinbase/rest-hooks/issues/494)) ([b8bb07f](https://github.com/coinbase/rest-hooks/commit/b8bb07f480549a97254a4fdf6b00acd9cb89a9eb))
 
-
 ### 🐛 Bug Fix
 
 * Support TypeScript <4 ([#489](https://github.com/coinbase/rest-hooks/issues/489)) ([267b541](https://github.com/coinbase/rest-hooks/commit/267b5412cf4e65f6e523aad764203b91a92cc427))
-
 
 ### 📝 Documentation
 
 * Improve rest-types and network transform ([#486](https://github.com/coinbase/rest-hooks/issues/486)) ([e61342a](https://github.com/coinbase/rest-hooks/commit/e61342acc920288ecb98f36e9aa8ecb13dd6fe44))
 * Update wording for 'cache lifetime' in feature list ([#483](https://github.com/coinbase/rest-hooks/issues/483)) ([5a62b73](https://github.com/coinbase/rest-hooks/commit/5a62b73d66cc232e21f5f8792e8d6f63d094b9f2))
 
-
-
 ## 1.0.0 (2021-01-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -895,7 +670,6 @@ not trigger a fetch if entities are fresh enough
 * Track and use entity resolution time ([54203f9](https://github.com/coinbase/rest-hooks/commit/54203f994a166a4ed786328c2ef85b20749a8d6b))
 * useFetchDispatcher() ([#407](https://github.com/coinbase/rest-hooks/issues/407)) ([f4e45be](https://github.com/coinbase/rest-hooks/commit/f4e45be370b99bdaf31b5f9dba77fbd55da2f1ea))
 
-
 ### 💅 Enhancement
 
 * `endpoint` package only exports definitions ([#473](https://github.com/coinbase/rest-hooks/issues/473)) ([51dcafe](https://github.com/coinbase/rest-hooks/commit/51dcafe98631998a1db1959f2796d7122d96960b))
@@ -911,7 +685,6 @@ not trigger a fetch if entities are fresh enough
 * Simplify endpoint memoization and provide new extensions ([#391](https://github.com/coinbase/rest-hooks/issues/391)) ([d874d0b](https://github.com/coinbase/rest-hooks/commit/d874d0b3e6433a616d2dbecd8076715f5caefaeb))
 * Support React 17 ([#397](https://github.com/coinbase/rest-hooks/issues/397)) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f0724c60fbb2dd3ff6d7d791ee53c3eff694))
 * Widen RestFetch types to make overriding not break ([#479](https://github.com/coinbase/rest-hooks/issues/479)) ([2bccf12](https://github.com/coinbase/rest-hooks/commit/2bccf12f7892ccbc1d342bd529b3659c2935fb71))
-
 
 ### 🐛 Bug Fix
 
@@ -933,13 +706,11 @@ not trigger a fetch if entities are fresh enough
 * SimpleRecord as schema in useDenormalized() ([#346](https://github.com/coinbase/rest-hooks/issues/346)) ([2b96335](https://github.com/coinbase/rest-hooks/commit/2b96335d2758b67fa5616fdafb6b338c8128c9a2))
 * useFetcher() return types ([#347](https://github.com/coinbase/rest-hooks/issues/347)) ([d921cbe](https://github.com/coinbase/rest-hooks/commit/d921cbe41dc4b0d3f2c80bb9b6ef99dc71a8a86d))
 
-
 ### 📦 Package
 
 * Add type exports: Normalize, Denormalize, and their nullables ([378078f](https://github.com/coinbase/rest-hooks/commit/378078f543526047ad76251e1ef73ae5899eaaf5))
 * Bump babel runtime ([c6bf844](https://github.com/coinbase/rest-hooks/commit/c6bf844fcf1a483988d34b5f09faa03ceff179ec))
 * Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a8c435c5ef74b3809c8950a2caceca8763))
-
 
 ### 📝 Documentation
 
@@ -952,10 +723,7 @@ not trigger a fetch if entities are fresh enough
 * Update readme examples ([68c69ab](https://github.com/coinbase/rest-hooks/commit/68c69ab4f4aebadb93ac30a6c37672dc585683fd))
 * Update readme tagline ([fe39b16](https://github.com/coinbase/rest-hooks/commit/fe39b1634535c265afe9a00fe44a3fea29773522))
 
-
-
 ## [1.0.0-rc.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-rc.0...@rest-hooks/core@1.0.0-rc.1) (2021-01-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -969,13 +737,10 @@ entities
 
 * Resources can have nested entities ([#469](https://github.com/coinbase/rest-hooks/issues/469)) ([4eeeaae](https://github.com/coinbase/rest-hooks/commit/4eeeaae1026715be4e72a66cd94d81934f2b0ce7))
 
-
 ### 💅 Enhancement
 
 * `endpoint` package only exports definitions ([#473](https://github.com/coinbase/rest-hooks/issues/473)) ([51dcafe](https://github.com/coinbase/rest-hooks/commit/51dcafe98631998a1db1959f2796d7122d96960b))
 * Widen RestFetch types to make overriding not break ([#479](https://github.com/coinbase/rest-hooks/issues/479)) ([2bccf12](https://github.com/coinbase/rest-hooks/commit/2bccf12f7892ccbc1d342bd529b3659c2935fb71))
-
-
 
 ## 1.0.0-rc.0 (2021-01-14)
 
@@ -983,15 +748,11 @@ entities
 * enhance: Maintain referential equality globally (#403) ([e1e353d](https://github.com/coinbase/rest-hooks/commit/e1e353d)), closes [#403](https://github.com/coinbase/rest-hooks/issues/403)
 * internal: Fix publish message (#461) ([e1691f5](https://github.com/coinbase/rest-hooks/commit/e1691f5)), closes [#461](https://github.com/coinbase/rest-hooks/issues/461)
 
-
 ### BREAKING CHANGE
 
 * Node engine requirement of >=0.12
 * useResource() inferred endpoint will sometimes
 not trigger a fetch if entities are fresh enough
-
-
-
 
 ## 1.0.0-k.5 (2021-01-06)
 
@@ -999,18 +760,10 @@ not trigger a fetch if entities are fresh enough
 * feat: Track and use entity resolution time ([54203f9](https://github.com/coinbase/rest-hooks/commit/54203f9))
 * pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
 
-
-
-
-
 ## 1.0.0-k.4 (2020-12-08)
 
 * fix: Clear promises on cleanup (#422) ([bcb236e](https://github.com/coinbase/rest-hooks/commit/bcb236e)), closes [#422](https://github.com/coinbase/rest-hooks/issues/422)
 * feat: Add useInvalidateDispatcher() (#413) ([e416c5f](https://github.com/coinbase/rest-hooks/commit/e416c5f)), closes [#413](https://github.com/coinbase/rest-hooks/issues/413)
-
-
-
-
 
 ## 1.0.0-k.3 (2020-09-08)
 
@@ -1018,111 +771,59 @@ not trigger a fetch if entities are fresh enough
 * feat: useFetchDispatcher() (#407) ([f4e45be](https://github.com/coinbase/rest-hooks/commit/f4e45be)), closes [#407](https://github.com/coinbase/rest-hooks/issues/407)
 * internal: Upgrade build pkgs (#404) ([dc56530](https://github.com/coinbase/rest-hooks/commit/dc56530)), closes [#404](https://github.com/coinbase/rest-hooks/issues/404)
 
-
-
-
-
 ## 1.0.0-k.2 (2020-08-13)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ## 1.0.0-k.1 (2020-08-12)
 
 * enhance: Support React 17 (#397) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f07)), closes [#397](https://github.com/coinbase/rest-hooks/issues/397)
-
-
-
-
 
 ## 1.0.0-k.0 (2020-08-09)
 
 * feat: Add @rest-hooks/hooks for composable utilities (#393) ([b225a2a](https://github.com/coinbase/rest-hooks/commit/b225a2a)), closes [#393](https://github.com/coinbase/rest-hooks/issues/393)
 * feat: Simple AbortController integration (#392) ([899563d](https://github.com/coinbase/rest-hooks/commit/899563d)), closes [#392](https://github.com/coinbase/rest-hooks/issues/392)
 
-
-
-
-
 ## 1.0.0-j.7 (2020-08-09)
 
 * enhance: console instead of throw when missing frequency ([8708b1f](https://github.com/coinbase/rest-hooks/commit/8708b1f))
 * fix: extend() correctly keeps options for FetchShape compat ([bf522a2](https://github.com/coinbase/rest-hooks/commit/bf522a2))
-
-
-
-
 
 ## 1.0.0-j.6 (2020-08-09)
 
 * enhance: Simplify endpoint memoization and provide new extensions (#391) ([d874d0b](https://github.com/coinbase/rest-hooks/commit/d874d0b)), closes [#391](https://github.com/coinbase/rest-hooks/issues/391)
 * fix: Resource endpoint memoization ([744431e](https://github.com/coinbase/rest-hooks/commit/744431e))
 
-
-
-
-
 ## 1.0.0-j.5 (2020-08-08)
 
 * internal: Test using endpoints directly (#389) ([bb0e8fd](https://github.com/coinbase/rest-hooks/commit/bb0e8fd)), closes [#389](https://github.com/coinbase/rest-hooks/issues/389)
 * feat: Support extra endpoint members and inheritance (#387) ([6ad5486](https://github.com/coinbase/rest-hooks/commit/6ad5486)), closes [#387](https://github.com/coinbase/rest-hooks/issues/387)
-
-
-
-
 
 ## 1.0.0-j.4 (2020-08-04)
 
 * fix: Handle entities updated with new indexes (#384) ([2ee3bb6](https://github.com/coinbase/rest-hooks/commit/2ee3bb6)), closes [#384](https://github.com/coinbase/rest-hooks/issues/384)
 * fix: Infer useFetcher() has no body when not present in fetch (#385) ([22dd399](https://github.com/coinbase/rest-hooks/commit/22dd399)), closes [#385](https://github.com/coinbase/rest-hooks/issues/385)
 
-
-
-
-
 ## 1.0.0-j.3 (2020-07-31)
 
 **Note:** Version bump only for package @rest-hooks/core
-
-
-
-
 
 ## 1.0.0-j.2 (2020-07-27)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ## 1.0.0-j.1 (2020-07-27)
 
 * fix: Inferred return of useCache() (#377) ([ce7a4f7](https://github.com/coinbase/rest-hooks/commit/ce7a4f7)), closes [#377](https://github.com/coinbase/rest-hooks/issues/377)
-
-
-
-
 
 ## 1.0.0-j.0 (2020-07-27)
 
 * feat: Add @rest-hooks/rest package (#375) ([5e5c125](https://github.com/coinbase/rest-hooks/commit/5e5c125)), closes [#375](https://github.com/coinbase/rest-hooks/issues/375)
 
-
-
-
-
 ## 1.0.0-i.4 (2020-07-22)
 
 * internal: Add add more disruption to referntial test ([f249b40](https://github.com/coinbase/rest-hooks/commit/f249b40))
 * docs: Add link to debugging docs from readme ([d75cbe8](https://github.com/coinbase/rest-hooks/commit/d75cbe8))
-
-
-
-
 
 ## 1.0.0-i.3 (2020-07-21)
 
@@ -1131,10 +832,6 @@ not trigger a fetch if entities are fresh enough
 * internal: Fix tests ([78332b3](https://github.com/coinbase/rest-hooks/commit/78332b3))
 * feat: Add fetch request creation time to meta ([1a6242f](https://github.com/coinbase/rest-hooks/commit/1a6242f))
 
-
-
-
-
 ## 1.0.0-i.2 (2020-07-20)
 
 * feat: Add DevToolsManager to integrate with redux-devtools (#371) ([aa171bc](https://github.com/coinbase/rest-hooks/commit/aa171bc)), closes [#371](https://github.com/coinbase/rest-hooks/issues/371)
@@ -1142,17 +839,9 @@ not trigger a fetch if entities are fresh enough
 * docs: Fix Endpoint def in readme example ([125ad57](https://github.com/coinbase/rest-hooks/commit/125ad57))
 * docs: Update readme tagline ([fe39b16](https://github.com/coinbase/rest-hooks/commit/fe39b16))
 
-
-
-
-
 ## 1.0.0-i.1 (2020-07-14)
 
 * fix: Export Endpoint through core ([8b60dea](https://github.com/coinbase/rest-hooks/commit/8b60dea))
-
-
-
-
 
 ## 1.0.0-i.0 (2020-07-14)
 
@@ -1160,13 +849,9 @@ not trigger a fetch if entities are fresh enough
 * enhance: Make Endpoint compatible with FetchShape ([caa967c](https://github.com/coinbase/rest-hooks/commit/caa967c))
 * enhance: Resource uses endpoint (#365) ([4472106](https://github.com/coinbase/rest-hooks/commit/4472106)), closes [#365](https://github.com/coinbase/rest-hooks/issues/365)
 
-
 ### BREAKING CHANGE
 
 * getFetchOptions() -> getEndpointExtra()
-
-
-
 
 ## 1.0.0-h.0 (2020-07-13)
 
@@ -1174,15 +859,10 @@ not trigger a fetch if entities are fresh enough
 * docs: Fix tags ([987f0ed](https://github.com/coinbase/rest-hooks/commit/987f0ed))
 * docs: Remove irrelevant tags ([ff137da](https://github.com/coinbase/rest-hooks/commit/ff137da))
 
-
-
-
-
 ## 1.0.0-delta.0 (2020-07-08)
 
 * feat: Deletes and invalidates trigger suspense always (#360) ([96175ba](https://github.com/coinbase/rest-hooks/commit/96175ba)), closes [#360](https://github.com/coinbase/rest-hooks/issues/360)
 * feat: Resource.fetch() arguments reflect browser fetch() (#362) ([1d19421](https://github.com/coinbase/rest-hooks/commit/1d19421)), closes [#362](https://github.com/coinbase/rest-hooks/issues/362)
-
 
 ### BREAKING CHANGE
 
@@ -1197,41 +877,22 @@ not trigger a fetch if entities are fresh enough
 - Added Resource.getFetchInit() which is called in shape generators
 - Resourece.fetch() interface changed to match browser fetch()
 
-
-
-
 ## 1.0.0-gamma.0 (2020-06-13)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ## 1.0.0-beta.15 (2020-06-13)
 
 * feat: Declarative schema deserialization (#355) ([9dbb019](https://github.com/coinbase/rest-hooks/commit/9dbb019)), closes [#355](https://github.com/coinbase/rest-hooks/issues/355)
-
-
-
-
 
 ## 1.0.0-beta.14 (2020-06-09)
 
 * fix: Clear invalidIfStale protections on mount (#357) ([b9a89dc](https://github.com/coinbase/rest-hooks/commit/b9a89dc)), closes [#357](https://github.com/coinbase/rest-hooks/issues/357)
 * internal: Add tests for malformed network responses ([96b788a](https://github.com/coinbase/rest-hooks/commit/96b788a))
 
-
-
-
-
 ## 1.0.0-beta.13 (2020-06-08)
 
 * fix: Looping fetches should still expire at some point ([ef560a9](https://github.com/coinbase/rest-hooks/commit/ef560a9))
-
-
-
-
 
 ## 1.0.0-beta.12 (2020-06-06)
 
@@ -1241,35 +902,23 @@ not trigger a fetch if entities are fresh enough
 * internal: Add additional type test for useFetcher() ([2f5c876](https://github.com/coinbase/rest-hooks/commit/2f5c876))
 * internal: Prepare tests to run in React Native env (#309) ([64efd70](https://github.com/coinbase/rest-hooks/commit/64efd70)), closes [#309](https://github.com/coinbase/rest-hooks/issues/309)
 
-
-
-
-
 ## [1.0.0-beta.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.10...@rest-hooks/core@1.0.0-beta.11) (2020-05-20)
-
 
 ### 🏠 Internal
 
 * Bump typescript patch and get rid of comment ([17174ea](https://github.com/coinbase/rest-hooks/commit/17174ea13577571db1c1d2f2d3d7e7f64ea1ed57))
 
-
-
 ## [1.0.0-beta.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.9...@rest-hooks/core@1.0.0-beta.10) (2020-05-20)
-
 
 ### 🐛 Bug Fix
 
 * Inferred return type of useFetcher() should be promise ([18f5654](https://github.com/coinbase/rest-hooks/commit/18f565491eecd69aa4b76774937e7dfd82822788))
 
-
-
 ## [1.0.0-beta.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.8...@rest-hooks/core@1.0.0-beta.9) (2020-05-20)
-
 
 ### 💅 Enhancement
 
 * Infer a reasonble type for fetch responses by default ([9d8c44c](https://github.com/coinbase/rest-hooks/commit/9d8c44cf2dfc085a8d5ad16fcc14095849283c68))
-
 
 ### 🐛 Bug Fix
 
@@ -1277,74 +926,45 @@ not trigger a fetch if entities are fresh enough
 * SimpleRecord as schema in useDenormalized() ([#346](https://github.com/coinbase/rest-hooks/issues/346)) ([2b96335](https://github.com/coinbase/rest-hooks/commit/2b96335d2758b67fa5616fdafb6b338c8128c9a2))
 * useFetcher() return types ([#347](https://github.com/coinbase/rest-hooks/issues/347)) ([d921cbe](https://github.com/coinbase/rest-hooks/commit/d921cbe41dc4b0d3f2c80bb9b6ef99dc71a8a86d))
 
-
-
 ## [1.0.0-beta.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.7...@rest-hooks/core@1.0.0-beta.8) (2020-05-19)
 
 **Note:** Version bump only for package @rest-hooks/core
-
-
-
-
 
 ## [1.0.0-beta.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.6...@rest-hooks/core@1.0.0-beta.7) (2020-05-19)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ## [1.0.0-beta.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.5...@rest-hooks/core@1.0.0-beta.6) (2020-05-19)
-
 
 ### 🐛 Bug Fix
 
 * No entity schemas should suspend when they have no results ([#344](https://github.com/coinbase/rest-hooks/issues/344)) ([d3cd45e](https://github.com/coinbase/rest-hooks/commit/d3cd45e03bd639c49bf010ff848d4a158f0e6bf9))
 
-
-
 ## [1.0.0-beta.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.4...@rest-hooks/core@1.0.0-beta.5) (2020-05-14)
-
 
 ### 📝 Documentation
 
 * Get rid of all references to asSchema() ([#339](https://github.com/coinbase/rest-hooks/issues/339)) ([01b878b](https://github.com/coinbase/rest-hooks/commit/01b878b85f7469a12e19912efc696a424663e5f5))
 
-
-
 ## [1.0.0-beta.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.3...@rest-hooks/core@1.0.0-beta.4) (2020-05-13)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ## [1.0.0-beta.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.2...@rest-hooks/core@1.0.0-beta.3) (2020-05-13)
-
 
 ### 💅 Enhancement
 
 * Add back remaining normalizr exports to rest-hooks ([b6878ee](https://github.com/coinbase/rest-hooks/commit/b6878eebbf1572a4b859828da81a058bc5c118e3))
 
-
 ### 📦 Package
 
 * Add type exports: Normalize, Denormalize, and their nullables ([378078f](https://github.com/coinbase/rest-hooks/commit/378078f543526047ad76251e1ef73ae5899eaaf5))
-
-
 
 ## [1.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@1.0.0-beta.1...@rest-hooks/core@1.0.0-beta.2) (2020-05-13)
 
 **Note:** Version bump only for package @rest-hooks/core
 
-
-
-
-
 ## 1.0.0-beta.1 (2020-05-12)
-
 
 ### 💅 Enhancement
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -102,9 +102,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^2.2.11",
-    "@rest-hooks/normalizr": "^8.2.10",
-    "@rest-hooks/use-enhanced-reducer": "^1.1.1",
+    "@rest-hooks/endpoint": "^2.2.12",
+    "@rest-hooks/normalizr": "^8.2.11",
+    "@rest-hooks/use-enhanced-reducer": "^1.1.2",
     "flux-standard-action": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,92 +3,66 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [2.2.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.10...@rest-hooks/endpoint@2.2.11) (2022-07-23)
+### [2.2.12](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.11...@rest-hooks/endpoint@2.2.12) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [2.2.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.10...@rest-hooks/endpoint@2.2.11) (2022-07-23)
 
 ### 🐛 Bug Fix
 
 * Ensure dual package hazard solved for non-node ([#2099](https://github.com/coinbase/rest-hooks/issues/2099)) ([6206e64](https://github.com/coinbase/rest-hooks/commit/6206e6463a7c3699d5c1d1b248e4d5418b1327f1))
 
-
-
 ### [2.2.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.7...@rest-hooks/endpoint@2.2.10) (2022-07-20)
-
 
 ### 🐛 Bug Fix
 
 * Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
 
-
-
 ### [2.2.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.6...@rest-hooks/endpoint@2.2.7) (2022-05-30)
-
 
 ### 📦 Package
 
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
 
-
-
 ### [2.2.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.5...@rest-hooks/endpoint@2.2.6) (2022-04-30)
-
 
 ### 📝 Documentation
 
 * Update README with newest practices ([#1920](https://github.com/coinbase/rest-hooks/issues/1920)) ([9bbd76c](https://github.com/coinbase/rest-hooks/commit/9bbd76c4fb20125d6318bd8ac5cc4238be4ab3d5))
 
-
-
 ### [2.2.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.4...@rest-hooks/endpoint@2.2.5) (2022-04-16)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ### [2.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.3...@rest-hooks/endpoint@2.2.4) (2022-04-11)
-
 
 ### 💅 Enhancement
 
 * Improve type inference for getFetchKey ([#1896](https://github.com/coinbase/rest-hooks/issues/1896)) ([36b11af](https://github.com/coinbase/rest-hooks/commit/36b11af67b08183288ad295ff0303eaf78f01dba))
 
-
-
 ### [2.2.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.2...@rest-hooks/endpoint@2.2.3) (2022-04-08)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
-
-
-
-
 
 ### [2.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.1...@rest-hooks/endpoint@2.2.2) (2022-04-02)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ### [2.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.0-beta.4...@rest-hooks/endpoint@2.2.1) (2022-04-01)
-
 
 ### 💅 Enhancement
 
 * Hooks should type return value based on 'null' arg ([#1783](https://github.com/coinbase/rest-hooks/issues/1783)) ([d14673e](https://github.com/coinbase/rest-hooks/commit/d14673eab0dad3f02edb54f7bf37e6fed1c47a62))
 * Loosen SnapshotInterface to allow compatible but distinct versions ([#1786](https://github.com/coinbase/rest-hooks/issues/1786)) ([7b31f4d](https://github.com/coinbase/rest-hooks/commit/7b31f4df787e4c0a838dc897a81755abbccf1984))
 
-
-
 ## [2.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.1.0...@rest-hooks/endpoint@2.2.0) (2022-03-17)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
-
 
 ### 💅 Enhancement
 
@@ -97,18 +71,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Loosen SnapshotInterface to allow compatible but distinct versions ([#1786](https://github.com/coinbase/rest-hooks/issues/1786)) ([7b31f4d](https://github.com/coinbase/rest-hooks/commit/7b31f4df787e4c0a838dc897a81755abbccf1984))
 * optimisticUpdater -> getOptimisticResponse ([#1769](https://github.com/coinbase/rest-hooks/issues/1769)) ([4d1cd66](https://github.com/coinbase/rest-hooks/commit/4d1cd66ea2677868aba402d362b9896dffc24462))
 
-
-
 ## [2.2.0-beta.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.0-beta.3...@rest-hooks/endpoint@2.2.0-beta.4) (2022-03-10)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ## [2.2.0-beta.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.0-beta.2...@rest-hooks/endpoint@2.2.0-beta.3) (2022-03-08)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -118,92 +85,57 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * optimisticUpdater -> getOptimisticResponse ([#1769](https://github.com/coinbase/rest-hooks/issues/1769)) ([4d1cd66](https://github.com/coinbase/rest-hooks/commit/4d1cd66ea2677868aba402d362b9896dffc24462))
 
-
-
 ## [2.2.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.0-beta.0...@rest-hooks/endpoint@2.2.0-beta.2) (2022-02-15)
-
 
 ### 💅 Enhancement
 
 * Fetch resolution only removes the optimistic update corresponding to that fetch ([#1653](https://github.com/coinbase/rest-hooks/issues/1653)) ([2fd93f2](https://github.com/coinbase/rest-hooks/commit/2fd93f235074d134200e81ddb16792647b3cffad))
-
-
 
 ## [2.2.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.0-beta.0...@rest-hooks/endpoint@2.2.0-beta.1) (2022-01-31)
 
-
 ### 💅 Enhancement
 
 * Fetch resolution only removes the optimistic update corresponding to that fetch ([#1653](https://github.com/coinbase/rest-hooks/issues/1653)) ([2fd93f2](https://github.com/coinbase/rest-hooks/commit/2fd93f235074d134200e81ddb16792647b3cffad))
 
-
-
 ## [2.2.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.1.0...@rest-hooks/endpoint@2.2.0-beta.0) (2022-01-23)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 
-
-
 ## [2.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.0.3...@rest-hooks/endpoint@2.1.0) (2021-11-26)
-
 
 ### 🚀 Features
 
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
 
-
 ### 🐛 Bug Fix
 
 * useFetcher() work with zero argument Endpoint ([#1514](https://github.com/coinbase/rest-hooks/issues/1514)) ([c5ac9e7](https://github.com/coinbase/rest-hooks/commit/c5ac9e7a1d66f57ddcee5c343b239cf2d6d5f782))
 
-
-
 ### [2.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.0.2...@rest-hooks/endpoint@2.0.3) (2021-10-11)
-
 
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
 
-
-
 ### [2.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.0.1...@rest-hooks/endpoint@2.0.2) (2021-09-29)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
-
-
-
-
 
 ### [2.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.0.0...@rest-hooks/endpoint@2.0.1) (2021-09-29)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ## [2.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.0.0-beta.2...@rest-hooks/endpoint@2.0.0) (2021-09-08)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
-
-
-
-
 
 ## [2.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.0.0-beta.1...@rest-hooks/endpoint@2.0.0-beta.2) (2021-09-06)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ## [2.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.2.3...@rest-hooks/endpoint@2.0.0-beta.1) (2021-07-12)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -224,23 +156,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Add errorPolicy to endpoint options ([#971](https://github.com/coinbase/rest-hooks/issues/971)) ([836f05b](https://github.com/coinbase/rest-hooks/commit/836f05b407b5ac96c8f094e652221aa5a95300b0))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Different babel targets for cjs and umd builds ([#989](https://github.com/coinbase/rest-hooks/issues/989)) ([f054814](https://github.com/coinbase/rest-hooks/commit/f05481410cf8daa2101d4dbda826e56ad10ec723))
 * Entities normalize to POJO ([#940](https://github.com/coinbase/rest-hooks/issues/940)) ([75ebdfe](https://github.com/coinbase/rest-hooks/commit/75ebdfe641ccf57fca35c44a94077e4a314e44d7))
 * Give Endpoint.extend() type a name ([#969](https://github.com/coinbase/rest-hooks/issues/969)) ([5afec16](https://github.com/coinbase/rest-hooks/commit/5afec16727f18af6d6acb52b7c0f094555d43e04))
 * Remove 'fallback' package.json exports ([#992](https://github.com/coinbase/rest-hooks/issues/992)) ([dc95f9d](https://github.com/coinbase/rest-hooks/commit/dc95f9dbad20d5740218c52c906596b6a3d6eae4))
-
 
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
 
-
-
 ## [2.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.2.2...@rest-hooks/endpoint@2.0.0-beta.0) (2021-06-30)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -261,14 +188,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Add errorPolicy to endpoint options ([#971](https://github.com/coinbase/rest-hooks/issues/971)) ([836f05b](https://github.com/coinbase/rest-hooks/commit/836f05b407b5ac96c8f094e652221aa5a95300b0))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Different babel targets for cjs and umd builds ([#989](https://github.com/coinbase/rest-hooks/issues/989)) ([f054814](https://github.com/coinbase/rest-hooks/commit/f05481410cf8daa2101d4dbda826e56ad10ec723))
 * Entities normalize to POJO ([#940](https://github.com/coinbase/rest-hooks/issues/940)) ([75ebdfe](https://github.com/coinbase/rest-hooks/commit/75ebdfe641ccf57fca35c44a94077e4a314e44d7))
 * Give Endpoint.extend() type a name ([#969](https://github.com/coinbase/rest-hooks/issues/969)) ([5afec16](https://github.com/coinbase/rest-hooks/commit/5afec16727f18af6d6acb52b7c0f094555d43e04))
 * Remove 'fallback' package.json exports ([#992](https://github.com/coinbase/rest-hooks/issues/992)) ([dc95f9d](https://github.com/coinbase/rest-hooks/commit/dc95f9dbad20d5740218c52c906596b6a3d6eae4))
-
 
 ### 📝 Documentation
 
@@ -278,225 +203,138 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ### [1.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.2.1...@rest-hooks/endpoint@1.2.2) (2021-06-19)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
-
-
-
-
 
 ### [1.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.2.0...@rest-hooks/endpoint@1.2.1) (2021-06-16)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ## [1.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.6...@rest-hooks/endpoint@1.2.0) (2021-06-13)
-
 
 ### 🚀 Features
 
 * Endpoint.name ([#914](https://github.com/coinbase/rest-hooks/issues/914)) ([aa5f80d](https://github.com/coinbase/rest-hooks/commit/aa5f80db6c47ff975b1d257352315a57b87addce))
 
-
-
 ### [1.1.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.5...@rest-hooks/endpoint@1.1.6) (2021-06-09)
-
 
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ### [1.1.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.3...@rest-hooks/endpoint@1.1.5) (2021-06-02)
-
 
 ### 💅 Enhancement
 
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
-
 ### [1.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.3...@rest-hooks/endpoint@1.1.4) (2021-05-30)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
-
-
-
-
 
 ### [1.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.2...@rest-hooks/endpoint@1.1.3) (2021-05-24)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ### [1.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.1...@rest-hooks/endpoint@1.1.2) (2021-05-24)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
-
-
-
-
 
 ### [1.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.1.0...@rest-hooks/endpoint@1.1.1) (2021-04-25)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ## [1.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.12...@rest-hooks/endpoint@1.1.0) (2021-04-24)
-
 
 ### 🚀 Features
 
 * Endpoint parameters can be of any length ([#767](https://github.com/coinbase/rest-hooks/issues/767)) ([552f837](https://github.com/coinbase/rest-hooks/commit/552f83740279376288879a661ff487c5c6f1d469))
 * Endpoint.bind() ([#762](https://github.com/coinbase/rest-hooks/issues/762)) ([b5ad3dd](https://github.com/coinbase/rest-hooks/commit/b5ad3dd8478bc8edbdfe752080e72024bc1686da))
 
-
 ### 💅 Enhancement
 
 * Support TypeScript 3.7 ([#752](https://github.com/coinbase/rest-hooks/issues/752)) ([68a10e0](https://github.com/coinbase/rest-hooks/commit/68a10e06dc0718f5e480097e6056a7a7954d1161))
-
-
 
 ### [1.0.12](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.11...@rest-hooks/endpoint@1.0.12) (2021-04-12)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ### [1.0.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.10...@rest-hooks/endpoint@1.0.11) (2021-04-12)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ### [1.0.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.9...@rest-hooks/endpoint@1.0.10) (2021-04-04)
-
 
 ### 🐛 Bug Fix
 
 * Endpoint 'type' in loose typescript mode ([#712](https://github.com/coinbase/rest-hooks/issues/712)) ([9ef9c4f](https://github.com/coinbase/rest-hooks/commit/9ef9c4ffc2813a597f15b571f639ad23fd8d6a03))
 
-
-
 ### [1.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.8...@rest-hooks/endpoint@1.0.9) (2021-03-26)
-
 
 ### 🐛 Bug Fix
 
 * Compatibility with TypeScript strict: false ([#683](https://github.com/coinbase/rest-hooks/issues/683)) ([8a6e7ed](https://github.com/coinbase/rest-hooks/commit/8a6e7ed4d179555c4ba5cb8957b1c63697a1ce1a))
 
-
-
 ### [1.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.7...@rest-hooks/endpoint@1.0.8) (2021-03-24)
-
 
 ### 💅 Enhancement
 
 * Mark Endpoint's back-compat members as 'deprecated' ([#665](https://github.com/coinbase/rest-hooks/issues/665)) ([6feade0](https://github.com/coinbase/rest-hooks/commit/6feade0ad28eb96c7906793b05d49991294ce858))
 
-
 ### 🐛 Bug Fix
 
 * 'type' inferred from 'sideEffects' correct in union case ([#678](https://github.com/coinbase/rest-hooks/issues/678)) ([2cda690](https://github.com/coinbase/rest-hooks/commit/2cda6900cc3c653637452772ec5439a60354b140))
 
-
-
 ### [1.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.6...@rest-hooks/endpoint@1.0.7) (2021-03-14)
-
 
 ### 📝 Documentation
 
 * Update package tags ([#650](https://github.com/coinbase/rest-hooks/issues/650)) ([4ef465a](https://github.com/coinbase/rest-hooks/commit/4ef465a129cd59668cd9c3542bb9ec03c84d2a4d))
 
-
-
 ### [1.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.5...@rest-hooks/endpoint@1.0.6) (2021-03-08)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
-
-
-
-
 
 ### [1.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.4...@rest-hooks/endpoint@1.0.5) (2021-03-03)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ### [1.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.3...@rest-hooks/endpoint@1.0.4) (2021-03-01)
-
 
 ### 💅 Enhancement
 
 * Support 'undefined' as schema ([#583](https://github.com/coinbase/rest-hooks/issues/583)) ([1e81470](https://github.com/coinbase/rest-hooks/commit/7ef172a3d8469b182cc7a19055920a308841b59e))
 
-
 ### 🐛 Bug Fix
 
 * Gracefully handle primitive entity responses ([#584](https://github.com/coinbase/rest-hooks/issues/584)) ([322b4c6](https://github.com/coinbase/rest-hooks/commit/322b4c6615ea02b09baf0bcfc9b214bb8be1ba4f))
-
 
 ### 📝 Documentation
 
 * Typos and minor improvements ([#561](https://github.com/coinbase/rest-hooks/issues/561)) ([aed902a](https://github.com/coinbase/rest-hooks/commit/aed902a7ee8a50f7f08fab261efa528a82c52b19))
 
-
-
 ### [1.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.2...@rest-hooks/endpoint@1.0.3) (2021-02-04)
-
 
 ### 📦 Package
 
 * Relax @babel/runtime requirement to ^7.7.2 ([#513](https://github.com/coinbase/rest-hooks/issues/513)) ([cc95b21](https://github.com/coinbase/rest-hooks/commit/cc95b219fbddebfbf334728887ca6d2fa070fce1))
 
-
 ### 📝 Documentation
 
 * Link improvements, flesh out test readme ([#511](https://github.com/coinbase/rest-hooks/issues/511)) ([9cab431](https://github.com/coinbase/rest-hooks/commit/9cab431803a8b7d9c18e02b3e9cb7e336215ccdb))
 
-
-
 ### [1.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.1...@rest-hooks/endpoint@1.0.2) (2021-01-30)
-
 
 ### 🐛 Bug Fix
 
 * Ensure Endpoint doesn't trigger CSP ([#505](https://github.com/coinbase/rest-hooks/issues/505)) ([a5a0011](https://github.com/coinbase/rest-hooks/commit/a5a00119c8888ce5c0440d2045febd9985fd2a8e))
 
-
-
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@1.0.0...@rest-hooks/endpoint@1.0.1) (2021-01-24)
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ## 1.0.0 (2021-01-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -513,7 +351,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Support extra endpoint members and inheritance ([#387](https://github.com/coinbase/rest-hooks/issues/387)) ([6ad5486](https://github.com/coinbase/rest-hooks/commit/6ad5486b6e333d8721b74fd4fb1b7ed783461435))
 * Support helper methods ([c3fb075](https://github.com/coinbase/rest-hooks/commit/c3fb075b390e7c8db28d53962563b92b65d7869d))
 
-
 ### 💅 Enhancement
 
 * `endpoint` package only exports definitions ([#473](https://github.com/coinbase/rest-hooks/issues/473)) ([51dcafe](https://github.com/coinbase/rest-hooks/commit/51dcafe98631998a1db1959f2796d7122d96960b))
@@ -521,7 +358,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Improve endpoint ([#364](https://github.com/coinbase/rest-hooks/issues/364)) ([503dd29](https://github.com/coinbase/rest-hooks/commit/503dd29f7cb89ecf1659d065932eae33f0855e1d))
 * Make Endpoint compatible with FetchShape ([caa967c](https://github.com/coinbase/rest-hooks/commit/caa967ceaa0c1288b15711b0c18b132689b94cc1))
 * Resource uses endpoint ([#365](https://github.com/coinbase/rest-hooks/issues/365)) ([4472106](https://github.com/coinbase/rest-hooks/commit/4472106afd05ad060399f0cd3a872ed07e3350ec))
-
 
 ### 🐛 Bug Fix
 
@@ -536,11 +372,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Remove broken type ([09e8268](https://github.com/coinbase/rest-hooks/commit/09e826841efc9d3cf1b6432ca2977fb0f8f558bd))
 * Remove broken type ([316e5a0](https://github.com/coinbase/rest-hooks/commit/316e5a0945d79ad82748a0e100d3a4a5c788e44c))
 
-
 ### 📦 Package
 
 * Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a8c435c5ef74b3809c8950a2caceca8763))
-
 
 ### 📝 Documentation
 
@@ -548,10 +382,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Add more to readme ([2fc29e5](https://github.com/coinbase/rest-hooks/commit/2fc29e5f94512a1fa9fb4b2777679a7499e360da))
 * Fix tags ([987f0ed](https://github.com/coinbase/rest-hooks/commit/987f0ed7d4980c3276bb8c9701f606364dad93d8))
 
-
-
 ## [0.8.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@0.7.4...@rest-hooks/endpoint@0.8.0) (2021-01-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -562,144 +393,78 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * `endpoint` package only exports definitions ([#473](https://github.com/coinbase/rest-hooks/issues/473)) ([51dcafe](https://github.com/coinbase/rest-hooks/commit/51dcafe98631998a1db1959f2796d7122d96960b))
 
-
-
 ## <small>0.7.4 (2021-01-14)</small>
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ## <small>0.7.3 (2021-01-06)</small>
 
 * pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
-
-
-
-
 
 ## <small>0.7.2 (2020-09-08)</small>
 
 * internal: Upgrade build pkgs (#404) ([dc56530](https://github.com/coinbase/rest-hooks/commit/dc56530)), closes [#404](https://github.com/coinbase/rest-hooks/issues/404)
 * enhance: EndpointInstance defaults should match everything ([d7067ba](https://github.com/coinbase/rest-hooks/commit/d7067ba))
 
-
-
-
-
 ## <small>0.7.1 (2020-08-13)</small>
 
 * fix: Export type correctly in endpoint (#401) ([f2b033a](https://github.com/coinbase/rest-hooks/commit/f2b033a)), closes [#401](https://github.com/coinbase/rest-hooks/issues/401)
-
-
-
-
 
 ## 0.7.0 (2020-08-12)
 
 * fix: Only export AbstractInstanceType in type-world (#396) ([131fa45](https://github.com/coinbase/rest-hooks/commit/131fa45)), closes [#396](https://github.com/coinbase/rest-hooks/issues/396)
 * feat: Simple AbortController integration (#392) ([899563d](https://github.com/coinbase/rest-hooks/commit/899563d)), closes [#392](https://github.com/coinbase/rest-hooks/issues/392)
 
-
-
-
-
 ## <small>0.6.1 (2020-08-09)</small>
 
 * fix: extend() correctly keeps options for FetchShape compat ([bf522a2](https://github.com/coinbase/rest-hooks/commit/bf522a2))
-
-
-
-
 
 ## 0.6.0 (2020-08-08)
 
 * internal: Test using endpoints directly (#389) ([bb0e8fd](https://github.com/coinbase/rest-hooks/commit/bb0e8fd)), closes [#389](https://github.com/coinbase/rest-hooks/issues/389)
 * feat: Support extra endpoint members and inheritance (#387) ([6ad5486](https://github.com/coinbase/rest-hooks/commit/6ad5486)), closes [#387](https://github.com/coinbase/rest-hooks/issues/387)
 
-
-
-
-
 ## <small>0.5.3 (2020-08-04)</small>
 
 * fix: Infer useFetcher() has no body when not present in fetch (#385) ([22dd399](https://github.com/coinbase/rest-hooks/commit/22dd399)), closes [#385](https://github.com/coinbase/rest-hooks/issues/385)
-
-
-
-
 
 ## <small>0.5.2 (2020-07-31)</small>
 
 **Note:** Version bump only for package @rest-hooks/endpoint
 
-
-
-
-
 ## <small>0.5.1 (2020-07-27)</small>
 
 **Note:** Version bump only for package @rest-hooks/endpoint
-
-
-
-
 
 ## 0.5.0 (2020-07-27)
 
 * feat: Add @rest-hooks/rest package (#375) ([5e5c125](https://github.com/coinbase/rest-hooks/commit/5e5c125)), closes [#375](https://github.com/coinbase/rest-hooks/issues/375)
 * feat: Support helper methods ([c3fb075](https://github.com/coinbase/rest-hooks/commit/c3fb075))
 
-
-
-
-
 ## <small>0.4.3 (2020-07-22)</small>
 
 * fix: Ambient files now typechecked, fixed some types there (#372) ([223d4a4](https://github.com/coinbase/rest-hooks/commit/223d4a4)), closes [#372](https://github.com/coinbase/rest-hooks/issues/372)
-
-
-
-
 
 ## <small>0.4.2 (2020-07-22)</small>
 
 * fix: Remove broken type ([09e8268](https://github.com/coinbase/rest-hooks/commit/09e8268))
 * fix: Remove broken type ([316e5a0](https://github.com/coinbase/rest-hooks/commit/316e5a0))
 
-
-
-
-
 ## <small>0.4.1 (2020-07-20)</small>
 
 * fix: Export Endpoint through core ([8b60dea](https://github.com/coinbase/rest-hooks/commit/8b60dea))
-
-
-
-
 
 ## 0.4.0 (2020-07-14)
 
 * enhance: Resource uses endpoint (#365) ([4472106](https://github.com/coinbase/rest-hooks/commit/4472106)), closes [#365](https://github.com/coinbase/rest-hooks/issues/365)
 
-
 ### BREAKING CHANGE
 
 * getFetchOptions() -> getEndpointExtra()
 
-
-
-
 ## <small>0.3.2 (2020-07-14)</small>
 
 * fix: Publish endpoint ambient typescript declarations ([2e982ca](https://github.com/coinbase/rest-hooks/commit/2e982ca))
-
-
-
-
 
 ## <small>0.3.1 (2020-07-13)</small>
 
@@ -707,19 +472,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * enhance: Improve endpoint (#364) ([503dd29](https://github.com/coinbase/rest-hooks/commit/503dd29)), closes [#364](https://github.com/coinbase/rest-hooks/issues/364)
 * enhance: Make Endpoint compatible with FetchShape ([caa967c](https://github.com/coinbase/rest-hooks/commit/caa967c))
 
-
-
-
-
 ## 0.3.0 (2020-07-13)
 
 * feat: Infer return type from schema ([2dccff4](https://github.com/coinbase/rest-hooks/commit/2dccff4))
 * docs: Add more to readme ([2fc29e5](https://github.com/coinbase/rest-hooks/commit/2fc29e5))
 * docs: Fix tags ([987f0ed](https://github.com/coinbase/rest-hooks/commit/987f0ed))
-
-
-
-
 
 ## 0.2.0 (2020-07-12)
 

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/normalizr": "^8.2.10"
+    "@rest-hooks/normalizr": "^8.2.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.9",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,45 +3,38 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [5.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.3...@rest-hooks/experimental@5.0.5) (2022-07-20)
+### [5.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.5...@rest-hooks/experimental@5.0.6) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [5.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.3...@rest-hooks/experimental@5.0.5) (2022-07-20)
 
 ### 📦 Package
 
 * build, eslint, webpack, typescript ([#2050](https://github.com/coinbase/rest-hooks/issues/2050)) ([9e2d363](https://github.com/coinbase/rest-hooks/commit/9e2d3636879d0c3c51763b9e74424640c4976e3a))
 
-
-
 ### [5.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.2...@rest-hooks/experimental@5.0.3) (2022-05-30)
-
 
 ### 📦 Package
 
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
 
-
-
 ### [5.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.1...@rest-hooks/experimental@5.0.2) (2022-04-16)
-
 
 ### 🐛 Bug Fix
 
 * urlRoot type inference handles escapes anywhere in string ([#1917](https://github.com/coinbase/rest-hooks/issues/1917)) ([e598a08](https://github.com/coinbase/rest-hooks/commit/e598a080df019242dcc0c778440edcad3c71dad3))
 
-
-
 ### [5.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.0...@rest-hooks/experimental@5.0.1) (2022-04-11)
-
 
 ### 💅 Enhancement
 
 * Better handle non-const urlRoot types ([#1900](https://github.com/coinbase/rest-hooks/issues/1900)) ([55a8bec](https://github.com/coinbase/rest-hooks/commit/55a8bec40c1936498b12b7827d1829dd83b7586a))
 * Infer parameter types from urlRoot ([#1897](https://github.com/coinbase/rest-hooks/issues/1897)) ([c751365](https://github.com/coinbase/rest-hooks/commit/c7513656f26ebe85cf990e8e635c37deea93555c))
 
-
-
 ## [5.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@4.0.0...@rest-hooks/experimental@5.0.0) (2022-04-10)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -55,10 +48,7 @@ instead
 * HookableResource - endpoints as hooks ([#1891](https://github.com/coinbase/rest-hooks/issues/1891)) ([dcd9fbb](https://github.com/coinbase/rest-hooks/commit/dcd9fbb4f4ce5583503187317ea0e065f5d31f1a))
 * Use path-to-regex for urls ([a8ee5bf](https://github.com/coinbase/rest-hooks/commit/a8ee5bff5686e1bca0cf239cb41fb56e792f08d9))
 
-
-
 ## [4.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@3.3.2...@rest-hooks/experimental@4.0.0) (2022-04-08)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -71,40 +61,28 @@ toObjectDefined, keysDefined, set
 * Improve update types ([b6b0334](https://github.com/coinbase/rest-hooks/commit/b6b033470c14bf9bed0e6b161570dde97b6390b4))
 * Resource extends from Entity rather than EntityRecord ([#1867](https://github.com/coinbase/rest-hooks/issues/1867)) ([0678298](https://github.com/coinbase/rest-hooks/commit/0678298fb4a42c90fb57e876d753e0851a1482cc))
 
-
-
 ### [3.3.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@3.3.0...@rest-hooks/experimental@3.3.2) (2022-04-01)
-
 
 ### 💅 Enhancement
 
 * Only import from packages in package.json ([#1785](https://github.com/coinbase/rest-hooks/issues/1785)) ([02fb843](https://github.com/coinbase/rest-hooks/commit/02fb8435bfa7a87a51de680ae6aa69da156c9a71))
-
-
 
 ### [3.3.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@3.3.0...@rest-hooks/experimental@3.3.1) (2022-03-17)
 
-
 ### 💅 Enhancement
 
 * Only import from packages in package.json ([#1785](https://github.com/coinbase/rest-hooks/issues/1785)) ([02fb843](https://github.com/coinbase/rest-hooks/commit/02fb8435bfa7a87a51de680ae6aa69da156c9a71))
 
-
-
 ## [3.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@3.1.0...@rest-hooks/experimental@3.3.0) (2022-02-26)
-
 
 ### 🚀 Features
 
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
 
-
 ### 🐛 Bug Fix
 
 * Resource.url properties are enumerable when provided ([#1737](https://github.com/coinbase/rest-hooks/issues/1737)) ([500ab87](https://github.com/coinbase/rest-hooks/commit/500ab87ebc49d5d573c6ed5a79f6e9501537fa70))
 * Return type of useSuspense should factor in null params ([#1456](https://github.com/coinbase/rest-hooks/issues/1456)) ([831afff](https://github.com/coinbase/rest-hooks/commit/831afff0827648b3ae5ca125a34bfbe3418c8252))
-
-
 
 ## [3.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@3.1.0...@rest-hooks/experimental@3.2.0) (2021-10-29)
 
@@ -112,24 +90,17 @@ toObjectDefined, keysDefined, set
 
 * Return type of useSuspense should factor in null params ([#1456](https://github.com/coinbase/rest-hooks/issues/1456)) ([831afff](https://github.com/coinbase/rest-hooks/commit/831afff0827648b3ae5ca125a34bfbe3418c8252))
 
-
-
 ## [3.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@3.0.0...@rest-hooks/experimental@3.1.0) (2021-10-18)
-
 
 ### 🚀 Features
 
 * useSubscription, useCache, useError ([#1402](https://github.com/coinbase/rest-hooks/issues/1402)) ([da82acd](https://github.com/coinbase/rest-hooks/commit/da82acdbd9f811932ff68d42ff472721f91fe457))
 
-
 ### 🐛 Bug Fix
 
 * Import ExpiryStatus correctly ([#1399](https://github.com/coinbase/rest-hooks/issues/1399)) ([3453764](https://github.com/coinbase/rest-hooks/commit/345376443c11f77a9c24a6d1c324518d6d524c27))
 
-
-
 ## [3.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@2.0.0...@rest-hooks/experimental@3.0.0) (2021-10-17)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -139,15 +110,11 @@ toObjectDefined, keysDefined, set
 
 * Add useSuspense() ([#1397](https://github.com/coinbase/rest-hooks/issues/1397)) ([a43e695](https://github.com/coinbase/rest-hooks/commit/a43e695e331fbec2f9b7b7c576f9b2ed23d001c9))
 
-
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
 
-
-
 ## [2.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@1.0.1...@rest-hooks/experimental@2.0.0) (2021-09-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -158,28 +125,18 @@ Throttle is inferred from Endpoint.sideEffect
 
 * Use @rest-hooks/core controller ([#1249](https://github.com/coinbase/rest-hooks/issues/1249)) ([3cd40f1](https://github.com/coinbase/rest-hooks/commit/3cd40f179f91c08d5720cb0337e11c58263abf38))
 
-
-
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@1.0.0...@rest-hooks/experimental@1.0.1) (2021-09-14)
-
 
 ### 💅 Enhancement
 
 * Improve list().paginated() types ([#1237](https://github.com/coinbase/rest-hooks/issues/1237)) ([94acf71](https://github.com/coinbase/rest-hooks/commit/94acf71fb735958473cfd8d4089176888c085f82))
 * Maintain order during pagination ([#1232](https://github.com/coinbase/rest-hooks/issues/1232)) ([b9b0973](https://github.com/coinbase/rest-hooks/commit/b9b0973a87dabb43b8e2cf50c92b3034c2086453))
 
-
-
 ## [1.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@1.0.0-beta.4...@rest-hooks/experimental@1.0.0) (2021-09-08)
 
 **Note:** Version bump only for package @rest-hooks/experimental
 
-
-
-
-
 ## [1.0.0-beta.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@1.0.0-beta.3...@rest-hooks/experimental@1.0.0-beta.4) (2021-09-06)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -191,68 +148,50 @@ Throttle is inferred from Endpoint.sideEffect
 * Give errors a name ([#1195](https://github.com/coinbase/rest-hooks/issues/1195)) ([caa1cd4](https://github.com/coinbase/rest-hooks/commit/caa1cd4c365eedc0e6bc8df6b00b9bfdf6492c63))
 * Improve NetworkError debuggability ([#1172](https://github.com/coinbase/rest-hooks/issues/1172)) ([9fb64bb](https://github.com/coinbase/rest-hooks/commit/9fb64bbf31827c65eaa1e6b0617e46f685d9ea58))
 
-
 ### 📝 Documentation
 
 * Minor typos ([#1188](https://github.com/coinbase/rest-hooks/issues/1188)) ([9fe6c0d](https://github.com/coinbase/rest-hooks/commit/9fe6c0d82f9b6f5922a8f2977609e0ff6e7c9551))
 * Some fixups for the usecontroller blog ([#1182](https://github.com/coinbase/rest-hooks/issues/1182)) ([9179c2e](https://github.com/coinbase/rest-hooks/commit/9179c2e8d867c84d92ca28475c82f77c8be356b3))
 
-
 * useController() takes configuration options (#1179) ([4847848](https://github.com/coinbase/rest-hooks/commit/4847848a2778b54488e66dd265e076d9fb140161)), closes [#1179](https://github.com/coinbase/rest-hooks/issues/1179)
 
-
-
 ## [1.0.0-beta.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@1.0.0-beta.2...@rest-hooks/experimental@1.0.0-beta.3) (2021-08-22)
-
 
 ### 💅 Enhancement
 
 * Resource.delete() handles empty object response ([#1131](https://github.com/coinbase/rest-hooks/issues/1131)) ([450127a](https://github.com/coinbase/rest-hooks/commit/450127a256d9e2d4fa20b7bd38768681c5f5412e))
 
-
 ### 🐛 Bug Fix
 
 * Cannot update a component while rendering a different component ([#1130](https://github.com/coinbase/rest-hooks/issues/1130)) ([0003388](https://github.com/coinbase/rest-hooks/commit/00033882ec88338b94bd78c8a7a5ad2954af40d6))
 
-
-
 ## [1.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@1.0.0-beta.1...@rest-hooks/experimental@1.0.0-beta.2) (2021-08-21)
-
 
 ### 🚀 Features
 
 * useController() ([#1048](https://github.com/coinbase/rest-hooks/issues/1048)) ([a485782](https://github.com/coinbase/rest-hooks/commit/a4857820ee37f2be467ab85b477f083f7f3f737c))
 
-
 ### 💅 Enhancement
 
 * Experimental fetcher resolves before react render ([#1046](https://github.com/coinbase/rest-hooks/issues/1046)) ([1ec90e5](https://github.com/coinbase/rest-hooks/commit/1ec90e5bb8d69bb47a4099a137c0935cd001c4fb))
-
 
 ### 🐛 Bug Fix
 
 * RESET clears inflight fetches ([#1085](https://github.com/coinbase/rest-hooks/issues/1085)) ([02fa0d5](https://github.com/coinbase/rest-hooks/commit/02fa0d527ef138961ba6dc2509648337c01e604d))
 * useFetchInit() hook calls same amount every render ([#1123](https://github.com/coinbase/rest-hooks/issues/1123)) ([6cd0b7c](https://github.com/coinbase/rest-hooks/commit/6cd0b7cc57de59b5f394942dfa9a3a08d9f2e912))
 
-
-
 ## [1.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@1.0.0-beta.0...@rest-hooks/experimental@1.0.0-beta.1) (2021-07-15)
-
 
 ### 🚀 Features
 
 * FixtureEndpoint & renderRestHook resolverFixtures ([#1027](https://github.com/coinbase/rest-hooks/issues/1027)) ([bbb69e9](https://github.com/coinbase/rest-hooks/commit/bbb69e9faaa523c46a0e309a44e0fd52f0ce91aa))
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([72da158](https://github.com/coinbase/rest-hooks/commit/72da158c19acf4c76b8b86eb37e063956b7347fd))
 
-
 ### 🐛 Bug Fix
 
 * Don't inline normalizr into cjs ([#1038](https://github.com/coinbase/rest-hooks/issues/1038)) ([f7c0822](https://github.com/coinbase/rest-hooks/commit/f7c08225180aa2284294982482105c119383df6d))
 
-
-
 ## [1.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.8.0...@rest-hooks/experimental@1.0.0-beta.0) (2021-06-30)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -271,52 +210,38 @@ Throttle is inferred from Endpoint.sideEffect
 * Add errorPolicy to endpoint options ([#971](https://github.com/coinbase/rest-hooks/issues/971)) ([836f05b](https://github.com/coinbase/rest-hooks/commit/836f05b407b5ac96c8f094e652221aa5a95300b0))
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([a30fe4c](https://github.com/coinbase/rest-hooks/commit/a30fe4c000878aafe724915f653594aa67c5c336))
 
-
 ### 💅 Enhancement
 
 * Entities normalize to POJO ([#940](https://github.com/coinbase/rest-hooks/issues/940)) ([75ebdfe](https://github.com/coinbase/rest-hooks/commit/75ebdfe641ccf57fca35c44a94077e4a314e44d7))
-
 
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
 
-
 ## [0.9.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.8.0...@rest-hooks/experimental@0.9.0) (2021-06-25)
-
 
 ### 🚀 Features
 
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([72da158](https://github.com/coinbase/rest-hooks/commit/72da158c19acf4c76b8b86eb37e063956b7347fd))
 
-
-
 ## [0.8.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.7.0...@rest-hooks/experimental@0.8.0) (2021-06-19)
-
 
 ### 🚀 Features
 
 * Add Entity.validate() ([#934](https://github.com/coinbase/rest-hooks/issues/934)) ([b236b91](https://github.com/coinbase/rest-hooks/commit/b236b9137043d12de5a07bfd5583b5cb2d15f6cd))
 
-
 ### 💅 Enhancement
 
 * More flexible fetch types to help with inheritance ([#932](https://github.com/coinbase/rest-hooks/issues/932)) ([3ff23cf](https://github.com/coinbase/rest-hooks/commit/3ff23cfbe67be4ce2bf314418bb865b05b94c352))
 
-
-
 ## [0.7.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.6.0...@rest-hooks/experimental@0.7.0) (2021-06-16)
-
 
 ### 🚀 Features
 
 * Add Entity.expiresAt() - entity TTL configuration  ([#920](https://github.com/coinbase/rest-hooks/issues/920)) ([e0919c2](https://github.com/coinbase/rest-hooks/commit/e0919c2aa523e0a2fc8c6935dcf38953d723527e))
 * Support deletes with responses ([#919](https://github.com/coinbase/rest-hooks/issues/919)) ([a8129cd](https://github.com/coinbase/rest-hooks/commit/a8129cd432a39d26fd7bb0ad7a9cec5094665ee5))
 
-
-
 ## [0.6.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.5.0...@rest-hooks/experimental@0.6.0) (2021-06-13)
-
 
 ### 🚀 Features
 
@@ -324,73 +249,53 @@ Throttle is inferred from Endpoint.sideEffect
 * Normalize merges entities, entitymeta, indexes ([#915](https://github.com/coinbase/rest-hooks/issues/915)) ([bd21d8c](https://github.com/coinbase/rest-hooks/commit/bd21d8ce0d004a56e6853918d9fb9ecaa2c730a8))
 * Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
 
-
-
 ## [0.5.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.4.0...@rest-hooks/experimental@0.5.0) (2021-06-09)
-
 
 ### 🚀 Features
 
 * Add inferResults() ([#900](https://github.com/coinbase/rest-hooks/issues/900)) ([5ad8287](https://github.com/coinbase/rest-hooks/commit/5ad8287fefd50637670c07252b01ea63ea05333a))
 
-
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ## [0.4.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.2.1...@rest-hooks/experimental@0.4.0) (2021-06-02)
-
 
 ### 🚀 Features
 
 * Export types for Resource ([#889](https://github.com/coinbase/rest-hooks/issues/889)) ([c2766ae](https://github.com/coinbase/rest-hooks/commit/c2766aefa2f1bd736d635c9b5bd51170d9fe104c))
 * Resource.list().paginate() ([#868](https://github.com/coinbase/rest-hooks/issues/868)) ([cecdd7d](https://github.com/coinbase/rest-hooks/commit/cecdd7dd0fc5d4bbffd7f7cf7fa1344be3807697))
 
-
 ### 💅 Enhancement
 
 * Cache entity default instances ([#883](https://github.com/coinbase/rest-hooks/issues/883)) ([842f6c8](https://github.com/coinbase/rest-hooks/commit/842f6c8e3dfc27e2946f5adc1bdbef849e8794ab))
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
 ### 📝 Documentation
 
 * Add paginated() to readme ([#891](https://github.com/coinbase/rest-hooks/issues/891)) ([44b85ed](https://github.com/coinbase/rest-hooks/commit/44b85edc6d3a4273a46a8e0f771ca281af25e254))
 
-
-
 ## [0.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.2.1...@rest-hooks/experimental@0.3.0) (2021-05-30)
-
 
 ### 🚀 Features
 
 * Resource.list().paginate() ([#868](https://github.com/coinbase/rest-hooks/issues/868)) ([cecdd7d](https://github.com/coinbase/rest-hooks/commit/cecdd7dd0fc5d4bbffd7f7cf7fa1344be3807697))
 
-
-
 ### [0.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@0.2.0...@rest-hooks/experimental@0.2.1) (2021-05-24)
-
 
 ### 💅 Enhancement
 
 * Provide args to update method ([#852](https://github.com/coinbase/rest-hooks/issues/852)) ([a552977](https://github.com/coinbase/rest-hooks/commit/a552977752c0f89852e0814cebd3956f0e1338bd))
 
-
 ### 🐛 Bug Fix
 
 * Correct peerDeps ([#855](https://github.com/coinbase/rest-hooks/issues/855)) ([07e3f6f](https://github.com/coinbase/rest-hooks/commit/07e3f6f8942efe5dcc72dcaa8df5feed06ea4aab))
-
 
 ### 📝 Documentation
 
 * Add instructions for experimental pieces ([#845](https://github.com/coinbase/rest-hooks/issues/845)) ([6e8c0ee](https://github.com/coinbase/rest-hooks/commit/6e8c0ee6c7ff5257f8159633bb94ff945f24198d))
 
-
-
 ## 0.2.0 (2021-05-24)
-
 
 ### 🚀 Features
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -3,89 +3,67 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.1.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.8...@rest-hooks/graphql@0.1.9) (2022-07-23)
+### [0.1.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.9...@rest-hooks/graphql@0.1.10) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [0.1.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.8...@rest-hooks/graphql@0.1.9) (2022-07-23)
 
 ### 🐛 Bug Fix
 
 * Ensure dual package hazard solved for non-node ([#2099](https://github.com/coinbase/rest-hooks/issues/2099)) ([6206e64](https://github.com/coinbase/rest-hooks/commit/6206e6463a7c3699d5c1d1b248e4d5418b1327f1))
 
-
-
 ### [0.1.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.6...@rest-hooks/graphql@0.1.8) (2022-07-20)
-
 
 ### 🐛 Bug Fix
 
 * Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
 
-
-
 ### [0.1.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.5...@rest-hooks/graphql@0.1.6) (2022-05-30)
-
 
 ### 📦 Package
 
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
 
-
-
 ### [0.1.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.4...@rest-hooks/graphql@0.1.5) (2022-04-30)
 
 **Note:** Version bump only for package @rest-hooks/graphql
 
-
-
-
-
 ### [0.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.3...@rest-hooks/graphql@0.1.4) (2022-04-02)
-
 
 ### 💅 Enhancement
 
 * More exact optional type handling ([#1858](https://github.com/coinbase/rest-hooks/issues/1858)) ([0459dbd](https://github.com/coinbase/rest-hooks/commit/0459dbdc3fe1555c5e6dc80290187ec8297d1aa6))
 
-
-
 ### [0.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.1...@rest-hooks/graphql@0.1.3) (2022-04-01)
-
 
 ### 💅 Enhancement
 
 * Only import from packages in package.json ([#1785](https://github.com/coinbase/rest-hooks/issues/1785)) ([02fb843](https://github.com/coinbase/rest-hooks/commit/02fb8435bfa7a87a51de680ae6aa69da156c9a71))
 
-
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
-
-
 
 ### [0.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.1...@rest-hooks/graphql@0.1.2) (2022-03-17)
 
-
 ### 💅 Enhancement
 
 * Only import from packages in package.json ([#1785](https://github.com/coinbase/rest-hooks/issues/1785)) ([02fb843](https://github.com/coinbase/rest-hooks/commit/02fb8435bfa7a87a51de680ae6aa69da156c9a71))
-
 
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
 
-
-
 ### [0.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.0...@rest-hooks/graphql@0.1.1) (2021-09-08)
-
 
 ### 📝 Documentation
 
 * Add more tags to packages ([#1223](https://github.com/coinbase/rest-hooks/issues/1223)) ([ef76efc](https://github.com/coinbase/rest-hooks/commit/ef76efc70f7c6acb73d22135a227f84e522729b4))
 
-
-
 ## 0.1.0 (2021-09-06)
-
 
 ### 🚀 Features
 

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,26 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [3.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.1...@rest-hooks/hooks@3.0.2) (2022-05-30)
+### [3.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.2...@rest-hooks/hooks@3.0.3) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [3.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.1...@rest-hooks/hooks@3.0.2) (2022-05-30)
 
 ### 📦 Package
 
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
 
-
-
 ### [3.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.0...@rest-hooks/hooks@3.0.1) (2022-04-30)
-
 
 ### 📝 Documentation
 
 * Update README with newest practices ([#1920](https://github.com/coinbase/rest-hooks/issues/1920)) ([9bbd76c](https://github.com/coinbase/rest-hooks/commit/9bbd76c4fb20125d6318bd8ac5cc4238be4ab3d5))
 
-
-
 ## [3.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@2.1.0...@rest-hooks/hooks@3.0.0) (2022-02-15)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -32,24 +31,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * useLoading() should consume rejections ([#1706](https://github.com/coinbase/rest-hooks/issues/1706)) ([e0ed328](https://github.com/coinbase/rest-hooks/commit/e0ed328ad386f268710ac92bda1fe259d93cb4ee))
 
-
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
 
-
-
 ## [2.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@2.0.0...@rest-hooks/hooks@2.1.0) (2021-09-20)
-
 
 ### 🚀 Features
 
 * Maintain referential stability when deps are used ([#1278](https://github.com/coinbase/rest-hooks/issues/1278)) ([09481c0](https://github.com/coinbase/rest-hooks/commit/09481c04a45d7280fd4fde08bfeca99a087f3813))
 
-
-
 ## [2.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.5.0...@rest-hooks/hooks@2.0.0) (2021-09-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -60,24 +52,15 @@ To handle this case, simply .catch() yourself.
 
 * useLoading() second argument is deps list ([#1250](https://github.com/coinbase/rest-hooks/issues/1250)) ([898599a](https://github.com/coinbase/rest-hooks/commit/898599a878e83f3435c0006f53fb64db8f8b38af))
 
-
-
 ## [1.5.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.5.0-beta.1...@rest-hooks/hooks@1.5.0) (2021-09-08)
 
 **Note:** Version bump only for package @rest-hooks/hooks
 
-
-
-
-
 ## [1.5.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.5.0-beta.0...@rest-hooks/hooks@1.5.0-beta.1) (2021-09-06)
-
 
 ### 🚀 Features
 
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([72da158](https://github.com/coinbase/rest-hooks/commit/72da158c19acf4c76b8b86eb37e063956b7347fd))
-
-
 
 ## [1.5.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.3.0...@rest-hooks/hooks@1.5.0-beta.0) (2021-06-30)
 
@@ -85,141 +68,95 @@ To handle this case, simply .catch() yourself.
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
 
-
 ## [1.4.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.3.0...@rest-hooks/hooks@1.4.0) (2021-06-25)
-
 
 ### 🚀 Features
 
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([a30fe4c](https://github.com/coinbase/rest-hooks/commit/a30fe4c000878aafe724915f653594aa67c5c336))
 
-
-
 ## [1.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.2.2...@rest-hooks/hooks@1.3.0) (2021-06-13)
-
 
 ### 🚀 Features
 
 * Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
 
-
-
 ### [1.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.2.1...@rest-hooks/hooks@1.2.2) (2021-06-09)
-
 
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ### [1.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.2.0...@rest-hooks/hooks@1.2.1) (2021-06-02)
-
 
 ### 💅 Enhancement
 
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
-
 ## [1.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.1.3...@rest-hooks/hooks@1.2.0) (2021-05-24)
-
 
 ### 🚀 Features
 
 * Add error state to useLoading() ([#778](https://github.com/coinbase/rest-hooks/issues/778)) ([cee4159](https://github.com/coinbase/rest-hooks/commit/cee4159bc50de78b3cce2ff815da82602abd1c8c))
 
-
-
 ### [1.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.1.2...@rest-hooks/hooks@1.1.3) (2021-04-24)
-
 
 ### 💅 Enhancement
 
 * Support TypeScript 3.7 ([#752](https://github.com/coinbase/rest-hooks/issues/752)) ([68a10e0](https://github.com/coinbase/rest-hooks/commit/68a10e06dc0718f5e480097e6056a7a7954d1161))
 
-
-
 ### [1.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.1.1...@rest-hooks/hooks@1.1.2) (2021-03-14)
-
 
 ### 📝 Documentation
 
 * Update package tags ([#650](https://github.com/coinbase/rest-hooks/issues/650)) ([4ef465a](https://github.com/coinbase/rest-hooks/commit/4ef465a129cd59668cd9c3542bb9ec03c84d2a4d))
 
-
-
 ### [1.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.1.0...@rest-hooks/hooks@1.1.1) (2021-03-10)
-
 
 ### 📝 Documentation
 
 * **fix:** Fix hooks package link ([#647](https://github.com/coinbase/rest-hooks/issues/647)) ([80a4aef](https://github.com/coinbase/rest-hooks/commit/80a4aef2d113af1cae5826d1e62110a539a00e3d))
 
-
-
 ## [1.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.0.1...@rest-hooks/hooks@1.1.0) (2021-03-08)
-
 
 ### 🚀 Features
 
 * Add useLoading() hook ([#626](https://github.com/coinbase/rest-hooks/issues/626)) ([caeccd2](https://github.com/coinbase/rest-hooks/commit/caeccd2b5be5806e5ebcdba2493f3f03420eb184))
 
-
 ### 📝 Documentation
 
 * Improve @rest-hooks/hooks README ([#627](https://github.com/coinbase/rest-hooks/issues/627)) ([0ccac81](https://github.com/coinbase/rest-hooks/commit/0ccac8154e43962a6636ea837009bdab236299b8))
 
-
-
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@1.0.0...@rest-hooks/hooks@1.0.1) (2021-02-04)
-
 
 ### 📦 Package
 
 * Relax @babel/runtime requirement to ^7.7.2 ([#513](https://github.com/coinbase/rest-hooks/issues/513)) ([cc95b21](https://github.com/coinbase/rest-hooks/commit/cc95b219fbddebfbf334728887ca6d2fa070fce1))
 
-
 ### 📝 Documentation
 
 * Link improvements, flesh out test readme ([#511](https://github.com/coinbase/rest-hooks/issues/511)) ([9cab431](https://github.com/coinbase/rest-hooks/commit/9cab431803a8b7d9c18e02b3e9cb7e336215ccdb))
 
-
-
 ## 1.0.0 (2021-01-19)
-
 
 ### 🚀 Features
 
 * Add @rest-hooks/hooks for composable utilities ([#393](https://github.com/coinbase/rest-hooks/issues/393)) ([b225a2a](https://github.com/coinbase/rest-hooks/commit/b225a2a80d68a94a3e0a68cf6f5289220373f022))
 
-
 ### 💅 Enhancement
 
 * Support React 17 ([#397](https://github.com/coinbase/rest-hooks/issues/397)) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f0724c60fbb2dd3ff6d7d791ee53c3eff694))
-
 
 ### 📦 Package
 
 * Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a8c435c5ef74b3809c8950a2caceca8763))
 
-
-
 ## <small>0.1.2 (2021-01-06)</small>
 
 * pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
 
-
-
-
-
 ## <small>0.1.1 (2020-08-12)</small>
 
 * enhance: Support React 17 (#397) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f07)), closes [#397](https://github.com/coinbase/rest-hooks/issues/397)
-
-
-
-
 
 ## 0.1.0 (2020-08-09)
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/img/CHANGELOG.md
+++ b/packages/img/CHANGELOG.md
@@ -3,113 +3,84 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.6.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.0...@rest-hooks/img@0.6.1) (2022-05-30)
+### [0.6.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.1...@rest-hooks/img@0.6.2) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [0.6.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.0...@rest-hooks/img@0.6.1) (2022-05-30)
 
 ### 📦 Package
 
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
 
-
 ### 📝 Documentation
 
 * Update README with newest practices ([#1920](https://github.com/coinbase/rest-hooks/issues/1920)) ([9bbd76c](https://github.com/coinbase/rest-hooks/commit/9bbd76c4fb20125d6318bd8ac5cc4238be4ab3d5))
 
-
-
 ## [0.6.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.5.2...@rest-hooks/img@0.6.0) (2022-02-26)
-
 
 ### 🚀 Features
 
 * Add component prop to Img ([#1725](https://github.com/coinbase/rest-hooks/issues/1725)) ([e272198](https://github.com/coinbase/rest-hooks/commit/e2721987f0b01a45489373eae031b5b239bf653e))
 
-
-
 ### [0.5.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.5.1...@rest-hooks/img@0.5.2) (2021-10-18)
-
 
 ### 💅 Enhancement
 
 * Mark compatibility with latest @rest-hooks/core ([#1409](https://github.com/coinbase/rest-hooks/issues/1409)) ([57993f3](https://github.com/coinbase/rest-hooks/commit/57993f38ea7ee12cc9eefb562572fea6de63cb1d))
 
-
-
 ### [0.5.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.5.0...@rest-hooks/img@0.5.1) (2021-10-11)
-
 
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
 * Reorganize docs ([#1345](https://github.com/coinbase/rest-hooks/issues/1345)) ([fa49b6b](https://github.com/coinbase/rest-hooks/commit/fa49b6bcf1d6838b85ce21e728f0630e2746e68f))
 
-
-
 ## [0.5.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.5.0-beta.0...@rest-hooks/img@0.5.0) (2021-09-08)
-
 
 ### 🚀 Features
 
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([72da158](https://github.com/coinbase/rest-hooks/commit/72da158c19acf4c76b8b86eb37e063956b7347fd))
-
-
 
 ## [0.4.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.3.0...@rest-hooks/img@0.4.0) (2021-06-25)
 
-
 ### 🚀 Features
 
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([72da158](https://github.com/coinbase/rest-hooks/commit/72da158c19acf4c76b8b86eb37e063956b7347fd))
 
-
-
 ## [0.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.2.4...@rest-hooks/img@0.3.0) (2021-06-13)
-
 
 ### 🚀 Features
 
 * Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
 
-
-
 ### [0.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.2.3...@rest-hooks/img@0.2.4) (2021-06-09)
-
 
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ### [0.2.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.2.2...@rest-hooks/img@0.2.3) (2021-06-02)
-
 
 ### 💅 Enhancement
 
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
-
 ### [0.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.2.1...@rest-hooks/img@0.2.2) (2021-04-24)
-
 
 ### 💅 Enhancement
 
 * Support TypeScript 3.7 ([#752](https://github.com/coinbase/rest-hooks/issues/752)) ([68a10e0](https://github.com/coinbase/rest-hooks/commit/68a10e06dc0718f5e480097e6056a7a7954d1161))
 
-
-
 ### [0.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.2.0...@rest-hooks/img@0.2.1) (2021-03-14)
-
 
 ### 📝 Documentation
 
 * Update package tags ([#650](https://github.com/coinbase/rest-hooks/issues/650)) ([4ef465a](https://github.com/coinbase/rest-hooks/commit/4ef465a129cd59668cd9c3542bb9ec03c84d2a4d))
 
-
-
 ## 0.2.0 (2021-03-01)
-
 
 ### 🚀 Features
 

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/img",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,124 +3,95 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [4.3.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.5...@rest-hooks/legacy@4.3.6) (2022-07-23)
+### [4.3.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.6...@rest-hooks/legacy@4.3.7) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [4.3.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.5...@rest-hooks/legacy@4.3.6) (2022-07-23)
 
 ### 🐛 Bug Fix
 
 * Ensure dual package hazard solved for non-node ([#2099](https://github.com/coinbase/rest-hooks/issues/2099)) ([6206e64](https://github.com/coinbase/rest-hooks/commit/6206e6463a7c3699d5c1d1b248e4d5418b1327f1))
 
-
-
 ### [4.3.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.3...@rest-hooks/legacy@4.3.5) (2022-07-20)
-
 
 ### 🐛 Bug Fix
 
 * Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
 
-
-
 ### [4.3.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.2...@rest-hooks/legacy@4.3.3) (2022-05-30)
-
 
 ### 🐛 Bug Fix
 
 * Missing import extension in legacy package ([#1977](https://github.com/coinbase/rest-hooks/issues/1977)) ([07e7f68](https://github.com/coinbase/rest-hooks/commit/07e7f68f0365f5e0ee31f3f99ec8f5ba1bca051d))
 
-
-
 ### [4.3.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.1...@rest-hooks/legacy@4.3.2) (2022-04-30)
-
 
 ### 💅 Enhancement
 
 * Improve robustness when using distinct schemas to normalize/denormalize ([#1908](https://github.com/coinbase/rest-hooks/issues/1908)) ([c8fdca9](https://github.com/coinbase/rest-hooks/commit/c8fdca9e0cd65622d41692b66c3e2744b20bef23)), closes [#1912](https://github.com/coinbase/rest-hooks/issues/1912)
 
-
 ### 🐛 Bug Fix
 
 * Accept undefined or null responses for schema entries ([#1963](https://github.com/coinbase/rest-hooks/issues/1963)) ([2d4214a](https://github.com/coinbase/rest-hooks/commit/2d4214a4c6b74725c9a6a92e36817bd26aa3c366))
 
-
-
 ### [4.3.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.0...@rest-hooks/legacy@4.3.1) (2022-04-08)
-
 
 ### 🐛 Bug Fix
 
 * Legacy exports ([#1881](https://github.com/coinbase/rest-hooks/issues/1881)) ([ec8d9bd](https://github.com/coinbase/rest-hooks/commit/ec8d9bd384baa6af81c5cac20d008c02e1813d33))
 
-
-
 ## [4.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.2.0...@rest-hooks/legacy@4.3.0) (2022-04-08)
-
 
 ### 🚀 Features
 
 * Add @rest-hooks/rest@3 ([e5c82f7](https://github.com/coinbase/rest-hooks/commit/e5c82f75e00c2c88190a9266ac7cbb1f8174264a))
 
-
-
 ## [4.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.0.0...@rest-hooks/legacy@4.2.0) (2022-04-01)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
 
-
 ### 💅 Enhancement
 
 * Hooks should type return value based on 'null' arg ([#1783](https://github.com/coinbase/rest-hooks/issues/1783)) ([d14673e](https://github.com/coinbase/rest-hooks/commit/d14673eab0dad3f02edb54f7bf37e6fed1c47a62))
 * Only import from packages in package.json ([#1785](https://github.com/coinbase/rest-hooks/issues/1785)) ([02fb843](https://github.com/coinbase/rest-hooks/commit/02fb8435bfa7a87a51de680ae6aa69da156c9a71))
-
 
 ### 🐛 Bug Fix
 
 * Default optimistic race condition handling should assume in-order server response ([#1852](https://github.com/coinbase/rest-hooks/issues/1852)) ([cf38c3f](https://github.com/coinbase/rest-hooks/commit/cf38c3f67ff0041b528e9d8cf21d31704b76fc01))
 * Hooks with null param maintain basic schema structure ([#1853](https://github.com/coinbase/rest-hooks/issues/1853)) ([0707e1a](https://github.com/coinbase/rest-hooks/commit/0707e1a6ee8233b2d1b6590db137e298e264635c))
 
-
-
 ## [4.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.0.0...@rest-hooks/legacy@4.1.0) (2022-03-17)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
-
 
 ### 💅 Enhancement
 
 * Hooks should type return value based on 'null' arg ([#1783](https://github.com/coinbase/rest-hooks/issues/1783)) ([d14673e](https://github.com/coinbase/rest-hooks/commit/d14673eab0dad3f02edb54f7bf37e6fed1c47a62))
 * Only import from packages in package.json ([#1785](https://github.com/coinbase/rest-hooks/issues/1785)) ([02fb843](https://github.com/coinbase/rest-hooks/commit/02fb8435bfa7a87a51de680ae6aa69da156c9a71))
 
-
-
 ## [4.1.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.0.0...@rest-hooks/legacy@4.1.0-beta.2) (2022-01-23)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
 
-
-
 ## [4.1.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.0.0...@rest-hooks/legacy@4.1.0-beta.0) (2021-10-24)
-
 
 ### 🚀 Features
 
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
 
-
-
 ## [4.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@3.0.1...@rest-hooks/legacy@4.0.0) (2021-10-17)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -136,67 +107,48 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Improve Controller.getResponse() interface ([#1396](https://github.com/coinbase/rest-hooks/issues/1396)) ([f57a909](https://github.com/coinbase/rest-hooks/commit/f57a909b98aa1c385a95f1dde437a0d6aa7ff916))
 * Normalize strings for entities ([#1364](https://github.com/coinbase/rest-hooks/issues/1364)) ([cb31e1f](https://github.com/coinbase/rest-hooks/commit/cb31e1f425d4ef727186ac3c447cc8c46ddabb4e))
 
-
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
 
-
-
 ### [3.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@3.0.0...@rest-hooks/legacy@3.0.1) (2021-09-29)
-
 
 ### 💅 Enhancement
 
 * infer() args are readonly ([#1293](https://github.com/coinbase/rest-hooks/issues/1293)) ([2dd880f](https://github.com/coinbase/rest-hooks/commit/2dd880f2815ca43ecb9bba70a10464133da8f88b))
 
-
-
 ## [3.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@3.0.0-beta.2...@rest-hooks/legacy@3.0.0) (2021-09-08)
-
 
 ### 🐛 Bug Fix
 
 * Updating nesting under arrays ([#1047](https://github.com/coinbase/rest-hooks/issues/1047)) ([a78a1a4](https://github.com/coinbase/rest-hooks/commit/a78a1a41149dbb0646660fdeef38918b2e16cc14))
 
-
-
 ## [3.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@3.0.0-beta.1...@rest-hooks/legacy@3.0.0-beta.2) (2021-09-06)
-
 
 ### 🚀 Features
 
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([72da158](https://github.com/coinbase/rest-hooks/commit/72da158c19acf4c76b8b86eb37e063956b7347fd))
-
 
 ### 💅 Enhancement
 
 * Give errors a name ([#1195](https://github.com/coinbase/rest-hooks/issues/1195)) ([caa1cd4](https://github.com/coinbase/rest-hooks/commit/caa1cd4c365eedc0e6bc8df6b00b9bfdf6492c63))
 * Improve NetworkError debuggability ([#1172](https://github.com/coinbase/rest-hooks/issues/1172)) ([9fb64bb](https://github.com/coinbase/rest-hooks/commit/9fb64bbf31827c65eaa1e6b0617e46f685d9ea58))
 
-
 ### 🐛 Bug Fix
 
 * Legacy cjs and unpkg should target 'legacy' ([31b6893](https://github.com/coinbase/rest-hooks/commit/31b68933245bfc6234ecea603618f43af8387729))
-
 
 ### 📝 Documentation
 
 * More udpates ([#1176](https://github.com/coinbase/rest-hooks/issues/1176)) ([e11b59c](https://github.com/coinbase/rest-hooks/commit/e11b59c26ee26eaeacf65a9ceaba74f35c27b66b))
 
-
-
 ## [3.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@3.0.0-beta.0...@rest-hooks/legacy@3.0.0-beta.1) (2021-06-30)
-
 
 ### 🐛 Bug Fix
 
 * module build import path ([#994](https://github.com/coinbase/rest-hooks/issues/994)) ([1f84f51](https://github.com/coinbase/rest-hooks/commit/1f84f51e0f3b62832945e75d0e241dba59b6623c))
 
-
-
 ## [3.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.2.0...@rest-hooks/legacy@3.0.0-beta.0) (2021-06-30)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -220,7 +172,6 @@ errors for missing entities
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([a30fe4c](https://github.com/coinbase/rest-hooks/commit/a30fe4c000878aafe724915f653594aa67c5c336))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Different babel targets for cjs and umd builds ([#989](https://github.com/coinbase/rest-hooks/issues/989)) ([f054814](https://github.com/coinbase/rest-hooks/commit/f05481410cf8daa2101d4dbda826e56ad10ec723))
@@ -228,115 +179,79 @@ errors for missing entities
 * Remove 'fallback' package.json exports ([#992](https://github.com/coinbase/rest-hooks/issues/992)) ([dc95f9d](https://github.com/coinbase/rest-hooks/commit/dc95f9dbad20d5740218c52c906596b6a3d6eae4))
 * useError() only checks meta error ([#938](https://github.com/coinbase/rest-hooks/issues/938)) ([b08d708](https://github.com/coinbase/rest-hooks/commit/b08d708ea50170de0dd25340aec84b86a7687f48))
 
-
 ### 🐛 Bug Fix
 
 * Legacy cjs and unpkg should target 'legacy' ([#961](https://github.com/coinbase/rest-hooks/issues/961)) ([ba76f35](https://github.com/coinbase/rest-hooks/commit/ba76f3501ae46b6d9d9162e52b76c96fa1fbca1d))
-
 
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
 
-
 ## [2.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.2.0...@rest-hooks/legacy@2.3.0) (2021-06-25)
-
 
 ### 🚀 Features
 
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([72da158](https://github.com/coinbase/rest-hooks/commit/72da158c19acf4c76b8b86eb37e063956b7347fd))
 
-
 ### 🐛 Bug Fix
 
 * Legacy cjs and unpkg should target 'legacy' ([31b6893](https://github.com/coinbase/rest-hooks/commit/31b68933245bfc6234ecea603618f43af8387729))
 
-
-
 ## [2.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.1.0...@rest-hooks/legacy@2.2.0) (2021-06-16)
-
 
 ### 🚀 Features
 
 * Add Resource+Entity to legacy ([#924](https://github.com/coinbase/rest-hooks/issues/924)) ([0c7ac83](https://github.com/coinbase/rest-hooks/commit/0c7ac834fa1c4fc07665601441422d5170313640))
 
-
-
 ## [2.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.9...@rest-hooks/legacy@2.1.0) (2021-06-13)
-
 
 ### 🚀 Features
 
 * Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
 
-
 ### 💅 Enhancement
 
 * Use inferResults() from normalizr ([#901](https://github.com/coinbase/rest-hooks/issues/901)) ([875cb6a](https://github.com/coinbase/rest-hooks/commit/875cb6acf31055e37e2d1faf4414bcbf31f5700f))
 
-
-
 ### [2.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.8...@rest-hooks/legacy@2.0.9) (2021-06-09)
-
 
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ### [2.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.7...@rest-hooks/legacy@2.0.8) (2021-06-02)
-
 
 ### 💅 Enhancement
 
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
-
 ### [2.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.6...@rest-hooks/legacy@2.0.7) (2021-05-24)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ### [2.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.5...@rest-hooks/legacy@2.0.6) (2021-04-24)
-
 
 ### 💅 Enhancement
 
 * Support TypeScript 3.7 ([#752](https://github.com/coinbase/rest-hooks/issues/752)) ([68a10e0](https://github.com/coinbase/rest-hooks/commit/68a10e06dc0718f5e480097e6056a7a7954d1161))
 
-
-
 ### [2.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.4...@rest-hooks/legacy@2.0.5) (2021-03-03)
-
 
 ### 🐛 Bug Fix
 
 * useStatefulResource() return type ([#613](https://github.com/coinbase/rest-hooks/issues/613)) ([05a4995](https://github.com/coinbase/rest-hooks/commit/05a49954c61f47deef18bc5d58d045ac79efd78e))
 
-
-
 ### [2.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.3...@rest-hooks/legacy@2.0.4) (2021-03-01)
-
 
 ### 🐛 Bug Fix
 
 * Rollup name for @rest-hooks/legacy ([#587](https://github.com/coinbase/rest-hooks/issues/587)) ([299c53e](https://github.com/coinbase/rest-hooks/commit/299c53e8eab427d209b6f74babc3602744ea5212))
 
-
-
 ### [2.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.2...@rest-hooks/legacy@2.0.3) (2021-02-27)
-
 
 ### 💅 Enhancement
 
 * Make type discrimination easier in error types ([#581](https://github.com/coinbase/rest-hooks/issues/581)) ([cd105f3](https://github.com/coinbase/rest-hooks/commit/cd105f378e3c97b6accd127a61759287fb8bb3b5))
-
-
 
 ## [2.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.1...@rest-hooks/legacy@2.0.2) (2021-02-24)
 
@@ -344,17 +259,11 @@ errors for missing entities
 
 * Improve error type preciseness ([#571](https://github.com/coinbase/rest-hooks/issues/571)) ([6f760be](https://github.com/coinbase/rest-hooks/commit/6f760be7149f04eb26727730e0ec0d67f2215ed5))
 
-
 ### [2.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.0...@rest-hooks/legacy@2.0.1) (2021-01-24)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ## 2.0.0 (2021-01-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -375,7 +284,6 @@ are in the cache
 
 * Deletes and invalidates trigger suspense always ([#360](https://github.com/coinbase/rest-hooks/issues/360)) ([96175ba](https://github.com/coinbase/rest-hooks/commit/96175ba24d6670d866b315794b039d21fd3ef081))
 
-
 ### 💅 Enhancement
 
 * Inferred endpoints expiry based on entities ([#464](https://github.com/coinbase/rest-hooks/issues/464)) ([975e0d8](https://github.com/coinbase/rest-hooks/commit/975e0d8ce1516d9cd62c00de7f1cce331fd4560a))
@@ -383,94 +291,58 @@ are in the cache
 * Support React 17 ([#397](https://github.com/coinbase/rest-hooks/issues/397)) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f0724c60fbb2dd3ff6d7d791ee53c3eff694))
 * useCache() and useStatefulResource() respect invalidIfStale ([#307](https://github.com/coinbase/rest-hooks/issues/307)) ([58f2c40](https://github.com/coinbase/rest-hooks/commit/58f2c40a66fb0d0c1f900840160e17ce87beace2))
 
-
 ### 🐛 Bug Fix
 
 * Catch maybePromise errors. ([#374](https://github.com/coinbase/rest-hooks/issues/374)) ([786b6cc](https://github.com/coinbase/rest-hooks/commit/786b6cc22166d180415a9fb9aa4e8f49d093ad78))
 * Rest Hooks beta peerdep ([43ef2a1](https://github.com/coinbase/rest-hooks/commit/43ef2a16043207d7e52ae31b008b87d28fac0151))
 * Update rest-hooks peerDep to 5 ([526df3c](https://github.com/coinbase/rest-hooks/commit/526df3c23d7a8be2b3c1ac603d165db26efa0f1b))
 
-
 ### 📦 Package
 
 * Bump babel runtime ([c6bf844](https://github.com/coinbase/rest-hooks/commit/c6bf844fcf1a483988d34b5f09faa03ceff179ec))
 * Bump internal pkgs ([#306](https://github.com/coinbase/rest-hooks/issues/306)) ([46bebad](https://github.com/coinbase/rest-hooks/commit/46bebad79d848404d02423fd2a3e2d647ee5bbbb))
 
-
 ## 2.0.0-rc.0 (2021-01-14)
 
 * enhance: Inferred endpoints expiry based on entities (#464) ([975e0d8](https://github.com/coinbase/rest-hooks/commit/975e0d8)), closes [#464](https://github.com/coinbase/rest-hooks/issues/464)
-
 
 ### BREAKING CHANGE
 
 * useResource() inferred endpoint will sometimes
 not trigger a fetch if entities are fresh enough
 
-
-
-
 ## 2.0.0-k.2 (2021-01-06)
 
 **Note:** Version bump only for package @rest-hooks/legacy
-
-
-
-
 
 ## 2.0.0-k.1 (2020-09-08)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ## 2.0.0-k.0 (2020-08-12)
 
 * enhance: Support React 17 (#397) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f07)), closes [#397](https://github.com/coinbase/rest-hooks/issues/397)
-
-
-
-
 
 ## 2.0.0-j.2 (2020-08-09)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ## 2.0.0-j.1 (2020-07-31)
 
 **Note:** Version bump only for package @rest-hooks/legacy
-
-
-
-
 
 ## 2.0.0-j.0 (2020-07-27)
 
 * fix: Catch maybePromise errors. (#374) ([786b6cc](https://github.com/coinbase/rest-hooks/commit/786b6cc)), closes [#374](https://github.com/coinbase/rest-hooks/issues/374)
 
-
-
-
-
 ## 2.0.0-h.0 (2020-07-13)
 
 * pkg: Bump babel runtime ([c6bf844](https://github.com/coinbase/rest-hooks/commit/c6bf844))
-
-
-
-
 
 ## 2.0.0-delta.0 (2020-07-08)
 
 * feat: Deletes and invalidates trigger suspense always (#360) ([96175ba](https://github.com/coinbase/rest-hooks/commit/96175ba)), closes [#360](https://github.com/coinbase/rest-hooks/issues/360)
 * internal: Prepare tests to run in React Native env (#309) ([64efd70](https://github.com/coinbase/rest-hooks/commit/64efd70)), closes [#309](https://github.com/coinbase/rest-hooks/issues/309)
-
 
 ### BREAKING CHANGE
 
@@ -482,42 +354,27 @@ not trigger a fetch if entities are fresh enough
 - required entities missing from network response will now throw error in useResource() just like other unexpected deserializations
 - FetchShape type is now just 'read' | 'mutate'. No more 'delete'. (use schema.Delete())
 
-
-
-
 ## [2.0.0-beta.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.0-beta.3...@rest-hooks/legacy@2.0.0-beta.4) (2020-05-13)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ## [2.0.0-beta.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.0-beta.2...@rest-hooks/legacy@2.0.0-beta.3) (2020-05-12)
-
 
 ### 💅 Enhancement
 
 * New package @rest-hooks/core ([#336](https://github.com/coinbase/rest-hooks/issues/336)) ([bf490c0](https://github.com/coinbase/rest-hooks/commit/bf490c030feb8a0e35e96c6dd7d180e45ac8bfd0))
 
-
-
 ## [2.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@2.0.0-beta.0...@rest-hooks/legacy@2.0.0-beta.2) (2020-05-04)
-
 
 ### 🐛 Bug Fix
 
 * Rest Hooks beta peerdep ([43ef2a1](https://github.com/coinbase/rest-hooks/commit/43ef2a16043207d7e52ae31b008b87d28fac0151))
 
-
 ### 🏠 Internal
 
 * Fix package versions for publish ([06d69ca](https://github.com/coinbase/rest-hooks/commit/06d69ca6d8e8d4dbf847f8a1593bfa65af8d79c6))
 
-
-
 ## [2.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.12...@rest-hooks/legacy@2.0.0-beta.0) (2020-04-26)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -529,123 +386,76 @@ are in the cache
 
 * useCache() and useStatefulResource() respect invalidIfStale ([#307](https://github.com/coinbase/rest-hooks/issues/307)) ([58f2c40](https://github.com/coinbase/rest-hooks/commit/58f2c40a66fb0d0c1f900840160e17ce87beace2))
 
-
 ### 🐛 Bug Fix
 
 * Update rest-hooks peerDep to 5 ([526df3c](https://github.com/coinbase/rest-hooks/commit/526df3c23d7a8be2b3c1ac603d165db26efa0f1b))
 
-
 ### 📦 Package
 
 * Bump internal pkgs ([#306](https://github.com/coinbase/rest-hooks/issues/306)) ([46bebad](https://github.com/coinbase/rest-hooks/commit/46bebad79d848404d02423fd2a3e2d647ee5bbbb))
-
 
 ### 🏠 Internal
 
 * Hoist coveralls to root, since testing is done there ([3b1dbaa](https://github.com/coinbase/rest-hooks/commit/3b1dbaac303048a1b1e543f99fb9758b21feb083))
 * Update prettier, format files ([88d5627](https://github.com/coinbase/rest-hooks/commit/88d5627fb1963842d2a644cfe06f0780cb3c2dde))
 
-
-
 ### [1.0.12](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.11...@rest-hooks/legacy@1.0.12) (2020-03-22)
-
 
 ### 🏠 Internal
 
 * Update eslint-plugin + prettier 2 ([#304](https://github.com/coinbase/rest-hooks/issues/304)) ([210eabc](https://github.com/coinbase/rest-hooks/commit/210eabcec4651f3150658535df6dce730bf7665e))
 
-
-
 ### [1.0.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.10...@rest-hooks/legacy@1.0.11) (2020-03-13)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ### [1.0.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.9...@rest-hooks/legacy@1.0.10) (2020-03-08)
-
 
 ### 🏠 Internal
 
 * Only allow building types from root ([0c3d7ae](https://github.com/coinbase/rest-hooks/commit/0c3d7ae1a9d6130848f31850ed8b15e6ed01d0ab))
 
-
-
 ### [1.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.8...@rest-hooks/legacy@1.0.9) (2020-02-19)
-
 
 ### 🏠 Internal
 
 * Check compressed size changes on PR ([#270](https://github.com/coinbase/rest-hooks/issues/270)) ([d70ccbf](https://github.com/coinbase/rest-hooks/commit/d70ccbf44ac5ba8fdc4f70886851ab18349f37e6))
 
-
-
 ### [1.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.8-beta.0...@rest-hooks/legacy@1.0.8) (2020-02-18)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ### [1.0.8-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.7...@rest-hooks/legacy@1.0.8-beta.0) (2020-02-18)
-
 
 ### 🏠 Internal
 
 * Centralize jest config ([#230](https://github.com/coinbase/rest-hooks/issues/230)) ([5d769d2](https://github.com/coinbase/rest-hooks/commit/5d769d2485fe62ba65f4176894768bdbb6faafb3))
 
-
 ### 📝 Documentation
 
 * Use bundlephobia badge for lib size ([eb76258](https://github.com/coinbase/rest-hooks/commit/eb76258db4be81a4a22ce01074c4a88cfc4ff0b8))
-
-
 
 ### [1.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.6...@rest-hooks/legacy@1.0.7) (2020-01-18)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ### [1.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.5...@rest-hooks/legacy@1.0.6) (2020-01-17)
 
 **Note:** Version bump only for package @rest-hooks/legacy
-
-
-
-
 
 ### [1.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.4...@rest-hooks/legacy@1.0.5) (2020-01-06)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ### [1.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.3...@rest-hooks/legacy@1.0.4) (2020-01-05)
 
 **Note:** Version bump only for package @rest-hooks/legacy
-
-
-
-
 
 ### [1.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.2...@rest-hooks/legacy@1.0.3) (2019-12-31)
 
 **Note:** Version bump only for package @rest-hooks/legacy
 
-
-
-
-
 ### [1.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.1...@rest-hooks/legacy@1.0.2) (2019-12-22)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -657,40 +467,30 @@ are in the cache
 
 * Resource.fetch uses fetch instead of superagent ([#199](https://github.com/coinbase/rest-hooks/issues/199)) ([5c740ec](https://github.com/coinbase/rest-hooks/commit/5c740ecf8f864e33cd9a6ab6cbc0a872ba0344ed))
 
-
 ### 🐛 Bug Fix
 
 * Correct peerdepencency version constraints ([37734a8](https://github.com/coinbase/rest-hooks/commit/37734a834b7c87419c744d02cbc17fbe424e4338))
-
 
 ### 📦 Package
 
 * testing ([138c846](https://github.com/coinbase/rest-hooks/commit/138c846035e704d78f751156e5587366310edf98))
 
-
 ### 🏠 Internal
 
 * Update lint rules ([#206](https://github.com/coinbase/rest-hooks/issues/206)) ([732f875](https://github.com/coinbase/rest-hooks/commit/732f87536e23d6b43cea3abce5be8cd6f1dd75c7))
 
-
-
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@1.0.0...@rest-hooks/legacy@1.0.1) (2019-12-11)
-
 
 ### 🏠 Internal
 
 * Centralize browserslist config ([b4be6ec](https://github.com/coinbase/rest-hooks/commit/b4be6ecbb3bce3e9c0b465a4de5196c00be351b9))
 * fix build:bundle ([9538e19](https://github.com/coinbase/rest-hooks/commit/9538e1932d926179fbcf0c3645a11fadc643e8c1))
 
-
 ### 📝 Documentation
 
 * Point to repository directory for npm ([942a563](https://github.com/coinbase/rest-hooks/commit/942a563493d35dca9787e541dd89599d2059be1c))
 
-
-
 ## 1.0.0 (2019-12-02)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -700,12 +500,9 @@ are in the cache
 
 * New @rest-hooks/legacy package ([#187](https://github.com/coinbase/rest-hooks/issues/187)) ([78c9321](https://github.com/coinbase/rest-hooks/commit/78c9321f3560d2ea57b4c8478e9bdd789762ae13))
 
-
 ### 📝 Documentation
 
 * Improve readme for new packages ([2406f2c](https://github.com/coinbase/rest-hooks/commit/2406f2c78a10e41f6aa1e7deeb4c957a3c94314d))
-
-
 
 # Change Log
 

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,184 +3,134 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [8.2.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.9...@rest-hooks/normalizr@8.2.10) (2022-07-23)
+### [8.2.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.10...@rest-hooks/normalizr@8.2.11) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [8.2.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.9...@rest-hooks/normalizr@8.2.10) (2022-07-23)
 
 ### 🐛 Bug Fix
 
 * Ensure dual package hazard solved for non-node ([#2099](https://github.com/coinbase/rest-hooks/issues/2099)) ([6206e64](https://github.com/coinbase/rest-hooks/commit/6206e6463a7c3699d5c1d1b248e4d5418b1327f1))
 
-
-
 ### [8.2.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.6...@rest-hooks/normalizr@8.2.9) (2022-07-20)
-
 
 ### 🐛 Bug Fix
 
 * Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
 
-
-
 ### [8.2.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.5...@rest-hooks/normalizr@8.2.6) (2022-05-30)
-
 
 ### 📦 Package
 
 * Update all non-major dependencies ([#2023](https://github.com/coinbase/rest-hooks/issues/2023)) ([9e1d0f7](https://github.com/coinbase/rest-hooks/commit/9e1d0f7d0082ae4375ef044a4b6f356cbaca373a))
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
 
-
-
 ### [8.2.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.4...@rest-hooks/normalizr@8.2.5) (2022-04-30)
-
 
 ### 🐛 Bug Fix
 
 * Accept undefined or null responses for schema entries ([#1963](https://github.com/coinbase/rest-hooks/issues/1963)) ([2d4214a](https://github.com/coinbase/rest-hooks/commit/2d4214a4c6b74725c9a6a92e36817bd26aa3c366))
 
-
-
 ### [8.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.3...@rest-hooks/normalizr@8.2.4) (2022-04-16)
-
 
 ### 💅 Enhancement
 
 * Improve robustness when using distinct schemas to normalize/denormalize ([#1908](https://github.com/coinbase/rest-hooks/issues/1908)) ([c8fdca9](https://github.com/coinbase/rest-hooks/commit/c8fdca9e0cd65622d41692b66c3e2744b20bef23)), closes [#1912](https://github.com/coinbase/rest-hooks/issues/1912)
 
-
-
 ### [8.2.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.2...@rest-hooks/normalizr@8.2.3) (2022-04-08)
-
 
 ### 🐛 Bug Fix
 
 * optimisticUpdate when used with controller.fetch or useSuspense ([e40f5ea](https://github.com/coinbase/rest-hooks/commit/e40f5ea75191ff5b4e170922744f1eaa95c09275))
 
-
-
 ### [8.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.1...@rest-hooks/normalizr@8.2.2) (2022-04-02)
-
 
 ### 💅 Enhancement
 
 * More exact optional type handling ([#1858](https://github.com/coinbase/rest-hooks/issues/1858)) ([0459dbd](https://github.com/coinbase/rest-hooks/commit/0459dbdc3fe1555c5e6dc80290187ec8297d1aa6))
 
-
-
 ### [8.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.0-beta.2...@rest-hooks/normalizr@8.2.1) (2022-04-01)
-
 
 ### 🐛 Bug Fix
 
 * Default optimistic race condition handling should assume in-order server response ([#1852](https://github.com/coinbase/rest-hooks/issues/1852)) ([cf38c3f](https://github.com/coinbase/rest-hooks/commit/cf38c3f67ff0041b528e9d8cf21d31704b76fc01))
 
-
 ### 📝 Documentation
 
 * **fix:** Restore version routes ([#1848](https://github.com/coinbase/rest-hooks/issues/1848)) ([72d81cd](https://github.com/coinbase/rest-hooks/commit/72d81cdfce7e20a0e583ff1f6cd854ca16801f9a))
 
-
-
 ## [8.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.1.0...@rest-hooks/normalizr@8.2.0) (2022-03-17)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 * Entity.useIncoming() for race condition handling ([#1771](https://github.com/coinbase/rest-hooks/issues/1771)) ([ffd70fe](https://github.com/coinbase/rest-hooks/commit/ffd70fe0aa12634d06d2e0d43a5b89d420e2220c))
 
-
 ### 🐛 Bug Fix
 
 * Union schemas with null args[0] hooks ([#1779](https://github.com/coinbase/rest-hooks/issues/1779)) ([fcf70a9](https://github.com/coinbase/rest-hooks/commit/fcf70a92ef15531b7fd12feb117f29ad8c3de3d8))
-
-
 
 ## [8.2.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.0-beta.1...@rest-hooks/normalizr@8.2.0-beta.2) (2022-03-10)
 
-
 ### 🐛 Bug Fix
 
 * Union schemas with null args[0] hooks ([#1779](https://github.com/coinbase/rest-hooks/issues/1779)) ([fcf70a9](https://github.com/coinbase/rest-hooks/commit/fcf70a92ef15531b7fd12feb117f29ad8c3de3d8))
 
-
-
 ## [8.2.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.1.0...@rest-hooks/normalizr@8.2.0-beta.1) (2022-03-08)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 * Entity.useIncoming() for race condition handling ([#1771](https://github.com/coinbase/rest-hooks/issues/1771)) ([ffd70fe](https://github.com/coinbase/rest-hooks/commit/ffd70fe0aa12634d06d2e0d43a5b89d420e2220c))
 
-
-
 ## [8.2.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.1.0...@rest-hooks/normalizr@8.2.0-beta.0) (2022-01-23)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 
-
-
 ## [8.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.0.2...@rest-hooks/normalizr@8.1.0) (2021-10-11)
-
 
 ### 🚀 Features
 
 * Normalize strings for entities ([#1364](https://github.com/coinbase/rest-hooks/issues/1364)) ([cb31e1f](https://github.com/coinbase/rest-hooks/commit/cb31e1f425d4ef727186ac3c447cc8c46ddabb4e))
 
-
 ### 🐛 Bug Fix
 
 * Validation with immutablejs ([#1363](https://github.com/coinbase/rest-hooks/issues/1363)) ([2fa3865](https://github.com/coinbase/rest-hooks/commit/2fa38655aa4a0684fa81d925159e6e913e4d655e))
-
 
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
 
-
-
 ### [8.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.0.1...@rest-hooks/normalizr@8.0.2) (2021-09-29)
-
 
 ### 💅 Enhancement
 
 * Detect multiple normalizr copies installed ([#1314](https://github.com/coinbase/rest-hooks/issues/1314)) ([f16ea01](https://github.com/coinbase/rest-hooks/commit/f16ea013938f7069c408ef0483fc58c09965479d))
 
-
-
 ### [8.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.0.0...@rest-hooks/normalizr@8.0.1) (2021-09-29)
-
 
 ### 💅 Enhancement
 
 * infer() args are readonly ([#1293](https://github.com/coinbase/rest-hooks/issues/1293)) ([2dd880f](https://github.com/coinbase/rest-hooks/commit/2dd880f2815ca43ecb9bba70a10464133da8f88b))
 
-
-
 ## [8.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.0.0-beta.2...@rest-hooks/normalizr@8.0.0) (2021-09-08)
-
 
 ### 🐛 Bug Fix
 
 * Updating nesting under arrays ([#1047](https://github.com/coinbase/rest-hooks/issues/1047)) ([a78a1a4](https://github.com/coinbase/rest-hooks/commit/a78a1a41149dbb0646660fdeef38918b2e16cc14))
 
-
-
 ## [8.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.0.0-beta.1...@rest-hooks/normalizr@8.0.0-beta.2) (2021-09-06)
-
 
 ### 💅 Enhancement
 
 * validate during denormalization ([#1183](https://github.com/coinbase/rest-hooks/issues/1183)) ([bca1e4a](https://github.com/coinbase/rest-hooks/commit/bca1e4a9158a294ee82745107e04e43564ccd5a0))
 
-
-
 ## [8.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.5.0...@rest-hooks/normalizr@8.0.0-beta.1) (2021-07-12)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -196,7 +146,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Allow normalizing entities that are just ids ([#1002](https://github.com/coinbase/rest-hooks/issues/1002)) ([377391f](https://github.com/coinbase/rest-hooks/commit/377391fa31ffe651f67e547aef13c5aa7bd5e702))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Different babel targets for cjs and umd builds ([#989](https://github.com/coinbase/rest-hooks/issues/989)) ([f054814](https://github.com/coinbase/rest-hooks/commit/f05481410cf8daa2101d4dbda826e56ad10ec723))
@@ -204,16 +153,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Remove 'fallback' package.json exports ([#992](https://github.com/coinbase/rest-hooks/issues/992)) ([dc95f9d](https://github.com/coinbase/rest-hooks/commit/dc95f9dbad20d5740218c52c906596b6a3d6eae4))
 * Use optional chaining ([#1003](https://github.com/coinbase/rest-hooks/issues/1003)) ([6e45937](https://github.com/coinbase/rest-hooks/commit/6e459377e3f0d90d1832c0173358c3c73f253831))
 
-
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
 * Update links ([#954](https://github.com/coinbase/rest-hooks/issues/954)) ([80c4f90](https://github.com/coinbase/rest-hooks/commit/80c4f90cc36e26297751fa8d5ee710f819d169b3))
 
-
-
 ## [8.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.4.0...@rest-hooks/normalizr@8.0.0-beta.0) (2021-06-30)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -228,103 +173,71 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Different babel targets for cjs and umd builds ([#989](https://github.com/coinbase/rest-hooks/issues/989)) ([f054814](https://github.com/coinbase/rest-hooks/commit/f05481410cf8daa2101d4dbda826e56ad10ec723))
 * Entities normalize to POJO ([#940](https://github.com/coinbase/rest-hooks/issues/940)) ([75ebdfe](https://github.com/coinbase/rest-hooks/commit/75ebdfe641ccf57fca35c44a94077e4a314e44d7))
 * Remove 'fallback' package.json exports ([#992](https://github.com/coinbase/rest-hooks/issues/992)) ([dc95f9d](https://github.com/coinbase/rest-hooks/commit/dc95f9dbad20d5740218c52c906596b6a3d6eae4))
 
-
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
 * Update links ([#954](https://github.com/coinbase/rest-hooks/issues/954)) ([80c4f90](https://github.com/coinbase/rest-hooks/commit/80c4f90cc36e26297751fa8d5ee710f819d169b3))
 
-
 ## [7.5.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.4.0...@rest-hooks/normalizr@7.5.0) (2021-07-06)
-
 
 ### 🚀 Features
 
 * Allow normalizing entities that are just ids ([#1002](https://github.com/coinbase/rest-hooks/issues/1002)) ([489e1ad](https://github.com/coinbase/rest-hooks/commit/489e1ad3e5e8943ddc3cb24c08947d67379a04c4))
 
-
-
 ## [7.4.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.3.0...@rest-hooks/normalizr@7.4.0) (2021-06-19)
-
 
 ### 🚀 Features
 
 * Add Entity.validate() ([#934](https://github.com/coinbase/rest-hooks/issues/934)) ([b236b91](https://github.com/coinbase/rest-hooks/commit/b236b9137043d12de5a07bfd5583b5cb2d15f6cd))
 
-
 ### 💅 Enhancement
 
 * Improve normalization speed ([#933](https://github.com/coinbase/rest-hooks/issues/933)) ([e68b0f9](https://github.com/coinbase/rest-hooks/commit/e68b0f955e6fab5a84b07012a84cfd6aef9d35dd))
 
-
-
 ## [7.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.2.0...@rest-hooks/normalizr@7.3.0) (2021-06-16)
-
 
 ### 🚀 Features
 
 * Add Entity.expiresAt() - entity TTL configuration  ([#920](https://github.com/coinbase/rest-hooks/issues/920)) ([e0919c2](https://github.com/coinbase/rest-hooks/commit/e0919c2aa523e0a2fc8c6935dcf38953d723527e))
 
-
-
 ## [7.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.1.0...@rest-hooks/normalizr@7.2.0) (2021-06-13)
-
 
 ### 🚀 Features
 
 * Normalize merges entities, entitymeta, indexes ([#915](https://github.com/coinbase/rest-hooks/issues/915)) ([bd21d8c](https://github.com/coinbase/rest-hooks/commit/bd21d8ce0d004a56e6853918d9fb9ecaa2c730a8))
 
-
-
 ## [7.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.0.3...@rest-hooks/normalizr@7.1.0) (2021-06-09)
-
 
 ### 🚀 Features
 
 * Add inferResults() ([#900](https://github.com/coinbase/rest-hooks/issues/900)) ([5ad8287](https://github.com/coinbase/rest-hooks/commit/5ad8287fefd50637670c07252b01ea63ea05333a))
 
-
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ### [7.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.0.1...@rest-hooks/normalizr@7.0.3) (2021-06-02)
-
 
 ### 💅 Enhancement
 
 * Cache entity default instances ([#883](https://github.com/coinbase/rest-hooks/issues/883)) ([842f6c8](https://github.com/coinbase/rest-hooks/commit/842f6c8e3dfc27e2946f5adc1bdbef849e8794ab))
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
-
 ### [7.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.0.1...@rest-hooks/normalizr@7.0.2) (2021-05-30)
 
 **Note:** Version bump only for package @rest-hooks/normalizr
-
-
-
-
 
 ### [7.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@7.0.0...@rest-hooks/normalizr@7.0.1) (2021-05-24)
 
 **Note:** Version bump only for package @rest-hooks/normalizr
 
-
-
-
-
 ## [7.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.1.1...@rest-hooks/normalizr@7.0.0) (2021-05-24)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -336,118 +249,81 @@ processed, id)
 * Remove dependency on fromJS() from denormalize ([#805](https://github.com/coinbase/rest-hooks/issues/805)) ([4387aeb](https://github.com/coinbase/rest-hooks/commit/4387aeb8f050b54a2059bc21f1060a49f539e4f6))
 * Simplify normalize addEntity function ([#820](https://github.com/coinbase/rest-hooks/issues/820)) ([18a805d](https://github.com/coinbase/rest-hooks/commit/18a805d3b6990beadf5426ce28448fd9ee47ad9a))
 
-
-
 ### [6.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.1.0...@rest-hooks/normalizr@6.1.1) (2021-04-25)
-
 
 ### 🐛 Bug Fix
 
 * Delete should only be triggered on finding DELETE symbol ([#770](https://github.com/coinbase/rest-hooks/issues/770)) ([20886f6](https://github.com/coinbase/rest-hooks/commit/20886f65cba2e741e1496990123f97f38852aaf4))
 
-
-
 ## [6.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.9...@rest-hooks/normalizr@6.1.0) (2021-04-24)
-
 
 ### 🚀 Features
 
 * Endpoint parameters can be of any length ([#767](https://github.com/coinbase/rest-hooks/issues/767)) ([552f837](https://github.com/coinbase/rest-hooks/commit/552f83740279376288879a661ff487c5c6f1d469))
 
-
 ### 💅 Enhancement
 
 * Schema assistance for Delete ([#756](https://github.com/coinbase/rest-hooks/issues/756)) ([4dd6a5a](https://github.com/coinbase/rest-hooks/commit/4dd6a5a3f6f0f6bf024731a082dc48afa74cb327))
 
-
-
 ### [6.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.8...@rest-hooks/normalizr@6.0.9) (2021-04-12)
-
 
 ### 🐛 Bug Fix
 
 * Publish legacy type files ([#741](https://github.com/coinbase/rest-hooks/issues/741)) ([bbae8bd](https://github.com/coinbase/rest-hooks/commit/bbae8bd44d9870e7f6ed599b0751ad264f9f2313))
 
-
-
 ### [6.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.7...@rest-hooks/normalizr@6.0.8) (2021-04-12)
-
 
 ### 💅 Enhancement
 
 * All schema members are optional by default ([#716](https://github.com/coinbase/rest-hooks/issues/716)) ([b8c6443](https://github.com/coinbase/rest-hooks/commit/b8c64438bb34bc1f9e9bc1461bd7e4d3bb4e330e))
 * Use namedtuples for denormalize ([#733](https://github.com/coinbase/rest-hooks/issues/733)) ([83382cc](https://github.com/coinbase/rest-hooks/commit/83382cce716ec22949127cc0f190bbeddf5a3722))
 
-
 ### 🐛 Bug Fix
 
 * Denormalizing polymoprhic with undefined no longer crashes ([#735](https://github.com/coinbase/rest-hooks/issues/735)) ([5fc380a](https://github.com/coinbase/rest-hooks/commit/5fc380a941e2af32b4ed4730cd006d38ffacd02a))
 * schema.Values singleSchema denormalization ([#723](https://github.com/coinbase/rest-hooks/issues/723)) ([99317d1](https://github.com/coinbase/rest-hooks/commit/99317d17db8293d6bf987d1cbfa99691cf58903e))
 
-
-
 ### [6.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.6...@rest-hooks/normalizr@6.0.7) (2021-04-04)
 
 **Note:** Version bump only for package @rest-hooks/normalizr
 
-
-
-
-
 ### [6.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.5...@rest-hooks/normalizr@6.0.6) (2021-03-14)
-
 
 ### 📝 Documentation
 
 * Update package tags ([#650](https://github.com/coinbase/rest-hooks/issues/650)) ([4ef465a](https://github.com/coinbase/rest-hooks/commit/4ef465a129cd59668cd9c3542bb9ec03c84d2a4d))
 
-
-
 ### [6.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.4...@rest-hooks/normalizr@6.0.5) (2021-03-08)
-
 
 ### 🐛 Bug Fix
 
 * **pkg:** Fix build scripts on windows ([#622](https://github.com/coinbase/rest-hooks/issues/622)) ([c86f00e](https://github.com/coinbase/rest-hooks/commit/c86f00e4529d2bcc53652f40aa17bd7839b9b1c7))
 
-
-
 ### [6.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.3...@rest-hooks/normalizr@6.0.4) (2021-03-03)
-
 
 ### 🐛 Bug Fix
 
 * Handle nulls when schema expects something ([#615](https://github.com/coinbase/rest-hooks/issues/615)) ([0afd813](https://github.com/coinbase/rest-hooks/commit/0afd813a5aa71683590fbbc97bbbc96c9c2bdf12))
 
-
-
 ### [6.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.2...@rest-hooks/normalizr@6.0.3) (2021-03-01)
-
 
 ### 💅 Enhancement
 
 * Support 'undefined' as schema ([#583](https://github.com/coinbase/rest-hooks/issues/583)) ([1e81470](https://github.com/coinbase/rest-hooks/commit/7ef172a3d8469b182cc7a19055920a308841b59e))
 * Throw useful error when schema key is missing from Entity ([#585](https://github.com/coinbase/rest-hooks/issues/585)) ([b5ed83a](https://github.com/coinbase/rest-hooks/commit/b5ed83a8e9e4b3a20b50f8f0b5d1d1a1e876fa81))
 
-
 ### 🐛 Bug Fix
 
 * Exclude browserslist config from published package ([#589](https://github.com/coinbase/rest-hooks/issues/589)) ([2e14d30](https://github.com/coinbase/rest-hooks/commit/2e14d300d24d21ced6d8f24004881396023dc722))
 * Gracefully handle primitive entity responses ([#584](https://github.com/coinbase/rest-hooks/issues/584)) ([322b4c6](https://github.com/coinbase/rest-hooks/commit/322b4c6615ea02b09baf0bcfc9b214bb8be1ba4f))
 
-
-
 ### [6.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.1...@rest-hooks/normalizr@6.0.2) (2021-02-04)
-
 
 ### 📦 Package
 
 * Relax @babel/runtime requirement to ^7.7.2 ([#513](https://github.com/coinbase/rest-hooks/issues/513)) ([cc95b21](https://github.com/coinbase/rest-hooks/commit/cc95b219fbddebfbf334728887ca6d2fa070fce1))
 
-
-
 ### [6.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0...@rest-hooks/normalizr@6.0.1) (2021-01-24)
-
 
 ### 💅 Enhancement
 
@@ -455,15 +331,11 @@ processed, id)
 * Add jsdocs deprecations to deprecated methods ([#487](https://github.com/coinbase/rest-hooks/issues/487)) ([cc7d626](https://github.com/coinbase/rest-hooks/commit/cc7d6269e752335e6502b7ada0da21a881c2afb6))
 * Improve malformed entity detection ([#494](https://github.com/coinbase/rest-hooks/issues/494)) ([b8bb07f](https://github.com/coinbase/rest-hooks/commit/b8bb07f480549a97254a4fdf6b00acd9cb89a9eb))
 
-
 ### 🐛 Bug Fix
 
 * Support TypeScript <4 ([#489](https://github.com/coinbase/rest-hooks/issues/489)) ([267b541](https://github.com/coinbase/rest-hooks/commit/267b5412cf4e65f6e523aad764203b91a92cc427))
 
-
-
 ## 6.0.0 (2021-01-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -493,7 +365,6 @@ recursion.
 * Simplified Entity class ([#315](https://github.com/coinbase/rest-hooks/issues/315)) ([0e6bfcb](https://github.com/coinbase/rest-hooks/commit/0e6bfcb3620006e285510d4e5121fce743214d55))
 * Support string schemas ([#222](https://github.com/coinbase/rest-hooks/issues/222)) ([3f025de](https://github.com/coinbase/rest-hooks/commit/3f025def8de1d949962f99c4411bca86a2e22b1f))
 
-
 ### 💅 Enhancement
 
 * Better dev error messaging with unexpected string to normalize ([#342](https://github.com/coinbase/rest-hooks/issues/342)) ([efc1b60](https://github.com/coinbase/rest-hooks/commit/efc1b609dc6e3b61b48f69a6bcb51c268cd39ef1))
@@ -513,7 +384,6 @@ recursion.
 * Use minified build for es modules ([a1a760c](https://github.com/coinbase/rest-hooks/commit/a1a760c74f5f389951ec1c827403e02bf5fb2442))
 * Warn about using asSchema() in dev-mode ([35b680e](https://github.com/coinbase/rest-hooks/commit/35b680e4d6ecea309d62a140941042fa2b0d1f0b))
 
-
 ### 🐛 Bug Fix
 
 * Allow for multiple pk methods ([#333](https://github.com/coinbase/rest-hooks/issues/333)) ([7ea9ed9](https://github.com/coinbase/rest-hooks/commit/7ea9ed9ee4701b2ba1bb1cf29743ae755ed909e8))
@@ -530,14 +400,12 @@ recursion.
 * TypeScript 4 compatibility ([#406](https://github.com/coinbase/rest-hooks/issues/406)) ([5d82e24](https://github.com/coinbase/rest-hooks/commit/5d82e2416b68992f6efccb63f694010ef1ea28e8))
 * **schemas:** don't use schema to attribute mapping on singular array schemas ([a39d3e5](https://github.com/coinbase/rest-hooks/commit/a39d3e5402adfaef4651e0e8efeea0f1587186d5))
 
-
 ### 📦 Package
 
 * Build things ([9d386aa](https://github.com/coinbase/rest-hooks/commit/9d386aa1ab944159f5ed4576b81d8d5e5f67847b))
 * Bump babel runtime ([c6bf844](https://github.com/coinbase/rest-hooks/commit/c6bf844fcf1a483988d34b5f09faa03ceff179ec))
 * Bump internal pkgs ([#306](https://github.com/coinbase/rest-hooks/issues/306)) ([46bebad](https://github.com/coinbase/rest-hooks/commit/46bebad79d848404d02423fd2a3e2d647ee5bbbb))
 * Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a8c435c5ef74b3809c8950a2caceca8763))
-
 
 ### 📝 Documentation
 
@@ -546,14 +414,11 @@ recursion.
 * Get rid of all references to asSchema() ([#339](https://github.com/coinbase/rest-hooks/issues/339)) ([01b878b](https://github.com/coinbase/rest-hooks/commit/01b878b85f7469a12e19912efc696a424663e5f5))
 * Switch to 'gamma' channel ([f932659](https://github.com/coinbase/rest-hooks/commit/f93265924bedf66c2f5ef6958f2f850849b5186a))
 
-
-
 ## 6.0.0-rc.0 (2021-01-14)
 
 * enhance: Inferred endpoints expiry based on entities (#464) ([975e0d8](https://github.com/coinbase/rest-hooks/commit/975e0d8)), closes [#464](https://github.com/coinbase/rest-hooks/issues/464)
 * enhance: Maintain referential equality globally (#403) ([e1e353d](https://github.com/coinbase/rest-hooks/commit/e1e353d)), closes [#403](https://github.com/coinbase/rest-hooks/issues/403)
 * internal: add missing dev dep ([51fc222](https://github.com/coinbase/rest-hooks/commit/51fc222))
-
 
 ### BREAKING CHANGE
 
@@ -561,72 +426,40 @@ recursion.
 * useResource() inferred endpoint will sometimes
 not trigger a fetch if entities are fresh enough
 
-
-
-
 ## 6.0.0-k.0 (2021-01-06)
 
 * pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
 * fix: TypeScript 4 compatibility (#406) ([5d82e24](https://github.com/coinbase/rest-hooks/commit/5d82e24)), closes [#406](https://github.com/coinbase/rest-hooks/issues/406)
 * internal: Upgrade build pkgs (#404) ([dc56530](https://github.com/coinbase/rest-hooks/commit/dc56530)), closes [#404](https://github.com/coinbase/rest-hooks/issues/404)
 
-
-
-
-
 ## 6.0.0-j.2 (2020-08-04)
 
 * fix: Handle entities updated with new indexes (#384) ([2ee3bb6](https://github.com/coinbase/rest-hooks/commit/2ee3bb6)), closes [#384](https://github.com/coinbase/rest-hooks/issues/384)
 * internal: Only import what is used (#383) ([10fef0c](https://github.com/coinbase/rest-hooks/commit/10fef0c)), closes [#383](https://github.com/coinbase/rest-hooks/issues/383)
 
-
-
-
-
 ## 6.0.0-j.1 (2020-07-31)
 
 * enhance: Normalizr ES build should be split into modules for code splitting (#381) ([c543a31](https://github.com/coinbase/rest-hooks/commit/c543a31)), closes [#381](https://github.com/coinbase/rest-hooks/issues/381)
-
-
-
-
 
 ## 6.0.0-j.0 (2020-07-27)
 
 * fix: Make normalizr commonjs bundle transpile classes ([6812990](https://github.com/coinbase/rest-hooks/commit/6812990))
 
-
-
-
-
 ## 6.0.0-i.1 (2020-07-22)
 
 * fix: Ambient files now typechecked, fixed some types there (#372) ([223d4a4](https://github.com/coinbase/rest-hooks/commit/223d4a4)), closes [#372](https://github.com/coinbase/rest-hooks/issues/372)
-
-
-
-
 
 ## 6.0.0-i.0 (2020-07-20)
 
 * build(deps): bump lodash in /packages/normalizr/examples/redux (#367) ([7e8c191](https://github.com/coinbase/rest-hooks/commit/7e8c191)), closes [#367](https://github.com/coinbase/rest-hooks/issues/367)
 
-
-
-
-
 ## 6.0.0-h.0 (2020-07-13)
 
 * pkg: Bump babel runtime ([c6bf844](https://github.com/coinbase/rest-hooks/commit/c6bf844))
 
-
-
-
-
 ## 6.0.0-delta.0 (2020-07-08)
 
 * feat: Deletes and invalidates trigger suspense always (#360) ([96175ba](https://github.com/coinbase/rest-hooks/commit/96175ba)), closes [#360](https://github.com/coinbase/rest-hooks/issues/360)
-
 
 ### BREAKING CHANGE
 
@@ -638,26 +471,15 @@ not trigger a fetch if entities are fresh enough
 - required entities missing from network response will now throw error in useResource() just like other unexpected deserializations
 - FetchShape type is now just 'read' | 'mutate'. No more 'delete'. (use schema.Delete())
 
-
-
-
 ## 6.0.0-gamma.2 (2020-06-13)
 
 * docs: Fix normalizr docs links ([11c2995](https://github.com/coinbase/rest-hooks/commit/11c2995))
 * docs: Switch to 'gamma' channel ([f932659](https://github.com/coinbase/rest-hooks/commit/f932659))
 
-
-
-
-
 ## 6.0.0-beta.12 (2020-06-13)
 
 * docs: Add field deserialization ([05686cb](https://github.com/coinbase/rest-hooks/commit/05686cb))
 * feat: Declarative schema deserialization (#355) ([9dbb019](https://github.com/coinbase/rest-hooks/commit/9dbb019)), closes [#355](https://github.com/coinbase/rest-hooks/issues/355)
-
-
-
-
 
 ## 6.0.0-beta.11 (2020-06-06)
 
@@ -666,44 +488,29 @@ not trigger a fetch if entities are fresh enough
 * internal: Add test for complex schema.Values() case (#349) ([d14802a](https://github.com/coinbase/rest-hooks/commit/d14802a)), closes [#349](https://github.com/coinbase/rest-hooks/issues/349)
 * internal: eslint major, plugin minor ([1532f7a](https://github.com/coinbase/rest-hooks/commit/1532f7a))
 
-
-
-
-
 ## [6.0.0-beta.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.9...@rest-hooks/normalizr@6.0.0-beta.10) (2020-05-20)
-
 
 ### 🐛 Bug Fix
 
 * Types for nested nullable Record or Entity account for not finding nested pieces ([#345](https://github.com/coinbase/rest-hooks/issues/345)) ([f822b53](https://github.com/coinbase/rest-hooks/commit/f822b53487deedf5ae85909584ed5d8343a9cef8))
 
-
-
 ## [6.0.0-beta.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.8...@rest-hooks/normalizr@6.0.0-beta.9) (2020-05-19)
-
 
 ### 🐛 Bug Fix
 
 * Types need to be exported ([0bf5aac](https://github.com/coinbase/rest-hooks/commit/0bf5aac7d41ec8f4795d77f03eba2d426765aff7))
 
-
-
 ## [6.0.0-beta.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.7...@rest-hooks/normalizr@6.0.0-beta.8) (2020-05-19)
-
 
 ### 🐛 Bug Fix
 
 * Import types properly into schema.d.ts ([2d95f55](https://github.com/coinbase/rest-hooks/commit/2d95f554702c1d882f38448ff339528333ef58ad))
 
-
-
 ## [6.0.0-beta.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.6...@rest-hooks/normalizr@6.0.0-beta.7) (2020-05-19)
-
 
 ### 💅 Enhancement
 
 * Better dev error messaging with unexpected string to normalize ([#342](https://github.com/coinbase/rest-hooks/issues/342)) ([efc1b60](https://github.com/coinbase/rest-hooks/commit/efc1b609dc6e3b61b48f69a6bcb51c268cd39ef1))
-
 
 ### 🏠 Internal
 
@@ -711,85 +518,60 @@ not trigger a fetch if entities are fresh enough
 * Add test for taking string response when expecting entity ([dfb2625](https://github.com/coinbase/rest-hooks/commit/dfb26259f47a21c7d95e9edc38a73e5db1367158))
 * Add test: methods are not expected in Entities ([d7c26e6](https://github.com/coinbase/rest-hooks/commit/d7c26e6a0c40b4fd059c496670f9dff394fc6c62))
 
-
-
 ## [6.0.0-beta.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.5...@rest-hooks/normalizr@6.0.0-beta.6) (2020-05-14)
-
 
 ### 💅 Enhancement
 
 * Rename merge variables to (existing, incoming) ([#340](https://github.com/coinbase/rest-hooks/issues/340)) ([1d68c30](https://github.com/coinbase/rest-hooks/commit/1d68c30c4b07204d20782f257c9bf0b0fd594c7c))
 
-
 ### 📝 Documentation
 
 * Get rid of all references to asSchema() ([#339](https://github.com/coinbase/rest-hooks/issues/339)) ([01b878b](https://github.com/coinbase/rest-hooks/commit/01b878b85f7469a12e19912efc696a424663e5f5))
 
-
-
 ## [6.0.0-beta.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.4...@rest-hooks/normalizr@6.0.0-beta.5) (2020-05-13)
-
 
 ### 💅 Enhancement
 
 * Include merge() in EntityInterface ([709cb38](https://github.com/coinbase/rest-hooks/commit/709cb380fa765c459a2b3edb72f7b7187c968f29))
 
-
-
 ## [6.0.0-beta.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.3...@rest-hooks/normalizr@6.0.0-beta.4) (2020-05-13)
-
 
 ### 💅 Enhancement
 
 * Improve malformed entity normalization algorithm ([#338](https://github.com/coinbase/rest-hooks/issues/338)) ([b6032b2](https://github.com/coinbase/rest-hooks/commit/b6032b21aec1e982b4b1abcbddbd28593b86c91b))
 * Warn about using asSchema() in dev-mode ([35b680e](https://github.com/coinbase/rest-hooks/commit/35b680e4d6ecea309d62a140941042fa2b0d1f0b))
 
-
-
 ## [6.0.0-beta.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.2...@rest-hooks/normalizr@6.0.0-beta.3) (2020-05-12)
-
 
 ### 🚀 Features
 
 * Allow SimpleRecords to be schemas ([#334](https://github.com/coinbase/rest-hooks/issues/334)) ([924c257](https://github.com/coinbase/rest-hooks/commit/924c2579f740434f62e3597503b2d4fb53b76916))
 
-
 ### 💅 Enhancement
 
 * No longer require 'asSchema()' ([#335](https://github.com/coinbase/rest-hooks/issues/335)) ([a29c41b](https://github.com/coinbase/rest-hooks/commit/a29c41b4449741e0e589d513261186e1a1cbe98a))
 
-
-
 ## [6.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.1...@rest-hooks/normalizr@6.0.0-beta.2) (2020-05-08)
-
 
 ### 💅 Enhancement
 
 * Detect more cases of network mismatching schema ([#331](https://github.com/coinbase/rest-hooks/issues/331)) ([2af464f](https://github.com/coinbase/rest-hooks/commit/2af464f54318c5f099899150371c911133a717cb))
 
-
 ### 🐛 Bug Fix
 
 * Allow for multiple pk methods ([#333](https://github.com/coinbase/rest-hooks/issues/333)) ([7ea9ed9](https://github.com/coinbase/rest-hooks/commit/7ea9ed9ee4701b2ba1bb1cf29743ae755ed909e8))
-
 
 ### 🏠 Internal
 
 * Improve test coverage ([#330](https://github.com/coinbase/rest-hooks/issues/330)) ([edc5f73](https://github.com/coinbase/rest-hooks/commit/edc5f73471fc2b68a95b4ef09d883e7dab016d7d))
 
-
-
 ## [6.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@6.0.0-beta.0...@rest-hooks/normalizr@6.0.0-beta.1) (2020-05-04)
-
 
 ### 🚀 Features
 
 * Entity fully denormalizes & Entity -> FlatEntity for non-nested ([#328](https://github.com/coinbase/rest-hooks/issues/328)) ([dd5e513](https://github.com/coinbase/rest-hooks/commit/dd5e5130e317bec5572f00e0d2a192ba2f1ea8cb))
 
-
-
 ## [6.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@5.0.6...@rest-hooks/normalizr@6.0.0-beta.0) (2020-04-26)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -800,96 +582,63 @@ recursion.
 
 * Simplified Entity class ([#315](https://github.com/coinbase/rest-hooks/issues/315)) ([0e6bfcb](https://github.com/coinbase/rest-hooks/commit/0e6bfcb3620006e285510d4e5121fce743214d55))
 
-
 ### 💅 Enhancement
 
 * More readable array return types ([#314](https://github.com/coinbase/rest-hooks/issues/314)) ([4ac8918](https://github.com/coinbase/rest-hooks/commit/4ac8918df19a4d386ff717c3ceef40e151c60c1f))
 
-
 ### 📦 Package
 
 * Bump internal pkgs ([#306](https://github.com/coinbase/rest-hooks/issues/306)) ([46bebad](https://github.com/coinbase/rest-hooks/commit/46bebad79d848404d02423fd2a3e2d647ee5bbbb))
-
 
 ### 🏠 Internal
 
 * Hoist coveralls to root, since testing is done there ([3b1dbaa](https://github.com/coinbase/rest-hooks/commit/3b1dbaac303048a1b1e543f99fb9758b21feb083))
 * Update packages in redux example ([dbba679](https://github.com/coinbase/rest-hooks/commit/dbba67935a7b756d66ce7b6cb9e2d93e7f2ce44a))
 
-
-
 ### [5.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@5.0.5...@rest-hooks/normalizr@5.0.6) (2020-03-13)
-
 
 ### 🐛 Bug Fix
 
 * Schema can be null (for media) ([#293](https://github.com/coinbase/rest-hooks/issues/293)) ([003b3ca](https://github.com/coinbase/rest-hooks/commit/003b3ca53703174b66c5fc9d546d2b340e293e86))
 
-
-
 ### [5.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@5.0.4...@rest-hooks/normalizr@5.0.5) (2020-02-26)
-
 
 ### 🏠 Internal
 
 * readonly should exist on all levels of internal state ([#276](https://github.com/coinbase/rest-hooks/issues/276)) ([a884186](https://github.com/coinbase/rest-hooks/commit/a884186e2696b40ab764979d646089aa625dfe8d))
 * Use Record<string, any> form for POJOs ([dae11b2](https://github.com/coinbase/rest-hooks/commit/dae11b233d4cc3d56ba93f1488a0b42ba7a1dfce))
 
-
-
 ### [5.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@5.0.3...@rest-hooks/normalizr@5.0.4) (2020-02-19)
-
 
 ### 🏠 Internal
 
 * Check compressed size changes on PR ([#270](https://github.com/coinbase/rest-hooks/issues/270)) ([d70ccbf](https://github.com/coinbase/rest-hooks/commit/d70ccbf44ac5ba8fdc4f70886851ab18349f37e6))
 
-
-
 ### [5.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@5.0.3-beta.0...@rest-hooks/normalizr@5.0.3) (2020-02-18)
 
 **Note:** Version bump only for package @rest-hooks/normalizr
 
-
-
-
-
 ### [5.0.3-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@5.0.2...@rest-hooks/normalizr@5.0.3-beta.0) (2020-02-18)
-
 
 ### 🏠 Internal
 
 * Centralize jest config ([#230](https://github.com/coinbase/rest-hooks/issues/230)) ([5d769d2](https://github.com/coinbase/rest-hooks/commit/5d769d2485fe62ba65f4176894768bdbb6faafb3))
 
-
-
 ### [5.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@5.0.2-beta.0...@rest-hooks/normalizr@5.0.2) (2020-02-10)
 
 **Note:** Version bump only for package @rest-hooks/normalizr
-
-
-
-
 
 ### [5.0.2-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@5.0.1...@rest-hooks/normalizr@5.0.2-beta.0) (2020-02-04)
 
 **Note:** Version bump only for package @rest-hooks/normalizr
 
-
-
-
-
 ### [5.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@5.0.0...@rest-hooks/normalizr@5.0.1) (2020-01-29)
-
 
 ### 🐛 Bug Fix
 
 * ES export is non-min version ([4b04b62](https://github.com/coinbase/rest-hooks/commit/4b04b629e67cce295c82743cb6d3a6d9f99df506))
 
-
-
 ## [5.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@4.3.3...@rest-hooks/normalizr@5.0.0) (2020-01-29)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -900,89 +649,63 @@ recursion.
 * Only export one denormalize ([3f77da2](https://github.com/coinbase/rest-hooks/commit/3f77da206c1e4bc4065b98c8bdcfcfa3693586b7))
 * Use minified build for es modules ([a1a760c](https://github.com/coinbase/rest-hooks/commit/a1a760c74f5f389951ec1c827403e02bf5fb2442))
 
-
 ### 🐛 Bug Fix
 
 * **schemas:** don't use schema to attribute mapping on singular array schemas ([a39d3e5](https://github.com/coinbase/rest-hooks/commit/a39d3e5402adfaef4651e0e8efeea0f1587186d5))
-
 
 ### 🏠 Internal
 
 * Upgrade jest to 25 ([#253](https://github.com/coinbase/rest-hooks/issues/253)) ([745a253](https://github.com/coinbase/rest-hooks/commit/745a2532cb1ec3471f1fcb9c90fd87ffb55d6d1a))
 
-
-
 ### [4.3.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@4.3.2...@rest-hooks/normalizr@4.3.3) (2020-01-27)
-
 
 ### 💅 Enhancement
 
 * Keep referential equality in list views ([#251](https://github.com/coinbase/rest-hooks/issues/251)) ([caf2bf7](https://github.com/coinbase/rest-hooks/commit/caf2bf78e6c48af8a32b080291ae60615ad05b34))
 
-
-
 ### [4.3.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@4.3.1...@rest-hooks/normalizr@4.3.2) (2020-01-18)
-
 
 ### 🐛 Bug Fix
 
 * Support extra members of schema that are empty in denormalize ([#244](https://github.com/coinbase/rest-hooks/issues/244)) ([86b1e0a](https://github.com/coinbase/rest-hooks/commit/86b1e0a30b87156f144629df8e24933a7f90ba66))
 
-
-
 ### [4.3.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@4.3.0...@rest-hooks/normalizr@4.3.1) (2020-01-18)
-
 
 ### 🐛 Bug Fix
 
 * Support extra members of schema that are only sometimes empty ([#243](https://github.com/coinbase/rest-hooks/issues/243)) ([74916a3](https://github.com/coinbase/rest-hooks/commit/74916a3f9c5a0e5a9843a6211517dfeff1b86eb6))
 
-
-
 ## [4.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@4.2.0...@rest-hooks/normalizr@4.3.0) (2020-01-17)
-
 
 ### 🚀 Features
 
 * Add indexes to Entity for improved performance ([#237](https://github.com/coinbase/rest-hooks/issues/237)) ([a2339f0](https://github.com/coinbase/rest-hooks/commit/a2339f0e61e9446da87af85440061b060ad0f444))
 
-
-
 ## [4.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@4.1.1...@rest-hooks/normalizr@4.2.0) (2020-01-06)
-
 
 ### 🚀 Features
 
 * Entity class added to Resource hierarchy ([#226](https://github.com/coinbase/rest-hooks/issues/226)) ([7c4efb7](https://github.com/coinbase/rest-hooks/commit/7c4efb7a55efbffa8a0cab3dab1b39e69535df49))
 
-
-
 ### [4.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@4.1.0...@rest-hooks/normalizr@4.1.1) (2020-01-05)
-
 
 ### 💅 Enhancement
 
 * Remove extraneous logic - schema is not allowed to be null ([775cc8a](https://github.com/coinbase/rest-hooks/commit/775cc8a47a7d016f3f33766aee83a0154b7385ac))
 
-
 ### 📦 Package
 
 * Build things ([9d386aa](https://github.com/coinbase/rest-hooks/commit/9d386aa1ab944159f5ed4576b81d8d5e5f67847b))
-
 
 ### 🏠 Internal
 
 * Run normalizr typescript tests ([#223](https://github.com/coinbase/rest-hooks/issues/223)) ([17a3f84](https://github.com/coinbase/rest-hooks/commit/17a3f84a390762173843736ad0b2d6a3ef8e031f))
 
-
-
 ## 4.1.0 (2019-12-31)
-
 
 ### 🚀 Features
 
 * Support string schemas ([#222](https://github.com/coinbase/rest-hooks/issues/222)) ([3f025de](https://github.com/coinbase/rest-hooks/commit/3f025def8de1d949962f99c4411bca86a2e22b1f))
-
 
 ### 🏠 Internal
 

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "8.2.10",
+  "version": "8.2.11",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,101 +3,71 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [6.3.8](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.7...rest-hooks@6.3.8) (2022-07-23)
+### [6.3.9](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.8...rest-hooks@6.3.9) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [6.3.8](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.7...rest-hooks@6.3.8) (2022-07-23)
 
 ### 🐛 Bug Fix
 
 * Ensure dual package hazard solved for non-node ([#2099](https://github.com/coinbase/rest-hooks/issues/2099)) ([6206e64](https://github.com/coinbase/rest-hooks/commit/6206e6463a7c3699d5c1d1b248e4d5418b1327f1))
 
-
-
 ### [6.3.7](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.4...rest-hooks@6.3.7) (2022-07-20)
-
 
 ### 🐛 Bug Fix
 
 * Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
 
-
-
 ### [6.3.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.3...rest-hooks@6.3.4) (2022-05-30)
-
 
 ### 📦 Package
 
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
 
-
-
 ### [6.3.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.2...rest-hooks@6.3.3) (2022-04-30)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ### [6.3.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.1...rest-hooks@6.3.2) (2022-04-16)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [6.3.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.0...rest-hooks@6.3.1) (2022-04-11)
-
 
 ### 💅 Enhancement
 
 * autopause devtools by default ([#1902](https://github.com/coinbase/rest-hooks/issues/1902)) ([586fa3c](https://github.com/coinbase/rest-hooks/commit/586fa3c0eaf4a2952e695bbb4fc1c1d216a3e833))
 
-
-
 ## [6.3.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.3...rest-hooks@6.3.0) (2022-04-10)
-
 
 ### 🚀 Features
 
 * Export useDLE() ([#1879](https://github.com/coinbase/rest-hooks/issues/1879)) ([25d57f3](https://github.com/coinbase/rest-hooks/commit/25d57f3729fda7c4dc50329588ce3c15d345b692))
 
-
-
 ### [6.2.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.2...rest-hooks@6.2.3) (2022-04-08)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [6.2.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.1...rest-hooks@6.2.2) (2022-04-02)
-
 
 ### 💅 Enhancement
 
 * More exact optional type handling ([#1858](https://github.com/coinbase/rest-hooks/issues/1858)) ([0459dbd](https://github.com/coinbase/rest-hooks/commit/0459dbdc3fe1555c5e6dc80290187ec8297d1aa6))
 
-
-
 ### [6.2.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.10...rest-hooks@6.2.1) (2022-04-01)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [6.2.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.1.7...rest-hooks@6.2.0) (2022-03-17)
-
 
 ### 🚀 Features
 
 * Add endpoint.getOptimisticResponse ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98)) ([#1769](https://github.com/coinbase/rest-hooks/issues/1769)) ([4d1cd66](https://github.com/coinbase/rest-hooks/commit/4d1cd66ea2677868aba402d362b9896dffc24462))
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
 * Entity.useIncoming() for race condition handling ([#1771](https://github.com/coinbase/rest-hooks/issues/1771)) ([ffd70fe](https://github.com/coinbase/rest-hooks/commit/ffd70fe0aa12634d06d2e0d43a5b89d420e2220c))
-
 
 ### 💅 Enhancement
 
@@ -114,145 +84,91 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * InvalidIfStale should be respected in no-schema endpoints ([#1724](https://github.com/coinbase/rest-hooks/issues/1724)) ([28fab73](https://github.com/coinbase/rest-hooks/commit/28fab739952aae6819ddfcaafe9fcb3c893f8d2f))
 * Union schemas with null args[0] hooks ([#1779](https://github.com/coinbase/rest-hooks/issues/1779)) ([fcf70a9](https://github.com/coinbase/rest-hooks/commit/fcf70a92ef15531b7fd12feb117f29ad8c3de3d8)
 
-
 ### 📝 Documentation
 
 * Use stackblitz for demos ([#1699](https://github.com/coinbase/rest-hooks/issues/1699)) ([ee7b4ca](https://github.com/coinbase/rest-hooks/commit/ee7b4ca6fbe5ccea4ea32a52885bf9fe64cbb947))
-
-
 
 ## [6.2.0-beta.10](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.9...rest-hooks@6.2.0-beta.10) (2022-03-10)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [6.2.0-beta.9](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.7...rest-hooks@6.2.0-beta.9) (2022-03-08)
-
 
 ### 💅 Enhancement
 
 * Use BackupBoundary to help debug setup issues ([3a68907](https://github.com/coinbase/rest-hooks/commit/3a68907882f35c3806b05244e68d61e503b91d0f))
-
 
 ### 🐛 Bug Fix
 
 * NetworkErrorBoundary should render Element ([#1775](https://github.com/coinbase/rest-hooks/issues/1775)) ([5e3cfd2](https://github.com/coinbase/rest-hooks/commit/5e3cfd28fda0e27319267e671500591f22f87d74))
 
-
-
 ## [6.2.0-beta.8](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.7...rest-hooks@6.2.0-beta.8) (2022-03-01)
-
 
 ### 💅 Enhancement
 
 * Use BackupBoundary to help debug setup issues ([3a68907](https://github.com/coinbase/rest-hooks/commit/3a68907882f35c3806b05244e68d61e503b91d0f))
 
-
-
 ## [6.2.0-beta.7](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.6...rest-hooks@6.2.0-beta.7) (2022-02-26)
-
 
 ### 💅 Enhancement
 
 * Devtools improvements ([#1743](https://github.com/coinbase/rest-hooks/issues/1743)) ([db2fd59](https://github.com/coinbase/rest-hooks/commit/db2fd590532c51f72165167c9e807ac2c26deab2))
 
-
-
 ## [6.2.0-beta.6](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.5...rest-hooks@6.2.0-beta.6) (2022-02-26)
-
 
 ### 💅 Enhancement
 
 * Format timestamps in redux devtools for ease of reading ([#1739](https://github.com/coinbase/rest-hooks/issues/1739)) ([6169f84](https://github.com/coinbase/rest-hooks/commit/6169f8417c304b52954a166e8f3f60fb4ba70747))
 
-
 ### 🐛 Bug Fix
 
 * Loosen PromiseifyMiddleware types to only what is needed ([#1735](https://github.com/coinbase/rest-hooks/issues/1735)) ([4831bd6](https://github.com/coinbase/rest-hooks/commit/4831bd64762554a7f46cff1699346200cecf4426))
 
-
-
 ## [6.2.0-beta.5](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.3...rest-hooks@6.2.0-beta.5) (2022-02-15)
-
 
 ### 📝 Documentation
 
 * Use stackblitz for demos ([#1699](https://github.com/coinbase/rest-hooks/issues/1699)) ([ee7b4ca](https://github.com/coinbase/rest-hooks/commit/ee7b4ca6fbe5ccea4ea32a52885bf9fe64cbb947))
 
-
-
 ## [6.2.0-beta.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.3...rest-hooks@6.2.0-beta.4) (2022-01-31)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [6.2.0-beta.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.2...rest-hooks@6.2.0-beta.3) (2022-01-23)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 
-
-
 ## [6.2.0-beta.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.2.0-beta.1...rest-hooks@6.2.0-beta.2) (2021-11-26)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [6.2.0-beta.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.1.7...rest-hooks@6.2.0-beta.0) (2021-10-24)
-
 
 ### 🚀 Features
 
 * useSuspense, useFetch, remaining hooks typed for Endpoint ([#1440](https://github.com/coinbase/rest-hooks/issues/1440)) ([2039d2c](https://github.com/coinbase/rest-hooks/commit/2039d2c4bf280b5a3c570824c25af3a4cc39af0d))
 
-
-
 ### [6.1.7](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.1.6...rest-hooks@6.1.7) (2021-10-21)
-
 
 ### 🐛 Bug Fix
 
 * passthrough error that are not NetworkError on NetworkErrorBoundary ([#1426](https://github.com/coinbase/rest-hooks/issues/1426)) ([34eb395](https://github.com/coinbase/rest-hooks/commit/34eb39531cc6fe2c24bc298000a368466773a5e6))
 
-
-
 ### [6.1.6](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.1.5...rest-hooks@6.1.6) (2021-10-20)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ### [6.1.5](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.1.4...rest-hooks@6.1.5) (2021-10-18)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [6.1.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.1.3...rest-hooks@6.1.4) (2021-10-17)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [6.1.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.1.2...rest-hooks@6.1.3) (2021-10-11)
-
 
 ### 📝 Documentation
 
@@ -262,27 +178,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Rearrange homepage ([#1352](https://github.com/coinbase/rest-hooks/issues/1352)) ([404b2b0](https://github.com/coinbase/rest-hooks/commit/404b2b0eaeea9be71594e031f9763b09c6c8fee7))
 * Reorganize docs ([#1345](https://github.com/coinbase/rest-hooks/issues/1345)) ([fa49b6b](https://github.com/coinbase/rest-hooks/commit/fa49b6bcf1d6838b85ce21e728f0630e2746e68f))
 
-
-
 ### [6.1.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.1.1...rest-hooks@6.1.2) (2021-09-29)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [6.1.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.1.0...rest-hooks@6.1.1) (2021-09-29)
-
 
 ### 📝 Documentation
 
 * Homepage has live code preview ([#1225](https://github.com/coinbase/rest-hooks/issues/1225)) ([1263430](https://github.com/coinbase/rest-hooks/commit/12634308d513fd252b5f33ba3255cc548028b889))
 
-
-
 ## [6.1.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.1...rest-hooks@6.1.0) (2021-09-19)
-
 
 ### 🚀 Features
 
@@ -290,69 +196,46 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Export useController() ([#1269](https://github.com/coinbase/rest-hooks/issues/1269)) ([baa31d8](https://github.com/coinbase/rest-hooks/commit/baa31d8c78aa26cd8da88b93804f8a014fbbe63c))
 * Send controller to middlewares ([#1271](https://github.com/coinbase/rest-hooks/issues/1271)) ([29db53c](https://github.com/coinbase/rest-hooks/commit/29db53c8ee7f5d770dd43b6e3d97346bc77f76d7))
 
-
-
 ### [6.0.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.0...rest-hooks@6.0.1) (2021-09-14)
-
 
 ### 🐛 Bug Fix
 
 * Provide same referential guarantees when using redux ([#1240](https://github.com/coinbase/rest-hooks/issues/1240)) ([a4db2ed](https://github.com/coinbase/rest-hooks/commit/a4db2eda51d730fbdd835285aa06b5970197f7eb))
 
-
-
 ## [6.0.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.0-beta.6...rest-hooks@6.0.0) (2021-09-08)
-
 
 ### 📝 Documentation
 
 * Add links to protocol specific docs ([#1218](https://github.com/coinbase/rest-hooks/issues/1218)) ([1570881](https://github.com/coinbase/rest-hooks/commit/1570881372bb1cc0a3d4034c24543bb8ea5d99c1))
 * Add more tags to packages ([#1223](https://github.com/coinbase/rest-hooks/issues/1223)) ([ef76efc](https://github.com/coinbase/rest-hooks/commit/ef76efc70f7c6acb73d22135a227f84e522729b4))
 
-
-
 ## [6.0.0-beta.6](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.0-beta.5...rest-hooks@6.0.0-beta.6) (2021-09-06)
-
 
 ### 📝 Documentation
 
 * Use current docs folder as 5.0 version ([#1170](https://github.com/coinbase/rest-hooks/issues/1170)) ([03ae6f4](https://github.com/coinbase/rest-hooks/commit/03ae6f49bd97de2a28f75b46257e33d936940e33))
 
-
-
 ## [6.0.0-beta.5](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.0-beta.4...rest-hooks@6.0.0-beta.5) (2021-08-25)
-
 
 ### 💅 Enhancement
 
 * Back to avoiding reducer for fetch ([#1149](https://github.com/coinbase/rest-hooks/issues/1149)) ([06ae6a4](https://github.com/coinbase/rest-hooks/commit/06ae6a450f65f0344a44e2c8d162b62e7461bfe8))
 
-
-
 ## [6.0.0-beta.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.0-beta.3...rest-hooks@6.0.0-beta.4) (2021-08-22)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [6.0.0-beta.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.0-beta.2...rest-hooks@6.0.0-beta.3) (2021-08-21)
-
 
 ### 💅 Enhancement
 
 * Hide throttled fetches from devtools ([#1083](https://github.com/coinbase/rest-hooks/issues/1083)) ([2f09c22](https://github.com/coinbase/rest-hooks/commit/2f09c227ef9dcc056a4e9f1c76b725aa063964d6))
 
-
 ### 🐛 Bug Fix
 
 * RESET clears inflight fetches ([#1085](https://github.com/coinbase/rest-hooks/issues/1085)) ([02fa0d5](https://github.com/coinbase/rest-hooks/commit/02fa0d527ef138961ba6dc2509648337c01e604d))
 
-
-
 ## [6.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.3.3...rest-hooks@6.0.0-beta.2) (2021-07-12)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -375,7 +258,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Add errorPolicy to endpoint options ([#971](https://github.com/coinbase/rest-hooks/issues/971)) ([836f05b](https://github.com/coinbase/rest-hooks/commit/836f05b407b5ac96c8f094e652221aa5a95300b0))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
-
 
 ### 💅 Enhancement
 
@@ -387,29 +269,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * setInterval types based on node/web rather than hardcoded ([#968](https://github.com/coinbase/rest-hooks/issues/968)) ([180822a](https://github.com/coinbase/rest-hooks/commit/180822a1093ac771b785e30b4346c56e9c2c5a56))
 * Use optional chaining ([#1003](https://github.com/coinbase/rest-hooks/issues/1003)) ([6e45937](https://github.com/coinbase/rest-hooks/commit/6e459377e3f0d90d1832c0173358c3c73f253831))
 
-
 ### 🐛 Bug Fix
 
 * module build import path ([#994](https://github.com/coinbase/rest-hooks/issues/994)) ([1f84f51](https://github.com/coinbase/rest-hooks/commit/1f84f51e0f3b62832945e75d0e241dba59b6623c))
-
 
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
 
-
-
 ## [6.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.0.0-beta.0...rest-hooks@6.0.0-beta.1) (2021-06-30)
-
 
 ### 🐛 Bug Fix
 
 * module build import path ([#994](https://github.com/coinbase/rest-hooks/issues/994)) ([1f84f51](https://github.com/coinbase/rest-hooks/commit/1f84f51e0f3b62832945e75d0e241dba59b6623c))
 
-
-
 ## [6.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.3.1...rest-hooks@6.0.0-beta.0) (2021-06-30)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -433,7 +307,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Add errorPolicy to endpoint options ([#971](https://github.com/coinbase/rest-hooks/issues/971)) ([836f05b](https://github.com/coinbase/rest-hooks/commit/836f05b407b5ac96c8f094e652221aa5a95300b0))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Different babel targets for cjs and umd builds ([#989](https://github.com/coinbase/rest-hooks/issues/989)) ([f054814](https://github.com/coinbase/rest-hooks/commit/f05481410cf8daa2101d4dbda826e56ad10ec723))
@@ -443,230 +316,145 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Remove Resource export from 'rest-hooks' package ([#939](https://github.com/coinbase/rest-hooks/issues/939)) ([0707920](https://github.com/coinbase/rest-hooks/commit/0707920bd9de70112b5287d101dcd4f6962f21d1))
 * setInterval types based on node/web rather than hardcoded ([#968](https://github.com/coinbase/rest-hooks/issues/968)) ([180822a](https://github.com/coinbase/rest-hooks/commit/180822a1093ac771b785e30b4346c56e9c2c5a56))
 
-
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
-
 
 ### [5.3.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.3.2...rest-hooks@5.3.3) (2021-07-06)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [5.3.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.3.1...rest-hooks@5.3.2) (2021-06-25)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ### [5.3.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.3.0...rest-hooks@5.3.1) (2021-06-19)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [5.3.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.2.0...rest-hooks@5.3.0) (2021-06-16)
-
 
 ### 🚀 Features
 
 * Add Resource+Entity to legacy ([#924](https://github.com/coinbase/rest-hooks/issues/924)) ([0c7ac83](https://github.com/coinbase/rest-hooks/commit/0c7ac834fa1c4fc07665601441422d5170313640))
 
-
-
 ## [5.2.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.1.4...rest-hooks@5.2.0) (2021-06-13)
-
 
 ### 🚀 Features
 
 * Normalize merges entities, entitymeta, indexes ([#915](https://github.com/coinbase/rest-hooks/issues/915)) ([bd21d8c](https://github.com/coinbase/rest-hooks/commit/bd21d8ce0d004a56e6853918d9fb9ecaa2c730a8))
 * Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
 
-
 ### 💅 Enhancement
 
 * Use inferResults() from normalizr ([#901](https://github.com/coinbase/rest-hooks/issues/901)) ([875cb6a](https://github.com/coinbase/rest-hooks/commit/875cb6acf31055e37e2d1faf4414bcbf31f5700f))
 
-
-
 ### [5.1.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.1.3...rest-hooks@5.1.4) (2021-06-09)
-
 
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ### [5.1.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.1.1...rest-hooks@5.1.3) (2021-06-02)
-
 
 ### 💅 Enhancement
 
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
-
 ### [5.1.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.1.1...rest-hooks@5.1.2) (2021-05-30)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ### [5.1.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.1.0...rest-hooks@5.1.1) (2021-05-24)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [5.1.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.23...rest-hooks@5.1.0) (2021-05-24)
-
 
 ### 🚀 Features
 
 * Deprecate Resource in main 'rest-hooks' package ([#842](https://github.com/coinbase/rest-hooks/issues/842)) ([54cc007](https://github.com/coinbase/rest-hooks/commit/54cc00759babc40f60460fba9f0dff4cf8db5d17))
 
-
 ### 💅 Enhancement
 
 * Simplify url logic for Resource ([#806](https://github.com/coinbase/rest-hooks/issues/806)) ([8f1bb8a](https://github.com/coinbase/rest-hooks/commit/8f1bb8a2ea1eec3e24a5f9e7e2d534cd818d05ab))
-
 
 ### 📝 Documentation
 
 * Change demo to todolist ([#839](https://github.com/coinbase/rest-hooks/issues/839)) ([924b992](https://github.com/coinbase/rest-hooks/commit/924b992ecc3479f0e0cbe1c3904248ec9718fabc))
 
-
-
 ### [5.0.23](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.22...rest-hooks@5.0.23) (2021-04-26)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ### [5.0.22](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.21...rest-hooks@5.0.22) (2021-04-25)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [5.0.21](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.20...rest-hooks@5.0.21) (2021-04-24)
-
 
 ### 💅 Enhancement
 
 * Schema assistance for Delete ([#756](https://github.com/coinbase/rest-hooks/issues/756)) ([4dd6a5a](https://github.com/coinbase/rest-hooks/commit/4dd6a5a3f6f0f6bf024731a082dc48afa74cb327))
 * Support TypeScript 3.7 ([#752](https://github.com/coinbase/rest-hooks/issues/752)) ([68a10e0](https://github.com/coinbase/rest-hooks/commit/68a10e06dc0718f5e480097e6056a7a7954d1161))
 
-
-
 ### [5.0.20](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.19...rest-hooks@5.0.20) (2021-04-13)
-
 
 ### 🐛 Bug Fix
 
 * Generate types that do not refer internally to other packages ([#749](https://github.com/coinbase/rest-hooks/issues/749)) ([2e55e32](https://github.com/coinbase/rest-hooks/commit/2e55e3229f23ba1d0d6eb15faf3dd5ba3de838c4))
 
-
-
 ### [5.0.19](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.18...rest-hooks@5.0.19) (2021-04-12)
-
 
 ### 🐛 Bug Fix
 
 * Relax DeleteShape def to be back-compat ([#743](https://github.com/coinbase/rest-hooks/issues/743)) ([20aa3a0](https://github.com/coinbase/rest-hooks/commit/20aa3a09bbe4419c23e37b331ca3208349f0e07c))
 
-
-
 ### [5.0.18](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.17...rest-hooks@5.0.18) (2021-04-12)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [5.0.17](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.16...rest-hooks@5.0.17) (2021-04-12)
-
 
 ### 💅 Enhancement
 
 * Refined deleteShape() definition ([#734](https://github.com/coinbase/rest-hooks/issues/734)) ([e34526d](https://github.com/coinbase/rest-hooks/commit/e34526d5dde5a2cc317cd9428ededc6a9893dc41))
 
-
-
 ### [5.0.16](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.15...rest-hooks@5.0.16) (2021-04-04)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [5.0.15](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.14...rest-hooks@5.0.15) (2021-03-26)
-
 
 ### 📝 Documentation
 
 * Update package description ([#684](https://github.com/coinbase/rest-hooks/issues/684)) ([c2b6915](https://github.com/coinbase/rest-hooks/commit/c2b6915c3a055816f345634416aeae9196de7051))
 
-
-
 ### [5.0.14](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.13...rest-hooks@5.0.14) (2021-03-24)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [5.0.13](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.12...rest-hooks@5.0.13) (2021-03-16)
-
 
 ### 🐛 Bug Fix
 
 * typeof Resource === typeof SimpleResource ([#662](https://github.com/coinbase/rest-hooks/issues/662)) ([4174149](https://github.com/coinbase/rest-hooks/commit/417414947a8a470ee84d3d98ee47646d6ca12798))
 
-
-
 ### [5.0.12](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.11...rest-hooks@5.0.12) (2021-03-14)
-
 
 ### 🐛 Bug Fix
 
 * non-JSON payloads on legacy Resource ([#655](https://github.com/coinbase/rest-hooks/issues/655)) ([141a02b](https://github.com/coinbase/rest-hooks/commit/141a02b5339a3f8bcf6fb441e236fecd47f0e465))
 
-
 ### 📝 Documentation
 
 * Update package tags ([#650](https://github.com/coinbase/rest-hooks/issues/650)) ([4ef465a](https://github.com/coinbase/rest-hooks/commit/4ef465a129cd59668cd9c3542bb9ec03c84d2a4d))
 
-
-
 ### [5.0.11](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.10...rest-hooks@5.0.11) (2021-03-10)
-
 
 ### 🐛 Bug Fix
 
 * Redux-integration needs state selection in middlewares: mapMiddleware() ([#643](https://github.com/coinbase/rest-hooks/issues/643)) ([a0f92eb](https://github.com/coinbase/rest-hooks/commit/a0f92eb5bd62a04bf92214c6cf3b6282048e723e))
-
-
 
 ## [5.0.10](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.9...rest-hooks@5.0.10) (2021-03-08)
 
@@ -675,19 +463,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Add getEndpointExtra(), getFetchInit() to legacy Resource ([#634](https://github.com/coinbase/rest-hooks/issues/634)) ([d6463ce](https://github.com/coinbase/rest-hooks/commit/d6463ce9940e0f96c49c0186bb84be9c54d657a6))
 * DevToolsConfig is type export ([#619](https://github.com/coinbase/rest-hooks/issues/619)) ([b8d9f7e](https://github.com/coinbase/rest-hooks/commit/b8d9f7e488ac5cbbd0c49ff678b689e008f0d34b))
 
-
-
 ### [5.0.9](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.8...rest-hooks@5.0.9) (2021-03-03)
-
 
 ### 🐛 Bug Fix
 
 * Actually send optimistic updates to devtool ([#616](https://github.com/coinbase/rest-hooks/issues/616)) ([6a96c63](https://github.com/coinbase/rest-hooks/commit/6a96c634dc63b56804b0055f33c2983d2212d323))
 
-
-
 ### [5.0.8](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.7...rest-hooks@5.0.8) (2021-03-01)
-
 
 ### 💅 Enhancement
 
@@ -695,93 +477,63 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Report optimistic state to devtools ([#603](https://github.com/coinbase/rest-hooks/issues/603)) ([5a1fa89](https://github.com/coinbase/rest-hooks/commit/5a1fa8998ffbfb5f04a1384076f406547293479d))
 * Support 'undefined' as schema ([#583](https://github.com/coinbase/rest-hooks/issues/583)) ([1e81470](https://github.com/coinbase/rest-hooks/commit/7ef172a3d8469b182cc7a19055920a308841b59e))
 
-
 ### 🐛 Bug Fix
 
 * Gracefully handle primitive entity responses ([#584](https://github.com/coinbase/rest-hooks/issues/584)) ([322b4c6](https://github.com/coinbase/rest-hooks/commit/322b4c6615ea02b09baf0bcfc9b214bb8be1ba4f))
-
-
 
 ### [5.0.7](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.6...rest-hooks@5.0.7) (2021-02-27)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [5.0.6](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.5...rest-hooks@5.0.6) (2021-02-24)
-
 
 ### 💅 Enhancement
 
 * Improve error type preciseness ([#571](https://github.com/coinbase/rest-hooks/issues/571)) ([6f760be](https://github.com/coinbase/rest-hooks/commit/6f760be7149f04eb26727730e0ec0d67f2215ed5))
 
-
-
 ### [5.0.5](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.4...rest-hooks@5.0.5) (2021-02-23)
-
 
 ### 🐛 Bug Fix
 
 * Support non-JSON payloads (like FormData) ([#552](https://github.com/coinbase/rest-hooks/issues/552)) ([82e68ac](https://github.com/coinbase/rest-hooks/commit/82e68ac8975fc4fa8ba468fe525662b6cbd627c1))
 
-
-
 ### [5.0.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.3...rest-hooks@5.0.4) (2021-02-18)
-
 
 ### 💅 Enhancement
 
 * legacy Resource should only warn on validation problems ([#540](https://github.com/coinbase/rest-hooks/issues/540)) ([eb83a51](https://github.com/coinbase/rest-hooks/commit/eb83a511d41c0b18ea3f5ecd6696e1013ed8e1c3))
 
-
-
 ### [5.0.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.2...rest-hooks@5.0.3) (2021-02-04)
-
 
 ### 📦 Package
 
 * Relax @babel/runtime requirement to ^7.7.2 ([#513](https://github.com/coinbase/rest-hooks/issues/513)) ([cc95b21](https://github.com/coinbase/rest-hooks/commit/cc95b219fbddebfbf334728887ca6d2fa070fce1))
 
-
 ### 📝 Documentation
 
 * Link improvements, flesh out test readme ([#511](https://github.com/coinbase/rest-hooks/issues/511)) ([9cab431](https://github.com/coinbase/rest-hooks/commit/9cab431803a8b7d9c18e02b3e9cb7e336215ccdb))
-
-
 
 ### [5.0.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.1...rest-hooks@5.0.2) (2021-01-30)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [5.0.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0...rest-hooks@5.0.1) (2021-01-24)
-
 
 ### 💅 Enhancement
 
 * Add jsdocs deprecations to deprecated methods ([#487](https://github.com/coinbase/rest-hooks/issues/487)) ([cc7d626](https://github.com/coinbase/rest-hooks/commit/cc7d6269e752335e6502b7ada0da21a881c2afb6))
 * Improve malformed entity detection ([#494](https://github.com/coinbase/rest-hooks/issues/494)) ([b8bb07f](https://github.com/coinbase/rest-hooks/commit/b8bb07f480549a97254a4fdf6b00acd9cb89a9eb))
 
-
 ### 🐛 Bug Fix
 
 * Wait til data is stale for first poll ([#491](https://github.com/coinbase/rest-hooks/issues/491)) ([82f7b5c](https://github.com/coinbase/rest-hooks/commit/82f7b5c7e50b44273867e10489d0631db9e64aa9))
-
 
 ### 📝 Documentation
 
 * Improve rest-types and network transform ([#486](https://github.com/coinbase/rest-hooks/issues/486)) ([e61342a](https://github.com/coinbase/rest-hooks/commit/e61342acc920288ecb98f36e9aa8ecb13dd6fe44))
 * Update wording for 'cache lifetime' in feature list ([#483](https://github.com/coinbase/rest-hooks/issues/483)) ([5a62b73](https://github.com/coinbase/rest-hooks/commit/5a62b73d66cc232e21f5f8792e8d6f63d094b9f2))
 
-
-
 ## 5.0.0 (2021-01-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -843,7 +595,6 @@ overrides
 * Simplified Entity class ([#315](https://github.com/coinbase/rest-hooks/issues/315)) ([0e6bfcb](https://github.com/coinbase/rest-hooks/commit/0e6bfcb3620006e285510d4e5121fce743214d55))
 * Support non JSON (aka binary) fetches ([#267](https://github.com/coinbase/rest-hooks/issues/267)) ([fb8e6d8](https://github.com/coinbase/rest-hooks/commit/fb8e6d8821d78dba11b4cac20762b94682110148))
 
-
 ### 💅 Enhancement
 
 * Add back remaining normalizr exports to rest-hooks ([b6878ee](https://github.com/coinbase/rest-hooks/commit/b6878eebbf1572a4b859828da81a058bc5c118e3))
@@ -894,7 +645,6 @@ overrides
 * useCache() and useStatefulResource() respect invalidIfStale ([#307](https://github.com/coinbase/rest-hooks/issues/307)) ([58f2c40](https://github.com/coinbase/rest-hooks/commit/58f2c40a66fb0d0c1f900840160e17ce87beace2))
 * useResource array parameters as readonly ([#319](https://github.com/coinbase/rest-hooks/issues/319)) ([fb1b39f](https://github.com/coinbase/rest-hooks/commit/fb1b39f54e2cfad062ba33eca8f7ffd15de7fe9d))
 
-
 ### 🐛 Bug Fix
 
 * 0 for expiryLength should not result in default ([#296](https://github.com/coinbase/rest-hooks/issues/296)) ([c75dca5](https://github.com/coinbase/rest-hooks/commit/c75dca5fce8a07dcec5bbb942bddcb31625c757f))
@@ -934,7 +684,6 @@ overrides
 * TypeScript 4 compatibility ([#406](https://github.com/coinbase/rest-hooks/issues/406)) ([5d82e24](https://github.com/coinbase/rest-hooks/commit/5d82e2416b68992f6efccb63f694010ef1ea28e8))
 * useCache() with indexes but no entities ever stored ([#279](https://github.com/coinbase/rest-hooks/issues/279)) ([67a1257](https://github.com/coinbase/rest-hooks/commit/67a12577620a3b2e8cec7498c0d654b210d2cce1))
 
-
 ### 📦 Package
 
 * Bump internal pkgs ([#306](https://github.com/coinbase/rest-hooks/issues/306)) ([46bebad](https://github.com/coinbase/rest-hooks/commit/46bebad79d848404d02423fd2a3e2d647ee5bbbb))
@@ -942,7 +691,6 @@ overrides
 * Update dev: types and linting ([#186](https://github.com/coinbase/rest-hooks/issues/186)) ([78e36a4](https://github.com/coinbase/rest-hooks/commit/78e36a49eba85d7839c13f871e9a5985eeeb2458))
 * Upgrade to TypeScript 3.8 ([#272](https://github.com/coinbase/rest-hooks/issues/272)) ([d9086b6](https://github.com/coinbase/rest-hooks/commit/d9086b6f0e7033a51e1ea5bd3850c4135d7a9b58))
 * Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a8c435c5ef74b3809c8950a2caceca8763))
-
 
 ### 📝 Documentation
 
@@ -956,196 +704,102 @@ overrides
 * Update useStatefulResource() in guides ([#183](https://github.com/coinbase/rest-hooks/issues/183)) ([0e59914](https://github.com/coinbase/rest-hooks/commit/0e599141b0cc9540428def9e26ea228275df899b))
 * Use bundlephobia badge for lib size ([eb76258](https://github.com/coinbase/rest-hooks/commit/eb76258db4be81a4a22ce01074c4a88cfc4ff0b8))
 
-
-
 ## [5.0.0-rc.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-rc.0...rest-hooks@5.0.0-rc.1) (2021-01-19)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## 5.0.0-rc.0 (2021-01-14)
 
 * enhance: Maintain referential equality globally (#403) ([e1e353d](https://github.com/coinbase/rest-hooks/commit/e1e353d)), closes [#403](https://github.com/coinbase/rest-hooks/issues/403)
 
-
 ### BREAKING CHANGE
 
 * Node engine requirement of >=0.12
-
-
-
 
 ## 5.0.0-k.5 (2021-01-06)
 
 * internal: Ignore dev env only paths for code coverage ([d425dfd](https://github.com/coinbase/rest-hooks/commit/d425dfd))
 * pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
 
-
-
-
-
 ## 5.0.0-k.4 (2020-12-08)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## 5.0.0-k.3 (2020-09-08)
 
 * fix: TypeScript 4 compatibility (#406) ([5d82e24](https://github.com/coinbase/rest-hooks/commit/5d82e24)), closes [#406](https://github.com/coinbase/rest-hooks/issues/406)
 
-
-
-
-
 ## 5.0.0-k.2 (2020-08-13)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## 5.0.0-k.1 (2020-08-12)
 
 * enhance: Support React 17 (#397) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f07)), closes [#397](https://github.com/coinbase/rest-hooks/issues/397)
 
-
-
-
-
 ## 5.0.0-k.0 (2020-08-09)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## 5.0.0-j.10 (2020-08-09)
 
 * enhance: console instead of throw when missing frequency ([8708b1f](https://github.com/coinbase/rest-hooks/commit/8708b1f))
 
-
-
-
-
 ## 5.0.0-j.9 (2020-08-09)
 
 * fix: Resource endpoint memoization ([744431e](https://github.com/coinbase/rest-hooks/commit/744431e))
-
-
-
-
 
 ## 5.0.0-j.8 (2020-08-08)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## 5.0.0-j.7 (2020-08-04)
 
 * fix: Infer useFetcher() has no body when not present in fetch (#385) ([22dd399](https://github.com/coinbase/rest-hooks/commit/22dd399)), closes [#385](https://github.com/coinbase/rest-hooks/issues/385)
-
-
-
-
 
 ## 5.0.0-j.6 (2020-07-31)
 
 * enhance: Only include DevToolsManager in dev mode (#382) ([5dbfbeb](https://github.com/coinbase/rest-hooks/commit/5dbfbeb)), closes [#382](https://github.com/coinbase/rest-hooks/issues/382)
 
-
-
-
-
 ## 5.0.0-j.5 (2020-07-31)
 
 * fix: DevToolsManager export in prod mode ([7f419cb](https://github.com/coinbase/rest-hooks/commit/7f419cb))
-
-
-
-
 
 ## 5.0.0-j.4 (2020-07-28)
 
 * fix: DevToolsManager being removed in production making exports not work ([024c27e](https://github.com/coinbase/rest-hooks/commit/024c27e))
 
-
-
-
-
 ## 5.0.0-j.3 (2020-07-27)
 
 * enhance: Export DevToolsManager from rest-hooks ([b8082ca](https://github.com/coinbase/rest-hooks/commit/b8082ca))
-
-
-
-
 
 ## 5.0.0-j.2 (2020-07-27)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## 5.0.0-j.1 (2020-07-27)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## 5.0.0-j.0 (2020-07-27)
 
 * enhance: Keep legacy Resource (#376) ([fdd1f7c](https://github.com/coinbase/rest-hooks/commit/fdd1f7c)), closes [#376](https://github.com/coinbase/rest-hooks/issues/376)
 
-
-
-
-
 ## 5.0.0-i.6 (2020-07-22)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## 5.0.0-i.5 (2020-07-22)
 
 * docs: Add link to debugging docs from readme ([d75cbe8](https://github.com/coinbase/rest-hooks/commit/d75cbe8))
 
-
-
-
-
 ## 5.0.0-i.4 (2020-07-21)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## 5.0.0-i.3 (2020-07-21)
 
 * fix: Put DevToolsManager at front so it captures all actions ([ec2169b](https://github.com/coinbase/rest-hooks/commit/ec2169b))
-
-
-
-
 
 ## 5.0.0-i.2 (2020-07-20)
 
@@ -1153,44 +807,27 @@ overrides
 * docs: Fix Endpoint def in readme example ([125ad57](https://github.com/coinbase/rest-hooks/commit/125ad57))
 * docs: Update readme tagline ([fe39b16](https://github.com/coinbase/rest-hooks/commit/fe39b16))
 
-
-
-
-
 ## 5.0.0-i.1 (2020-07-14)
 
 * fix: Export Endpoint through core ([8b60dea](https://github.com/coinbase/rest-hooks/commit/8b60dea))
-
-
-
-
 
 ## 5.0.0-i.0 (2020-07-14)
 
 * docs: Update readme examples ([68c69ab](https://github.com/coinbase/rest-hooks/commit/68c69ab))
 * enhance: Resource uses endpoint (#365) ([4472106](https://github.com/coinbase/rest-hooks/commit/4472106)), closes [#365](https://github.com/coinbase/rest-hooks/issues/365)
 
-
 ### BREAKING CHANGE
 
 * getFetchOptions() -> getEndpointExtra()
-
-
-
 
 ## 5.0.0-h.0 (2020-07-13)
 
 * fix: Fix schema.Delete import ([6106447](https://github.com/coinbase/rest-hooks/commit/6106447))
 
-
-
-
-
 ## 5.0.0-delta.0 (2020-07-08)
 
 * feat: Deletes and invalidates trigger suspense always (#360) ([96175ba](https://github.com/coinbase/rest-hooks/commit/96175ba)), closes [#360](https://github.com/coinbase/rest-hooks/issues/360)
 * feat: Resource.fetch() arguments reflect browser fetch() (#362) ([1d19421](https://github.com/coinbase/rest-hooks/commit/1d19421)), closes [#362](https://github.com/coinbase/rest-hooks/issues/362)
-
 
 ### BREAKING CHANGE
 
@@ -1205,40 +842,21 @@ overrides
 - Added Resource.getFetchInit() which is called in shape generators
 - Resourece.fetch() interface changed to match browser fetch()
 
-
-
-
 ## 5.0.0-gamma.0 (2020-06-13)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## 5.0.0-beta.22 (2020-06-13)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## 5.0.0-beta.21 (2020-06-09)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## 5.0.0-beta.20 (2020-06-08)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## 5.0.0-beta.19 (2020-06-06)
 
@@ -1250,148 +868,92 @@ overrides
 * internal: eslint major, plugin minor ([1532f7a](https://github.com/coinbase/rest-hooks/commit/1532f7a))
 * internal: Prepare tests to run in React Native env (#309) ([64efd70](https://github.com/coinbase/rest-hooks/commit/64efd70)), closes [#309](https://github.com/coinbase/rest-hooks/issues/309)
 
-
 ### BREAKING CHANGE
 
 * Resource getKey() deleted. Use `get key()`
 * Resource.getEntitySchema() removed, use Resource
 directly
 
-
-
-
 ## [5.0.0-beta.18](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.17...rest-hooks@5.0.0-beta.18) (2020-05-20)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## [5.0.0-beta.17](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.16...rest-hooks@5.0.0-beta.17) (2020-05-20)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [5.0.0-beta.16](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.15...rest-hooks@5.0.0-beta.16) (2020-05-20)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## [5.0.0-beta.15](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.14...rest-hooks@5.0.0-beta.15) (2020-05-19)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [5.0.0-beta.14](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.13...rest-hooks@5.0.0-beta.14) (2020-05-19)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ## [5.0.0-beta.13](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.12...rest-hooks@5.0.0-beta.13) (2020-05-19)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [5.0.0-beta.12](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.11...rest-hooks@5.0.0-beta.12) (2020-05-14)
-
 
 ### 🏠 Internal
 
 * Test rest-hooks specific CacheProvider ([724f780](https://github.com/coinbase/rest-hooks/commit/724f7805ece06d69e3f7150f7ce347d3cb8d0f04))
 
-
 ### 📝 Documentation
 
 * Get rid of all references to asSchema() ([#339](https://github.com/coinbase/rest-hooks/issues/339)) ([01b878b](https://github.com/coinbase/rest-hooks/commit/01b878b85f7469a12e19912efc696a424663e5f5))
 
-
-
 ## [5.0.0-beta.11](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.10...rest-hooks@5.0.0-beta.11) (2020-05-13)
-
 
 ### 🐛 Bug Fix
 
 * CacheProvider in rest-hooks no longer infinitely recurses ([d2ded89](https://github.com/coinbase/rest-hooks/commit/d2ded895a09e7bd7d52054b6265f1c3e8c2de783))
 
-
-
 ## [5.0.0-beta.10](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.9...rest-hooks@5.0.0-beta.10) (2020-05-13)
-
 
 ### 🐛 Bug Fix
 
 * Export correct CacheManager with PolingManager as default ([a6a99a0](https://github.com/coinbase/rest-hooks/commit/a6a99a07a2afe300f3b8a2b9c00735688bdb3b72))
 
-
-
 ## [5.0.0-beta.9](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.8...rest-hooks@5.0.0-beta.9) (2020-05-13)
-
 
 ### 💅 Enhancement
 
 * Add back remaining normalizr exports to rest-hooks ([b6878ee](https://github.com/coinbase/rest-hooks/commit/b6878eebbf1572a4b859828da81a058bc5c118e3))
 
-
-
 ## [5.0.0-beta.8](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.7...rest-hooks@5.0.0-beta.8) (2020-05-13)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [5.0.0-beta.7](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.6...rest-hooks@5.0.0-beta.7) (2020-05-12)
-
 
 ### 💅 Enhancement
 
 * New package @rest-hooks/core ([#336](https://github.com/coinbase/rest-hooks/issues/336)) ([bf490c0](https://github.com/coinbase/rest-hooks/commit/bf490c030feb8a0e35e96c6dd7d180e45ac8bfd0))
 * No longer require 'asSchema()' ([#335](https://github.com/coinbase/rest-hooks/issues/335)) ([a29c41b](https://github.com/coinbase/rest-hooks/commit/a29c41b4449741e0e589d513261186e1a1cbe98a))
 
-
-
 ## [5.0.0-beta.6](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.5...rest-hooks@5.0.0-beta.6) (2020-05-08)
-
 
 ### 💅 Enhancement
 
 * Detect more cases of network mismatching schema ([#331](https://github.com/coinbase/rest-hooks/issues/331)) ([2af464f](https://github.com/coinbase/rest-hooks/commit/2af464f54318c5f099899150371c911133a717cb))
 
-
 ### 🏠 Internal
 
 * Improve test coverage ([#330](https://github.com/coinbase/rest-hooks/issues/330)) ([edc5f73](https://github.com/coinbase/rest-hooks/commit/edc5f73471fc2b68a95b4ef09d883e7dab016d7d))
 
-
-
 ## [5.0.0-beta.5](https://github.com/coinbase/rest-hooks/compare/rest-hooks@5.0.0-beta.1...rest-hooks@5.0.0-beta.5) (2020-05-04)
-
 
 ### 🏠 Internal
 
 * Fix package versions for publish ([06d69ca](https://github.com/coinbase/rest-hooks/commit/06d69ca6d8e8d4dbf847f8a1593bfa65af8d79c6))
 
-
-
 ## [5.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.9...rest-hooks@5.0.0-beta.0) (2020-04-26)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -1406,7 +968,6 @@ are in the cache
 * Add createFetch() action creator ([#320](https://github.com/coinbase/rest-hooks/issues/320)) ([392ea15](https://github.com/coinbase/rest-hooks/commit/392ea151ec1a08dbf47480f19c149e869e28939e))
 * Simplified Entity class ([#315](https://github.com/coinbase/rest-hooks/issues/315)) ([0e6bfcb](https://github.com/coinbase/rest-hooks/commit/0e6bfcb3620006e285510d4e5121fce743214d55))
 
-
 ### 💅 Enhancement
 
 * Add optional generic for fetch return value in shape types ([#311](https://github.com/coinbase/rest-hooks/issues/311)) ([280fa3d](https://github.com/coinbase/rest-hooks/commit/280fa3d19935e7f0b16b84c6532a71d64bc45da5))
@@ -1419,426 +980,293 @@ are in the cache
 * useCache() and useStatefulResource() respect invalidIfStale ([#307](https://github.com/coinbase/rest-hooks/issues/307)) ([58f2c40](https://github.com/coinbase/rest-hooks/commit/58f2c40a66fb0d0c1f900840160e17ce87beace2))
 * useResource array parameters as readonly ([#319](https://github.com/coinbase/rest-hooks/issues/319)) ([fb1b39f](https://github.com/coinbase/rest-hooks/commit/fb1b39f54e2cfad062ba33eca8f7ffd15de7fe9d))
 
-
 ### 🐛 Bug Fix
 
 * Connection listener feature detection ([5b360df](https://github.com/coinbase/rest-hooks/commit/5b360df5f23a0ce36f3638198ddb4938717401b4))
 * Inferred results are considered stale ([fc4ee61](https://github.com/coinbase/rest-hooks/commit/fc4ee61bb692f98f053b14e0aff20d5e76c8c131))
 * Inferring with union types ([5ab6159](https://github.com/coinbase/rest-hooks/commit/5ab6159a1887a216564ac15f84774c9b7b9e76bf))
 
-
 ### 📦 Package
 
 * Bump internal pkgs ([#306](https://github.com/coinbase/rest-hooks/issues/306)) ([46bebad](https://github.com/coinbase/rest-hooks/commit/46bebad79d848404d02423fd2a3e2d647ee5bbbb))
-
 
 ### 🏠 Internal
 
 * Hoist coveralls to root, since testing is done there ([3b1dbaa](https://github.com/coinbase/rest-hooks/commit/3b1dbaac303048a1b1e543f99fb9758b21feb083))
 * Update prettier, format files ([88d5627](https://github.com/coinbase/rest-hooks/commit/88d5627fb1963842d2a644cfe06f0780cb3c2dde))
 
-
-
 ### [4.5.9](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.8...rest-hooks@4.5.9) (2020-03-22)
-
 
 ### 🐛 Bug Fix
 
 * Do not run reducer on non-optimistic fetches ([#302](https://github.com/coinbase/rest-hooks/issues/302)) ([86cc80b](https://github.com/coinbase/rest-hooks/commit/86cc80bdef15ba1e8c0ebe011989405c334e458b))
 
-
 ### 🏠 Internal
 
 * Update eslint-plugin + prettier 2 ([#304](https://github.com/coinbase/rest-hooks/issues/304)) ([210eabc](https://github.com/coinbase/rest-hooks/commit/210eabcec4651f3150658535df6dce730bf7665e))
 
-
-
 ### [4.5.8](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.7...rest-hooks@4.5.8) (2020-03-13)
-
 
 ### 💅 Enhancement
 
 * Be more descriptive for not implemented ([#292](https://github.com/coinbase/rest-hooks/issues/292)) ([bb55212](https://github.com/coinbase/rest-hooks/commit/bb55212c206831acb2a669c5fba826e2fd0e96ca))
-
 
 ### 🐛 Bug Fix
 
 * 0 for expiryLength should not result in default ([#296](https://github.com/coinbase/rest-hooks/issues/296)) ([c75dca5](https://github.com/coinbase/rest-hooks/commit/c75dca5fce8a07dcec5bbb942bddcb31625c757f))
 * Don't crash polling subscriptions on react native ([f57cd41](https://github.com/coinbase/rest-hooks/commit/f57cd41210547f3e3c8c57a32c2ba35311992fac))
 
-
-
 ### [4.5.7](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.6...rest-hooks@4.5.7) (2020-03-12)
-
 
 ### 🐛 Bug Fix
 
 * Don't throw when RN tries to poll ([#291](https://github.com/coinbase/rest-hooks/issues/291)) ([6a57af9](https://github.com/coinbase/rest-hooks/commit/6a57af9107fbd15eeac16365335f0d75825cc6bc))
 
-
-
 ### [4.5.6](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.5...rest-hooks@4.5.6) (2020-03-11)
-
 
 ### 🐛 Bug Fix
 
 * Index updates should possibly rerender ([#289](https://github.com/coinbase/rest-hooks/issues/289)) ([ad2927e](https://github.com/coinbase/rest-hooks/commit/ad2927eb30311f09b0b03abfd6a8364bc9ea2301))
 
-
-
 ### [4.5.5](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.4...rest-hooks@4.5.5) (2020-03-08)
-
 
 ### 🏠 Internal
 
 * Only allow building types from root ([0c3d7ae](https://github.com/coinbase/rest-hooks/commit/0c3d7ae1a9d6130848f31850ed8b15e6ed01d0ab))
 
-
-
 ### [4.5.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.3...rest-hooks@4.5.4) (2020-03-03)
-
 
 ### 🐛 Bug Fix
 
 * Add generic useResource parallel overloads for up to 16 arguments ([#281](https://github.com/coinbase/rest-hooks/issues/281)) ([da1578e](https://github.com/coinbase/rest-hooks/commit/da1578eeae6ee3b38b2a3406685032907cdaee16))
 
-
-
 ### [4.5.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.2...rest-hooks@4.5.3) (2020-03-01)
-
 
 ### 🐛 Bug Fix
 
 * useCache() with indexes but no entities ever stored ([#279](https://github.com/coinbase/rest-hooks/issues/279)) ([67a1257](https://github.com/coinbase/rest-hooks/commit/67a12577620a3b2e8cec7498c0d654b210d2cce1))
 
-
-
 ### [4.5.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.1...rest-hooks@4.5.2) (2020-02-26)
-
 
 ### 🐛 Bug Fix
 
 * type SimpleRecord._unq should be private ([#274](https://github.com/coinbase/rest-hooks/issues/274)) ([e6ad2c1](https://github.com/coinbase/rest-hooks/commit/e6ad2c1c50d16b23e6b067b936a70f6672e8ce1c))
 
-
 ### 📦 Package
 
 * Upgrade to TypeScript 3.8 ([#272](https://github.com/coinbase/rest-hooks/issues/272)) ([d9086b6](https://github.com/coinbase/rest-hooks/commit/d9086b6f0e7033a51e1ea5bd3850c4135d7a9b58))
-
 
 ### 🏠 Internal
 
 * readonly should exist on all levels of internal state ([#276](https://github.com/coinbase/rest-hooks/issues/276)) ([a884186](https://github.com/coinbase/rest-hooks/commit/a884186e2696b40ab764979d646089aa625dfe8d))
 * Use Record<string, any> form for POJOs ([dae11b2](https://github.com/coinbase/rest-hooks/commit/dae11b233d4cc3d56ba93f1488a0b42ba7a1dfce))
 
-
-
 ### [4.5.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.0...rest-hooks@4.5.1) (2020-02-19)
-
 
 ### 🐛 Bug Fix
 
 * Fix commonjs bundle ([#271](https://github.com/coinbase/rest-hooks/issues/271)) ([a898bd0](https://github.com/coinbase/rest-hooks/commit/a898bd0c3497711a25c584f78d1e9c0cbde29949))
 
-
 ### 🏠 Internal
 
 * Check compressed size changes on PR ([#270](https://github.com/coinbase/rest-hooks/issues/270)) ([d70ccbf](https://github.com/coinbase/rest-hooks/commit/d70ccbf44ac5ba8fdc4f70886851ab18349f37e6))
-
-
 
 ## [4.5.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.0-beta.3...rest-hooks@4.5.0) (2020-02-18)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [4.5.0-beta.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.0-beta.2...rest-hooks@4.5.0-beta.3) (2020-02-18)
-
 
 ### 🏠 Internal
 
 * Pull out new package @rest-hooks/use-enhanced-reducer ([#269](https://github.com/coinbase/rest-hooks/issues/269)) ([bb99aeb](https://github.com/coinbase/rest-hooks/commit/bb99aebf6133b34950b1ce3c422fb034fd2971ed))
 
-
-
 ## [4.5.0-beta.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.0-beta.1...rest-hooks@4.5.0-beta.2) (2020-02-18)
-
 
 ### 🐛 Bug Fix
 
 * Poll fetches while testing should be wrapped in act ([#268](https://github.com/coinbase/rest-hooks/issues/268)) ([9c264bb](https://github.com/coinbase/rest-hooks/commit/9c264bb1e5a736b6bdab2077185cebd754c39b6f))
 
-
 ### 🏠 Internal
 
 * Centralize jest config ([#230](https://github.com/coinbase/rest-hooks/issues/230)) ([5d769d2](https://github.com/coinbase/rest-hooks/commit/5d769d2485fe62ba65f4176894768bdbb6faafb3))
 
-
-
 ## [4.5.0-beta.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.5.0-beta.0...rest-hooks@4.5.0-beta.1) (2020-02-13)
-
 
 ### 🚀 Features
 
 * Support non JSON (aka binary) fetches ([#267](https://github.com/coinbase/rest-hooks/issues/267)) ([fb8e6d8](https://github.com/coinbase/rest-hooks/commit/fb8e6d8821d78dba11b4cac20762b94682110148))
 
-
-
 ## [4.5.0-beta.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.4.0...rest-hooks@4.5.0-beta.0) (2020-02-13)
-
 
 ### 🚀 Features
 
 * Include all FetchOptions in subscribe action ([#265](https://github.com/coinbase/rest-hooks/issues/265)) ([e27f420](https://github.com/coinbase/rest-hooks/commit/e27f420f9a562535d1c1784570be80c9606948cf))
 
-
-
 ## [4.4.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.4.0-beta.1...rest-hooks@4.4.0) (2020-02-10)
-
 
 ### 💅 Enhancement
 
 * Commonjs bundle uses native-compatible code ([#263](https://github.com/coinbase/rest-hooks/issues/263)) ([5da9047](https://github.com/coinbase/rest-hooks/commit/5da9047aa1021b452732f6438fc49a8382f0dc77))
 
-
-
 ## [4.4.0-beta.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.4.0-beta.0...rest-hooks@4.4.0-beta.1) (2020-02-06)
-
 
 ### 🚀 Features
 
 * Export EntitySchema and EntityInstance types ([edef484](https://github.com/coinbase/rest-hooks/commit/edef48457e1a0acebbcc099e5900468e606156f4))
 
-
-
 ## [4.4.0-beta.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.3.1...rest-hooks@4.4.0-beta.0) (2020-02-04)
-
 
 ### 🚀 Features
 
 * Add SetShapeParams ([#259](https://github.com/coinbase/rest-hooks/issues/259)) ([0c1a78e](https://github.com/coinbase/rest-hooks/commit/0c1a78e971f72b6c4fb288c2afa428b20de40464))
 * Export ParamsFromShape type ([df12329](https://github.com/coinbase/rest-hooks/commit/df1232995a0b2b62728a6b2e940e185d5d6ef8fd))
 
-
 ### 🐛 Bug Fix
 
 * Export * for types ([3968d51](https://github.com/coinbase/rest-hooks/commit/3968d511647143c6934f14a4db4b906fe046123b))
 * listUrl() on react native no longer throws error ([#262](https://github.com/coinbase/rest-hooks/issues/262)) ([aeae764](https://github.com/coinbase/rest-hooks/commit/aeae76475be0fe350f066e3869b2a4936513214e))
 
-
 ### 📝 Documentation
 
 * Use bundlephobia badge for lib size ([eb76258](https://github.com/coinbase/rest-hooks/commit/eb76258db4be81a4a22ce01074c4a88cfc4ff0b8))
-
-
 
 ### [4.3.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.3.0...rest-hooks@4.3.1) (2020-01-29)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [4.3.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.3.0-beta.2...rest-hooks@4.3.0) (2020-01-29)
-
 
 ### 💅 Enhancement
 
 * Use latest normalizr denormalize export ([4a55ce1](https://github.com/coinbase/rest-hooks/commit/4a55ce18816d7cf84a416217a0e51ae81c9fc7d0))
 
-
-
 ## [4.3.0-beta.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.3.0-beta.1...rest-hooks@4.3.0-beta.2) (2020-01-27)
-
 
 ### 💅 Enhancement
 
 * Keep referential equality in list views ([#251](https://github.com/coinbase/rest-hooks/issues/251)) ([caf2bf7](https://github.com/coinbase/rest-hooks/commit/caf2bf78e6c48af8a32b080291ae60615ad05b34))
 * Remove lodash dependency, reducing total bundle size ([#250](https://github.com/coinbase/rest-hooks/issues/250)) ([1e2bff1](https://github.com/coinbase/rest-hooks/commit/1e2bff1f2f3014903d1bc9302412930bbe62f927))
 
-
-
 ## [4.3.0-beta.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.3.0-beta.0...rest-hooks@4.3.0-beta.1) (2020-01-22)
-
 
 ### 💅 Enhancement
 
 * NM only marks fetch processing in dev mode ([3bfec50](https://github.com/coinbase/rest-hooks/commit/3bfec50e9af7d1331dc78a01d5d360fb2a0fd3e5))
 
-
 ### 🐛 Bug Fix
 
 * Optimistic updates now trigger for results with empty string ([#248](https://github.com/coinbase/rest-hooks/issues/248)) ([6ac25ac](https://github.com/coinbase/rest-hooks/commit/6ac25acfff37e91e9e00c3449f1c5ee83285d46e))
 
-
-
 ## [4.3.0-beta.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.2.4...rest-hooks@4.3.0-beta.0) (2020-01-19)
-
 
 ### 🚀 Features
 
 * Add optimistic updates ([#246](https://github.com/coinbase/rest-hooks/issues/246)) ([d448c55](https://github.com/coinbase/rest-hooks/commit/d448c55aeb87aae40902db4c4d5ec4535c6f7167))
 
-
 ### 🏠 Internal
 
 * Move action creation into own functions ([#245](https://github.com/coinbase/rest-hooks/issues/245)) ([46edd0a](https://github.com/coinbase/rest-hooks/commit/46edd0a38d083f6cc00b411424b5f5b1eb8158e4))
 
-
-
 ### [4.2.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.2.3...rest-hooks@4.2.4) (2020-01-18)
-
 
 ### 🐛 Bug Fix
 
 * Entity export ([c4d3136](https://github.com/coinbase/rest-hooks/commit/c4d3136f47945960e4b7bdeab7bc108b33ecd268))
 
-
-
 ### [4.2.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.2.2...rest-hooks@4.2.3) (2020-01-18)
 
 **Note:** Version bump only for package rest-hooks
-
-
-
-
 
 ### [4.2.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.2.1...rest-hooks@4.2.2) (2020-01-18)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ### [4.2.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.2.0...rest-hooks@4.2.1) (2020-01-17)
-
 
 ### 💅 Enhancement
 
 * Add buildInferredResults and isEntity to __INTERNAL__ ([f88717b](https://github.com/coinbase/rest-hooks/commit/f88717b82b06f7226a6ca3044d47d311744a881d))
 
-
-
 ## [4.2.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.1.3...rest-hooks@4.2.0) (2020-01-17)
-
 
 ### 🚀 Features
 
 * Add indexes to Entity for improved performance ([#237](https://github.com/coinbase/rest-hooks/issues/237)) ([a2339f0](https://github.com/coinbase/rest-hooks/commit/a2339f0e61e9446da87af85440061b060ad0f444))
-
 
 ### 💅 Enhancement
 
 * Devmode: Throw error if delete shape fetched with wrong schema ([#240](https://github.com/coinbase/rest-hooks/issues/240)) ([130e070](https://github.com/coinbase/rest-hooks/commit/130e07059936d255d72ef9ee35a738c755fada00))
 * Don't export action types ([#239](https://github.com/coinbase/rest-hooks/issues/239)) ([41fedfe](https://github.com/coinbase/rest-hooks/commit/41fedfe1890834950e5330c61329abe6d734e768))
 
-
 ### 🐛 Bug Fix
 
 * Test coverage ([c3d51e2](https://github.com/coinbase/rest-hooks/commit/c3d51e2927d48dfdda51764fc6e0fabb27b4dbaf))
 
-
-
 ### [4.1.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.1.2...rest-hooks@4.1.3) (2020-01-16)
-
 
 ### 💅 Enhancement
 
 * Centralize action type string definitions ([#238](https://github.com/coinbase/rest-hooks/issues/238)) ([b558986](https://github.com/coinbase/rest-hooks/commit/b558986b1c17bc4217d4d5ec9d31d28e410e9725))
 
-
-
 ### [4.1.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.1.0...rest-hooks@4.1.2) (2020-01-14)
-
 
 ### 🐛 Bug Fix
 
 * Make SubscriptionManager type compatible with redux-toolkit ([#235](https://github.com/coinbase/rest-hooks/issues/235)) ([9e04388](https://github.com/coinbase/rest-hooks/commit/9e04388114dcb2f31da37a29cc5971661241e80c))
 * Re-publish correct typings ([3520594](https://github.com/coinbase/rest-hooks/commit/3520594b090ff1231e1d8c65620257af46e8ffcb))
 
-
-
 ## [4.1.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.4...rest-hooks@4.1.0) (2020-01-06)
-
 
 ### 🚀 Features
 
 * Entity class added to Resource hierarchy ([#226](https://github.com/coinbase/rest-hooks/issues/226)) ([7c4efb7](https://github.com/coinbase/rest-hooks/commit/7c4efb7a55efbffa8a0cab3dab1b39e69535df49))
 
-
 ### 🏠 Internal
 
 * Avoid circular depdency (and note it) ([a47cf7e](https://github.com/coinbase/rest-hooks/commit/a47cf7e5518883d4afe95fe34324220e5aa33d45))
 
-
-
 ### [4.0.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.3...rest-hooks@4.0.4) (2020-01-05)
-
 
 ### 🐛 Bug Fix
 
 * Import @rest-hooks/normalizr properly ([#229](https://github.com/coinbase/rest-hooks/issues/229)) ([c9d0474](https://github.com/coinbase/rest-hooks/commit/c9d04740ce2c8823f812c91a230b46077c286873))
 
-
-
 ### [4.0.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.2...rest-hooks@4.0.3) (2020-01-05)
-
 
 ### 🐛 Bug Fix
 
 * Type inferencing for hooks ([1fa5f2c](https://github.com/coinbase/rest-hooks/commit/1fa5f2c368ad4485e808fd3ee4d4e6bc36bd39e7))
 
-
-
 ### [4.0.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.1...rest-hooks@4.0.2) (2020-01-05)
-
 
 ### 💅 Enhancement
 
 * Immediately fetch polling subscriptions ([#228](https://github.com/coinbase/rest-hooks/issues/228)) ([ae02bff](https://github.com/coinbase/rest-hooks/commit/ae02bfffc08d16cd41e6c285a8ddf1b802302e9b))
 * Polling subscriptions handle offline/online ([#227](https://github.com/coinbase/rest-hooks/issues/227)) ([38c9bc6](https://github.com/coinbase/rest-hooks/commit/38c9bc6b3aad62ad0ea17d43f366b98a968e529e))
 
-
-
 ### [4.0.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.0...rest-hooks@4.0.1) (2019-12-31)
-
 
 ### 🏠 Internal
 
 * Move normalizr code into repo ([#212](https://github.com/coinbase/rest-hooks/issues/212)) ([7d290f4](https://github.com/coinbase/rest-hooks/commit/7d290f404016073b64b4cddfc723e3591241b358))
 
-
 ### 📝 Documentation
 
 * Fix svg links in README ([7cad255](https://github.com/coinbase/rest-hooks/commit/7cad255a338f14fd165b54d79aa337f6dafe3c6a))
-
-
 
 ## [4.0.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.0-beta.5...rest-hooks@4.0.0) (2019-12-23)
 
 **Note:** Version bump only for package rest-hooks
 
-
-
-
-
 ## [4.0.0-beta.5](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.0-beta.4...rest-hooks@4.0.0-beta.5) (2019-12-23)
-
 
 ### 💅 Enhancement
 
 * Non-ES bundlers will use IE11 compatible build ([29eaefc](https://github.com/coinbase/rest-hooks/commit/29eaefcf380830a5bb0be92254d3217b371c893c))
 * Remove extraneous generics on Resource statics ([3be6a6a](https://github.com/coinbase/rest-hooks/commit/3be6a6a17a789f6a3909cf0d7401aa1394be8196))
 
-
-
 ## [4.0.0-beta.4](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.0-beta.3...rest-hooks@4.0.0-beta.4) (2019-12-22)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -1854,34 +1282,27 @@ overrides
 
 * export SimpleRecord which has the data methods of Resource ([#203](https://github.com/coinbase/rest-hooks/issues/203)) ([0c0dd49](https://github.com/coinbase/rest-hooks/commit/0c0dd4932a1c33c7477d77252f6a11b5adb3be5e))
 
-
 ### 💅 Enhancement
 
 * Easier to handle http fetch headers in response ([#208](https://github.com/coinbase/rest-hooks/issues/208)) ([86074a6](https://github.com/coinbase/rest-hooks/commit/86074a6f51acf0c689a74386c2ee9be3efc240d5))
 * Include context in error message when failing to build PK ([b754a64](https://github.com/coinbase/rest-hooks/commit/b754a64bc506f2b88a5e307b215f57c20c21abb5))
 * Resource.fetch() is no longer generic ([#207](https://github.com/coinbase/rest-hooks/issues/207)) ([e41da6c](https://github.com/coinbase/rest-hooks/commit/e41da6cf175f0c8e901e7f0f4dd90920f836a1e3))
 
-
 ### 🐛 Bug Fix
 
 * NetworkError type export should not be exposed to js build ([de9413c](https://github.com/coinbase/rest-hooks/commit/de9413c0cf29bc9e8aa752494e749f607370b8a3))
 * Tests run in node 12 ([#202](https://github.com/coinbase/rest-hooks/issues/202)) ([58e55e0](https://github.com/coinbase/rest-hooks/commit/58e55e0d08f1d79ab4b24408dbd5603afb8e8505))
 
-
 ### 📦 Package
 
 * testing ([138c846](https://github.com/coinbase/rest-hooks/commit/138c846035e704d78f751156e5587366310edf98))
-
 
 ### 🏠 Internal
 
 * Ignore process.env.NODE_ENV checks for coverage ([e71a0c1](https://github.com/coinbase/rest-hooks/commit/e71a0c1b7244ecf3e9db15e27600c7fb35a9a0d4))
 * Update lint rules ([#206](https://github.com/coinbase/rest-hooks/issues/206)) ([732f875](https://github.com/coinbase/rest-hooks/commit/732f87536e23d6b43cea3abce5be8cd6f1dd75c7))
 
-
-
 ## [4.0.0-beta.3](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.0-beta.2...rest-hooks@4.0.0-beta.3) (2019-12-16)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -1893,30 +1314,22 @@ overrides
 
 * Resource.fetch uses fetch instead of superagent ([#199](https://github.com/coinbase/rest-hooks/issues/199)) ([5c740ec](https://github.com/coinbase/rest-hooks/commit/5c740ecf8f864e33cd9a6ab6cbc0a872ba0344ed))
 
-
-
 ## [4.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@4.0.0-beta.1...rest-hooks@4.0.0-beta.2) (2019-12-11)
-
 
 ### 🐛 Bug Fix
 
 * Add lodash types ([#198](https://github.com/coinbase/rest-hooks/issues/198)) ([0523401](https://github.com/coinbase/rest-hooks/commit/05234010b884cbfcf1d5341a5bd5b318a1260360))
 * export PromiseifyMiddleware ([#197](https://github.com/coinbase/rest-hooks/issues/197)) ([89370ff](https://github.com/coinbase/rest-hooks/commit/89370ffccaee39a6e147b449a76a1ce9778f7010))
 
-
 ### 🏠 Internal
 
 * React.createContext -> createContext ([c5ff9cc](https://github.com/coinbase/rest-hooks/commit/c5ff9ccd41e1d4bf92aed3bf0ff9a42edaaa8985))
-
 
 ### 📝 Documentation
 
 * Point to repository directory for npm ([942a563](https://github.com/coinbase/rest-hooks/commit/942a563493d35dca9787e541dd89599d2059be1c))
 
-
-
 ## 4.0.0-beta.1 (2019-12-02)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -1926,28 +1339,22 @@ overrides
 
 * New @rest-hooks/legacy package ([#187](https://github.com/coinbase/rest-hooks/issues/187)) ([78c9321](https://github.com/coinbase/rest-hooks/commit/78c9321f3560d2ea57b4c8478e9bdd789762ae13))
 
-
 ### 💅 Enhancement
 
 * Move testing modules to own package ([#182](https://github.com/coinbase/rest-hooks/issues/182)) ([174461a](https://github.com/coinbase/rest-hooks/commit/174461a3c7568c53842eb6f4ea64e5b85dd20ce5))
 
-
 ### 📦 Package
 
 * Update dev: types and linting ([#186](https://github.com/coinbase/rest-hooks/issues/186)) ([78e36a4](https://github.com/coinbase/rest-hooks/commit/78e36a49eba85d7839c13f871e9a5985eeeb2458))
-
 
 ### 🏠 Internal
 
 * Centralize babel config & common test ([#189](https://github.com/coinbase/rest-hooks/issues/189)) ([16d22a3](https://github.com/coinbase/rest-hooks/commit/16d22a3ea0dab1b48ae59cdbd3ef8d53c33167f8))
 * Use TypeScript project references ([#188](https://github.com/coinbase/rest-hooks/issues/188)) ([412c674](https://github.com/coinbase/rest-hooks/commit/412c6740cd825b06e8784d0d0f4d39e6cb331062))
 
-
 ### 📝 Documentation
 
 * Update useStatefulResource() in guides ([#183](https://github.com/coinbase/rest-hooks/issues/183)) ([0e59914](https://github.com/coinbase/rest-hooks/commit/0e599141b0cc9540428def9e26ea228275df899b))
-
-
 
 # Change Log
 

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "6.3.8",
+  "version": "6.3.9",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -102,8 +102,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/core": "^3.2.8",
-    "@rest-hooks/endpoint": "^2.2.11"
+    "@rest-hooks/core": "^3.2.9",
+    "@rest-hooks/endpoint": "^2.2.12"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,44 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [5.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.4...@rest-hooks/rest@5.0.5) (2022-07-23)
+### [5.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.5...@rest-hooks/rest@5.0.6) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [5.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.4...@rest-hooks/rest@5.0.5) (2022-07-23)
 
 ### 🐛 Bug Fix
 
 * Ensure dual package hazard solved for non-node ([#2099](https://github.com/coinbase/rest-hooks/issues/2099)) ([6206e64](https://github.com/coinbase/rest-hooks/commit/6206e6463a7c3699d5c1d1b248e4d5418b1327f1))
 
-
-
 ### [5.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.2...@rest-hooks/rest@5.0.4) (2022-07-20)
-
 
 ### 🐛 Bug Fix
 
 * Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
 
-
-
 ### [5.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.1...@rest-hooks/rest@5.0.2) (2022-05-30)
-
 
 ### 📦 Package
 
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
 
-
-
 ### [5.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.0...@rest-hooks/rest@5.0.1) (2022-04-30)
-
 
 ### 📝 Documentation
 
 * Update README with newest practices ([#1920](https://github.com/coinbase/rest-hooks/issues/1920)) ([9bbd76c](https://github.com/coinbase/rest-hooks/commit/9bbd76c4fb20125d6318bd8ac5cc4238be4ab3d5))
 
-
-
 ## [5.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@4.0.0...@rest-hooks/rest@5.0.0) (2022-04-10)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -54,10 +47,7 @@ instead
 * Resource.create() can take 1-2 args ([ed4f55c](https://github.com/coinbase/rest-hooks/commit/ed4f55c8b4b80eb93f3c01108c2177b97f5dc4e8))
 * Simplify Resource.create() & Resource.list() arguments ([153f8fa](https://github.com/coinbase/rest-hooks/commit/153f8fac3ff64a3b9fc3df31c7ce31ad8193633a))
 
-
-
 ## [4.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@3.0.3...@rest-hooks/rest@4.0.0) (2022-04-08)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -73,70 +63,47 @@ fix: imports
 
 * Improved Resource ([7d7c79c](https://github.com/coinbase/rest-hooks/commit/7d7c79cb062d564b6b591629c4e836eb00024d48))
 
-
-
 ### [3.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@3.0.2...@rest-hooks/rest@3.0.3) (2022-02-26)
-
 
 ### 🐛 Bug Fix
 
 * Resource.url properties are enumerable when provided ([#1737](https://github.com/coinbase/rest-hooks/issues/1737)) ([500ab87](https://github.com/coinbase/rest-hooks/commit/500ab87ebc49d5d573c6ed5a79f6e9501537fa70))
 
-
-
 ### [3.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@3.0.1...@rest-hooks/rest@3.0.2) (2022-02-15)
-
 
 ### 🐛 Bug Fix
 
 * Only import from explicit dependencies ([#1705](https://github.com/coinbase/rest-hooks/issues/1705)) ([b7c2eeb](https://github.com/coinbase/rest-hooks/commit/b7c2eeb38c41be0181e84bf0efbc3502bc85c75c))
 
-
-
 ### [3.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@3.0.0...@rest-hooks/rest@3.0.1) (2021-10-11)
-
 
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
 
-
-
 ## [3.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@3.0.0-beta.2...@rest-hooks/rest@3.0.0) (2021-09-08)
 
 **Note:** Version bump only for package @rest-hooks/rest
 
-
-
-
-
 ## [3.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@3.0.0-beta.1...@rest-hooks/rest@3.0.0-beta.2) (2021-09-06)
-
 
 ### 💅 Enhancement
 
 * Give errors a name ([#1195](https://github.com/coinbase/rest-hooks/issues/1195)) ([caa1cd4](https://github.com/coinbase/rest-hooks/commit/caa1cd4c365eedc0e6bc8df6b00b9bfdf6492c63))
 * Improve NetworkError debuggability ([#1172](https://github.com/coinbase/rest-hooks/issues/1172)) ([9fb64bb](https://github.com/coinbase/rest-hooks/commit/9fb64bbf31827c65eaa1e6b0617e46f685d9ea58))
 
-
 ### 📝 Documentation
 
 * Add subscriptions to colocate ([#1175](https://github.com/coinbase/rest-hooks/issues/1175)) ([b311a61](https://github.com/coinbase/rest-hooks/commit/b311a6143d9b9087bae56591e531ff9030d6b704))
 * Rework introduction ([#614](https://github.com/coinbase/rest-hooks/issues/614)) ([85bc2a9](https://github.com/coinbase/rest-hooks/commit/85bc2a9a53ec751ca64b18894012167f6fb8e609))
 
-
-
 ## [3.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@3.0.0-beta.0...@rest-hooks/rest@3.0.0-beta.1) (2021-08-21)
-
 
 ### 🐛 Bug Fix
 
 * useFetchInit() hook calls same amount every render ([#1123](https://github.com/coinbase/rest-hooks/issues/1123)) ([6cd0b7c](https://github.com/coinbase/rest-hooks/commit/6cd0b7cc57de59b5f394942dfa9a3a08d9f2e912))
 
-
-
 ## [3.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.1.4...@rest-hooks/rest@3.0.0-beta.0) (2021-06-30)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -158,7 +125,6 @@ fix: imports
 * Normalize merges entities, entitymeta, indexes ([#915](https://github.com/coinbase/rest-hooks/issues/915)) ([bd21d8c](https://github.com/coinbase/rest-hooks/commit/bd21d8ce0d004a56e6853918d9fb9ecaa2c730a8))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Different babel targets for cjs and umd builds ([#989](https://github.com/coinbase/rest-hooks/issues/989)) ([f054814](https://github.com/coinbase/rest-hooks/commit/f05481410cf8daa2101d4dbda826e56ad10ec723))
@@ -166,120 +132,82 @@ fix: imports
 * Remove 'fallback' package.json exports ([#992](https://github.com/coinbase/rest-hooks/issues/992)) ([dc95f9d](https://github.com/coinbase/rest-hooks/commit/dc95f9dbad20d5740218c52c906596b6a3d6eae4))
 * SimpleResource is deprecated ([#991](https://github.com/coinbase/rest-hooks/issues/991)) ([cf5c0bf](https://github.com/coinbase/rest-hooks/commit/cf5c0bfb5f732b9dd80945cf670d1ffbf9913942))
 
-
 ### 📝 Documentation
 
 * Add doc links to jsdocs ([#966](https://github.com/coinbase/rest-hooks/issues/966)) ([dc7fcfe](https://github.com/coinbase/rest-hooks/commit/dc7fcfec24c30d5f405d24ccc1828620d837ea6b))
 
-
-
 ### [2.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.1.3...@rest-hooks/rest@2.1.4) (2021-06-09)
-
 
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ### [2.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.1.2...@rest-hooks/rest@2.1.3) (2021-06-02)
-
 
 ### 💅 Enhancement
 
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
-
 ### [2.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.1.1...@rest-hooks/rest@2.1.2) (2021-05-24)
-
 
 ### 💅 Enhancement
 
 * Simplify url logic for Resource ([#806](https://github.com/coinbase/rest-hooks/issues/806)) ([8f1bb8a](https://github.com/coinbase/rest-hooks/commit/8f1bb8a2ea1eec3e24a5f9e7e2d534cd818d05ab))
 
-
-
 ### [2.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.1.0...@rest-hooks/rest@2.1.1) (2021-04-26)
-
 
 ### 💅 Enhancement
 
 * Flexible url parameters for RestEndpoint ([#776](https://github.com/coinbase/rest-hooks/issues/776)) ([382d3b1](https://github.com/coinbase/rest-hooks/commit/382d3b112ebee0141260b0a41600568a02fda3fb))
 
-
-
 ## [2.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.0.6...@rest-hooks/rest@2.1.0) (2021-04-24)
-
 
 ### 🚀 Features
 
 * Endpoint parameters can be of any length ([#767](https://github.com/coinbase/rest-hooks/issues/767)) ([552f837](https://github.com/coinbase/rest-hooks/commit/552f83740279376288879a661ff487c5c6f1d469))
-
 
 ### 💅 Enhancement
 
 * Schema assistance for Delete ([#756](https://github.com/coinbase/rest-hooks/issues/756)) ([4dd6a5a](https://github.com/coinbase/rest-hooks/commit/4dd6a5a3f6f0f6bf024731a082dc48afa74cb327))
 * Support TypeScript 3.7 ([#752](https://github.com/coinbase/rest-hooks/issues/752)) ([68a10e0](https://github.com/coinbase/rest-hooks/commit/68a10e06dc0718f5e480097e6056a7a7954d1161))
 
-
-
 ### [2.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.0.5...@rest-hooks/rest@2.0.6) (2021-04-12)
-
 
 ### 🐛 Bug Fix
 
 * Relax DeleteShape def to be back-compat ([#743](https://github.com/coinbase/rest-hooks/issues/743)) ([20aa3a0](https://github.com/coinbase/rest-hooks/commit/20aa3a09bbe4419c23e37b331ca3208349f0e07c))
 
-
-
 ### [2.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.0.4...@rest-hooks/rest@2.0.5) (2021-04-12)
-
 
 ### 💅 Enhancement
 
 * Refined deleteShape() definition ([#734](https://github.com/coinbase/rest-hooks/issues/734)) ([e34526d](https://github.com/coinbase/rest-hooks/commit/e34526d5dde5a2cc317cd9428ededc6a9893dc41))
 
-
-
 ### [2.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.0.3...@rest-hooks/rest@2.0.4) (2021-04-04)
-
 
 ### 💅 Enhancement
 
 * Throw error when urlRoot is not defined ([#688](https://github.com/coinbase/rest-hooks/issues/688)) ([038bfcf](https://github.com/coinbase/rest-hooks/commit/038bfcf79963043f1f991b54dc1badfa5d70775c))
 
-
-
 ### [2.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.0.2...@rest-hooks/rest@2.0.3) (2021-03-26)
-
 
 ### 🐛 Bug Fix
 
 * Compatibility with TypeScript strict: false ([#683](https://github.com/coinbase/rest-hooks/issues/683)) ([8a6e7ed](https://github.com/coinbase/rest-hooks/commit/8a6e7ed4d179555c4ba5cb8957b1c63697a1ce1a))
 
-
-
 ### [2.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.0.1...@rest-hooks/rest@2.0.2) (2021-03-16)
-
 
 ### 🐛 Bug Fix
 
 * typeof Resource === typeof SimpleResource ([#662](https://github.com/coinbase/rest-hooks/issues/662)) ([4174149](https://github.com/coinbase/rest-hooks/commit/417414947a8a470ee84d3d98ee47646d6ca12798))
 
-
-
 ### [2.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@2.0.0...@rest-hooks/rest@2.0.1) (2021-03-14)
-
 
 ### 📝 Documentation
 
 * Update package tags ([#650](https://github.com/coinbase/rest-hooks/issues/650)) ([4ef465a](https://github.com/coinbase/rest-hooks/commit/4ef465a129cd59668cd9c3542bb9ec03c84d2a4d))
 
-
-
 ## [2.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@1.0.4...@rest-hooks/rest@2.0.0) (2021-03-08)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -291,47 +219,33 @@ fix: imports
 
 * Add Resource.useFetchInit() ([#635](https://github.com/coinbase/rest-hooks/issues/635)) ([9571870](https://github.com/coinbase/rest-hooks/commit/957187071bc5b654e2f8273b7527f44f27cf0139))
 
-
-
 ### [1.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@1.0.3...@rest-hooks/rest@1.0.4) (2021-02-24)
-
 
 ### 💅 Enhancement
 
 * Explicitly defined Resource endpoint return types ([#576](https://github.com/coinbase/rest-hooks/issues/576)) ([bc72fa7](https://github.com/coinbase/rest-hooks/commit/bc72fa76a76f769479e6ae3f2e8515a8a9e2e8d2))
 
-
-
 ### [1.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@1.0.2...@rest-hooks/rest@1.0.3) (2021-02-23)
-
 
 ### 🐛 Bug Fix
 
 * Support non-JSON payloads (like FormData) ([#552](https://github.com/coinbase/rest-hooks/issues/552)) ([82e68ac](https://github.com/coinbase/rest-hooks/commit/82e68ac8975fc4fa8ba468fe525662b6cbd627c1))
 
-
 ### 📝 Documentation
 
 * Typos and minor improvements ([#561](https://github.com/coinbase/rest-hooks/issues/561)) ([aed902a](https://github.com/coinbase/rest-hooks/commit/aed902a7ee8a50f7f08fab261efa528a82c52b19))
 
-
-
 ### [1.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@1.0.1...@rest-hooks/rest@1.0.2) (2021-02-04)
-
 
 ### 📦 Package
 
 * Relax @babel/runtime requirement to ^7.7.2 ([#513](https://github.com/coinbase/rest-hooks/issues/513)) ([cc95b21](https://github.com/coinbase/rest-hooks/commit/cc95b219fbddebfbf334728887ca6d2fa070fce1))
 
-
 ### 📝 Documentation
 
 * Link improvements, flesh out test readme ([#511](https://github.com/coinbase/rest-hooks/issues/511)) ([9cab431](https://github.com/coinbase/rest-hooks/commit/9cab431803a8b7d9c18e02b3e9cb7e336215ccdb))
 
-
-
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@1.0.0...@rest-hooks/rest@1.0.1) (2021-01-30)
-
 
 ### 💅 Enhancement
 
@@ -339,20 +253,15 @@ fix: imports
 * Expand matches peerdeps for endpoint ([#504](https://github.com/coinbase/rest-hooks/issues/504)) ([9682b7c](https://github.com/coinbase/rest-hooks/commit/9682b7ce955419fa7e1095c377b45400758fd101))
 * Improve malformed entity detection ([#494](https://github.com/coinbase/rest-hooks/issues/494)) ([b8bb07f](https://github.com/coinbase/rest-hooks/commit/b8bb07f480549a97254a4fdf6b00acd9cb89a9eb))
 
-
 ### 🐛 Bug Fix
 
 * Widen Resource.delete() just like other endpoints ([#503](https://github.com/coinbase/rest-hooks/issues/503)) ([2aaa882](https://github.com/coinbase/rest-hooks/commit/2aaa8829487574ca05d71163af44053f52b304d8))
-
 
 ### 📝 Documentation
 
 * Add chat badge ([#501](https://github.com/coinbase/rest-hooks/issues/501)) ([787e250](https://github.com/coinbase/rest-hooks/commit/787e25022f8a8949e5dfb818c63fd1574dbd2787))
 
-
-
 ## 1.0.0 (2021-01-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -369,7 +278,6 @@ entities
 * Simple AbortController integration ([#392](https://github.com/coinbase/rest-hooks/issues/392)) ([899563d](https://github.com/coinbase/rest-hooks/commit/899563deccaccc214c3504b91b96e1460ddfab2f))
 * Support extra endpoint members and inheritance ([#387](https://github.com/coinbase/rest-hooks/issues/387)) ([6ad5486](https://github.com/coinbase/rest-hooks/commit/6ad5486b6e333d8721b74fd4fb1b7ed783461435))
 
-
 ### 💅 Enhancement
 
 * Keep legacy Resource ([#376](https://github.com/coinbase/rest-hooks/issues/376)) ([fdd1f7c](https://github.com/coinbase/rest-hooks/commit/fdd1f7cd276871d1f92e2a7bd17118a3e6df12e9))
@@ -378,7 +286,6 @@ entities
 * Simplify endpoint memoization and provide new extensions ([#391](https://github.com/coinbase/rest-hooks/issues/391)) ([d874d0b](https://github.com/coinbase/rest-hooks/commit/d874d0b3e6433a616d2dbecd8076715f5caefaeb))
 * Widen RestFetch types to make overriding not break ([#479](https://github.com/coinbase/rest-hooks/issues/479)) ([2bccf12](https://github.com/coinbase/rest-hooks/commit/2bccf12f7892ccbc1d342bd529b3659c2935fb71))
 
-
 ### 🐛 Bug Fix
 
 * Handle entities updated with new indexes ([#384](https://github.com/coinbase/rest-hooks/issues/384)) ([2ee3bb6](https://github.com/coinbase/rest-hooks/commit/2ee3bb60217bed1f91a6d3d086b354ce151b8e0c))
@@ -386,38 +293,29 @@ entities
 * Resource endpoint memoization ([744431e](https://github.com/coinbase/rest-hooks/commit/744431ef435dfab1969cd883f01b6a4b50b6c75d))
 * TypeScript 4 compatibility ([#406](https://github.com/coinbase/rest-hooks/issues/406)) ([5d82e24](https://github.com/coinbase/rest-hooks/commit/5d82e2416b68992f6efccb63f694010ef1ea28e8))
 
-
 ### 📦 Package
 
 * Rely on latest endpoint ([801f5e7](https://github.com/coinbase/rest-hooks/commit/801f5e7fcdd10bc8526615042a2e40a946222a9c))
 * Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a8c435c5ef74b3809c8950a2caceca8763))
 
-
 ### 📝 Documentation
 
 * Update nested response docs with behaviors of rest package ([#471](https://github.com/coinbase/rest-hooks/issues/471)) ([04fe9b3](https://github.com/coinbase/rest-hooks/commit/04fe9b390e4e097605a96f268168d8918c4948df))
 
-
-
 ### [0.6.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@0.6.0...@rest-hooks/rest@0.6.1) (2021-01-19)
-
 
 ### 💅 Enhancement
 
 * Widen RestFetch types to make overriding not break ([#479](https://github.com/coinbase/rest-hooks/issues/479)) ([2bccf12](https://github.com/coinbase/rest-hooks/commit/2bccf12f7892ccbc1d342bd529b3659c2935fb71))
 
-
 ### 📝 Documentation
 
 * Update nested response docs with behaviors of rest package ([#471](https://github.com/coinbase/rest-hooks/issues/471)) ([04fe9b3](https://github.com/coinbase/rest-hooks/commit/04fe9b390e4e097605a96f268168d8918c4948df))
-
-
 
 ## 0.6.0 (2021-01-15)
 
 * feat: Resources can have nested entities (#469) ([4eeeaae](https://github.com/coinbase/rest-hooks/commit/4eeeaae)), closes [#469](https://github.com/coinbase/rest-hooks/issues/469)
 * enhance: Remove Readonly on Resource endpoint schemas (#468) ([0b98987](https://github.com/coinbase/rest-hooks/commit/0b98987)), closes [#468](https://github.com/coinbase/rest-hooks/issues/468)
-
 
 ### BREAKING CHANGE
 
@@ -425,50 +323,27 @@ entities
 entities from their schemas, rather than the `pk` of those
 entities
 
-
-
-
 ## <small>0.5.1 (2021-01-06)</small>
 
 * pkg: Use @babel/runtime @ 7.12 ([e631f6a](https://github.com/coinbase/rest-hooks/commit/e631f6a))
-
-
-
-
 
 ## 0.5.0 (2020-12-08)
 
 * feat: Add RestEndpoint type (#427) ([dc47667](https://github.com/coinbase/rest-hooks/commit/dc47667)), closes [#427](https://github.com/coinbase/rest-hooks/issues/427)
 
-
-
-
-
 ## <small>0.4.1 (2020-09-08)</small>
 
 * fix: TypeScript 4 compatibility (#406) ([5d82e24](https://github.com/coinbase/rest-hooks/commit/5d82e24)), closes [#406](https://github.com/coinbase/rest-hooks/issues/406)
-
-
-
-
 
 ## 0.4.0 (2020-08-09)
 
 * feat: Simple AbortController integration (#392) ([899563d](https://github.com/coinbase/rest-hooks/commit/899563d)), closes [#392](https://github.com/coinbase/rest-hooks/issues/392)
 * pkg: Rely on latest endpoint ([801f5e7](https://github.com/coinbase/rest-hooks/commit/801f5e7))
 
-
-
-
-
 ## <small>0.3.1 (2020-08-09)</small>
 
 * enhance: Simplify endpoint memoization and provide new extensions (#391) ([d874d0b](https://github.com/coinbase/rest-hooks/commit/d874d0b)), closes [#391](https://github.com/coinbase/rest-hooks/issues/391)
 * fix: Resource endpoint memoization ([744431e](https://github.com/coinbase/rest-hooks/commit/744431e))
-
-
-
-
 
 ## 0.3.0 (2020-08-08)
 
@@ -476,26 +351,14 @@ entities
 * internal: Test using endpoints directly (#389) ([bb0e8fd](https://github.com/coinbase/rest-hooks/commit/bb0e8fd)), closes [#389](https://github.com/coinbase/rest-hooks/issues/389)
 * feat: Support extra endpoint members and inheritance (#387) ([6ad5486](https://github.com/coinbase/rest-hooks/commit/6ad5486)), closes [#387](https://github.com/coinbase/rest-hooks/issues/387)
 
-
-
-
-
 ## <small>0.2.1 (2020-08-04)</small>
 
 * fix: Handle entities updated with new indexes (#384) ([2ee3bb6](https://github.com/coinbase/rest-hooks/commit/2ee3bb6)), closes [#384](https://github.com/coinbase/rest-hooks/issues/384)
 * fix: Infer useFetcher() has no body when not present in fetch (#385) ([22dd399](https://github.com/coinbase/rest-hooks/commit/22dd399)), closes [#385](https://github.com/coinbase/rest-hooks/issues/385)
 
-
-
-
-
 ## 0.2.0 (2020-07-31)
 
 * feat: Re-export normalizr from 'rest' lib ([4362686](https://github.com/coinbase/rest-hooks/commit/4362686))
-
-
-
-
 
 ## 0.1.0 (2020-07-27)
 

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -3,65 +3,49 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.2...@rest-hooks/ssr@0.2.3) (2022-07-23)
+### [0.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.3...@rest-hooks/ssr@0.2.4) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [0.2.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.2...@rest-hooks/ssr@0.2.3) (2022-07-23)
 
 ### 🐛 Bug Fix
 
 * Ensure dual package hazard solved for non-node ([#2099](https://github.com/coinbase/rest-hooks/issues/2099)) ([6206e64](https://github.com/coinbase/rest-hooks/commit/6206e6463a7c3699d5c1d1b248e4d5418b1327f1))
 
-
-
 ### [0.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.0...@rest-hooks/ssr@0.2.2) (2022-07-20)
-
 
 ### 🐛 Bug Fix
 
 * Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
 
-
-
 ## [0.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.1.4...@rest-hooks/ssr@0.2.0) (2022-05-30)
-
 
 ### 🚀 Features
 
 * Add nonce property for security in SSR ([#2029](https://github.com/coinbase/rest-hooks/issues/2029)) ([6016126](https://github.com/coinbase/rest-hooks/commit/601612623b569d0f104b34ae05ebea9770e3cf62))
 
-
 ### 📦 Package
 
 * Use @babel/runtime@^7.13.0 to use CJS/ESM exports support ([#2019](https://github.com/coinbase/rest-hooks/issues/2019)) ([78a22f2](https://github.com/coinbase/rest-hooks/commit/78a22f29f86527ac10eb2c9b031984e044226dce))
-
-
 
 ### [0.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.1.3...@rest-hooks/ssr@0.1.4) (2022-04-30)
 
 **Note:** Version bump only for package @rest-hooks/ssr
 
-
-
-
-
 ### [0.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.1.2...@rest-hooks/ssr@0.1.3) (2022-04-18)
-
 
 ### 🐛 Bug Fix
 
 * createPersistedStore import ([#1921](https://github.com/coinbase/rest-hooks/issues/1921)) ([17ce1dc](https://github.com/coinbase/rest-hooks/commit/17ce1dce132a9705937de173a8ad44e0532ffa96))
 
-
-
 ### [0.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.1.1-beta.0...@rest-hooks/ssr@0.1.2) (2022-04-01)
 
 **Note:** Version bump only for package @rest-hooks/ssr
 
-
-
-
-
 ### 0.1.1 (2022-03-17)
-
 
 ### 🚀 Features
 

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/ssr",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,167 +3,124 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [7.3.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.3...@rest-hooks/test@7.3.4) (2022-07-23)
+### [7.3.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.4...@rest-hooks/test@7.3.5) (2022-07-26)
 
+### 🐛 Bug Fix
+
+* **pkg:** Missing @babel/runtime in deps list ([#2112](https://github.com/coinbase/rest-hooks/issues/2112)) ([373eb72](https://github.com/coinbase/rest-hooks/commit/373eb726cfa3b5fead130fbca6de9e3ccf839245))
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [7.3.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.3...@rest-hooks/test@7.3.4) (2022-07-23)
 
 ### 🐛 Bug Fix
 
 * Ensure dual package hazard solved for non-node ([#2099](https://github.com/coinbase/rest-hooks/issues/2099)) ([6206e64](https://github.com/coinbase/rest-hooks/commit/6206e6463a7c3699d5c1d1b248e4d5418b1327f1))
 
-
-
 ### [7.3.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.1...@rest-hooks/test@7.3.3) (2022-07-20)
-
 
 ### 🐛 Bug Fix
 
 * Fix package exports support for latest resolve pkg ([#2062](https://github.com/coinbase/rest-hooks/issues/2062)) ([0088494](https://github.com/coinbase/rest-hooks/commit/0088494e5cab91da7becebe7d9b62796fb9f4f2e))
 
-
 ### 📦 Package
 
 * Update `@testing-library/react-hooks` to v8 ([#2070](https://github.com/coinbase/rest-hooks/issues/2070)) ([174d896](https://github.com/coinbase/rest-hooks/commit/174d896af4fe77443037409b336a12efd86ce5ad))
 
-
-
 ### [7.3.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.0...@rest-hooks/test@7.3.1) (2022-04-30)
-
 
 ### 📝 Documentation
 
 * Update README with newest practices ([#1920](https://github.com/coinbase/rest-hooks/issues/1920)) ([9bbd76c](https://github.com/coinbase/rest-hooks/commit/9bbd76c4fb20125d6318bd8ac5cc4238be4ab3d5))
 
-
-
 ## [7.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.2.2...@rest-hooks/test@7.3.0) (2022-04-08)
-
 
 ### 🚀 Features
 
 * Support controller.fetch and useSuspense ([0c140ae](https://github.com/coinbase/rest-hooks/commit/0c140ae4ec0c214e699fd9c91d5d60a546a458ae))
 
-
-
 ### [7.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.2.1...@rest-hooks/test@7.2.2) (2022-04-02)
-
 
 ### 🐛 Bug Fix
 
 * Use imported State interface rather than a copy ([#1857](https://github.com/coinbase/rest-hooks/issues/1857)) ([c2535d4](https://github.com/coinbase/rest-hooks/commit/c2535d44a14118b169b701287e3a69f3fe9116e7))
 
-
-
 ### [7.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.2.0...@rest-hooks/test@7.2.1) (2022-02-15)
-
 
 ### 🐛 Bug Fix
 
 * Compatibility with webpack builds for test ([#1711](https://github.com/coinbase/rest-hooks/issues/1711)) ([a3990fd](https://github.com/coinbase/rest-hooks/commit/a3990fdcdec43a6997f62cf8e43e64b73ea38ca6))
 
-
-
 ## [7.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.1.3...@rest-hooks/test@7.2.0) (2022-02-15)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
-
 
 ### 🐛 Bug Fix
 
 * exports.require filepath ([#1701](https://github.com/coinbase/rest-hooks/issues/1701)) ([a84d6fe](https://github.com/coinbase/rest-hooks/commit/a84d6fe2abdbb03e69f2356080d94a576387838b))
 
-
-
 ## [7.2.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.1.3...@rest-hooks/test@7.2.0-beta.0) (2022-01-23)
-
 
 ### 🚀 Features
 
 * Add endpoint.optimisticUpdater ([#1616](https://github.com/coinbase/rest-hooks/issues/1616)) ([7a99fae](https://github.com/coinbase/rest-hooks/commit/7a99fae20ee9abf5f2121c1f1719bdcce3e78d98))
 
-
-
 ### [7.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.1.2...@rest-hooks/test@7.1.3) (2021-10-18)
-
 
 ### 💅 Enhancement
 
 * Mark compatibility with latest @rest-hooks/core ([#1409](https://github.com/coinbase/rest-hooks/issues/1409)) ([57993f3](https://github.com/coinbase/rest-hooks/commit/57993f38ea7ee12cc9eefb562572fea6de63cb1d))
 
-
-
 ### [7.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.1.1...@rest-hooks/test@7.1.2) (2021-10-14)
-
 
 ### 🐛 Bug Fix
 
 * Correct controller override ([#1386](https://github.com/coinbase/rest-hooks/issues/1386)) ([c1d4a70](https://github.com/coinbase/rest-hooks/commit/c1d4a70d09f0bd501ea5c0112a48b377d553ca45))
 
-
-
 ### [7.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.1.0...@rest-hooks/test@7.1.1) (2021-10-14)
-
 
 ### 🐛 Bug Fix
 
 * MockResolver also overrides controller ([#1384](https://github.com/coinbase/rest-hooks/issues/1384)) ([362bb26](https://github.com/coinbase/rest-hooks/commit/362bb2600009e5b08f566442ea5073228607200b))
 
-
-
 ## [7.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.0.0...@rest-hooks/test@7.1.0) (2021-09-19)
-
 
 ### 🚀 Features
 
 * Send controller to middlewares ([#1271](https://github.com/coinbase/rest-hooks/issues/1271)) ([29db53c](https://github.com/coinbase/rest-hooks/commit/29db53c8ee7f5d770dd43b6e3d97346bc77f76d7))
 
-
-
 ## [7.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.0.0-beta.3...@rest-hooks/test@7.0.0) (2021-09-08)
 
 **Note:** Version bump only for package @rest-hooks/test
 
-
-
-
-
 ## [7.0.0-beta.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.0.0-beta.2...@rest-hooks/test@7.0.0-beta.3) (2021-09-06)
-
 
 ### 💅 Enhancement
 
 * Warn users if they are missing Suspense boundary ([#1169](https://github.com/coinbase/rest-hooks/issues/1169)) ([ccf819a](https://github.com/coinbase/rest-hooks/commit/ccf819ab65163aa056a3317e1c1eca17c003ecf6))
 
-
-
 ## [7.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.0.0-beta.1...@rest-hooks/test@7.0.0-beta.2) (2021-08-21)
-
 
 ### 🐛 Bug Fix
 
 * RESET clears inflight fetches ([#1085](https://github.com/coinbase/rest-hooks/issues/1085)) ([02fa0d5](https://github.com/coinbase/rest-hooks/commit/02fa0d527ef138961ba6dc2509648337c01e604d))
 
-
-
 ## [7.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.0.0-beta.0...@rest-hooks/test@7.0.0-beta.1) (2021-07-12)
-
 
 ### 🚀 Features
 
 * FixtureEndpoint & renderRestHook resolverFixtures ([#1027](https://github.com/coinbase/rest-hooks/issues/1027)) ([bbb69e9](https://github.com/coinbase/rest-hooks/commit/bbb69e9faaa523c46a0e309a44e0fd52f0ce91aa))
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([72da158](https://github.com/coinbase/rest-hooks/commit/72da158c19acf4c76b8b86eb37e063956b7347fd))
 
-
 ### 💅 Enhancement
 
 * Use optional chaining ([#1003](https://github.com/coinbase/rest-hooks/issues/1003)) ([6e45937](https://github.com/coinbase/rest-hooks/commit/6e459377e3f0d90d1832c0173358c3c73f253831))
 
-
-
 ## [7.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@6.1.0...@rest-hooks/test@7.0.0-beta.0) (2021-06-30)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -175,42 +132,30 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([a30fe4c](https://github.com/coinbase/rest-hooks/commit/a30fe4c000878aafe724915f653594aa67c5c336))
 * Use 'exports' package.json member ([#955](https://github.com/coinbase/rest-hooks/issues/955)) ([7e9d39f](https://github.com/coinbase/rest-hooks/commit/7e9d39f15b4b321352ece0caddb93e2c414df8ae))
 
-
 ### 💅 Enhancement
 
 * Remove 'fallback' package.json exports ([#992](https://github.com/coinbase/rest-hooks/issues/992)) ([dc95f9d](https://github.com/coinbase/rest-hooks/commit/dc95f9dbad20d5740218c52c906596b6a3d6eae4))
 * Use .js for cjs like other packages ([#988](https://github.com/coinbase/rest-hooks/issues/988)) ([2320ef7](https://github.com/coinbase/rest-hooks/commit/2320ef7777bcd991c3ca3d3fc8873f433e04fcfd))
 
-
 ## [6.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@6.1.0...@rest-hooks/test@6.2.0) (2021-06-25)
-
 
 ### 🚀 Features
 
 * Mark compatibility with upcoming versions ([#959](https://github.com/coinbase/rest-hooks/issues/959)) ([72da158](https://github.com/coinbase/rest-hooks/commit/72da158c19acf4c76b8b86eb37e063956b7347fd))
 
-
-
 ## [6.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@6.0.1...@rest-hooks/test@6.1.0) (2021-06-13)
-
 
 ### 🚀 Features
 
 * Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
 
-
-
 ### [6.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@6.0.0...@rest-hooks/test@6.0.1) (2021-06-09)
-
 
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ## [6.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.1.4...@rest-hooks/test@6.0.0) (2021-06-02)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -223,20 +168,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
 ### 📦 Package
 
 * react-hooks-testing-library v7 ([#866](https://github.com/coinbase/rest-hooks/issues/866)) ([249883b](https://github.com/coinbase/rest-hooks/commit/249883b11624d1adbd440fbbb96f597a81162857))
-
 
 ### 🏠 Internal
 
 * Major version bump ([#874](https://github.com/coinbase/rest-hooks/issues/874)) ([37931f3](https://github.com/coinbase/rest-hooks/commit/37931f331a08268fb12f752f26f3281b0cb11adf))
 
-
-
 ## [5.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.1.4...@rest-hooks/test@5.0.0) (2021-05-30)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -249,73 +189,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * react-hooks-testing-library v7 ([#866](https://github.com/coinbase/rest-hooks/issues/866)) ([249883b](https://github.com/coinbase/rest-hooks/commit/249883b11624d1adbd440fbbb96f597a81162857))
 
-
 ### 🏠 Internal
 
 * Major version bump ([#874](https://github.com/coinbase/rest-hooks/issues/874)) ([37931f3](https://github.com/coinbase/rest-hooks/commit/37931f331a08268fb12f752f26f3281b0cb11adf))
-
-
 
 ### [4.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.1.3...@rest-hooks/test@4.1.4) (2021-05-24)
 
 **Note:** Version bump only for package @rest-hooks/test
 
-
-
-
-
 ### [4.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.1.2...@rest-hooks/test@4.1.3) (2021-04-26)
-
 
 ### 🐛 Bug Fix
 
 * useMeta() parameters type ([#775](https://github.com/coinbase/rest-hooks/issues/775)) ([9f7fae4](https://github.com/coinbase/rest-hooks/commit/9f7fae4dba0d797fdfac114e52cdd5ea90f4d61f))
 
-
-
 ### [4.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.1.1...@rest-hooks/test@4.1.2) (2021-04-24)
-
 
 ### 💅 Enhancement
 
 * Support TypeScript 3.7 ([#752](https://github.com/coinbase/rest-hooks/issues/752)) ([68a10e0](https://github.com/coinbase/rest-hooks/commit/68a10e06dc0718f5e480097e6056a7a7954d1161))
 
-
-
 ### [4.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.1.0...@rest-hooks/test@4.1.1) (2021-03-14)
-
 
 ### 📝 Documentation
 
 * Update package tags ([#650](https://github.com/coinbase/rest-hooks/issues/650)) ([4ef465a](https://github.com/coinbase/rest-hooks/commit/4ef465a129cd59668cd9c3542bb9ec03c84d2a4d))
 
-
-
 ## [4.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.0.1...@rest-hooks/test@4.1.0) (2021-03-10)
-
 
 ### 🚀 Features
 
 * Rely on mapMiddleware for redux testing ([#648](https://github.com/coinbase/rest-hooks/issues/648)) ([43dca21](https://github.com/coinbase/rest-hooks/commit/43dca21dedd8e7379c5a8305a48001ee80db3d7c))
 
-
 ### 🐛 Bug Fix
 
 * Redux-integration needs state selection in middlewares: mapMiddleware() ([#643](https://github.com/coinbase/rest-hooks/issues/643)) ([a0f92eb](https://github.com/coinbase/rest-hooks/commit/a0f92eb5bd62a04bf92214c6cf3b6282048e723e))
 
-
-
 ### [4.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@4.0.0...@rest-hooks/test@4.0.1) (2021-03-08)
-
 
 ### 🐛 Bug Fix
 
 * Explicit extensions for ESM ([#628](https://github.com/coinbase/rest-hooks/issues/628)) ([ece85e4](https://github.com/coinbase/rest-hooks/commit/ece85e4e96f446afcfdacc76e03891848a4c6fd4))
 
-
-
 ## [4.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@3.0.1...@rest-hooks/test@4.0.0) (2021-03-01)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -328,25 +244,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Define package exports for modern tooling ([#590](https://github.com/coinbase/rest-hooks/issues/590)) ([5a3e00b](https://github.com/coinbase/rest-hooks/commit/5a3e00b26451c6d0a480925f5f1ab7099a7aedeb))
 
-
-
 ### [3.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@3.0.0...@rest-hooks/test@3.0.1) (2021-02-23)
-
 
 ### 🐛 Bug Fix
 
 * Gracefully handle webpack builds ([#551](https://github.com/coinbase/rest-hooks/issues/551)) ([d53a2a1](https://github.com/coinbase/rest-hooks/commit/d53a2a181d27077e4da9cd6152bbee116fbca1ad))
-
 
 ### 📝 Documentation
 
 * Link improvements, flesh out test readme ([#511](https://github.com/coinbase/rest-hooks/issues/511)) ([9cab431](https://github.com/coinbase/rest-hooks/commit/9cab431803a8b7d9c18e02b3e9cb7e336215ccdb))
 * Typo fix + better test example ([#512](https://github.com/coinbase/rest-hooks/issues/512)) ([70c29ac](https://github.com/coinbase/rest-hooks/commit/70c29ac472ee88227da32ea6ffdddebfff813b99))
 
-
-
 ## [3.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@2.0.1...@rest-hooks/test@3.0.0) (2021-01-31)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -365,25 +274,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * react-hooks-testing-library major ([#497](https://github.com/coinbase/rest-hooks/issues/497)) ([e6a5210](https://github.com/coinbase/rest-hooks/commit/e6a5210f066dddcad065c3737dbfb9ac8f9e8d89))
 
-
 ### 📝 Documentation
 
 * Update readme for test pkg ([#509](https://github.com/coinbase/rest-hooks/issues/509)) ([55afd72](https://github.com/coinbase/rest-hooks/commit/55afd72a1a859bdac2139589a3e4f061d06bea0e))
 
-
-
 ### [2.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@2.0.0...@rest-hooks/test@2.0.1) (2021-01-24)
-
 
 ### 🐛 Bug Fix
 
 * Disallow breaking 3.6 version of @testing-library/react-hooks ([#498](https://github.com/coinbase/rest-hooks/issues/498)) ([b3b057b](https://github.com/coinbase/rest-hooks/commit/b3b057bdbe5f2da6ce2a55a7129989e3f9d7b30b))
 * MockResolver intercepts subscriptions matching fixtures ([#490](https://github.com/coinbase/rest-hooks/issues/490)) ([63e631f](https://github.com/coinbase/rest-hooks/commit/63e631ffa66505cba290723ce4dd773fe9be4a26))
 
-
-
 ## 2.0.0 (2021-01-19)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -396,7 +298,6 @@ Testing lib now relies on new export in rest-hooks 5
 
 * Add <MockResolver /> ([#446](https://github.com/coinbase/rest-hooks/issues/446)) ([614576a](https://github.com/coinbase/rest-hooks/commit/614576ac051b1d82e4181bd4278d4f6a16b82ab8))
 
-
 ### 💅 Enhancement
 
 * New package @rest-hooks/core ([#336](https://github.com/coinbase/rest-hooks/issues/336)) ([bf490c0](https://github.com/coinbase/rest-hooks/commit/bf490c030feb8a0e35e96c6dd7d180e45ac8bfd0))
@@ -404,7 +305,6 @@ Testing lib now relies on new export in rest-hooks 5
 * Refine action creator interface ([#327](https://github.com/coinbase/rest-hooks/issues/327)) ([8cdc119](https://github.com/coinbase/rest-hooks/commit/8cdc1198a37d1a253e1b7a9a54aec2ab76eddaaa))
 * Rename action.meta.url to 'key' ([#325](https://github.com/coinbase/rest-hooks/issues/325)) ([5a06fe4](https://github.com/coinbase/rest-hooks/commit/5a06fe4d1799f0d8806b57d6929813e00a23cffd))
 * Support React 17 ([#397](https://github.com/coinbase/rest-hooks/issues/397)) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f0724c60fbb2dd3ff6d7d791ee53c3eff694))
-
 
 ### 🐛 Bug Fix
 
@@ -416,11 +316,9 @@ Testing lib now relies on new export in rest-hooks 5
 * Test types ([#379](https://github.com/coinbase/rest-hooks/issues/379)) ([f4353d9](https://github.com/coinbase/rest-hooks/commit/f4353d964e41acd51e75e016d910448a7613990e))
 * Testing should be using context from @rest-hooks/core in cjs ([cf84798](https://github.com/coinbase/rest-hooks/commit/cf8479888638b78f36bd2ba1396ba372f4df70a5))
 
-
 ### 📝 Documentation
 
 * Improve readme for new packages ([2406f2c](https://github.com/coinbase/rest-hooks/commit/2406f2c78a10e41f6aa1e7deeb4c957a3c94314d))
-
 
 ## 2.0.0-k.2 (2021-01-06)
 
@@ -429,72 +327,41 @@ Testing lib now relies on new export in rest-hooks 5
 * feat: Add FixtureNetworkManager to provide fixtures for imperative fetch ([0d015dc](https://github.com/coinbase/rest-hooks/commit/0d015dc))
 * fix: FixtureManager should dispatch receive async to not break react (#445) ([e1645cb](https://github.com/coinbase/rest-hooks/commit/e1645cb)), closes [#445](https://github.com/coinbase/rest-hooks/issues/445)
 
-
-
-
-
 ## 2.0.0-k.1 (2020-09-08)
 
 * fix: Only block suspense if errors are synthetic (#410) ([af8ab26](https://github.com/coinbase/rest-hooks/commit/af8ab26)), closes [#410](https://github.com/coinbase/rest-hooks/issues/410)
 * fix: Only console fetch dispatches ([4b3e046](https://github.com/coinbase/rest-hooks/commit/4b3e046))
 
-
-
-
-
 ## 2.0.0-k.0 (2020-08-12)
 
 * enhance: Support React 17 (#397) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f07)), closes [#397](https://github.com/coinbase/rest-hooks/issues/397)
 
-
-
-
-
 ## 2.0.0-j.2 (2020-08-09)
 
 * fix: Improve Wrapper types ([b30321d](https://github.com/coinbase/rest-hooks/commit/b30321d))
-
-
-
-
 
 ## 2.0.0-j.1 (2020-07-31)
 
 * fix: Test types ([17fe727](https://github.com/coinbase/rest-hooks/commit/17fe727))
 * fix: Test types (#379) ([f4353d9](https://github.com/coinbase/rest-hooks/commit/f4353d9)), closes [#379](https://github.com/coinbase/rest-hooks/issues/379)
 
-
-
-
-
 ## 2.0.0-j.0 (2020-07-27)
 
 * enhance: Print the action in mockDispatch, so users know what they need to mock. (#373) ([18a7628](https://github.com/coinbase/rest-hooks/commit/18a7628)), closes [#373](https://github.com/coinbase/rest-hooks/issues/373)
 
-
-
-
-
 ## [2.0.0-beta.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@2.0.0-beta.1...@rest-hooks/test@2.0.0-beta.2) (2020-05-13)
-
 
 ### 🐛 Bug Fix
 
 * Testing should be using context from @rest-hooks/core in cjs ([cf84798](https://github.com/coinbase/rest-hooks/commit/cf8479888638b78f36bd2ba1396ba372f4df70a5))
 
-
-
 ## [2.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@2.0.0-beta.0...@rest-hooks/test@2.0.0-beta.1) (2020-05-12)
-
 
 ### 💅 Enhancement
 
 * New package @rest-hooks/core ([#336](https://github.com/coinbase/rest-hooks/issues/336)) ([bf490c0](https://github.com/coinbase/rest-hooks/commit/bf490c030feb8a0e35e96c6dd7d180e45ac8bfd0))
 
-
-
 ## [2.0.0-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.18...@rest-hooks/test@2.0.0-beta.0) (2020-05-04)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -508,155 +375,93 @@ Testing lib now relies on new export in rest-hooks 5
 * Refine action creator interface ([#327](https://github.com/coinbase/rest-hooks/issues/327)) ([8cdc119](https://github.com/coinbase/rest-hooks/commit/8cdc1198a37d1a253e1b7a9a54aec2ab76eddaaa))
 * Rename action.meta.url to 'key' ([#325](https://github.com/coinbase/rest-hooks/issues/325)) ([5a06fe4](https://github.com/coinbase/rest-hooks/commit/5a06fe4d1799f0d8806b57d6929813e00a23cffd))
 
-
 ### 🐛 Bug Fix
 
 * Rest Hooks beta peerdep ([43ef2a1](https://github.com/coinbase/rest-hooks/commit/43ef2a16043207d7e52ae31b008b87d28fac0151))
 
-
-
 ### [1.0.18](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.17...@rest-hooks/test@1.0.18) (2020-04-26)
-
 
 ### 🐛 Bug Fix
 
 * Make expiry time more testable and realistic ([5878998](https://github.com/coinbase/rest-hooks/commit/58789981ce54eb9718d704451285e48fa0b977cb))
 
-
-
 ### [1.0.17](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.16...@rest-hooks/test@1.0.17) (2020-03-22)
-
 
 ### 🏠 Internal
 
 * Update eslint-plugin + prettier 2 ([#304](https://github.com/coinbase/rest-hooks/issues/304)) ([210eabc](https://github.com/coinbase/rest-hooks/commit/210eabcec4651f3150658535df6dce730bf7665e))
 
-
-
 ### [1.0.16](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.15...@rest-hooks/test@1.0.16) (2020-03-13)
-
 
 ### 💅 Enhancement
 
 * MockProvider with mismatched fixtures console message ([#295](https://github.com/coinbase/rest-hooks/issues/295)) ([121bb10](https://github.com/coinbase/rest-hooks/commit/121bb109d456dba58fec41ea73c6924223942e71))
 
-
-
 ### [1.0.15](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.14...@rest-hooks/test@1.0.15) (2020-03-08)
-
 
 ### 🏠 Internal
 
 * Only allow building types from root ([0c3d7ae](https://github.com/coinbase/rest-hooks/commit/0c3d7ae1a9d6130848f31850ed8b15e6ed01d0ab))
 
-
-
 ### [1.0.14](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.14-beta.0...@rest-hooks/test@1.0.14) (2020-02-18)
 
 **Note:** Version bump only for package @rest-hooks/test
 
-
-
-
-
 ### [1.0.14-beta.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.13...@rest-hooks/test@1.0.14-beta.0) (2020-02-18)
-
 
 ### 🐛 Bug Fix
 
 * Poll fetches while testing should be wrapped in act ([#268](https://github.com/coinbase/rest-hooks/issues/268)) ([9c264bb](https://github.com/coinbase/rest-hooks/commit/9c264bb1e5a736b6bdab2077185cebd754c39b6f))
 
-
 ### 🏠 Internal
 
 * Centralize jest config ([#230](https://github.com/coinbase/rest-hooks/issues/230)) ([5d769d2](https://github.com/coinbase/rest-hooks/commit/5d769d2485fe62ba65f4176894768bdbb6faafb3))
 
-
-
 ### [1.0.13](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.12...@rest-hooks/test@1.0.13) (2020-01-18)
-
 
 ### 🏠 Internal
 
 * Remove devDep of rest-hooks from test ([#241](https://github.com/coinbase/rest-hooks/issues/241)) ([e00fdb6](https://github.com/coinbase/rest-hooks/commit/e00fdb6151a96e3ef6221ce1880a21db0c70320c))
 
-
-
 ### [1.0.12](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.11...@rest-hooks/test@1.0.12) (2020-01-17)
 
 **Note:** Version bump only for package @rest-hooks/test
 
-
-
-
-
 ### [1.0.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.9...@rest-hooks/test@1.0.11) (2020-01-17)
-
 
 ### 🏠 Internal
 
 * Fix test package version ([f3a5a25](https://github.com/coinbase/rest-hooks/commit/f3a5a2507378e810f705b63fcc3ea3cb6869f7a3))
 
-
-
 ### [1.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.8...@rest-hooks/test@1.0.9) (2020-01-16)
 
 **Note:** Version bump only for package @rest-hooks/test
-
-
-
-
 
 ### [1.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.7...@rest-hooks/test@1.0.8) (2020-01-14)
 
 **Note:** Version bump only for package @rest-hooks/test
 
-
-
-
-
 ### [1.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.6...@rest-hooks/test@1.0.7) (2020-01-06)
 
 **Note:** Version bump only for package @rest-hooks/test
-
-
-
-
 
 ### [1.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.5...@rest-hooks/test@1.0.6) (2020-01-05)
 
 **Note:** Version bump only for package @rest-hooks/test
 
-
-
-
-
 ### [1.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.4...@rest-hooks/test@1.0.5) (2020-01-05)
 
 **Note:** Version bump only for package @rest-hooks/test
-
-
-
-
 
 ### [1.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.3...@rest-hooks/test@1.0.4) (2020-01-05)
 
 **Note:** Version bump only for package @rest-hooks/test
 
-
-
-
-
 ### [1.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.2...@rest-hooks/test@1.0.3) (2019-12-31)
 
 **Note:** Version bump only for package @rest-hooks/test
 
-
-
-
-
 ### [1.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.1...@rest-hooks/test@1.0.2) (2019-12-22)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -668,34 +473,25 @@ Testing lib now relies on new export in rest-hooks 5
 
 * Resource.fetch uses fetch instead of superagent ([#199](https://github.com/coinbase/rest-hooks/issues/199)) ([5c740ec](https://github.com/coinbase/rest-hooks/commit/5c740ecf8f864e33cd9a6ab6cbc0a872ba0344ed))
 
-
 ### 🐛 Bug Fix
 
 * Correct peerdepencency version constraints ([ab88e04](https://github.com/coinbase/rest-hooks/commit/ab88e0445f763d0648b39a376340f76a7710c197))
-
 
 ### 🏠 Internal
 
 * Update lint rules ([#206](https://github.com/coinbase/rest-hooks/issues/206)) ([732f875](https://github.com/coinbase/rest-hooks/commit/732f87536e23d6b43cea3abce5be8cd6f1dd75c7))
 
-
-
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@1.0.0...@rest-hooks/test@1.0.1) (2019-12-11)
-
 
 ### 🐛 Bug Fix
 
 * export PromiseifyMiddleware ([#197](https://github.com/coinbase/rest-hooks/issues/197)) ([89370ff](https://github.com/coinbase/rest-hooks/commit/89370ffccaee39a6e147b449a76a1ce9778f7010))
 
-
 ### 📝 Documentation
 
 * Point to repository directory for npm ([942a563](https://github.com/coinbase/rest-hooks/commit/942a563493d35dca9787e541dd89599d2059be1c))
 
-
-
 ## 1.0.0 (2019-12-02)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -706,18 +502,14 @@ Testing lib now relies on new export in rest-hooks 5
 
 * Move testing modules to own package ([#182](https://github.com/coinbase/rest-hooks/issues/182)) ([174461a](https://github.com/coinbase/rest-hooks/commit/174461a3c7568c53842eb6f4ea64e5b85dd20ce5))
 
-
 ### 🏠 Internal
 
 * Centralize babel config & common test ([#189](https://github.com/coinbase/rest-hooks/issues/189)) ([16d22a3](https://github.com/coinbase/rest-hooks/commit/16d22a3ea0dab1b48ae59cdbd3ef8d53c33167f8))
 * Use TypeScript project references ([#188](https://github.com/coinbase/rest-hooks/issues/188)) ([412c674](https://github.com/coinbase/rest-hooks/commit/412c6740cd825b06e8784d0d0f4d39e6cb331062))
 
-
 ### 📝 Documentation
 
 * Improve readme for new packages ([2406f2c](https://github.com/coinbase/rest-hooks/commit/2406f2c78a10e41f6aa1e7deeb4c957a3c94314d))
-
-
 
 # Change Log
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "7.3.4",
+  "version": "7.3.5",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/use-enhanced-reducer/CHANGELOG.md
+++ b/packages/use-enhanced-reducer/CHANGELOG.md
@@ -3,132 +3,96 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [1.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.0...@rest-hooks/use-enhanced-reducer@1.1.1) (2021-10-11)
+### [1.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.1...@rest-hooks/use-enhanced-reducer@1.1.2) (2022-07-26)
 
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+
+### [1.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.0...@rest-hooks/use-enhanced-reducer@1.1.1) (2021-10-11)
 
 ### 💅 Enhancement
 
 * Unified unset dispatch function ([#1362](https://github.com/coinbase/rest-hooks/issues/1362)) ([1b6d718](https://github.com/coinbase/rest-hooks/commit/1b6d71850d5adf38de879181ba62115db73e4e45))
 
-
 ### 📝 Documentation
 
 * Only validate circleCI badge against master ([#1322](https://github.com/coinbase/rest-hooks/issues/1322)) ([04e9642](https://github.com/coinbase/rest-hooks/commit/04e96426a865cbef362947da3a8f74f7347859e9))
 
-
-
 ## [1.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.9...@rest-hooks/use-enhanced-reducer@1.1.0) (2021-06-13)
-
 
 ### 🚀 Features
 
 * Support React 18 ([#907](https://github.com/coinbase/rest-hooks/issues/907)) ([63e8bc9](https://github.com/coinbase/rest-hooks/commit/63e8bc9887a080e1aa510d972645c037dfc96128))
 
-
-
 ### [1.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.8...@rest-hooks/use-enhanced-reducer@1.0.9) (2021-06-09)
-
 
 ### 💅 Enhancement
 
 * 'module' entrypoint targets 2019 browsers ([#905](https://github.com/coinbase/rest-hooks/issues/905)) ([d988abe](https://github.com/coinbase/rest-hooks/commit/d988abe063fc67c74fce12e234c9c3ffdb7cc230))
 
-
-
 ### [1.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.7...@rest-hooks/use-enhanced-reducer@1.0.8) (2021-06-02)
-
 
 ### 💅 Enhancement
 
 * Improve autoimport handling in vscode ([#890](https://github.com/coinbase/rest-hooks/issues/890)) ([f8f2bef](https://github.com/coinbase/rest-hooks/commit/f8f2bef411183676009c6a9df24a26d147c6d9f6))
 
-
-
 ### [1.0.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.6...@rest-hooks/use-enhanced-reducer@1.0.7) (2021-05-24)
 
 **Note:** Version bump only for package @rest-hooks/use-enhanced-reducer
 
-
-
-
-
 ### [1.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.6...@rest-hooks/use-enhanced-reducer@1.0.6) (2021-04-24)
-
 
 ### 💅 Enhancement
 
 * Support TypeScript 3.7 ([#752](https://github.com/coinbase/rest-hooks/issues/752)) ([68a10e0](https://github.com/coinbase/rest-hooks/commit/68a10e06dc0718f5e480097e6056a7a7954d1161))
 
-
-
 ## <small>1.0.5 (2020-08-12)</small>
 
 * enhance: Support React 17 (#397) ([a833f07](https://github.com/coinbase/rest-hooks/commit/a833f07)), closes [#397](https://github.com/coinbase/rest-hooks/issues/397)
-
-
-
-
 
 ## <small>1.0.4 (2020-06-06)</small>
 
 * internal: eslint major, plugin minor ([1532f7a](https://github.com/coinbase/rest-hooks/commit/1532f7a))
 * internal: Prepare tests to run in React Native env (#309) ([64efd70](https://github.com/coinbase/rest-hooks/commit/64efd70)), closes [#309](https://github.com/coinbase/rest-hooks/issues/309)
 
-
-
-
-
 ### [1.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.2...@rest-hooks/use-enhanced-reducer@1.0.3) (2020-04-26)
-
 
 ### 📦 Package
 
 * Bump internal pkgs ([#306](https://github.com/coinbase/rest-hooks/issues/306)) ([46bebad](https://github.com/coinbase/rest-hooks/commit/46bebad79d848404d02423fd2a3e2d647ee5bbbb))
-
 
 ### 🏠 Internal
 
 * Better test coverage by using type-only exports ([1867dd7](https://github.com/coinbase/rest-hooks/commit/1867dd7e2d732540b1814076c88359ba299a2367))
 * Hoist coveralls to root, since testing is done there ([3b1dbaa](https://github.com/coinbase/rest-hooks/commit/3b1dbaac303048a1b1e543f99fb9758b21feb083))
 
-
-
 ### [1.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.1...@rest-hooks/use-enhanced-reducer@1.0.2) (2020-03-08)
-
 
 ### 🏠 Internal
 
 * Add zero middleware test for use-enhanced-reducer ([af77661](https://github.com/coinbase/rest-hooks/commit/af77661924f4233e0420b43edcb35a329201407c))
 * Only allow building types from root ([0c3d7ae](https://github.com/coinbase/rest-hooks/commit/0c3d7ae1a9d6130848f31850ed8b15e6ed01d0ab))
 
-
 ### 📝 Documentation
 
 * Improve logging middleware example ([80b2553](https://github.com/coinbase/rest-hooks/commit/80b2553f765970fe4da1e23d506834f5cfc769e0))
 
-
-
 ### [1.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.0.0...@rest-hooks/use-enhanced-reducer@1.0.1) (2020-02-19)
-
 
 ### 🐛 Bug Fix
 
 * Fix commonjs bundle ([#271](https://github.com/coinbase/rest-hooks/issues/271)) ([a898bd0](https://github.com/coinbase/rest-hooks/commit/a898bd0c3497711a25c584f78d1e9c0cbde29949))
 
-
 ### 🏠 Internal
 
 * Check compressed size changes on PR ([#270](https://github.com/coinbase/rest-hooks/issues/270)) ([d70ccbf](https://github.com/coinbase/rest-hooks/commit/d70ccbf44ac5ba8fdc4f70886851ab18349f37e6))
-
 
 ### 📝 Documentation
 
 * Add more tags ([cf99994](https://github.com/coinbase/rest-hooks/commit/cf99994f03e5a4b0e972e268a15f408aefe5318c))
 
-
-
 ## [1.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@0.1.1-beta.0...@rest-hooks/use-enhanced-reducer@1.0.0) (2020-02-18)
-
 
 ### ⚠ 💥 BREAKING CHANGES
 
@@ -138,15 +102,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * Adjust package tags ([d485d9e](https://github.com/coinbase/rest-hooks/commit/d485d9e2315b1a3e0cf4982bc220c5d0e2f87300))
 
-
-
 ### 0.1.1-beta.0 (2020-02-18)
-
 
 ### 🏠 Internal
 
 * Pull out new package @rest-hooks/use-enhanced-reducer ([#269](https://github.com/coinbase/rest-hooks/issues/269)) ([bb99aeb](https://github.com/coinbase/rest-hooks/commit/bb99aebf6133b34950b1ce3c422fb034fd2971ed))
-
 
 ### 📝 Documentation
 

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5078,16 +5078,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/core@^3.2.8, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
+"@rest-hooks/core@^3.2.8, @rest-hooks/core@^3.2.9, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/core@workspace:packages/core"
   dependencies:
     "@babel/cli": ^7.18.9
     "@babel/core": ^7.18.9
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^2.2.11
-    "@rest-hooks/normalizr": ^8.2.10
-    "@rest-hooks/use-enhanced-reducer": ^1.1.1
+    "@rest-hooks/endpoint": ^2.2.12
+    "@rest-hooks/normalizr": ^8.2.11
+    "@rest-hooks/use-enhanced-reducer": ^1.1.2
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
@@ -5109,14 +5109,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/endpoint@^2.2.11, @rest-hooks/endpoint@workspace:packages/endpoint":
+"@rest-hooks/endpoint@^2.2.11, @rest-hooks/endpoint@^2.2.12, @rest-hooks/endpoint@workspace:packages/endpoint":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/endpoint@workspace:packages/endpoint"
   dependencies:
     "@babel/cli": ^7.18.9
     "@babel/core": ^7.18.9
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/normalizr": ^8.2.10
+    "@rest-hooks/normalizr": ^8.2.11
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -5267,7 +5267,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/normalizr@^8.2.10, @rest-hooks/normalizr@^8.2.6, @rest-hooks/normalizr@workspace:packages/normalizr":
+"@rest-hooks/normalizr@^8.2.11, @rest-hooks/normalizr@^8.2.6, @rest-hooks/normalizr@workspace:packages/normalizr":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/normalizr@workspace:packages/normalizr"
   dependencies:
@@ -5375,7 +5375,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/use-enhanced-reducer@^1.1.1, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
+"@rest-hooks/use-enhanced-reducer@^1.1.2, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:
@@ -21395,8 +21395,8 @@ __metadata:
     "@babel/cli": ^7.18.9
     "@babel/core": ^7.18.9
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/core": ^3.2.8
-    "@rest-hooks/endpoint": ^2.2.11
+    "@rest-hooks/core": ^3.2.9
+    "@rest-hooks/endpoint": ^2.2.12
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5


### PR DESCRIPTION
 - @rest-hooks/core@3.2.9
 - @rest-hooks/endpoint@2.2.12
 - @rest-hooks/experimental@5.0.6
 - @rest-hooks/graphql@0.1.10
 - @rest-hooks/hooks@3.0.3
 - @rest-hooks/img@0.6.2
 - @rest-hooks/legacy@4.3.7
 - @rest-hooks/normalizr@8.2.11
 - rest-hooks@6.3.9
 - @rest-hooks/rest@5.0.6
 - @rest-hooks/ssr@0.2.4
 - @rest-hooks/test@7.3.5
 - @rest-hooks/use-enhanced-reducer@1.1.2