### PR TITLE
internal: publish

### DIFF
--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,118 +3,76 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.1.5](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.4...benchmark@0.1.5) (2022-05-30)
-
-**Note:** Version bump only for package benchmark
-
-
-
-
-
-### [0.1.4](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.3...benchmark@0.1.4) (2022-04-30)
-
-**Note:** Version bump only for package benchmark
-
-
-
-
-
-### [0.1.3](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.2...benchmark@0.1.3) (2022-04-16)
-
-**Note:** Version bump only for package benchmark
-
-
-
-
-
-### [0.1.2](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.1...benchmark@0.1.2) (2022-04-08)
-
-**Note:** Version bump only for package benchmark
-
-
-
-
-
-### [0.1.1](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.0...benchmark@0.1.1) (2022-04-02)
-
-**Note:** Version bump only for package benchmark
-
-
-
-
-
-## [0.1.0](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.5...benchmark@0.1.0) (2022-04-01)
-
+## 0.2.0 (2022-09-04)
 
 ### 🚀 Features
 
 * Use @anansi/router and latest hooks ([#1854](https://github.com/coinbase/rest-hooks/issues/1854)) ([7202cc2](https://github.com/coinbase/rest-hooks/commit/7202cc269311c492ec0b2b883d961829a8a2e3f9))
 
+### 📦 Package
 
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+
+### [0.1.5](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.4...benchmark@0.1.5) (2022-05-30)
+
+**Note:** Version bump only for package benchmark
+
+### [0.1.4](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.3...benchmark@0.1.4) (2022-04-30)
+
+**Note:** Version bump only for package benchmark
+
+### [0.1.3](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.2...benchmark@0.1.3) (2022-04-16)
+
+**Note:** Version bump only for package benchmark
+
+### [0.1.2](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.1...benchmark@0.1.2) (2022-04-08)
+
+**Note:** Version bump only for package benchmark
+
+### [0.1.1](https://github.com/coinbase/rest-hooks/compare/benchmark@0.1.0...benchmark@0.1.1) (2022-04-02)
+
+**Note:** Version bump only for package benchmark
+
+## [0.1.0](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.5...benchmark@0.1.0) (2022-04-01)
+
+### 🚀 Features
+
+* Use @anansi/router and latest hooks ([#1854](https://github.com/coinbase/rest-hooks/issues/1854)) ([7202cc2](https://github.com/coinbase/rest-hooks/commit/7202cc269311c492ec0b2b883d961829a8a2e3f9))
 
 ### [0.0.6](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.4...benchmark@0.0.6) (2022-03-17)
 
 **Note:** Version bump only for package benchmark
 
-
-
-
-
 ### [0.0.5](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.4...benchmark@0.0.5) (2022-03-10)
 
 **Note:** Version bump only for package benchmark
-
-
-
-
 
 ### [0.0.4](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.3...benchmark@0.0.4) (2021-10-11)
 
 **Note:** Version bump only for package benchmark
 
-
-
-
-
 ### [0.0.3](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.2...benchmark@0.0.3) (2021-09-29)
 
 **Note:** Version bump only for package benchmark
-
-
-
-
 
 ### [0.0.2](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.1...benchmark@0.0.2) (2021-09-29)
 
 **Note:** Version bump only for package benchmark
 
-
-
-
-
 ### [0.0.1](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.1-beta.2...benchmark@0.0.1) (2021-09-08)
 
 **Note:** Version bump only for package benchmark
-
-
-
-
 
 ### [0.0.1-beta.2](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.1-beta.1...benchmark@0.0.1-beta.2) (2021-09-06)
 
 **Note:** Version bump only for package benchmark
 
-
-
-
-
 ### [0.0.1-beta.1](https://github.com/coinbase/rest-hooks/compare/benchmark@0.0.1-beta.0...benchmark@0.0.1-beta.1) (2021-07-12)
 
 **Note:** Version bump only for package benchmark
-
-
-
-
 
 ### 0.0.1-beta.0 (2021-06-30)
 

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-benchmark",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Benchmark for normalizr",
   "main": "index.js",
   "author": "Nathaniel Tucker",
@@ -10,8 +10,8 @@
     "start": "NODE_ENV=production BROWSERSLIST_ENV=modern babel-node --root-mode upward ./ --extensions '.ts,.tsx,.js'"
   },
   "dependencies": {
-    "@rest-hooks/core": "^3.2.8",
-    "@rest-hooks/normalizr": "^8.2.6",
+    "@rest-hooks/core": "^3.2.10",
+    "@rest-hooks/normalizr": "^8.3.0",
     "benchmark": "^2.1.4",
     "react": "^18.2.0"
   },

--- a/examples/github-app/CHANGELOG.md
+++ b/examples/github-app/CHANGELOG.md
@@ -3,8 +3,56 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.8](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.7...github-app@0.2.8) (2022-05-30)
+## [0.3.0](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.8...github-app@0.3.0) (2022-09-04)
 
+### ⚠ 💥 BREAKING CHANGES
+
+* Removed BaseResource, Resource
+
+### 🚀 Features
+
+* Add EndpointInstanceInterface ([89a76b5](https://github.com/coinbase/rest-hooks/commit/89a76b50c8d89ea3d7fa19e70274f391b147017e))
+* RestEndpoint, createResource ([19e1863](https://github.com/coinbase/rest-hooks/commit/19e1863043e0446762430a728cb5114dd541e486))
+
+### 📦 Package
+
+* @anansi/eslint-plugin ([#2092](https://github.com/coinbase/rest-hooks/issues/2092)) ([e281ab2](https://github.com/coinbase/rest-hooks/commit/e281ab29f07c4f0bf88b919447788a5b04f28d92))
+* build, eslint, webpack, typescript ([#2050](https://github.com/coinbase/rest-hooks/issues/2050)) ([9e2d363](https://github.com/coinbase/rest-hooks/commit/9e2d3636879d0c3c51763b9e74424640c4976e3a))
+* Update `@anansi/babel-preset` to v3.2.15 ([#2132](https://github.com/coinbase/rest-hooks/issues/2132)) ([8282683](https://github.com/coinbase/rest-hooks/commit/8282683e2f767b6d2b34c9bc69f646aa35ceffe8))
+* Update `@anansi/webpack-config` to v12 ([#2087](https://github.com/coinbase/rest-hooks/issues/2087)) ([59df15f](https://github.com/coinbase/rest-hooks/commit/59df15ff04c036eb087086ba52c1594dce877832))
+* Update `@anansi/webpack-config` to v13.0.3 ([#2127](https://github.com/coinbase/rest-hooks/issues/2127)) ([0bd86c3](https://github.com/coinbase/rest-hooks/commit/0bd86c3627083c3bf0277d6a9795a58e2e314523))
+* Update `eslint` to v8.22.0 ([#2134](https://github.com/coinbase/rest-hooks/issues/2134)) ([eb6ed07](https://github.com/coinbase/rest-hooks/commit/eb6ed071a5cfec423393c76eed283c36ee9b2380))
+* Update `serve` to v14 ([#2086](https://github.com/coinbase/rest-hooks/issues/2086)) ([80c6c31](https://github.com/coinbase/rest-hooks/commit/80c6c31f6c347fc109c4f8137a3498dc8551a5a2))
+* Update `webpack` to v5.74.0 ([#2118](https://github.com/coinbase/rest-hooks/issues/2118)) ([5e0228a](https://github.com/coinbase/rest-hooks/commit/5e0228afbba1c56970f9b60a0883215875cac68f))
+* Update all non-major dependencies ([#2034](https://github.com/coinbase/rest-hooks/issues/2034)) ([a3963b2](https://github.com/coinbase/rest-hooks/commit/a3963b2618981992bab115a8e8543abdb9cdc655))
+* Update all non-major dependencies ([#2068](https://github.com/coinbase/rest-hooks/issues/2068)) ([cdb5adb](https://github.com/coinbase/rest-hooks/commit/cdb5adb174ef5f0f3ec1354d5c34a70efaed2b85))
+* Update all non-major dependencies ([#2076](https://github.com/coinbase/rest-hooks/issues/2076)) ([9bd006c](https://github.com/coinbase/rest-hooks/commit/9bd006c668413e223625a14c6481a29c4251781c))
+* Update all non-major dependencies ([#2079](https://github.com/coinbase/rest-hooks/issues/2079)) ([a264250](https://github.com/coinbase/rest-hooks/commit/a2642508971948a08a78477c351b70962d89229b))
+* Update all non-major dependencies ([#2085](https://github.com/coinbase/rest-hooks/issues/2085)) ([99db184](https://github.com/coinbase/rest-hooks/commit/99db184aa801f750c2506103e929e5996f4cf9df))
+* Update all non-major dependencies ([#2090](https://github.com/coinbase/rest-hooks/issues/2090)) ([c47de18](https://github.com/coinbase/rest-hooks/commit/c47de186f70d753d2c6e6cf6de6e74a1315ead41))
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2122](https://github.com/coinbase/rest-hooks/issues/2122)) ([942cb5b](https://github.com/coinbase/rest-hooks/commit/942cb5bd045d3196d49fb6a583991cf2e15d41af))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2137](https://github.com/coinbase/rest-hooks/issues/2137)) ([82e1cbb](https://github.com/coinbase/rest-hooks/commit/82e1cbbd70373d36ec44272ff581e3cf531e5fed))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel monorepo to v7.18.6 ([#2075](https://github.com/coinbase/rest-hooks/issues/2075)) ([01052b0](https://github.com/coinbase/rest-hooks/commit/01052b076b353689a2621b6fecf5536b02c4f7dc))
+* Update babel monorepo to v7.18.9 ([#2089](https://github.com/coinbase/rest-hooks/issues/2089)) ([c7cf024](https://github.com/coinbase/rest-hooks/commit/c7cf0241dbe27de8780e2cab1bdc52f437766ec0))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update linters ([#2106](https://github.com/coinbase/rest-hooks/issues/2106)) ([33f837c](https://github.com/coinbase/rest-hooks/commit/33f837c19a36635a6867b8100220972c1f564b67))
+* Update linting packages ([#2125](https://github.com/coinbase/rest-hooks/issues/2125)) ([9cc2b75](https://github.com/coinbase/rest-hooks/commit/9cc2b75f0efb11e55023d9dd1765f3721a0bab7e))
+* Update linting packages ([#2135](https://github.com/coinbase/rest-hooks/issues/2135)) ([b78fecd](https://github.com/coinbase/rest-hooks/commit/b78fecdeac649a96c98bfa5f1c2e0b2ef49f05f5))
+* Update linting packages ([#2138](https://github.com/coinbase/rest-hooks/issues/2138)) ([4b62fa8](https://github.com/coinbase/rest-hooks/commit/4b62fa861fe84d33a5db01f8a3f34c5d9ce0b2ea))
+* Update linting packages ([#2143](https://github.com/coinbase/rest-hooks/issues/2143)) ([630fdc7](https://github.com/coinbase/rest-hooks/commit/630fdc7ac4cd2f29d03a4bfc9fe6d838bd15eaf1))
+* Update linting packages to v5.33.0 ([#2130](https://github.com/coinbase/rest-hooks/issues/2130)) ([6c026ce](https://github.com/coinbase/rest-hooks/commit/6c026ce73df034d01b1056079bcbe059f10295cf))
+* Update linting packages to v5.36.1 ([#2145](https://github.com/coinbase/rest-hooks/issues/2145)) ([9a9c6bd](https://github.com/coinbase/rest-hooks/commit/9a9c6bd2edb5229d2d4a751e7ea68a45d2a88d38))
+* Update react monorepo ([#2063](https://github.com/coinbase/rest-hooks/issues/2063)) ([427a4d9](https://github.com/coinbase/rest-hooks/commit/427a4d99069ab379560642549bdb57e2fa0b3bb1))
+* Update webpack packages ([#2117](https://github.com/coinbase/rest-hooks/issues/2117)) ([334c623](https://github.com/coinbase/rest-hooks/commit/334c6234a230df721e1193e0c2f9eb4cda270ea9))
+* Update webpack packages ([#2131](https://github.com/coinbase/rest-hooks/issues/2131)) ([7503cfb](https://github.com/coinbase/rest-hooks/commit/7503cfbe61a7e5edf1dfb3b1cf09a7b93855d368))
+* Update webpack packages ([#2147](https://github.com/coinbase/rest-hooks/issues/2147)) ([cb9fd71](https://github.com/coinbase/rest-hooks/commit/cb9fd7139d3ec55e96c0b625d6d776811c3c644b))
+
+### [0.2.8](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.7...github-app@0.2.8) (2022-05-30)
 
 ### 📦 Package
 
@@ -16,196 +64,125 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Update all non-major dependencies ([#2021](https://github.com/coinbase/rest-hooks/issues/2021)) ([3b9f77e](https://github.com/coinbase/rest-hooks/commit/3b9f77e0bb95cf788ed8b3ff1041f5fa4b1fec85))
 * Update all non-major dependencies ([#2023](https://github.com/coinbase/rest-hooks/issues/2023)) ([9e1d0f7](https://github.com/coinbase/rest-hooks/commit/9e1d0f7d0082ae4375ef044a4b6f356cbaca373a))
 
-
-
 ### [0.2.7](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.6...github-app@0.2.7) (2022-04-30)
-
 
 ### 📦 Package
 
 * react, babel, jest, eslint ([#1968](https://github.com/coinbase/rest-hooks/issues/1968)) ([219e644](https://github.com/coinbase/rest-hooks/commit/219e644192a5b2520f7bf076213c1f715b50f2bc))
 
-
-
 ### [0.2.6](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.5...github-app@0.2.6) (2022-04-18)
 
 **Note:** Version bump only for package github-app
-
-
-
-
 
 ### [0.2.5](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.4...github-app@0.2.5) (2022-04-16)
 
 **Note:** Version bump only for package github-app
 
-
-
-
-
 ### [0.2.4](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.3...github-app@0.2.4) (2022-04-11)
-
 
 ### 💅 Enhancement
 
 * Add labels to github example ([#1901](https://github.com/coinbase/rest-hooks/issues/1901)) ([ce9c7c9](https://github.com/coinbase/rest-hooks/commit/ce9c7c9bcbab6004035fe7fa5abebd0d48ea1b2c))
 
-
 ### 🐛 Bug Fix
 
 * Update github example to use latest experimental Resource ([#1898](https://github.com/coinbase/rest-hooks/issues/1898)) ([75f1254](https://github.com/coinbase/rest-hooks/commit/75f1254b7c1658e83f74ba7d3a659d1db2d04d50))
 
-
-
 ### [0.2.3](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.2...github-app@0.2.3) (2022-04-10)
-
 
 ### 📦 Package
 
 * webpack, @anansi/webpack-config, @testing-library/react-hooks ([#1890](https://github.com/coinbase/rest-hooks/issues/1890)) ([40d14f2](https://github.com/coinbase/rest-hooks/commit/40d14f2e34e2fd5ee656aacc4b83001a46c75f55))
 
-
-
 ### [0.2.2](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.1...github-app@0.2.2) (2022-04-08)
-
 
 ### 💅 Enhancement
 
 * Improve pagination types ([#1863](https://github.com/coinbase/rest-hooks/issues/1863)) ([12d1912](https://github.com/coinbase/rest-hooks/commit/12d1912bb9ee61d2a5fcf831d3a11e36c0e65c55))
 
-
 ### 📦 Package
 
 * babel, webpack configs, linaria, react-refresh ([#1873](https://github.com/coinbase/rest-hooks/issues/1873)) ([698332f](https://github.com/coinbase/rest-hooks/commit/698332ff7c95a2046fb6e861e5f9a37da409e26a))
-
-
 
 ### [0.2.1](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.0...github-app@0.2.1) (2022-04-02)
 
 **Note:** Version bump only for package github-app
 
-
-
-
-
 ## [0.2.0](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.9...github-app@0.2.0) (2022-04-01)
-
 
 ### 🚀 Features
 
 * Use @anansi/router and latest hooks ([#1854](https://github.com/coinbase/rest-hooks/issues/1854)) ([7202cc2](https://github.com/coinbase/rest-hooks/commit/7202cc269311c492ec0b2b883d961829a8a2e3f9))
 
-
 ### 📦 Package
 
 * Upgrade react to 18 final ([#1845](https://github.com/coinbase/rest-hooks/issues/1845)) ([71d3d47](https://github.com/coinbase/rest-hooks/commit/71d3d47137949b988d6d26b714980f28c69ed629))
 
-
-
 ### [0.1.10](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.8...github-app@0.1.10) (2022-03-17)
-
 
 ### 💅 Enhancement
 
 * Use const enums for ExpiryStatus ([#1417](https://github.com/coinbase/rest-hooks/issues/1417)) ([8d3f7f9](https://github.com/coinbase/rest-hooks/commit/8d3f7f973155680b2d52ed3f2e2758327b76d356))
 
-
 ### 🐛 Bug Fix
 
 * Union schemas with null args[0] hooks ([#1779](https://github.com/coinbase/rest-hooks/issues/1779)) ([fcf70a9](https://github.com/coinbase/rest-hooks/commit/fcf70a92ef15531b7fd12feb117f29ad8c3de3d8))
-
 
 ### 📦 Package
 
 * react 18-rc.0 ([#1598](https://github.com/coinbase/rest-hooks/issues/1598)) ([daa136a](https://github.com/coinbase/rest-hooks/commit/daa136a71dca2bbe13a08176bdae5bef59ad92d1))
 
-
 ### 📝 Documentation
 
 * Use stackblitz for demos ([#1699](https://github.com/coinbase/rest-hooks/issues/1699)) ([ee7b4ca](https://github.com/coinbase/rest-hooks/commit/ee7b4ca6fbe5ccea4ea32a52885bf9fe64cbb947))
-
-
 
 ### [0.1.9](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.8...github-app@0.1.9) (2022-03-10)
 
-
 ### 💅 Enhancement
 
 * Use const enums for ExpiryStatus ([#1417](https://github.com/coinbase/rest-hooks/issues/1417)) ([8d3f7f9](https://github.com/coinbase/rest-hooks/commit/8d3f7f973155680b2d52ed3f2e2758327b76d356))
-
 
 ### 🐛 Bug Fix
 
 * Union schemas with null args[0] hooks ([#1779](https://github.com/coinbase/rest-hooks/issues/1779)) ([fcf70a9](https://github.com/coinbase/rest-hooks/commit/fcf70a92ef15531b7fd12feb117f29ad8c3de3d8))
 
-
 ### 📦 Package
 
 * react 18-rc.0 ([#1598](https://github.com/coinbase/rest-hooks/issues/1598)) ([daa136a](https://github.com/coinbase/rest-hooks/commit/daa136a71dca2bbe13a08176bdae5bef59ad92d1))
 
-
 ### 📝 Documentation
 
 * Use stackblitz for demos ([#1699](https://github.com/coinbase/rest-hooks/issues/1699)) ([ee7b4ca](https://github.com/coinbase/rest-hooks/commit/ee7b4ca6fbe5ccea4ea32a52885bf9fe64cbb947))
-
-
 
 ### [0.1.8](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.7...github-app@0.1.8) (2021-10-11)
 
 **Note:** Version bump only for package github-app
 
-
-
-
-
 ### [0.1.7](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.6...github-app@0.1.7) (2021-09-29)
 
 **Note:** Version bump only for package github-app
-
-
-
-
 
 ### [0.1.6](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.5...github-app@0.1.6) (2021-09-29)
 
 **Note:** Version bump only for package github-app
 
-
-
-
-
 ### [0.1.5](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.4...github-app@0.1.5) (2021-09-20)
 
 **Note:** Version bump only for package github-app
 
-
-
-
-
 ### [0.1.4](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.3...github-app@0.1.4) (2021-09-19)
-
 
 ### 💅 Enhancement
 
 * useController() in examples ([#1270](https://github.com/coinbase/rest-hooks/issues/1270)) ([9f0e874](https://github.com/coinbase/rest-hooks/commit/9f0e87401856c0b51f12cd4cfc672aecb1f9a24e))
 
-
-
 ### [0.1.3](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.2...github-app@0.1.3) (2021-09-14)
 
 **Note:** Version bump only for package github-app
 
-
-
-
-
 ### [0.1.2](https://github.com/coinbase/rest-hooks/compare/github-app@0.1.1...github-app@0.1.2) (2021-09-08)
 
 **Note:** Version bump only for package github-app
-
-
-
-
 
 ### 0.1.1 (2021-09-06)
 

--- a/examples/github-app/package.json
+++ b/examples/github-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "github-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -61,12 +61,12 @@
   "dependencies": {
     "@anansi/router": "0.6.18",
     "@ant-design/icons": "^4.7.0",
-    "@rest-hooks/core": "^3.2.8",
-    "@rest-hooks/endpoint": "^2.2.11",
-    "@rest-hooks/experimental": "^5.0.3",
+    "@rest-hooks/core": "^3.2.10",
+    "@rest-hooks/endpoint": "^2.3.0",
+    "@rest-hooks/experimental": "^6.0.0",
     "@rest-hooks/graphql": "workspace:^",
     "@rest-hooks/hooks": "workspace:^",
-    "@rest-hooks/rest": "^5.0.5",
+    "@rest-hooks/rest": "^5.1.0",
     "antd": "4.22.8",
     "parse-link-header": "^2.0.0",
     "react": "18.2.0",
@@ -76,7 +76,7 @@
     "rehype-highlight": "^5.0.2",
     "remark-gfm": "^3.0.1",
     "remark-remove-comments": "^0.2.0",
-    "rest-hooks": "^6.3.4",
+    "rest-hooks": "^6.3.10",
     "uuid": "^8.3.2"
   }
 }

--- a/examples/normalizr-github/CHANGELOG.md
+++ b/examples/normalizr-github/CHANGELOG.md
@@ -3,117 +3,72 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.0.13](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.12...normalizr-github-example@0.0.13) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+
 ### [0.0.12](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.11...normalizr-github-example@0.0.12) (2022-05-30)
 
 **Note:** Version bump only for package normalizr-github-example
-
-
-
-
 
 ### [0.0.11](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.10...normalizr-github-example@0.0.11) (2022-04-30)
 
 **Note:** Version bump only for package normalizr-github-example
 
-
-
-
-
 ### [0.0.10](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.9...normalizr-github-example@0.0.10) (2022-04-16)
 
 **Note:** Version bump only for package normalizr-github-example
-
-
-
-
 
 ### [0.0.9](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.8...normalizr-github-example@0.0.9) (2022-04-08)
 
 **Note:** Version bump only for package normalizr-github-example
 
-
-
-
-
 ### [0.0.8](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.7...normalizr-github-example@0.0.8) (2022-04-02)
 
 **Note:** Version bump only for package normalizr-github-example
-
-
-
-
 
 ### [0.0.7](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.5...normalizr-github-example@0.0.7) (2022-04-01)
 
 **Note:** Version bump only for package normalizr-github-example
 
-
-
-
-
 ### [0.0.6](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.1-beta.2...normalizr-github-example@0.0.6) (2022-03-17)
 
 **Note:** Version bump only for package normalizr-github-example
-
-
-
-
 
 ### [0.0.5](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.4...normalizr-github-example@0.0.5) (2022-03-10)
 
 **Note:** Version bump only for package normalizr-github-example
 
-
-
-
-
 ### [0.0.4](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.3...normalizr-github-example@0.0.4) (2021-10-11)
 
 **Note:** Version bump only for package normalizr-github-example
-
-
-
-
 
 ### [0.0.3](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.2...normalizr-github-example@0.0.3) (2021-09-29)
 
 **Note:** Version bump only for package normalizr-github-example
 
-
-
-
-
 ### [0.0.2](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.1...normalizr-github-example@0.0.2) (2021-09-29)
 
 **Note:** Version bump only for package normalizr-github-example
-
-
-
-
 
 ### [0.0.1](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.1-beta.2...normalizr-github-example@0.0.1) (2021-09-08)
 
 **Note:** Version bump only for package normalizr-github-example
 
-
-
-
-
 ### [0.0.1-beta.2](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.1-beta.1...normalizr-github-example@0.0.1-beta.2) (2021-09-06)
 
 **Note:** Version bump only for package normalizr-github-example
 
-
-
-
-
 ### [0.0.1-beta.1](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.1-beta.0...normalizr-github-example@0.0.1-beta.1) (2021-07-12)
 
 **Note:** Version bump only for package normalizr-github-example
-
-
-
-
 
 ### 0.0.1-beta.0 (2021-06-30)
 

--- a/examples/normalizr-github/package.json
+++ b/examples/normalizr-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-github-example",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "And example of using Normalizr with github",
   "main": "index.js",
   "author": "Paul Armstrong",
@@ -10,7 +10,7 @@
     "start": "babel-node ./ --root-mode upward --extensions '.ts,.tsx,.js'"
   },
   "dependencies": {
-    "@rest-hooks/normalizr": "^8.2.6"
+    "@rest-hooks/normalizr": "^8.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.18.13",

--- a/examples/normalizr-redux/CHANGELOG.md
+++ b/examples/normalizr-redux/CHANGELOG.md
@@ -3,121 +3,77 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.0.12](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.11...normalizr-redux-example@0.0.12) (2022-05-30)
+### [0.0.13](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.12...normalizr-redux-example@0.0.13) (2022-09-04)
 
+### 📦 Package
+
+* Update `@octokit/rest` to v19 ([#2082](https://github.com/coinbase/rest-hooks/issues/2082)) ([0b53b34](https://github.com/coinbase/rest-hooks/commit/0b53b347b328b58314ca769919ffb6501ea0b67d))
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+
+### [0.0.12](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.11...normalizr-redux-example@0.0.12) (2022-05-30)
 
 ### 📦 Package
 
 * [@anansi](https://github.com/anansi), types, antd, eslint, node, redux, typescript, webpack ([#2015](https://github.com/coinbase/rest-hooks/issues/2015)) ([972d646](https://github.com/coinbase/rest-hooks/commit/972d6463c6d1946254673bb7029898b19ce4ffdd))
 
-
-
 ### [0.0.11](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.10...normalizr-redux-example@0.0.11) (2022-04-30)
 
 **Note:** Version bump only for package normalizr-redux-example
-
-
-
-
 
 ### [0.0.10](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.9...normalizr-redux-example@0.0.10) (2022-04-16)
 
 **Note:** Version bump only for package normalizr-redux-example
 
-
-
-
-
 ### [0.0.9](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.8...normalizr-redux-example@0.0.9) (2022-04-08)
 
 **Note:** Version bump only for package normalizr-redux-example
-
-
-
-
 
 ### [0.0.8](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.7...normalizr-redux-example@0.0.8) (2022-04-02)
 
 **Note:** Version bump only for package normalizr-redux-example
 
-
-
-
-
 ### [0.0.7](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.5...normalizr-redux-example@0.0.7) (2022-04-01)
 
 **Note:** Version bump only for package normalizr-redux-example
-
-
-
-
 
 ### [0.0.6](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.1-beta.2...normalizr-redux-example@0.0.6) (2022-03-17)
 
 **Note:** Version bump only for package normalizr-redux-example
 
-
-
-
-
 ### [0.0.5](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.4...normalizr-redux-example@0.0.5) (2022-03-10)
 
 **Note:** Version bump only for package normalizr-redux-example
-
-
-
-
 
 ### [0.0.4](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.3...normalizr-redux-example@0.0.4) (2021-10-11)
 
 **Note:** Version bump only for package normalizr-redux-example
 
-
-
-
-
 ### [0.0.3](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.2...normalizr-redux-example@0.0.3) (2021-09-29)
 
 **Note:** Version bump only for package normalizr-redux-example
-
-
-
-
 
 ### [0.0.2](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.1...normalizr-redux-example@0.0.2) (2021-09-29)
 
 **Note:** Version bump only for package normalizr-redux-example
 
-
-
-
-
 ### [0.0.1](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.1-beta.2...normalizr-redux-example@0.0.1) (2021-09-08)
 
 **Note:** Version bump only for package normalizr-redux-example
-
-
-
-
 
 ### [0.0.1-beta.2](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.1-beta.1...normalizr-redux-example@0.0.1-beta.2) (2021-09-06)
 
 **Note:** Version bump only for package normalizr-redux-example
 
-
-
-
-
 ### [0.0.1-beta.1](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.1-beta.0...normalizr-redux-example@0.0.1-beta.1) (2021-07-12)
 
 **Note:** Version bump only for package normalizr-redux-example
 
-
-
-
-
 ### 0.0.1-beta.0 (2021-06-30)
-
 
 ### 📝 Documentation
 

--- a/examples/normalizr-redux/package.json
+++ b/examples/normalizr-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-redux-example",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "And example of using Normalizr with Redux",
   "main": "index.js",
   "author": "Paul Armstrong",
@@ -13,7 +13,7 @@
     "@babel/core": "7.18.13",
     "@babel/node": "7.18.10",
     "@octokit/rest": "19.0.4",
-    "@rest-hooks/normalizr": "^8.2.6",
+    "@rest-hooks/normalizr": "^8.3.0",
     "@types/babel__core": "^7",
     "inquirer": "^8.1.1",
     "redux": "4.2.0",

--- a/examples/normalizr-relationships/CHANGELOG.md
+++ b/examples/normalizr-relationships/CHANGELOG.md
@@ -3,120 +3,74 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.0.13](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.12...normalizr-relationships@0.0.13) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+
 ### [0.0.12](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.11...normalizr-relationships@0.0.12) (2022-05-30)
 
 **Note:** Version bump only for package normalizr-relationships
-
-
-
-
 
 ### [0.0.11](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.10...normalizr-relationships@0.0.11) (2022-04-30)
 
 **Note:** Version bump only for package normalizr-relationships
 
-
-
-
-
 ### [0.0.10](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.9...normalizr-relationships@0.0.10) (2022-04-16)
 
 **Note:** Version bump only for package normalizr-relationships
-
-
-
-
 
 ### [0.0.9](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.8...normalizr-relationships@0.0.9) (2022-04-08)
 
 **Note:** Version bump only for package normalizr-relationships
 
-
-
-
-
 ### [0.0.8](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.7...normalizr-relationships@0.0.8) (2022-04-02)
 
 **Note:** Version bump only for package normalizr-relationships
-
-
-
-
 
 ### [0.0.7](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.5...normalizr-relationships@0.0.7) (2022-04-01)
 
 **Note:** Version bump only for package normalizr-relationships
 
-
-
-
-
 ### [0.0.6](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.1-beta.2...normalizr-relationships@0.0.6) (2022-03-17)
 
 **Note:** Version bump only for package normalizr-relationships
-
-
-
-
 
 ### [0.0.5](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.4...normalizr-relationships@0.0.5) (2022-03-10)
 
 **Note:** Version bump only for package normalizr-relationships
 
-
-
-
-
 ### [0.0.4](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.3...normalizr-relationships@0.0.4) (2021-10-11)
 
 **Note:** Version bump only for package normalizr-relationships
-
-
-
-
 
 ### [0.0.3](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.2...normalizr-relationships@0.0.3) (2021-09-29)
 
 **Note:** Version bump only for package normalizr-relationships
 
-
-
-
-
 ### [0.0.2](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.1...normalizr-relationships@0.0.2) (2021-09-29)
 
 **Note:** Version bump only for package normalizr-relationships
-
-
-
-
 
 ### [0.0.1](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.1-beta.2...normalizr-relationships@0.0.1) (2021-09-08)
 
 **Note:** Version bump only for package normalizr-relationships
 
-
-
-
-
 ### [0.0.1-beta.2](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.1-beta.1...normalizr-relationships@0.0.1-beta.2) (2021-09-06)
 
 **Note:** Version bump only for package normalizr-relationships
-
-
-
-
 
 ### [0.0.1-beta.1](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.1-beta.0...normalizr-relationships@0.0.1-beta.1) (2021-07-12)
 
 **Note:** Version bump only for package normalizr-relationships
 
-
-
-
-
 ### 0.0.1-beta.0 (2021-06-30)
-
 
 ### 📝 Documentation
 

--- a/examples/normalizr-relationships/package.json
+++ b/examples/normalizr-relationships/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-relationships",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "And example of using Normalizr with relationships",
   "main": "index.js",
   "author": "Paul Armstrong",
@@ -24,6 +24,6 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@rest-hooks/normalizr": "^8.2.6"
+    "@rest-hooks/normalizr": "^8.3.0"
   }
 }

--- a/examples/todo-app/CHANGELOG.md
+++ b/examples/todo-app/CHANGELOG.md
@@ -3,8 +3,44 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-### [0.2.8](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.7...todo-app@0.2.8) (2022-05-30)
+### [0.2.9](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.8...todo-app@0.2.9) (2022-09-04)
 
+### 📦 Package
+
+* @anansi/eslint-plugin ([#2092](https://github.com/coinbase/rest-hooks/issues/2092)) ([e281ab2](https://github.com/coinbase/rest-hooks/commit/e281ab29f07c4f0bf88b919447788a5b04f28d92))
+* build, eslint, webpack, typescript ([#2050](https://github.com/coinbase/rest-hooks/issues/2050)) ([9e2d363](https://github.com/coinbase/rest-hooks/commit/9e2d3636879d0c3c51763b9e74424640c4976e3a))
+* Update `@anansi/babel-preset` to v3.2.15 ([#2132](https://github.com/coinbase/rest-hooks/issues/2132)) ([8282683](https://github.com/coinbase/rest-hooks/commit/8282683e2f767b6d2b34c9bc69f646aa35ceffe8))
+* Update `@anansi/webpack-config` to v12 ([#2087](https://github.com/coinbase/rest-hooks/issues/2087)) ([59df15f](https://github.com/coinbase/rest-hooks/commit/59df15ff04c036eb087086ba52c1594dce877832))
+* Update `@anansi/webpack-config` to v13.0.3 ([#2127](https://github.com/coinbase/rest-hooks/issues/2127)) ([0bd86c3](https://github.com/coinbase/rest-hooks/commit/0bd86c3627083c3bf0277d6a9795a58e2e314523))
+* Update `eslint` to v8.22.0 ([#2134](https://github.com/coinbase/rest-hooks/issues/2134)) ([eb6ed07](https://github.com/coinbase/rest-hooks/commit/eb6ed071a5cfec423393c76eed283c36ee9b2380))
+* Update `serve` to v14 ([#2086](https://github.com/coinbase/rest-hooks/issues/2086)) ([80c6c31](https://github.com/coinbase/rest-hooks/commit/80c6c31f6c347fc109c4f8137a3498dc8551a5a2))
+* Update `webpack` to v5.74.0 ([#2118](https://github.com/coinbase/rest-hooks/issues/2118)) ([5e0228a](https://github.com/coinbase/rest-hooks/commit/5e0228afbba1c56970f9b60a0883215875cac68f))
+* Update all non-major dependencies ([#2034](https://github.com/coinbase/rest-hooks/issues/2034)) ([a3963b2](https://github.com/coinbase/rest-hooks/commit/a3963b2618981992bab115a8e8543abdb9cdc655))
+* Update all non-major dependencies ([#2068](https://github.com/coinbase/rest-hooks/issues/2068)) ([cdb5adb](https://github.com/coinbase/rest-hooks/commit/cdb5adb174ef5f0f3ec1354d5c34a70efaed2b85))
+* Update all non-major dependencies ([#2076](https://github.com/coinbase/rest-hooks/issues/2076)) ([9bd006c](https://github.com/coinbase/rest-hooks/commit/9bd006c668413e223625a14c6481a29c4251781c))
+* Update all non-major dependencies ([#2079](https://github.com/coinbase/rest-hooks/issues/2079)) ([a264250](https://github.com/coinbase/rest-hooks/commit/a2642508971948a08a78477c351b70962d89229b))
+* Update all non-major dependencies ([#2090](https://github.com/coinbase/rest-hooks/issues/2090)) ([c47de18](https://github.com/coinbase/rest-hooks/commit/c47de186f70d753d2c6e6cf6de6e74a1315ead41))
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel monorepo to v7.18.6 ([#2075](https://github.com/coinbase/rest-hooks/issues/2075)) ([01052b0](https://github.com/coinbase/rest-hooks/commit/01052b076b353689a2621b6fecf5536b02c4f7dc))
+* Update babel monorepo to v7.18.9 ([#2089](https://github.com/coinbase/rest-hooks/issues/2089)) ([c7cf024](https://github.com/coinbase/rest-hooks/commit/c7cf0241dbe27de8780e2cab1bdc52f437766ec0))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update linters ([#2106](https://github.com/coinbase/rest-hooks/issues/2106)) ([33f837c](https://github.com/coinbase/rest-hooks/commit/33f837c19a36635a6867b8100220972c1f564b67))
+* Update linting packages ([#2125](https://github.com/coinbase/rest-hooks/issues/2125)) ([9cc2b75](https://github.com/coinbase/rest-hooks/commit/9cc2b75f0efb11e55023d9dd1765f3721a0bab7e))
+* Update linting packages ([#2135](https://github.com/coinbase/rest-hooks/issues/2135)) ([b78fecd](https://github.com/coinbase/rest-hooks/commit/b78fecdeac649a96c98bfa5f1c2e0b2ef49f05f5))
+* Update linting packages ([#2138](https://github.com/coinbase/rest-hooks/issues/2138)) ([4b62fa8](https://github.com/coinbase/rest-hooks/commit/4b62fa861fe84d33a5db01f8a3f34c5d9ce0b2ea))
+* Update linting packages ([#2143](https://github.com/coinbase/rest-hooks/issues/2143)) ([630fdc7](https://github.com/coinbase/rest-hooks/commit/630fdc7ac4cd2f29d03a4bfc9fe6d838bd15eaf1))
+* Update linting packages to v5.33.0 ([#2130](https://github.com/coinbase/rest-hooks/issues/2130)) ([6c026ce](https://github.com/coinbase/rest-hooks/commit/6c026ce73df034d01b1056079bcbe059f10295cf))
+* Update linting packages to v5.36.1 ([#2145](https://github.com/coinbase/rest-hooks/issues/2145)) ([9a9c6bd](https://github.com/coinbase/rest-hooks/commit/9a9c6bd2edb5229d2d4a751e7ea68a45d2a88d38))
+* Update react monorepo ([#2063](https://github.com/coinbase/rest-hooks/issues/2063)) ([427a4d9](https://github.com/coinbase/rest-hooks/commit/427a4d99069ab379560642549bdb57e2fa0b3bb1))
+* Update webpack packages ([#2117](https://github.com/coinbase/rest-hooks/issues/2117)) ([334c623](https://github.com/coinbase/rest-hooks/commit/334c6234a230df721e1193e0c2f9eb4cda270ea9))
+* Update webpack packages ([#2131](https://github.com/coinbase/rest-hooks/issues/2131)) ([7503cfb](https://github.com/coinbase/rest-hooks/commit/7503cfbe61a7e5edf1dfb3b1cf09a7b93855d368))
+* Update webpack packages ([#2147](https://github.com/coinbase/rest-hooks/issues/2147)) ([cb9fd71](https://github.com/coinbase/rest-hooks/commit/cb9fd7139d3ec55e96c0b625d6d776811c3c644b))
+
+### [0.2.8](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.7...todo-app@0.2.8) (2022-05-30)
 
 ### 📦 Package
 
@@ -15,235 +51,148 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Update all non-major dependencies ([#2021](https://github.com/coinbase/rest-hooks/issues/2021)) ([3b9f77e](https://github.com/coinbase/rest-hooks/commit/3b9f77e0bb95cf788ed8b3ff1041f5fa4b1fec85))
 * Update all non-major dependencies ([#2023](https://github.com/coinbase/rest-hooks/issues/2023)) ([9e1d0f7](https://github.com/coinbase/rest-hooks/commit/9e1d0f7d0082ae4375ef044a4b6f356cbaca373a))
 
-
 ### 📝 Documentation
 
 * **example:** Use single arg create from rest@5 ([#1979](https://github.com/coinbase/rest-hooks/issues/1979)) ([339282e](https://github.com/coinbase/rest-hooks/commit/339282e4442357a93494c3c5e220279e4c3db05d))
 * Move resource-lifetime into expiry-policy page ([#1978](https://github.com/coinbase/rest-hooks/issues/1978)) ([b84239d](https://github.com/coinbase/rest-hooks/commit/b84239d18f5ed24a185ffde719f9abd8b376d936))
 
-
-
 ### [0.2.7](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.6...todo-app@0.2.7) (2022-04-30)
-
 
 ### 📦 Package
 
 * react, babel, jest, eslint ([#1968](https://github.com/coinbase/rest-hooks/issues/1968)) ([219e644](https://github.com/coinbase/rest-hooks/commit/219e644192a5b2520f7bf076213c1f715b50f2bc))
 
-
-
 ### [0.2.6](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.5...todo-app@0.2.6) (2022-04-18)
 
 **Note:** Version bump only for package todo-app
-
-
-
-
 
 ### [0.2.5](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.4...todo-app@0.2.5) (2022-04-16)
 
 **Note:** Version bump only for package todo-app
 
-
-
-
-
 ### [0.2.4](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.3...todo-app@0.2.4) (2022-04-11)
 
 **Note:** Version bump only for package todo-app
 
-
-
-
-
 ### [0.2.3](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.2...todo-app@0.2.3) (2022-04-10)
-
 
 ### 📦 Package
 
 * webpack, @anansi/webpack-config, @testing-library/react-hooks ([#1890](https://github.com/coinbase/rest-hooks/issues/1890)) ([40d14f2](https://github.com/coinbase/rest-hooks/commit/40d14f2e34e2fd5ee656aacc4b83001a46c75f55))
 
-
-
 ### [0.2.2](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.1...todo-app@0.2.2) (2022-04-08)
-
 
 ### 📦 Package
 
 * babel, webpack configs, linaria, react-refresh ([#1873](https://github.com/coinbase/rest-hooks/issues/1873)) ([698332f](https://github.com/coinbase/rest-hooks/commit/698332ff7c95a2046fb6e861e5f9a37da409e26a))
 
-
-
 ### [0.2.1](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.0...todo-app@0.2.1) (2022-04-02)
 
 **Note:** Version bump only for package todo-app
 
-
-
-
-
 ## [0.2.0](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.12...todo-app@0.2.0) (2022-04-01)
-
 
 ### 🚀 Features
 
 * Use @anansi/router and latest hooks ([#1854](https://github.com/coinbase/rest-hooks/issues/1854)) ([7202cc2](https://github.com/coinbase/rest-hooks/commit/7202cc269311c492ec0b2b883d961829a8a2e3f9))
 
-
 ### 📦 Package
 
 * Upgrade react to 18 final ([#1845](https://github.com/coinbase/rest-hooks/issues/1845)) ([71d3d47](https://github.com/coinbase/rest-hooks/commit/71d3d47137949b988d6d26b714980f28c69ed629))
 
-
-
 ### [0.1.13](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.5...todo-app@0.1.13) (2022-03-17)
-
 
 ### 💅 Enhancement
 
 * Use const enums for ExpiryStatus ([#1417](https://github.com/coinbase/rest-hooks/issues/1417)) ([8d3f7f9](https://github.com/coinbase/rest-hooks/commit/8d3f7f973155680b2d52ed3f2e2758327b76d356))
 * useController() in examples ([#1270](https://github.com/coinbase/rest-hooks/issues/1270)) ([9f0e874](https://github.com/coinbase/rest-hooks/commit/9f0e87401856c0b51f12cd4cfc672aecb1f9a24e))
 
-
 ### 🐛 Bug Fix
 
 * Union schemas with null args[0] hooks ([#1779](https://github.com/coinbase/rest-hooks/issues/1779)) ([fcf70a9](https://github.com/coinbase/rest-hooks/commit/fcf70a92ef15531b7fd12feb117f29ad8c3de3d8))
-
 
 ### 📦 Package
 
 * react 18-rc.0 ([#1598](https://github.com/coinbase/rest-hooks/issues/1598)) ([daa136a](https://github.com/coinbase/rest-hooks/commit/daa136a71dca2bbe13a08176bdae5bef59ad92d1))
 
-
 ### 📝 Documentation
 
 * Use stackblitz for demos ([#1699](https://github.com/coinbase/rest-hooks/issues/1699)) ([ee7b4ca](https://github.com/coinbase/rest-hooks/commit/ee7b4ca6fbe5ccea4ea32a52885bf9fe64cbb947))
 
-
-
 ### [0.1.12](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.11...todo-app@0.1.12) (2022-03-10)
-
 
 ### 💅 Enhancement
 
 * Use const enums for ExpiryStatus ([#1417](https://github.com/coinbase/rest-hooks/issues/1417)) ([8d3f7f9](https://github.com/coinbase/rest-hooks/commit/8d3f7f973155680b2d52ed3f2e2758327b76d356))
 
-
 ### 🐛 Bug Fix
 
 * Union schemas with null args[0] hooks ([#1779](https://github.com/coinbase/rest-hooks/issues/1779)) ([fcf70a9](https://github.com/coinbase/rest-hooks/commit/fcf70a92ef15531b7fd12feb117f29ad8c3de3d8))
-
 
 ### 📦 Package
 
 * react 18-rc.0 ([#1598](https://github.com/coinbase/rest-hooks/issues/1598)) ([daa136a](https://github.com/coinbase/rest-hooks/commit/daa136a71dca2bbe13a08176bdae5bef59ad92d1))
 
-
 ### 📝 Documentation
 
 * Use stackblitz for demos ([#1699](https://github.com/coinbase/rest-hooks/issues/1699)) ([ee7b4ca](https://github.com/coinbase/rest-hooks/commit/ee7b4ca6fbe5ccea4ea32a52885bf9fe64cbb947))
-
-
 
 ### [0.1.11](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.10...todo-app@0.1.11) (2021-10-11)
 
 **Note:** Version bump only for package todo-app
 
-
-
-
-
 ### [0.1.10](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.9...todo-app@0.1.10) (2021-09-29)
 
 **Note:** Version bump only for package todo-app
-
-
-
-
 
 ### [0.1.9](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.8...todo-app@0.1.9) (2021-09-29)
 
 **Note:** Version bump only for package todo-app
 
-
-
-
-
 ### [0.1.8](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.7...todo-app@0.1.8) (2021-09-20)
 
 **Note:** Version bump only for package todo-app
 
-
-
-
-
 ### [0.1.7](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.6...todo-app@0.1.7) (2021-09-19)
-
 
 ### 💅 Enhancement
 
 * useController() in examples ([#1270](https://github.com/coinbase/rest-hooks/issues/1270)) ([9f0e874](https://github.com/coinbase/rest-hooks/commit/9f0e87401856c0b51f12cd4cfc672aecb1f9a24e))
 
-
-
 ### [0.1.6](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.5...todo-app@0.1.6) (2021-09-14)
 
 **Note:** Version bump only for package todo-app
-
-
-
-
 
 ### [0.1.5](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.4...todo-app@0.1.5) (2021-09-08)
 
 **Note:** Version bump only for package todo-app
 
-
-
-
-
 ### [0.1.4](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.3...todo-app@0.1.4) (2021-09-06)
 
 **Note:** Version bump only for package todo-app
-
-
-
-
 
 ### [0.1.3](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.2...todo-app@0.1.3) (2021-08-25)
 
 **Note:** Version bump only for package todo-app
 
-
-
-
-
 ### [0.1.2](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.1...todo-app@0.1.2) (2021-08-22)
-
 
 ### 📦 Package
 
 * Bump anansi - compat with webpack-dev-server@4 ([#1133](https://github.com/coinbase/rest-hooks/issues/1133)) ([474aae6](https://github.com/coinbase/rest-hooks/commit/474aae607351f045b1284ba7f1d7c80a08933314))
 * Latest react 18 prerelease ([#1132](https://github.com/coinbase/rest-hooks/issues/1132)) ([4865557](https://github.com/coinbase/rest-hooks/commit/48655577418e68803873734f77b95c36fbf216ad))
 
-
-
 ### [0.1.1](https://github.com/coinbase/rest-hooks/compare/todo-app@0.1.0...todo-app@0.1.1) (2021-08-21)
-
 
 ### 🐛 Bug Fix
 
 * useFetchInit() hook calls same amount every render ([#1123](https://github.com/coinbase/rest-hooks/issues/1123)) ([6cd0b7c](https://github.com/coinbase/rest-hooks/commit/6cd0b7cc57de59b5f394942dfa9a3a08d9f2e912))
 
-
-
 ## 0.1.0 (2021-07-12)
-
 
 ### 🚀 Features
 
 * Add todo example ([#996](https://github.com/coinbase/rest-hooks/issues/996)) ([7616d40](https://github.com/coinbase/rest-hooks/commit/7616d40a07d881b7b938ecbc19dc29e3cae91348))
-
 
 ### 💅 Enhancement
 

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-app",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "todo-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -56,10 +56,10 @@
     "webpack-dev-server": "4.10.1"
   },
   "dependencies": {
-    "@rest-hooks/endpoint": "^2.2.11",
-    "@rest-hooks/rest": "^5.0.2",
+    "@rest-hooks/endpoint": "^2.3.0",
+    "@rest-hooks/rest": "^5.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "rest-hooks": "^6.3.4"
+    "rest-hooks": "^6.3.10"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.2.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.9...@rest-hooks/core@3.2.10) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [3.2.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.8...@rest-hooks/core@3.2.9) (2022-07-26)
 
 ### 📦 Package

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -102,9 +102,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^2.2.12",
-    "@rest-hooks/normalizr": "^8.2.11",
-    "@rest-hooks/use-enhanced-reducer": "^1.1.2",
+    "@rest-hooks/endpoint": "^2.3.0",
+    "@rest-hooks/normalizr": "^8.3.0",
+    "@rest-hooks/use-enhanced-reducer": "^1.1.3",
     "flux-standard-action": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.12...@rest-hooks/endpoint@2.3.0) (2022-09-04)
+
+### 🚀 Features
+
+* Add EndpointInstanceInterface ([89a76b5](https://github.com/coinbase/rest-hooks/commit/89a76b50c8d89ea3d7fa19e70274f391b147017e))
+* Add validateRequired() ([#2116](https://github.com/coinbase/rest-hooks/issues/2116)) ([85e2bd9](https://github.com/coinbase/rest-hooks/commit/85e2bd9ef2696694ce18c713d35d2c9aaabbedc1))
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [2.2.12](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.11...@rest-hooks/endpoint@2.2.12) (2022-07-26)
 
 ### 📦 Package

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "2.2.12",
+  "version": "2.3.0",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/normalizr": "^8.2.11"
+    "@rest-hooks/normalizr": "^8.3.0"
   },
   "devDependencies": {
     "@babel/cli": "7.18.10",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.6...@rest-hooks/experimental@6.0.0) (2022-09-04)
+
+### ⚠ 💥 BREAKING CHANGES
+
+* Removed BaseResource, Resource
+
+### 🚀 Features
+
+* RestEndpoint, createResource ([19e1863](https://github.com/coinbase/rest-hooks/commit/19e1863043e0446762430a728cb5114dd541e486))
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [5.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.5...@rest-hooks/experimental@5.0.6) (2022-07-26)
 
 ### 📦 Package

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "5.0.6",
+  "version": "6.0.0",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.10...@rest-hooks/graphql@0.1.11) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [0.1.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.9...@rest-hooks/graphql@0.1.10) (2022-07-26)
 
 ### 📦 Package

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.3...@rest-hooks/hooks@3.0.4) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [3.0.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.2...@rest-hooks/hooks@3.0.3) (2022-07-26)
 
 ### 📦 Package

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/img/CHANGELOG.md
+++ b/packages/img/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.6.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.2...@rest-hooks/img@0.6.3) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+
 ### [0.6.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.1...@rest-hooks/img@0.6.2) (2022-07-26)
 
 ### 📦 Package

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/img",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.3.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.7...@rest-hooks/legacy@4.3.8) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [4.3.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.6...@rest-hooks/legacy@4.3.7) (2022-07-26)
 
 ### 📦 Package

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [8.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.11...@rest-hooks/normalizr@8.3.0) (2022-09-04)
+
+### 🚀 Features
+
+* Add validateRequired() ([#2116](https://github.com/coinbase/rest-hooks/issues/2116)) ([85e2bd9](https://github.com/coinbase/rest-hooks/commit/85e2bd9ef2696694ce18c713d35d2c9aaabbedc1))
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2137](https://github.com/coinbase/rest-hooks/issues/2137)) ([82e1cbb](https://github.com/coinbase/rest-hooks/commit/82e1cbbd70373d36ec44272ff581e3cf531e5fed))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [8.2.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.10...@rest-hooks/normalizr@8.2.11) (2022-07-26)
 
 ### 📦 Package

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "8.2.11",
+  "version": "8.3.0",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.3.10](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.9...rest-hooks@6.3.10) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [6.3.9](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.8...rest-hooks@6.3.9) (2022-07-26)
 
 ### 📦 Package

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "6.3.9",
+  "version": "6.3.10",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -102,8 +102,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/core": "^3.2.9",
-    "@rest-hooks/endpoint": "^2.2.12"
+    "@rest-hooks/core": "^3.2.10",
+    "@rest-hooks/endpoint": "^2.3.0"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.6...@rest-hooks/rest@5.1.0) (2022-09-04)
+
+### 🚀 Features
+
+* Add EndpointInstanceInterface ([89a76b5](https://github.com/coinbase/rest-hooks/commit/89a76b50c8d89ea3d7fa19e70274f391b147017e))
+* Add validateRequired() ([#2116](https://github.com/coinbase/rest-hooks/issues/2116)) ([85e2bd9](https://github.com/coinbase/rest-hooks/commit/85e2bd9ef2696694ce18c713d35d2c9aaabbedc1))
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [5.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.5...@rest-hooks/rest@5.0.6) (2022-07-26)
 
 ### 📦 Package

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "5.0.6",
+  "version": "5.1.0",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.4...@rest-hooks/ssr@0.2.5) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+
 ### [0.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.3...@rest-hooks/ssr@0.2.4) (2022-07-26)
 
 ### 📦 Package

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/ssr",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.3.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.5...@rest-hooks/test@7.3.6) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+
 ### [7.3.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.4...@rest-hooks/test@7.3.5) (2022-07-26)
 
 ### 🐛 Bug Fix

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "7.3.5",
+  "version": "7.3.6",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/use-enhanced-reducer/CHANGELOG.md
+++ b/packages/use-enhanced-reducer/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.2...@rest-hooks/use-enhanced-reducer@1.1.3) (2022-09-04)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+
 ### [1.1.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.1...@rest-hooks/use-enhanced-reducer@1.1.2) (2022-07-26)
 
 ### 📦 Package

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/website/package.json
+++ b/website/package.json
@@ -39,7 +39,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-json-tree": "0.17.0",
-    "rest-hooks": "file:../packages/rest-hooks"
+    "rest-hooks": "file:../packages/rest-hooks",
+    "typescript": "4.7.0-dev.20220425"
   },
   "resolutions": {
     "@rest-hooks/core": "file:../packages/core",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2836,13 +2836,13 @@ __metadata:
   linkType: hard
 
 "@rest-hooks/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 3.2.9
-  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=174641&locator=root-workspace-0b6124%40workspace%3A."
+  version: 3.2.10
+  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=c8b496&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^2.2.12
-    "@rest-hooks/normalizr": ^8.2.11
-    "@rest-hooks/use-enhanced-reducer": ^1.1.2
+    "@rest-hooks/endpoint": ^2.3.0
+    "@rest-hooks/normalizr": ^8.3.0
+    "@rest-hooks/use-enhanced-reducer": ^1.1.3
     flux-standard-action: ^2.1.1
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
@@ -2850,34 +2850,34 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 840142c80e2d1108250ffa85551ebd955d8e060af7dc39627ad7da6b34860a8a88a4e9b05119708108a0cf17b56ea987f0446e367aae4f2c35d0a7edab3b7da8
+  checksum: 8f8a145ffb36a948f921af33569c73c8aa10cce710de3626d7ccce5ca468aeca95c203657980a99622f8db356f9f629e3299cc02e6029caf08c8d3725db5ce2f
   languageName: node
   linkType: hard
 
 "@rest-hooks/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 2.2.12
-  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=dbbcab&locator=root-workspace-0b6124%40workspace%3A."
+  version: 2.3.0
+  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=e62983&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/normalizr": ^8.2.11
-  checksum: 5fc0a6f5f2841d2b7a1cdf7c888a3e68cf472312b812e6fb7928265ebf6beebb40ad8db8165884c91b7726e06c2fdb17804a8c41f79ac8633c13a23eb7451668
+    "@rest-hooks/normalizr": ^8.3.0
+  checksum: 92ec9139f648decfb27d8e97007b09235561994fe8e54c8a5115d3d28f07c28f56ffb6de09d1904f93f8e0b1bc7b9121155324f6675795e7e6cb626e014888ca
   languageName: node
   linkType: hard
 
 "@rest-hooks/graphql@file:../packages/graphql::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 0.1.10
-  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=e59f7b&locator=root-workspace-0b6124%40workspace%3A."
+  version: 0.1.11
+  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=0a0874&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.13.0
   peerDependencies:
     "@rest-hooks/endpoint": ^2.0.0
-  checksum: 3a2c9243939ef8906b20205e3bf02aaec7c272fe329165514d427fccc36584eec466443e83f5f80e55e3c60155ad6b0d167c9cec90d6b4c34315996bc194ab8c
+  checksum: bb71045977a1d682b4a8b0fb44634fda1465f95adbfaa64fca6e389bfdac69a78ef61de53bdb2d5527404f9692b73fd9afb49a955b71e0a7908a6bdeb2389307
   languageName: node
   linkType: hard
 
 "@rest-hooks/hooks@file:../packages/hooks::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 3.0.3
-  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=142bae&locator=root-workspace-0b6124%40workspace%3A."
+  version: 3.0.4
+  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=862f5e&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.13.0
   peerDependencies:
@@ -2887,41 +2887,41 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10695a992c035134f39cc4b883ae8e511dfd9b883a40e355f46390b251faaeece4e718696f5724722490bb1b329906de462081c87e94fab532d8f46ab3dc9cf6
+  checksum: 0b39f724b02bac6003332fb6dc1b1efd3c2874190f63dd748ac1b351b46965415b3911734babc8b0aad29a3fbb720275e2594b635e1a834312faa955a2d0ecf3
   languageName: node
   linkType: hard
 
 "@rest-hooks/normalizr@file:../packages/normalizr::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 8.2.11
-  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=2e3674&locator=root-workspace-0b6124%40workspace%3A."
+  version: 8.3.0
+  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=833348&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.13.0
     npm-run-all: ^4.1.5
-  checksum: 3c907ed779fb60a34a81e75e9b827ce1a111b5d36091ce33100c03aa53508fae6da6e56eaf8d1add4b0df19503df69eaf62054f8a9be8a427367cd9513dfc547
+  checksum: 1e50ef517d0347080b169224a591c8ba663a027f00869b8639aa3b564cb87b84834fa810d1460b3d6c4e5025c83f3063fd1bfaee51d5f11c7c95d097137b1db9
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 5.0.6
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=378ce6&locator=root-workspace-0b6124%40workspace%3A."
+  version: 5.1.0
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=3831fc&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.13.0
   peerDependencies:
     "@rest-hooks/endpoint": ^2.1.0
-  checksum: fb8628a109e7910b52a962ebffd81518a9435af5049671a26232f53f1c5e31e1c65504f7aee48d45d2897c499a51b0c63434d2f8f8787c8ab614dd06664a1509
+  checksum: ac7ceb26d4a427a92b5a32f7d06597d8b84260e43cf3482813c50f676b1efd39c373cb58fe68caeb24238d14643aeae8d93f03a6ed10a7d21036405b18d6d778
   languageName: node
   linkType: hard
 
 "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 1.1.2
-  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=99a7e6&locator=root-workspace-0b6124%40workspace%3A."
+  version: 1.1.3
+  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=017b74&locator=root-workspace-0b6124%40workspace%3A."
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: c360b7e1de726d9e99b56f09eb3677a8c9137e6673f8464628519e968a9e34cc35e50fb2ac111bea1af6d94c584a5e9f9a20b3f7c5af0ad2bddbf37f6a3013a4
+  checksum: 68a8529d5e95b5a2722ee57cea49a4cf5125a5340dfbf879119725e573a6e7b8fe993450f0c661507112716a6706f875ac9df24ba275dcb6ecf09b5c80d2359a
   languageName: node
   linkType: hard
 
@@ -11918,19 +11918,19 @@ __metadata:
   linkType: hard
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 6.3.9
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=c36c59&locator=root-workspace-0b6124%40workspace%3A."
+  version: 6.3.10
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=337f0f&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/core": ^3.2.9
-    "@rest-hooks/endpoint": ^2.2.12
+    "@rest-hooks/core": ^3.2.10
+    "@rest-hooks/endpoint": ^2.3.0
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 8208fe37388973035415926c3fd2f57f59bb7ce469b904f6bea8cd537fa0ba8b795998b0abfd893dd1a96f8583989fc5733b44c8b19d87c2b448302e60fab927
+  checksum: cabe0ab0091f56f7ee99735c66dae30361fb9696e2e01011583404f66e8a364da8a778c1e68f231e64dd34a0e8b6dc7118d5b7db70f0c363542471ea91828310
   languageName: node
   linkType: hard
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -12025,6 +12025,7 @@ __metadata:
     react-json-tree: 0.17.0
     rest-hooks: "file:../packages/rest-hooks"
     serve: 14.0.1
+    typescript: 4.7.0-dev.20220425
     webpack: ^5.74.0
   languageName: unknown
   linkType: soft
@@ -13322,6 +13323,26 @@ __metadata:
   dependencies:
     is-typedarray: ^1.0.0
   checksum: 99c11aaa8f45189fcfba6b8a4825fd684a321caa9bd7a76a27cf0c7732c174d198b99f449c52c3818107430b5f41c0ccbbfb75cb2ee3ca4a9451710986d61a60
+  languageName: node
+  linkType: hard
+
+"typescript@npm:4.7.0-dev.20220425":
+  version: 4.7.0-dev.20220425
+  resolution: "typescript@npm:4.7.0-dev.20220425"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 9b3984483a09dd36a7d039b30eb8b085c27f04d5bc94445c609beff268df4ef11648e12651288d7010819e72d880e81841335a3ea203b5696c20f3881f39e6db
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@4.7.0-dev.20220425#~builtin<compat/typescript>":
+  version: 4.7.0-dev.20220425
+  resolution: "typescript@patch:typescript@npm%3A4.7.0-dev.20220425#~builtin<compat/typescript>::version=4.7.0-dev.20220425&hash=a1c5e5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 4d739276fe6f556dab590fa11e7b9a334b337b5bd4536758f0bca3d4f11ebdc2aaa10f36360375a9b65168302ca1b16b53e8ff590bd27cfda140337e87ace38c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3770,16 +3770,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/core@^3.2.8, @rest-hooks/core@^3.2.9, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
+"@rest-hooks/core@^3.2.10, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/core@workspace:packages/core"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.18.13
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^2.2.12
-    "@rest-hooks/normalizr": ^8.2.11
-    "@rest-hooks/use-enhanced-reducer": ^1.1.2
+    "@rest-hooks/endpoint": ^2.3.0
+    "@rest-hooks/normalizr": ^8.3.0
+    "@rest-hooks/use-enhanced-reducer": ^1.1.3
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
@@ -3801,14 +3801,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/endpoint@^2.2.11, @rest-hooks/endpoint@^2.2.12, @rest-hooks/endpoint@workspace:packages/endpoint":
+"@rest-hooks/endpoint@^2.3.0, @rest-hooks/endpoint@workspace:packages/endpoint":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/endpoint@workspace:packages/endpoint"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.18.13
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/normalizr": ^8.2.11
+    "@rest-hooks/normalizr": ^8.3.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -3823,7 +3823,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/experimental@^5.0.3, @rest-hooks/experimental@workspace:packages/experimental":
+"@rest-hooks/experimental@^6.0.0, @rest-hooks/experimental@workspace:packages/experimental":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/experimental@workspace:packages/experimental"
   dependencies:
@@ -3959,7 +3959,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/normalizr@^8.2.11, @rest-hooks/normalizr@^8.2.6, @rest-hooks/normalizr@workspace:packages/normalizr":
+"@rest-hooks/normalizr@^8.3.0, @rest-hooks/normalizr@workspace:packages/normalizr":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/normalizr@workspace:packages/normalizr"
   dependencies:
@@ -3982,7 +3982,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/rest@^5.0.2, @rest-hooks/rest@^5.0.5, @rest-hooks/rest@workspace:packages/rest":
+"@rest-hooks/rest@^5.1.0, @rest-hooks/rest@workspace:packages/rest":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/rest@workspace:packages/rest"
   dependencies:
@@ -4067,7 +4067,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/use-enhanced-reducer@^1.1.2, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
+"@rest-hooks/use-enhanced-reducer@^1.1.3, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:
@@ -9539,8 +9539,8 @@ __metadata:
   dependencies:
     "@babel/core": 7.18.13
     "@babel/node": 7.18.10
-    "@rest-hooks/core": ^3.2.8
-    "@rest-hooks/normalizr": ^8.2.6
+    "@rest-hooks/core": ^3.2.10
+    "@rest-hooks/normalizr": ^8.3.0
     "@types/babel__core": ^7
     "@types/benchmark": 2.1.2
     "@types/react": 18.0.18
@@ -10459,12 +10459,12 @@ __metadata:
     "@linaria/core": 4.1.1
     "@linaria/react": 4.1.2
     "@linaria/shaker": 4.1.2
-    "@rest-hooks/core": ^3.2.8
-    "@rest-hooks/endpoint": ^2.2.11
-    "@rest-hooks/experimental": ^5.0.3
+    "@rest-hooks/core": ^3.2.10
+    "@rest-hooks/endpoint": ^2.3.0
+    "@rest-hooks/experimental": ^6.0.0
     "@rest-hooks/graphql": "workspace:^"
     "@rest-hooks/hooks": "workspace:^"
-    "@rest-hooks/rest": ^5.0.5
+    "@rest-hooks/rest": ^5.1.0
     "@types/eslint": 8.4.6
     "@types/parse-link-header": ^2.0.0
     "@types/prettier": 2.7.0
@@ -10489,7 +10489,7 @@ __metadata:
     rehype-highlight: ^5.0.2
     remark-gfm: ^3.0.1
     remark-remove-comments: ^0.2.0
-    rest-hooks: ^6.3.4
+    rest-hooks: ^6.3.10
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
     rollup-plugin-commonjs: ^10.1.0
@@ -15175,7 +15175,7 @@ __metadata:
   dependencies:
     "@babel/core": 7.18.13
     "@babel/node": 7.18.10
-    "@rest-hooks/normalizr": ^8.2.6
+    "@rest-hooks/normalizr": ^8.3.0
     "@types/babel__core": ^7
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
@@ -15195,7 +15195,7 @@ __metadata:
     "@babel/core": 7.18.13
     "@babel/node": 7.18.10
     "@octokit/rest": 19.0.4
-    "@rest-hooks/normalizr": ^8.2.6
+    "@rest-hooks/normalizr": ^8.3.0
     "@types/babel__core": ^7
     inquirer: ^8.1.1
     redux: 4.2.0
@@ -15217,7 +15217,7 @@ __metadata:
   dependencies:
     "@babel/core": 7.18.13
     "@babel/node": 7.18.10
-    "@rest-hooks/normalizr": ^8.2.6
+    "@rest-hooks/normalizr": ^8.3.0
     "@types/babel__core": ^7
     mockdate: ^3.0.5
     rollup: 2.79.0
@@ -18911,15 +18911,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rest-hooks@^6.3.4, rest-hooks@workspace:^, rest-hooks@workspace:packages/rest-hooks":
+"rest-hooks@^6.3.10, rest-hooks@workspace:^, rest-hooks@workspace:packages/rest-hooks":
   version: 0.0.0-use.local
   resolution: "rest-hooks@workspace:packages/rest-hooks"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.18.13
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/core": ^3.2.9
-    "@rest-hooks/endpoint": ^2.2.12
+    "@rest-hooks/core": ^3.2.10
+    "@rest-hooks/endpoint": ^2.3.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -20766,8 +20766,8 @@ __metadata:
     "@linaria/core": 4.1.1
     "@linaria/react": 4.1.2
     "@linaria/shaker": 4.1.2
-    "@rest-hooks/endpoint": ^2.2.11
-    "@rest-hooks/rest": ^5.0.2
+    "@rest-hooks/endpoint": ^2.3.0
+    "@rest-hooks/rest": ^5.1.0
     "@types/eslint": 8.4.6
     "@types/prettier": 2.7.0
     "@types/react-dom": 18.0.6
@@ -20782,7 +20782,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-refresh: 0.14.0
-    rest-hooks: ^6.3.4
+    rest-hooks: ^6.3.10
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
     rollup-plugin-commonjs: ^10.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -21153,16 +21153,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-typescript@next:
-  version: 4.7.0-dev.20220425
-  resolution: "typescript@npm:4.7.0-dev.20220425"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 9b3984483a09dd36a7d039b30eb8b085c27f04d5bc94445c609beff268df4ef11648e12651288d7010819e72d880e81841335a3ea203b5696c20f3881f39e6db
-  languageName: node
-  linkType: hard
-
 "typescript@npm:4.8.2, typescript@npm:^4.6.4":
   version: 4.8.2
   resolution: "typescript@npm:4.8.2"
@@ -21170,6 +21160,16 @@ typescript@next:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 7f5b81d0d558c9067f952c7af52ab7f19c2e70a916817929e4a5b256c93990bf3178eccb1ac8a850bc75df35f6781b6f4cb3370ce20d8b1ded92ed462348f628
+  languageName: node
+  linkType: hard
+
+"typescript@npm:next":
+  version: 4.9.0-dev.20220903
+  resolution: "typescript@npm:4.9.0-dev.20220903"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 6a1c8498c3b45f5bee9300f5712e82359922dc6d15800add996765767a54f184adeb274febbde23ffb1b32b863fa599b3828296173f194c9ecd6f507a6371f27
   languageName: node
   linkType: hard
 
@@ -21184,12 +21184,12 @@ typescript@next:
   linkType: hard
 
 "typescript@patch:typescript@next#~builtin<compat/typescript>":
-  version: 4.7.0-dev.20220425
-  resolution: "typescript@patch:typescript@npm%3A4.7.0-dev.20220425#~builtin<compat/typescript>::version=4.7.0-dev.20220425&hash=a1c5e5"
+  version: 4.9.0-dev.20220903
+  resolution: "typescript@patch:typescript@npm%3A4.9.0-dev.20220903#~builtin<compat/typescript>::version=4.9.0-dev.20220903&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 4d739276fe6f556dab590fa11e7b9a334b337b5bd4536758f0bca3d4f11ebdc2aaa10f36360375a9b65168302ca1b16b53e8ff590bd27cfda140337e87ace38c
+  checksum: 0a8bb73e63861996741e37b29a513acf558459d894484463e3363b036c5b4a3611de5b19ac5cb5b4fcce2d3b0a752ea1440ae0fc681d1e05eed8315e3f1cb3f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 - @rest-hooks/core: 3.2.9 => 3.2.10
 - @rest-hooks/endpoint: 2.2.12 => 2.3.0
 - @rest-hooks/experimental: 5.0.6 => 6.0.0
 - @rest-hooks/graphql: 0.1.10 => 0.1.11
 - @rest-hooks/hooks: 3.0.3 => 3.0.4
 - @rest-hooks/img: 0.6.2 => 0.6.3
 - @rest-hooks/legacy: 4.3.7 => 4.3.8
 - @rest-hooks/normalizr: 8.2.11 => 8.3.0
 - rest-hooks: 6.3.9 => 6.3.10
 - @rest-hooks/rest: 5.0.6 => 5.1.0
 - @rest-hooks/ssr: 0.2.4 => 0.2.5
 - @rest-hooks/test: 7.3.5 => 7.3.6
 - @rest-hooks/use-enhanced-reducer: 1.1.2 => 1.1.3