### PR TITLE
internal: publish

### DIFF
--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.3.0 (2022-09-10)
+
+### 🚀 Features
+
+* Use @anansi/router and latest hooks ([#1854](https://github.com/coinbase/rest-hooks/issues/1854)) ([7202cc2](https://github.com/coinbase/rest-hooks/commit/7202cc269311c492ec0b2b883d961829a8a2e3f9))
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update all non-major dependencies ([#2164](https://github.com/coinbase/rest-hooks/issues/2164)) ([5bab22a](https://github.com/coinbase/rest-hooks/commit/5bab22a75898c5a61d2e0ef9e1c8f4067f15f55f))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ## 0.2.0 (2022-09-04)
 
 ### 🚀 Features

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-benchmark",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Benchmark for normalizr",
   "main": "index.js",
   "author": "Nathaniel Tucker",
@@ -10,8 +10,8 @@
     "start": "NODE_ENV=production BROWSERSLIST_ENV=modern babel-node --root-mode upward ./ --extensions '.ts,.tsx,.js'"
   },
   "dependencies": {
-    "@rest-hooks/core": "^3.2.10",
-    "@rest-hooks/normalizr": "^8.3.0",
+    "@rest-hooks/core": "^3.2.11",
+    "@rest-hooks/normalizr": "^8.3.1",
     "benchmark": "^2.1.4",
     "react": "^18.2.0"
   },

--- a/examples/github-app/CHANGELOG.md
+++ b/examples/github-app/CHANGELOG.md
@@ -3,6 +3,66 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.0](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.8...github-app@0.4.0) (2022-09-10)
+
+### ⚠ 💥 BREAKING CHANGES
+
+* urlRoot -> path
+* Removed BaseResource, Resource
+
+### 🚀 Features
+
+* Add EndpointInstanceInterface ([89a76b5](https://github.com/coinbase/rest-hooks/commit/89a76b50c8d89ea3d7fa19e70274f391b147017e))
+* RestEndpoint, createResource ([19e1863](https://github.com/coinbase/rest-hooks/commit/19e1863043e0446762430a728cb5114dd541e486))
+
+### 💅 Enhancement
+
+* Better handling of errors ([#2168](https://github.com/coinbase/rest-hooks/issues/2168)) ([0d75952](https://github.com/coinbase/rest-hooks/commit/0d75952dc74fe6c7b67c12745842d4ba3577af5e))
+* urlRoot -> path ([#2170](https://github.com/coinbase/rest-hooks/issues/2170)) ([20ef4a9](https://github.com/coinbase/rest-hooks/commit/20ef4a9dcc05a4914fe4450fab10621064f467c1))
+
+### 📦 Package
+
+* @anansi/eslint-plugin ([#2092](https://github.com/coinbase/rest-hooks/issues/2092)) ([e281ab2](https://github.com/coinbase/rest-hooks/commit/e281ab29f07c4f0bf88b919447788a5b04f28d92))
+* build, eslint, webpack, typescript ([#2050](https://github.com/coinbase/rest-hooks/issues/2050)) ([9e2d363](https://github.com/coinbase/rest-hooks/commit/9e2d3636879d0c3c51763b9e74424640c4976e3a))
+* Update `@anansi/babel-preset` to v3.2.15 ([#2132](https://github.com/coinbase/rest-hooks/issues/2132)) ([8282683](https://github.com/coinbase/rest-hooks/commit/8282683e2f767b6d2b34c9bc69f646aa35ceffe8))
+* Update `@anansi/webpack-config` to v12 ([#2087](https://github.com/coinbase/rest-hooks/issues/2087)) ([59df15f](https://github.com/coinbase/rest-hooks/commit/59df15ff04c036eb087086ba52c1594dce877832))
+* Update `@anansi/webpack-config` to v13.0.3 ([#2127](https://github.com/coinbase/rest-hooks/issues/2127)) ([0bd86c3](https://github.com/coinbase/rest-hooks/commit/0bd86c3627083c3bf0277d6a9795a58e2e314523))
+* Update `eslint` to v8.22.0 ([#2134](https://github.com/coinbase/rest-hooks/issues/2134)) ([eb6ed07](https://github.com/coinbase/rest-hooks/commit/eb6ed071a5cfec423393c76eed283c36ee9b2380))
+* Update `serve` to v14 ([#2086](https://github.com/coinbase/rest-hooks/issues/2086)) ([80c6c31](https://github.com/coinbase/rest-hooks/commit/80c6c31f6c347fc109c4f8137a3498dc8551a5a2))
+* Update `webpack` to v5.74.0 ([#2118](https://github.com/coinbase/rest-hooks/issues/2118)) ([5e0228a](https://github.com/coinbase/rest-hooks/commit/5e0228afbba1c56970f9b60a0883215875cac68f))
+* Update all non-major dependencies ([#2034](https://github.com/coinbase/rest-hooks/issues/2034)) ([a3963b2](https://github.com/coinbase/rest-hooks/commit/a3963b2618981992bab115a8e8543abdb9cdc655))
+* Update all non-major dependencies ([#2068](https://github.com/coinbase/rest-hooks/issues/2068)) ([cdb5adb](https://github.com/coinbase/rest-hooks/commit/cdb5adb174ef5f0f3ec1354d5c34a70efaed2b85))
+* Update all non-major dependencies ([#2076](https://github.com/coinbase/rest-hooks/issues/2076)) ([9bd006c](https://github.com/coinbase/rest-hooks/commit/9bd006c668413e223625a14c6481a29c4251781c))
+* Update all non-major dependencies ([#2079](https://github.com/coinbase/rest-hooks/issues/2079)) ([a264250](https://github.com/coinbase/rest-hooks/commit/a2642508971948a08a78477c351b70962d89229b))
+* Update all non-major dependencies ([#2085](https://github.com/coinbase/rest-hooks/issues/2085)) ([99db184](https://github.com/coinbase/rest-hooks/commit/99db184aa801f750c2506103e929e5996f4cf9df))
+* Update all non-major dependencies ([#2090](https://github.com/coinbase/rest-hooks/issues/2090)) ([c47de18](https://github.com/coinbase/rest-hooks/commit/c47de186f70d753d2c6e6cf6de6e74a1315ead41))
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2122](https://github.com/coinbase/rest-hooks/issues/2122)) ([942cb5b](https://github.com/coinbase/rest-hooks/commit/942cb5bd045d3196d49fb6a583991cf2e15d41af))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2137](https://github.com/coinbase/rest-hooks/issues/2137)) ([82e1cbb](https://github.com/coinbase/rest-hooks/commit/82e1cbbd70373d36ec44272ff581e3cf531e5fed))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update all non-major dependencies ([#2164](https://github.com/coinbase/rest-hooks/issues/2164)) ([5bab22a](https://github.com/coinbase/rest-hooks/commit/5bab22a75898c5a61d2e0ef9e1c8f4067f15f55f))
+* Update babel monorepo to v7.18.6 ([#2075](https://github.com/coinbase/rest-hooks/issues/2075)) ([01052b0](https://github.com/coinbase/rest-hooks/commit/01052b076b353689a2621b6fecf5536b02c4f7dc))
+* Update babel monorepo to v7.18.9 ([#2089](https://github.com/coinbase/rest-hooks/issues/2089)) ([c7cf024](https://github.com/coinbase/rest-hooks/commit/c7cf0241dbe27de8780e2cab1bdc52f437766ec0))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+* Update linters ([#2106](https://github.com/coinbase/rest-hooks/issues/2106)) ([33f837c](https://github.com/coinbase/rest-hooks/commit/33f837c19a36635a6867b8100220972c1f564b67))
+* Update linting packages ([#2125](https://github.com/coinbase/rest-hooks/issues/2125)) ([9cc2b75](https://github.com/coinbase/rest-hooks/commit/9cc2b75f0efb11e55023d9dd1765f3721a0bab7e))
+* Update linting packages ([#2135](https://github.com/coinbase/rest-hooks/issues/2135)) ([b78fecd](https://github.com/coinbase/rest-hooks/commit/b78fecdeac649a96c98bfa5f1c2e0b2ef49f05f5))
+* Update linting packages ([#2138](https://github.com/coinbase/rest-hooks/issues/2138)) ([4b62fa8](https://github.com/coinbase/rest-hooks/commit/4b62fa861fe84d33a5db01f8a3f34c5d9ce0b2ea))
+* Update linting packages ([#2143](https://github.com/coinbase/rest-hooks/issues/2143)) ([630fdc7](https://github.com/coinbase/rest-hooks/commit/630fdc7ac4cd2f29d03a4bfc9fe6d838bd15eaf1))
+* Update linting packages ([#2163](https://github.com/coinbase/rest-hooks/issues/2163)) ([5cb3c6b](https://github.com/coinbase/rest-hooks/commit/5cb3c6b928a671c304dee31fdade14a6601a37a7))
+* Update linting packages to v5.33.0 ([#2130](https://github.com/coinbase/rest-hooks/issues/2130)) ([6c026ce](https://github.com/coinbase/rest-hooks/commit/6c026ce73df034d01b1056079bcbe059f10295cf))
+* Update linting packages to v5.36.1 ([#2145](https://github.com/coinbase/rest-hooks/issues/2145)) ([9a9c6bd](https://github.com/coinbase/rest-hooks/commit/9a9c6bd2edb5229d2d4a751e7ea68a45d2a88d38))
+* Update react monorepo ([#2063](https://github.com/coinbase/rest-hooks/issues/2063)) ([427a4d9](https://github.com/coinbase/rest-hooks/commit/427a4d99069ab379560642549bdb57e2fa0b3bb1))
+* Update webpack packages ([#2117](https://github.com/coinbase/rest-hooks/issues/2117)) ([334c623](https://github.com/coinbase/rest-hooks/commit/334c6234a230df721e1193e0c2f9eb4cda270ea9))
+* Update webpack packages ([#2131](https://github.com/coinbase/rest-hooks/issues/2131)) ([7503cfb](https://github.com/coinbase/rest-hooks/commit/7503cfbe61a7e5edf1dfb3b1cf09a7b93855d368))
+* Update webpack packages ([#2147](https://github.com/coinbase/rest-hooks/issues/2147)) ([cb9fd71](https://github.com/coinbase/rest-hooks/commit/cb9fd7139d3ec55e96c0b625d6d776811c3c644b))
+* Update webpack packages ([#2165](https://github.com/coinbase/rest-hooks/issues/2165)) ([e8119bc](https://github.com/coinbase/rest-hooks/commit/e8119bcf902d1caf4ef9043d67ea5dee12bc7452))
+* Update webpack packages ([#2166](https://github.com/coinbase/rest-hooks/issues/2166)) ([83ca869](https://github.com/coinbase/rest-hooks/commit/83ca869ce51a98751f84bd7f2bab4c551f4ee832))
+
 ## [0.3.0](https://github.com/coinbase/rest-hooks/compare/github-app@0.2.8...github-app@0.3.0) (2022-09-04)
 
 ### ⚠ 💥 BREAKING CHANGES

--- a/examples/github-app/package.json
+++ b/examples/github-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "github-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -61,12 +61,12 @@
   "dependencies": {
     "@anansi/router": "0.6.20",
     "@ant-design/icons": "^4.7.0",
-    "@rest-hooks/core": "^3.2.10",
-    "@rest-hooks/endpoint": "^2.3.0",
-    "@rest-hooks/experimental": "^6.0.0",
-    "@rest-hooks/graphql": "^0.1.11",
-    "@rest-hooks/hooks": "^3.0.4",
-    "@rest-hooks/rest": "^5.1.0",
+    "@rest-hooks/core": "^3.2.11",
+    "@rest-hooks/endpoint": "^2.3.1",
+    "@rest-hooks/experimental": "^7.0.0",
+    "@rest-hooks/graphql": "^0.1.12",
+    "@rest-hooks/hooks": "^3.0.5",
+    "@rest-hooks/rest": "^5.1.1",
     "antd": "4.23.1",
     "parse-link-header": "^2.0.0",
     "react": "18.2.0",
@@ -76,7 +76,7 @@
     "rehype-highlight": "^5.0.2",
     "remark-gfm": "^3.0.1",
     "remark-remove-comments": "^0.2.0",
-    "rest-hooks": "^6.3.10",
+    "rest-hooks": "^6.3.11",
     "uuid": "^8.3.2"
   }
 }

--- a/examples/normalizr-github/CHANGELOG.md
+++ b/examples/normalizr-github/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.0.14](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.12...normalizr-github-example@0.0.14) (2022-09-10)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [0.0.13](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.12...normalizr-github-example@0.0.13) (2022-09-04)
 
 ### 📦 Package

--- a/examples/normalizr-github/package.json
+++ b/examples/normalizr-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-github-example",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "And example of using Normalizr with github",
   "main": "index.js",
   "author": "Paul Armstrong",
@@ -10,7 +10,7 @@
     "start": "babel-node ./ --root-mode upward --extensions '.ts,.tsx,.js'"
   },
   "dependencies": {
-    "@rest-hooks/normalizr": "^8.3.0"
+    "@rest-hooks/normalizr": "^8.3.1"
   },
   "devDependencies": {
     "@babel/core": "7.19.0",

--- a/examples/normalizr-redux/CHANGELOG.md
+++ b/examples/normalizr-redux/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.0.14](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.12...normalizr-redux-example@0.0.14) (2022-09-10)
+
+### 📦 Package
+
+* Update `@octokit/rest` to v19 ([#2082](https://github.com/coinbase/rest-hooks/issues/2082)) ([0b53b34](https://github.com/coinbase/rest-hooks/commit/0b53b347b328b58314ca769919ffb6501ea0b67d))
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [0.0.13](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.12...normalizr-redux-example@0.0.13) (2022-09-04)
 
 ### 📦 Package

--- a/examples/normalizr-redux/package.json
+++ b/examples/normalizr-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-redux-example",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "And example of using Normalizr with Redux",
   "main": "index.js",
   "author": "Paul Armstrong",
@@ -13,7 +13,7 @@
     "@babel/core": "7.19.0",
     "@babel/node": "7.18.10",
     "@octokit/rest": "19.0.4",
-    "@rest-hooks/normalizr": "^8.3.0",
+    "@rest-hooks/normalizr": "^8.3.1",
     "@types/babel__core": "^7",
     "inquirer": "^8.1.1",
     "redux": "4.2.0",

--- a/examples/normalizr-relationships/CHANGELOG.md
+++ b/examples/normalizr-relationships/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.0.14](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.12...normalizr-relationships@0.0.14) (2022-09-10)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [0.0.13](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.12...normalizr-relationships@0.0.13) (2022-09-04)
 
 ### 📦 Package

--- a/examples/normalizr-relationships/package.json
+++ b/examples/normalizr-relationships/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-relationships",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "And example of using Normalizr with relationships",
   "main": "index.js",
   "author": "Paul Armstrong",
@@ -24,6 +24,6 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@rest-hooks/normalizr": "^8.3.0"
+    "@rest-hooks/normalizr": "^8.3.1"
   }
 }

--- a/examples/todo-app/CHANGELOG.md
+++ b/examples/todo-app/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.10](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.8...todo-app@0.2.10) (2022-09-10)
+
+### 📦 Package
+
+* @anansi/eslint-plugin ([#2092](https://github.com/coinbase/rest-hooks/issues/2092)) ([e281ab2](https://github.com/coinbase/rest-hooks/commit/e281ab29f07c4f0bf88b919447788a5b04f28d92))
+* build, eslint, webpack, typescript ([#2050](https://github.com/coinbase/rest-hooks/issues/2050)) ([9e2d363](https://github.com/coinbase/rest-hooks/commit/9e2d3636879d0c3c51763b9e74424640c4976e3a))
+* Update `@anansi/babel-preset` to v3.2.15 ([#2132](https://github.com/coinbase/rest-hooks/issues/2132)) ([8282683](https://github.com/coinbase/rest-hooks/commit/8282683e2f767b6d2b34c9bc69f646aa35ceffe8))
+* Update `@anansi/webpack-config` to v12 ([#2087](https://github.com/coinbase/rest-hooks/issues/2087)) ([59df15f](https://github.com/coinbase/rest-hooks/commit/59df15ff04c036eb087086ba52c1594dce877832))
+* Update `@anansi/webpack-config` to v13.0.3 ([#2127](https://github.com/coinbase/rest-hooks/issues/2127)) ([0bd86c3](https://github.com/coinbase/rest-hooks/commit/0bd86c3627083c3bf0277d6a9795a58e2e314523))
+* Update `eslint` to v8.22.0 ([#2134](https://github.com/coinbase/rest-hooks/issues/2134)) ([eb6ed07](https://github.com/coinbase/rest-hooks/commit/eb6ed071a5cfec423393c76eed283c36ee9b2380))
+* Update `serve` to v14 ([#2086](https://github.com/coinbase/rest-hooks/issues/2086)) ([80c6c31](https://github.com/coinbase/rest-hooks/commit/80c6c31f6c347fc109c4f8137a3498dc8551a5a2))
+* Update `webpack` to v5.74.0 ([#2118](https://github.com/coinbase/rest-hooks/issues/2118)) ([5e0228a](https://github.com/coinbase/rest-hooks/commit/5e0228afbba1c56970f9b60a0883215875cac68f))
+* Update all non-major dependencies ([#2034](https://github.com/coinbase/rest-hooks/issues/2034)) ([a3963b2](https://github.com/coinbase/rest-hooks/commit/a3963b2618981992bab115a8e8543abdb9cdc655))
+* Update all non-major dependencies ([#2068](https://github.com/coinbase/rest-hooks/issues/2068)) ([cdb5adb](https://github.com/coinbase/rest-hooks/commit/cdb5adb174ef5f0f3ec1354d5c34a70efaed2b85))
+* Update all non-major dependencies ([#2076](https://github.com/coinbase/rest-hooks/issues/2076)) ([9bd006c](https://github.com/coinbase/rest-hooks/commit/9bd006c668413e223625a14c6481a29c4251781c))
+* Update all non-major dependencies ([#2079](https://github.com/coinbase/rest-hooks/issues/2079)) ([a264250](https://github.com/coinbase/rest-hooks/commit/a2642508971948a08a78477c351b70962d89229b))
+* Update all non-major dependencies ([#2090](https://github.com/coinbase/rest-hooks/issues/2090)) ([c47de18](https://github.com/coinbase/rest-hooks/commit/c47de186f70d753d2c6e6cf6de6e74a1315ead41))
+* Update all non-major dependencies ([#2113](https://github.com/coinbase/rest-hooks/issues/2113)) ([f9b7a6e](https://github.com/coinbase/rest-hooks/commit/f9b7a6e5b19a0d6f26208af517451affa161b070))
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel monorepo to v7.18.6 ([#2075](https://github.com/coinbase/rest-hooks/issues/2075)) ([01052b0](https://github.com/coinbase/rest-hooks/commit/01052b076b353689a2621b6fecf5536b02c4f7dc))
+* Update babel monorepo to v7.18.9 ([#2089](https://github.com/coinbase/rest-hooks/issues/2089)) ([c7cf024](https://github.com/coinbase/rest-hooks/commit/c7cf0241dbe27de8780e2cab1bdc52f437766ec0))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+* Update linters ([#2106](https://github.com/coinbase/rest-hooks/issues/2106)) ([33f837c](https://github.com/coinbase/rest-hooks/commit/33f837c19a36635a6867b8100220972c1f564b67))
+* Update linting packages ([#2125](https://github.com/coinbase/rest-hooks/issues/2125)) ([9cc2b75](https://github.com/coinbase/rest-hooks/commit/9cc2b75f0efb11e55023d9dd1765f3721a0bab7e))
+* Update linting packages ([#2135](https://github.com/coinbase/rest-hooks/issues/2135)) ([b78fecd](https://github.com/coinbase/rest-hooks/commit/b78fecdeac649a96c98bfa5f1c2e0b2ef49f05f5))
+* Update linting packages ([#2138](https://github.com/coinbase/rest-hooks/issues/2138)) ([4b62fa8](https://github.com/coinbase/rest-hooks/commit/4b62fa861fe84d33a5db01f8a3f34c5d9ce0b2ea))
+* Update linting packages ([#2143](https://github.com/coinbase/rest-hooks/issues/2143)) ([630fdc7](https://github.com/coinbase/rest-hooks/commit/630fdc7ac4cd2f29d03a4bfc9fe6d838bd15eaf1))
+* Update linting packages ([#2163](https://github.com/coinbase/rest-hooks/issues/2163)) ([5cb3c6b](https://github.com/coinbase/rest-hooks/commit/5cb3c6b928a671c304dee31fdade14a6601a37a7))
+* Update linting packages to v5.33.0 ([#2130](https://github.com/coinbase/rest-hooks/issues/2130)) ([6c026ce](https://github.com/coinbase/rest-hooks/commit/6c026ce73df034d01b1056079bcbe059f10295cf))
+* Update linting packages to v5.36.1 ([#2145](https://github.com/coinbase/rest-hooks/issues/2145)) ([9a9c6bd](https://github.com/coinbase/rest-hooks/commit/9a9c6bd2edb5229d2d4a751e7ea68a45d2a88d38))
+* Update react monorepo ([#2063](https://github.com/coinbase/rest-hooks/issues/2063)) ([427a4d9](https://github.com/coinbase/rest-hooks/commit/427a4d99069ab379560642549bdb57e2fa0b3bb1))
+* Update webpack packages ([#2117](https://github.com/coinbase/rest-hooks/issues/2117)) ([334c623](https://github.com/coinbase/rest-hooks/commit/334c6234a230df721e1193e0c2f9eb4cda270ea9))
+* Update webpack packages ([#2131](https://github.com/coinbase/rest-hooks/issues/2131)) ([7503cfb](https://github.com/coinbase/rest-hooks/commit/7503cfbe61a7e5edf1dfb3b1cf09a7b93855d368))
+* Update webpack packages ([#2147](https://github.com/coinbase/rest-hooks/issues/2147)) ([cb9fd71](https://github.com/coinbase/rest-hooks/commit/cb9fd7139d3ec55e96c0b625d6d776811c3c644b))
+* Update webpack packages ([#2165](https://github.com/coinbase/rest-hooks/issues/2165)) ([e8119bc](https://github.com/coinbase/rest-hooks/commit/e8119bcf902d1caf4ef9043d67ea5dee12bc7452))
+* Update webpack packages ([#2166](https://github.com/coinbase/rest-hooks/issues/2166)) ([83ca869](https://github.com/coinbase/rest-hooks/commit/83ca869ce51a98751f84bd7f2bab4c551f4ee832))
+
 ### [0.2.9](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.8...todo-app@0.2.9) (2022-09-04)
 
 ### 📦 Package

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-app",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "todo-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -56,10 +56,10 @@
     "webpack-dev-server": "4.11.0"
   },
   "dependencies": {
-    "@rest-hooks/endpoint": "^2.3.0",
-    "@rest-hooks/rest": "^5.1.0",
+    "@rest-hooks/endpoint": "^2.3.1",
+    "@rest-hooks/rest": "^5.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "rest-hooks": "^6.3.10"
+    "rest-hooks": "^6.3.11"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.2.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.10...@rest-hooks/core@3.2.11) (2022-09-10)
+
+### 📦 Package
+
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [3.2.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.9...@rest-hooks/core@3.2.10) (2022-09-04)
 
 ### 📦 Package

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -102,9 +102,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^2.3.0",
-    "@rest-hooks/normalizr": "^8.3.0",
-    "@rest-hooks/use-enhanced-reducer": "^1.1.3",
+    "@rest-hooks/endpoint": "^2.3.1",
+    "@rest-hooks/normalizr": "^8.3.1",
+    "@rest-hooks/use-enhanced-reducer": "^1.1.4",
     "flux-standard-action": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [2.3.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.3.0...@rest-hooks/endpoint@2.3.1) (2022-09-10)
+
+### 📦 Package
+
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ## [2.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.2.12...@rest-hooks/endpoint@2.3.0) (2022-09-04)
 
 ### 🚀 Features

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/normalizr": "^8.3.0"
+    "@rest-hooks/normalizr": "^8.3.1"
   },
   "devDependencies": {
     "@babel/cli": "7.18.10",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@6.0.0...@rest-hooks/experimental@7.0.0) (2022-09-10)
+
+### ⚠ 💥 BREAKING CHANGES
+
+* urlRoot -> path
+
+### 💅 Enhancement
+
+* urlRoot -> path ([#2170](https://github.com/coinbase/rest-hooks/issues/2170)) ([20ef4a9](https://github.com/coinbase/rest-hooks/commit/20ef4a9dcc05a4914fe4450fab10621064f467c1))
+
+### 📦 Package
+
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ## [6.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@5.0.6...@rest-hooks/experimental@6.0.0) (2022-09-04)
 
 ### ⚠ 💥 BREAKING CHANGES

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.1.12](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.10...@rest-hooks/graphql@0.1.12) (2022-09-10)
+
+### 💅 Enhancement
+
+* Better handling of errors ([#2168](https://github.com/coinbase/rest-hooks/issues/2168)) ([0d75952](https://github.com/coinbase/rest-hooks/commit/0d75952dc74fe6c7b67c12745842d4ba3577af5e))
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [0.1.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.10...@rest-hooks/graphql@0.1.11) (2022-09-04)
 
 ### 📦 Package

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.3...@rest-hooks/hooks@3.0.5) (2022-09-10)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [3.0.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.3...@rest-hooks/hooks@3.0.4) (2022-09-04)
 
 ### 📦 Package

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/img/CHANGELOG.md
+++ b/packages/img/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.6.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.2...@rest-hooks/img@0.6.4) (2022-09-10)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [0.6.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.2...@rest-hooks/img@0.6.3) (2022-09-04)
 
 ### 📦 Package

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/img",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.3.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.8...@rest-hooks/legacy@4.3.9) (2022-09-10)
+
+### 📦 Package
+
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [4.3.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.7...@rest-hooks/legacy@4.3.8) (2022-09-04)
 
 ### 📦 Package

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [8.3.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.3.0...@rest-hooks/normalizr@8.3.1) (2022-09-10)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2164](https://github.com/coinbase/rest-hooks/issues/2164)) ([5bab22a](https://github.com/coinbase/rest-hooks/commit/5bab22a75898c5a61d2e0ef9e1c8f4067f15f55f))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ## [8.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.2.11...@rest-hooks/normalizr@8.3.0) (2022-09-04)
 
 ### 🚀 Features

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.3.11](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.10...rest-hooks@6.3.11) (2022-09-10)
+
+### 📦 Package
+
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [6.3.10](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.9...rest-hooks@6.3.10) (2022-09-04)
 
 ### 📦 Package

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "6.3.10",
+  "version": "6.3.11",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -102,8 +102,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/core": "^3.2.10",
-    "@rest-hooks/endpoint": "^2.3.0"
+    "@rest-hooks/core": "^3.2.11",
+    "@rest-hooks/endpoint": "^2.3.1"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.6...@rest-hooks/rest@5.1.1) (2022-09-10)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+* Update JS test packages to v29 (major) ([#2141](https://github.com/coinbase/rest-hooks/issues/2141)) ([70759cf](https://github.com/coinbase/rest-hooks/commit/70759cfc8a2de9d42a060727d9f91fe4e6945296))
+
 ### [5.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.0.6...@rest-hooks/rest@5.1.0) (2022-09-04)
 
 ### 🚀 Features

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.4...@rest-hooks/ssr@0.2.6) (2022-09-10)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [0.2.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.4...@rest-hooks/ssr@0.2.5) (2022-09-04)
 
 ### 📦 Package

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/ssr",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.3.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.5...@rest-hooks/test@7.3.7) (2022-09-10)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2119](https://github.com/coinbase/rest-hooks/issues/2119)) ([3003348](https://github.com/coinbase/rest-hooks/commit/3003348ba96781085a6f8a6a86a882438ba2b5ea))
+* Update all non-major dependencies ([#2136](https://github.com/coinbase/rest-hooks/issues/2136)) ([f7c8649](https://github.com/coinbase/rest-hooks/commit/f7c864998abc68cae1a4130f2de50e055c7a5269))
+* Update all non-major dependencies ([#2150](https://github.com/coinbase/rest-hooks/issues/2150)) ([eb480f1](https://github.com/coinbase/rest-hooks/commit/eb480f1f567944208483c9239256e7bcf81351e7))
+* Update babel packages ([#2124](https://github.com/coinbase/rest-hooks/issues/2124)) ([bab76ae](https://github.com/coinbase/rest-hooks/commit/bab76ae4ac54474634d3cb323b69ef9be5773a03))
+* Update babel packages ([#2140](https://github.com/coinbase/rest-hooks/issues/2140)) ([bc4d12d](https://github.com/coinbase/rest-hooks/commit/bc4d12d5369f4eee17f32d9379793cfc9b679d61))
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [7.3.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.5...@rest-hooks/test@7.3.6) (2022-09-04)
 
 ### 📦 Package

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "7.3.6",
+  "version": "7.3.7",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/use-enhanced-reducer/CHANGELOG.md
+++ b/packages/use-enhanced-reducer/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.3...@rest-hooks/use-enhanced-reducer@1.1.4) (2022-09-10)
+
+### 📦 Package
+
+* Update babel packages ([#2161](https://github.com/coinbase/rest-hooks/issues/2161)) ([31b2c8f](https://github.com/coinbase/rest-hooks/commit/31b2c8ff3d9f9001c31f3f5c15bec1321a15361d))
+
 ### [1.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.2...@rest-hooks/use-enhanced-reducer@1.1.3) (2022-09-04)
 
 ### 📦 Package

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3760,16 +3760,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/core@^3.2.10, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
+"@rest-hooks/core@^3.2.11, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/core@workspace:packages/core"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.0
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^2.3.0
-    "@rest-hooks/normalizr": ^8.3.0
-    "@rest-hooks/use-enhanced-reducer": ^1.1.3
+    "@rest-hooks/endpoint": ^2.3.1
+    "@rest-hooks/normalizr": ^8.3.1
+    "@rest-hooks/use-enhanced-reducer": ^1.1.4
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
@@ -3791,14 +3791,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/endpoint@^2.3.0, @rest-hooks/endpoint@workspace:packages/endpoint":
+"@rest-hooks/endpoint@^2.3.1, @rest-hooks/endpoint@workspace:packages/endpoint":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/endpoint@workspace:packages/endpoint"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.0
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/normalizr": ^8.3.0
+    "@rest-hooks/normalizr": ^8.3.1
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -3813,7 +3813,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/experimental@^6.0.0, @rest-hooks/experimental@workspace:packages/experimental":
+"@rest-hooks/experimental@^7.0.0, @rest-hooks/experimental@workspace:packages/experimental":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/experimental@workspace:packages/experimental"
   dependencies:
@@ -3844,7 +3844,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/graphql@^0.1.11, @rest-hooks/graphql@workspace:packages/graphql":
+"@rest-hooks/graphql@^0.1.12, @rest-hooks/graphql@workspace:packages/graphql":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/graphql@workspace:packages/graphql"
   dependencies:
@@ -3867,7 +3867,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/hooks@^3.0.4, @rest-hooks/hooks@workspace:packages/hooks":
+"@rest-hooks/hooks@^3.0.5, @rest-hooks/hooks@workspace:packages/hooks":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/hooks@workspace:packages/hooks"
   dependencies:
@@ -3949,7 +3949,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/normalizr@^8.3.0, @rest-hooks/normalizr@workspace:packages/normalizr":
+"@rest-hooks/normalizr@^8.3.1, @rest-hooks/normalizr@workspace:packages/normalizr":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/normalizr@workspace:packages/normalizr"
   dependencies:
@@ -3972,7 +3972,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/rest@^5.1.0, @rest-hooks/rest@workspace:packages/rest":
+"@rest-hooks/rest@^5.1.1, @rest-hooks/rest@workspace:packages/rest":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/rest@workspace:packages/rest"
   dependencies:
@@ -4057,7 +4057,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/use-enhanced-reducer@^1.1.3, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
+"@rest-hooks/use-enhanced-reducer@^1.1.4, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:
@@ -9536,8 +9536,8 @@ __metadata:
   dependencies:
     "@babel/core": 7.19.0
     "@babel/node": 7.18.10
-    "@rest-hooks/core": ^3.2.10
-    "@rest-hooks/normalizr": ^8.3.0
+    "@rest-hooks/core": ^3.2.11
+    "@rest-hooks/normalizr": ^8.3.1
     "@types/babel__core": ^7
     "@types/benchmark": 2.1.2
     "@types/react": 18.0.19
@@ -10456,12 +10456,12 @@ __metadata:
     "@linaria/core": 4.1.2
     "@linaria/react": 4.1.3
     "@linaria/shaker": 4.2.0
-    "@rest-hooks/core": ^3.2.10
-    "@rest-hooks/endpoint": ^2.3.0
-    "@rest-hooks/experimental": ^6.0.0
-    "@rest-hooks/graphql": ^0.1.11
-    "@rest-hooks/hooks": ^3.0.4
-    "@rest-hooks/rest": ^5.1.0
+    "@rest-hooks/core": ^3.2.11
+    "@rest-hooks/endpoint": ^2.3.1
+    "@rest-hooks/experimental": ^7.0.0
+    "@rest-hooks/graphql": ^0.1.12
+    "@rest-hooks/hooks": ^3.0.5
+    "@rest-hooks/rest": ^5.1.1
     "@types/eslint": 8.4.6
     "@types/parse-link-header": ^2.0.0
     "@types/prettier": 2.7.0
@@ -10486,7 +10486,7 @@ __metadata:
     rehype-highlight: ^5.0.2
     remark-gfm: ^3.0.1
     remark-remove-comments: ^0.2.0
-    rest-hooks: ^6.3.10
+    rest-hooks: ^6.3.11
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
     rollup-plugin-commonjs: ^10.1.0
@@ -15251,7 +15251,7 @@ __metadata:
   dependencies:
     "@babel/core": 7.19.0
     "@babel/node": 7.18.10
-    "@rest-hooks/normalizr": ^8.3.0
+    "@rest-hooks/normalizr": ^8.3.1
     "@types/babel__core": ^7
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
@@ -15271,7 +15271,7 @@ __metadata:
     "@babel/core": 7.19.0
     "@babel/node": 7.18.10
     "@octokit/rest": 19.0.4
-    "@rest-hooks/normalizr": ^8.3.0
+    "@rest-hooks/normalizr": ^8.3.1
     "@types/babel__core": ^7
     inquirer: ^8.1.1
     redux: 4.2.0
@@ -15293,7 +15293,7 @@ __metadata:
   dependencies:
     "@babel/core": 7.19.0
     "@babel/node": 7.18.10
-    "@rest-hooks/normalizr": ^8.3.0
+    "@rest-hooks/normalizr": ^8.3.1
     "@types/babel__core": ^7
     mockdate: ^3.0.5
     rollup: 2.79.0
@@ -18984,15 +18984,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rest-hooks@^6.3.10, rest-hooks@workspace:^, rest-hooks@workspace:packages/rest-hooks":
+"rest-hooks@^6.3.11, rest-hooks@workspace:^, rest-hooks@workspace:packages/rest-hooks":
   version: 0.0.0-use.local
   resolution: "rest-hooks@workspace:packages/rest-hooks"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.0
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/core": ^3.2.10
-    "@rest-hooks/endpoint": ^2.3.0
+    "@rest-hooks/core": ^3.2.11
+    "@rest-hooks/endpoint": ^2.3.1
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -20839,8 +20839,8 @@ __metadata:
     "@linaria/core": 4.1.2
     "@linaria/react": 4.1.3
     "@linaria/shaker": 4.2.0
-    "@rest-hooks/endpoint": ^2.3.0
-    "@rest-hooks/rest": ^5.1.0
+    "@rest-hooks/endpoint": ^2.3.1
+    "@rest-hooks/rest": ^5.1.1
     "@types/eslint": 8.4.6
     "@types/prettier": 2.7.0
     "@types/react-dom": 18.0.6
@@ -20855,7 +20855,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-refresh: 0.14.0
-    rest-hooks: ^6.3.10
+    rest-hooks: ^6.3.11
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
     rollup-plugin-commonjs: ^10.1.0


### PR DESCRIPTION
 - @rest-hooks/core@3.2.11
 - @rest-hooks/endpoint@2.3.1
 - @rest-hooks/experimental@7.0.0
 - @rest-hooks/graphql@0.1.12
 - @rest-hooks/hooks@3.0.5
 - @rest-hooks/img@0.6.4
 - @rest-hooks/legacy@4.3.9
 - @rest-hooks/normalizr@8.3.1
 - rest-hooks@6.3.11
 - @rest-hooks/rest@5.1.1
 - @rest-hooks/ssr@0.2.6
 - @rest-hooks/test@7.3.7
 - @rest-hooks/use-enhanced-reducer@1.1.4
