### PR TITLE
enhance: urlRoot -> path

### DIFF
--- a/examples/github-app/src/resources/Base.ts
+++ b/examples/github-app/src/resources/Base.ts
@@ -82,12 +82,12 @@ export class GithubEndpoint<
 }
 
 export function createGithubResource<U extends string, S extends Schema>(
-  urlRoot: U,
+  path: U,
   schema: S,
   Endpoint: typeof GithubEndpoint = GithubEndpoint,
 ): GithubResource<U, S> {
   const baseResource = createResource(
-    urlRoot,
+    path,
     schema,
     Endpoint,
     ({ page, ...rest }: { page: string | number } & PathArgs<ShortenPath<U>>) =>

--- a/examples/github-app/src/resources/Comment.ts
+++ b/examples/github-app/src/resources/Comment.ts
@@ -31,11 +31,11 @@ const baseResource = createGithubResource(
   Comment,
 );
 const getList = baseResource.getList.extend({
-  urlRoot: '/repos/:owner/:repo/issues/:number/comments' as const,
+  path: '/repos/:owner/:repo/issues/:number/comments' as const,
   body: undefined,
 });
 const create = baseResource.create.extend({
-  urlRoot: '/repos/:owner/:repo/issues/:number/comments' as const,
+  path: '/repos/:owner/:repo/issues/:number/comments' as const,
   body: { body: '' },
   update: (newId: string, params: any) => ({
     [getList.key(params)]: ({ results = [], ...rest } = {}) => ({

--- a/examples/github-app/src/resources/Event.tsx
+++ b/examples/github-app/src/resources/Event.tsx
@@ -112,7 +112,7 @@ const base = createGithubResource(
 export const EventResource = {
   ...base,
   getList: base.getList.extend({
-    urlRoot: '/users/:login/events/public\\?per_page=50',
+    path: '/users/:login/events/public\\?per_page=50',
     body: undefined,
   }),
 };

--- a/examples/github-app/src/resources/Reaction.tsx
+++ b/examples/github-app/src/resources/Reaction.tsx
@@ -60,7 +60,7 @@ const base = createGithubResource(
 export const ReactionResource = {
   ...base,
   getByComment: base.getList.extend({
-    urlRoot: 'repos/:owner/:repo/issues/comments/:comment/reactions' as const,
+    path: 'repos/:owner/:repo/issues/comments/:comment/reactions' as const,
     body: undefined,
   }),
   create: base.create.extend({

--- a/examples/github-app/src/resources/Repository.tsx
+++ b/examples/github-app/src/resources/Repository.tsx
@@ -67,7 +67,7 @@ const base = createGithubResource('/repos/:owner/:repo' as const, Repository);
 export const RepositoryResource = {
   ...base,
   getByUser: base.getList.extend({
-    urlRoot: '/users/:login/repos' as const,
+    path: '/users/:login/repos' as const,
     body: undefined,
   }),
   getByPinned: GithubGqlEndpoint.query(

--- a/examples/github-app/src/resources/User.ts
+++ b/examples/github-app/src/resources/User.ts
@@ -48,7 +48,7 @@ export class User extends GithubEntity {
 export const UserResource = {
   ...createGithubResource('/users/:login' as const, User),
   current: new GithubEndpoint({
-    urlRoot: '/user' as const,
+    path: '/user' as const,
     schema: User,
   }),
 };

--- a/packages/experimental/src/rest/RestEndpoint.d.ts
+++ b/packages/experimental/src/rest/RestEndpoint.d.ts
@@ -14,7 +14,7 @@ export interface RestInstance<
   S extends Schema | undefined = any,
   M extends true | undefined = true | undefined,
 > extends EndpointInstanceInterface<F, S, M> {
-  readonly urlRoot: string;
+  readonly path: string;
   readonly fetchInit: RequestInit;
   readonly method: string;
   readonly signal: AbortSignal | undefined;
@@ -50,7 +50,7 @@ export interface RestInstance<
 }
 
 export interface RestGenerics {
-  urlRoot: string;
+  path: string;
   schema?: Schema | undefined;
   method?: string;
   body?: any;
@@ -86,13 +86,13 @@ export interface RestEndpointOptions<F extends FetchFunction = FetchFunction>
 
 export type RestEndpointConstructorOptions<O extends RestGenerics = any> =
   RestEndpointOptions<
-    RestFetch<PathArgs<O['urlRoot']>, BodyDefault<O>, Denormalize<O['schema']>>
+    RestFetch<PathArgs<O['path']>, BodyDefault<O>, Denormalize<O['schema']>>
   >;
 
 export interface RestEndpointExtendOptions<
   F extends FetchFunction = FetchFunction,
 > extends RestEndpointOptions<F> {
-  urlRoot?: string;
+  path?: string;
   schema?: Schema | undefined;
   method?: string;
   body?: any;
@@ -105,7 +105,7 @@ export interface RestEndpointConstructor {
     name,
     ...options
   }: RestEndpointConstructorOptions<O> & O): RestInstance<
-    RestFetch<PathArgs<O['urlRoot']>, BodyDefault<O>, Denormalize<O['schema']>>,
+    RestFetch<PathArgs<O['path']>, BodyDefault<O>, Denormalize<O['schema']>>,
     O['schema'] extends Schema | undefined ? O['schema'] : undefined,
     MethodToSide<O['method']>
   >;
@@ -176,9 +176,9 @@ export type RestExtendedEndpoint<
   O extends RestEndpointExtendOptions<F>,
   E extends RestInstance,
   F extends FetchFunction,
-> = ('urlRoot' extends keyof O
+> = ('path' extends keyof O
   ? RestType<
-      PathArgs<Exclude<O['urlRoot'], undefined>>,
+      PathArgs<Exclude<O['path'], undefined>>,
       'body' extends keyof O ? O['body'] : undefined,
       'schema' extends keyof O ? O['schema'] : E['_schema'],
       'method' extends keyof O ? MethodToSide<O['method']> : E['sideEffect']

--- a/packages/experimental/src/rest/RestEndpoint.js
+++ b/packages/experimental/src/rest/RestEndpoint.js
@@ -40,8 +40,8 @@ export default class RestEndpoint extends Endpoint {
 
   /** Get the url */
   url(urlParams = {}) {
-    const urlBase = getUrlBase(this.urlRoot)(urlParams);
-    const tokens = getUrlTokens(this.urlRoot);
+    const urlBase = getUrlBase(this.path)(urlParams);
+    const tokens = getUrlTokens(this.path);
     const searchParams = {};
     Object.keys(urlParams).forEach(k => {
       if (!tokens.has(k)) {

--- a/packages/experimental/src/rest/RestHelpers.ts
+++ b/packages/experimental/src/rest/RestHelpers.ts
@@ -3,24 +3,24 @@ import { compile, PathFunction, parse } from 'path-to-regexp';
 import { ShortenPath } from './types';
 
 const urlBaseCache: Record<string, PathFunction<object>> = {};
-export function getUrlBase(urlRoot: string): PathFunction {
-  if (!Object.hasOwnProperty.call(urlBaseCache, urlRoot)) {
-    urlBaseCache[urlRoot] = compile(urlRoot, {
+export function getUrlBase(path: string): PathFunction {
+  if (!Object.hasOwnProperty.call(urlBaseCache, path)) {
+    urlBaseCache[path] = compile(path, {
       encode: encodeURIComponent,
       validate: false,
     });
   }
-  return urlBaseCache[urlRoot];
+  return urlBaseCache[path];
 }
 
 const urlTokensCache: Record<string, Set<string>> = {};
-export function getUrlTokens(urlRoot: string): Set<string> {
-  if (!Object.hasOwnProperty.call(urlTokensCache, urlRoot)) {
-    urlTokensCache[urlRoot] = new Set(
-      parse(urlRoot).map(t => (typeof t === 'string' ? t : `${t['name']}`)),
+export function getUrlTokens(path: string): Set<string> {
+  if (!Object.hasOwnProperty.call(urlTokensCache, path)) {
+    urlTokensCache[path] = new Set(
+      parse(path).map(t => (typeof t === 'string' ? t : `${t['name']}`)),
     );
   }
-  return urlTokensCache[urlRoot];
+  return urlTokensCache[path];
 }
 
 const proto = Object.prototype;
@@ -33,11 +33,11 @@ export function isPojo(obj: unknown): obj is Record<string, any> {
   return gpo(obj) === proto;
 }
 
-export function shortenUrlRoot<S extends string>(urlRoot: S): ShortenPath<S> {
+export function shortenPath<S extends string>(path: S): ShortenPath<S> {
   // this is for when not specifying a specific item like create/list
-  let shortUrlRoot: ShortenPath<S> = urlRoot.substring(
+  let shortUrlRoot: ShortenPath<S> = path.substring(
     0,
-    urlRoot.lastIndexOf(':'),
+    path.lastIndexOf(':'),
   ) as any;
   if (shortUrlRoot[shortUrlRoot.length - 1] === '/')
     shortUrlRoot = shortUrlRoot.substring(

--- a/packages/experimental/src/rest/__tests__/Resource.test.ts
+++ b/packages/experimental/src/rest/__tests__/Resource.test.ts
@@ -47,13 +47,13 @@ export class PaginatedArticle extends Entity {
   };
 }
 function createPaginatableResource<U extends string, S extends Schema>(
-  urlRoot: U,
+  path: U,
   schema: S,
   Endpoint: typeof RestEndpoint = RestEndpoint,
 ) {
-  const baseResource = createResource(urlRoot, schema, Endpoint);
+  const baseResource = createResource(path, schema, Endpoint);
   const getList = baseResource.getList.extend({
-    urlRoot: 'http\\://test.com/article-paginated' as const,
+    path: 'http\\://test.com/article-paginated' as const,
     schema: {
       nextPage: '',
       results: [PaginatedArticle],

--- a/packages/experimental/src/rest/__tests__/RestEndpoint.ts
+++ b/packages/experimental/src/rest/__tests__/RestEndpoint.ts
@@ -31,7 +31,7 @@ export class User extends Entity {
   }
 }
 const getUser = new RestEndpoint({
-  urlRoot: 'http\\://test.com/user/:id' as const,
+  path: 'http\\://test.com/user/:id' as const,
   name: 'User.get',
   schema: User,
   method: 'GET' as const,
@@ -52,7 +52,7 @@ export class PaginatedArticle extends Entity {
   };
 }
 const getArticleList = new RestEndpoint({
-  urlRoot: 'http\\://test.com/article-paginated' as const,
+  path: 'http\\://test.com/article-paginated' as const,
   name: 'get',
   schema: {
     nextPage: '',
@@ -65,7 +65,7 @@ const getNextPage = getArticleList.paginated(
 );
 
 const getArticleList2 = new RestEndpoint({
-  urlRoot: 'http\\://test.com/article-paginated/:group' as const,
+  path: 'http\\://test.com/article-paginated/:group' as const,
   name: 'get',
   schema: {
     nextPage: '',
@@ -124,7 +124,7 @@ describe('RestEndpoint', () => {
   });
 
   it('should assign members', () => {
-    expect(getUser.urlRoot).toBe('http\\://test.com/user/:id');
+    expect(getUser.path).toBe('http\\://test.com/user/:id');
     expect(getUser.sideEffect).toBe(undefined);
     expect(getUser.method).toBe('GET');
 
@@ -138,7 +138,7 @@ describe('RestEndpoint', () => {
     ((m: 'POST') => {})(getUser.method);
 
     const updateUser = new RestEndpoint({
-      urlRoot: 'http\\://test.com/user/:id' as const,
+      path: 'http\\://test.com/user/:id' as const,
       name: 'update',
       schema: User,
       method: 'POST' as const,
@@ -150,7 +150,7 @@ describe('RestEndpoint', () => {
 
   /* TODO: it('should allow sideEffect overrides', () => {
     const weirdGetUser = new RestEndpoint({
-      urlRoot: 'http\\://test.com/user/:id' as const,
+      path: 'http\\://test.com/user/:id' as const,
       name: 'getter',
       schema: User,
       method: 'POST' as const,
@@ -172,7 +172,7 @@ describe('RestEndpoint', () => {
 
   it('should handle multiarg urls', () => {
     const getMyUser = new RestEndpoint({
-      urlRoot: 'http\\://test.com/groups/:group/users/:id' as const,
+      path: 'http\\://test.com/groups/:group/users/:id' as const,
       schema: User,
       method: 'GET' as const,
       extra: 5,
@@ -232,7 +232,7 @@ describe('RestEndpoint', () => {
     expect(result.current.articles.map(({ id }) => id)).toEqual([5, 3, 7, 8]);
   });
 
-  it('should update on get for a paginated resource with parameter in urlRoot', async () => {
+  it('should update on get for a paginated resource with parameter in path', async () => {
     mynock.get(`/article-paginated/happy`).reply(200, paginatedFirstPage);
     mynock
       .get(`/article-paginated/happy?cursor=2`)
@@ -302,7 +302,7 @@ describe('RestEndpoint', () => {
       }
     }
     const getComplex = new RestEndpoint({
-      urlRoot: '/complex-thing/:id' as const,
+      path: '/complex-thing/:id' as const,
       schema: ComplexEntity,
       method: 'GET' as const,
     });
@@ -350,7 +350,7 @@ describe('RestEndpoint', () => {
     }));
     const updateUser = new RestEndpoint({
       method: 'PUT' as const,
-      urlRoot: 'http\\://test.com/user/:id' as const,
+      path: 'http\\://test.com/user/:id' as const,
       name: 'get',
       schema: User,
       getFetchInit(body: any): RequestInit {
@@ -411,7 +411,7 @@ describe('RestEndpoint', () => {
 
       const updateUser = new MyEndpoint({
         method: 'PUT' as const,
-        urlRoot: 'http\\://test.com/user/:id' as const,
+        path: 'http\\://test.com/user/:id' as const,
         name: 'update',
         schema: User,
       });
@@ -438,12 +438,12 @@ describe('RestEndpoint', () => {
 
       const updateUser = new MyEndpoint({
         method: 'PUT' as const,
-        urlRoot: 'http\\://test.com/user/:id' as const,
+        path: 'http\\://test.com/user/:id' as const,
         name: 'update',
         schema: User,
       }).extend({
         body: 5,
-        urlRoot: 'http\\://test.com/charmer/:charm' as const,
+        path: 'http\\://test.com/charmer/:charm' as const,
       });
       const response = await updateUser(
         { charm: 5 },
@@ -460,7 +460,7 @@ describe('RestEndpoint', () => {
       `);
       expect(updateUser.additional).toBe(5);
       const nobody = updateUser.extend({
-        urlRoot: 'http\\://test.com/user/:charm' as const,
+        path: 'http\\://test.com/user/:charm' as const,
       });
       () => nobody({ charm: 5 });
       // @ts-expect-error
@@ -475,7 +475,7 @@ describe('RestEndpoint', () => {
       }));
 
       const getUser = new MyEndpoint({
-        urlRoot: 'http\\://test.com/user/:id' as const,
+        path: 'http\\://test.com/user/:id' as const,
         name: 'update',
       });
       const { result, waitForNextUpdate } = renderRestHook(() => {
@@ -490,7 +490,7 @@ describe('RestEndpoint', () => {
       expect(result.current.email).toBe('bob@gmail.com');
     });
 
-    it('should work with default urlRoot in class definition', async () => {
+    it('should work with default path in class definition', async () => {
       mynock.get('/user/5').reply(200, (uri, body: any) => ({
         id: 5,
         username: 'bob',
@@ -500,19 +500,16 @@ describe('RestEndpoint', () => {
       class UserEndpoint<
         O extends Partial<RestGenerics> = {
           schema: DefaultUser;
-          urlRoot: 'http\\://test.com/user/:id';
+          path: 'http\\://test.com/user/:id';
         },
       > extends MyEndpoint<
-        Defaults<
-          O,
-          { schema: DefaultUser; urlRoot: 'http\\://test.com/user/:id' }
-        >
+        Defaults<O, { schema: DefaultUser; path: 'http\\://test.com/user/:id' }>
       > {
         constructor(options: O & { name: string }) {
           super(options as any);
         }
 
-        urlRoot = 'http\\://test.com/user/:id' as const;
+        path = 'http\\://test.com/user/:id' as const;
       }
 
       const getUser = new UserEndpoint({
@@ -547,11 +544,11 @@ describe('RestEndpoint', () => {
 
       const updateUser = new MyEndpoint({
         method: 'PUT' as const,
-        urlRoot: 'http\\://test.com/user/:id' as const,
+        path: 'http\\://test.com/user/:id' as const,
         name: 'update',
         schema: User,
       }).extend({
-        urlRoot: 'http\\://test.com/:group/user/:id' as const,
+        path: 'http\\://test.com/:group/user/:id' as const,
         body: 0 as Partial<User>,
       });
       expect(updateUser.additional).toBe(5);
@@ -588,12 +585,12 @@ describe('RestEndpoint', () => {
 
       const getUserBase = new MyEndpoint({
         method: 'GET',
-        urlRoot: 'http\\://test.com/user/:id' as const,
+        path: 'http\\://test.com/user/:id' as const,
         name: 'getuser',
         schema: User,
       });
       const getUser = getUserBase.extend({
-        urlRoot: 'http\\://test.com/:group/user/:id' as const,
+        path: 'http\\://test.com/:group/user/:id' as const,
         schema: User2,
       });
       expect(getUserBase.name).toBe('getuser');

--- a/packages/experimental/src/rest/__tests__/createResource.test.ts
+++ b/packages/experimental/src/rest/__tests__/createResource.test.ts
@@ -311,7 +311,7 @@ describe('resource', () => {
     const UserResourceExtend = {
       ...UserResource,
       get: UserResource.get.extend({
-        urlRoot: 'http\\://test.com/groups/:magic/users/:id' as const,
+        path: 'http\\://test.com/groups/:magic/users/:id' as const,
         schema: User2,
       }),
     };

--- a/packages/experimental/src/rest/createResource.ts
+++ b/packages/experimental/src/rest/createResource.ts
@@ -5,7 +5,7 @@ import RestEndpoint, {
   MutateEndpoint,
   RestTypeNoBody,
 } from './RestEndpoint';
-import { shortenUrlRoot } from './RestHelpers';
+import { shortenPath } from './RestHelpers';
 import { PathArgs, ShortenPath } from './types';
 
 const { Delete } = schema;
@@ -17,22 +17,22 @@ export default function createResource<
     | ((...args: any) => PathArgs<ShortenPath<U>>)
     | undefined = undefined,
 >(
-  urlRoot: U,
+  path: U,
   schema: S,
   Endpoint: typeof RestEndpoint = RestEndpoint,
   removeCursor?: R,
 ): Resource<U, S, R> {
-  const shortenedUrl = shortenUrlRoot(urlRoot);
+  const shortenedPath = shortenPath(path);
   const getName = (name: string) => `${(schema as any)?.name}.${name}`;
   const getList = new Endpoint({
-    urlRoot: shortenedUrl,
+    path: shortenedPath,
     schema: [schema],
     name: getName('getList'),
   });
   return {
-    get: new Endpoint({ urlRoot, schema, name: getName('get') }),
+    get: new Endpoint({ path, schema, name: getName('get') }),
     getList: new Endpoint({
-      urlRoot: shortenedUrl,
+      path: shortenedPath,
       schema: [schema],
       name: getName('getList'),
     }),
@@ -40,25 +40,25 @@ export default function createResource<
       ? getList.paginated(removeCursor as any)
       : undefined,
     create: new Endpoint({
-      urlRoot: shortenedUrl,
+      path: shortenedPath,
       schema,
       method: 'POST',
       name: getName('create'),
     }),
     update: new Endpoint({
-      urlRoot,
+      path,
       schema,
       method: 'PUT',
       name: getName('update'),
     }),
     partialUpdate: new Endpoint({
-      urlRoot,
+      path,
       schema,
       method: 'PATCH',
       name: getName('partialUpdate'),
     }),
     delete: new Endpoint({
-      urlRoot,
+      path,
       schema: (schema as any).process ? new Delete(schema as any) : schema,
       method: 'DELETE',
       name: getName('delete'),

--- a/packages/experimental/src/rest/types.ts
+++ b/packages/experimental/src/rest/types.ts
@@ -36,7 +36,7 @@ type RemoveEscapes<S extends string> = S extends `${infer K}\\?${string}`
   ? K
   : S;
 
-/** Parameters for a given urlRoot */
+/** Parameters for a given path */
 export type PathArgs<S extends string> = {
   [K in PathKeys<S> as OnlyOptional<K>]?: string | number;
 } & {


### PR DESCRIPTION
BREAKING CHANGE: urlRoot -> path

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
More canonical name for url construction pattern like this. urlRoot only makes sense when it's a base url that is extended, rather than specifying patterns
