### PR TITLE
fix: React native to use es6 modules

### DIFF
--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-benchmark",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "description": "Benchmark for normalizr",
   "main": "index.js",
   "author": "Nathaniel Tucker",

--- a/examples/github-app/package.json
+++ b/examples/github-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app",
-  "version": "0.4.1-beta.1",
+  "version": "0.4.1-beta.2",
   "description": "github-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -61,12 +61,12 @@
   "dependencies": {
     "@anansi/router": "0.6.23",
     "@ant-design/icons": "^4.7.0",
-    "@rest-hooks/core": "^3.3.0-beta.1",
-    "@rest-hooks/endpoint": "^3.0.0-beta.1",
-    "@rest-hooks/experimental": "^7.1.0-beta.1",
-    "@rest-hooks/graphql": "^0.2.0-beta.1",
-    "@rest-hooks/hooks": "^3.0.6-beta.1",
-    "@rest-hooks/rest": "^5.2.0-beta.1",
+    "@rest-hooks/core": "^3.3.0-beta.2",
+    "@rest-hooks/endpoint": "^3.0.0-beta.2",
+    "@rest-hooks/experimental": "^7.1.0-beta.2",
+    "@rest-hooks/graphql": "^0.2.0-beta.2",
+    "@rest-hooks/hooks": "^3.0.6-beta.2",
+    "@rest-hooks/rest": "^5.2.0-beta.2",
     "antd": "4.23.2",
     "parse-link-header": "^2.0.0",
     "react": "18.2.0",
@@ -76,7 +76,7 @@
     "rehype-highlight": "^5.0.2",
     "remark-gfm": "^3.0.1",
     "remark-remove-comments": "^0.2.0",
-    "rest-hooks": "^6.4.0-beta.1",
+    "rest-hooks": "^6.4.0-beta.2",
     "uuid": "^8.3.2"
   }
 }

--- a/examples/normalizr-github/package.json
+++ b/examples/normalizr-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-github-example",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "And example of using Normalizr with github",
   "main": "index.js",
   "author": "Paul Armstrong",

--- a/examples/normalizr-redux/package.json
+++ b/examples/normalizr-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-redux-example",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "And example of using Normalizr with Redux",
   "main": "index.js",
   "author": "Paul Armstrong",
@@ -13,7 +13,7 @@
     "@babel/core": "7.19.1",
     "@babel/node": "7.19.1",
     "@octokit/rest": "19.0.4",
-    "@rest-hooks/normalizr": "^9.0.0-beta.1",
+    "@rest-hooks/normalizr": "^9.0.0-beta.2",
     "@types/babel__core": "^7",
     "inquirer": "^8.1.1",
     "redux": "4.2.0",

--- a/examples/normalizr-relationships/package.json
+++ b/examples/normalizr-relationships/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-relationships",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "And example of using Normalizr with relationships",
   "main": "index.js",
   "author": "Paul Armstrong",

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-app",
-  "version": "0.2.11-beta.1",
+  "version": "0.2.11-beta.2",
   "description": "todo-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -56,10 +56,10 @@
     "webpack-dev-server": "4.11.0"
   },
   "dependencies": {
-    "@rest-hooks/endpoint": "^3.0.0-beta.1",
-    "@rest-hooks/rest": "^5.2.0-beta.1",
+    "@rest-hooks/endpoint": "^3.0.0-beta.2",
+    "@rest-hooks/rest": "^5.2.0-beta.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "rest-hooks": "^6.4.0-beta.1"
+    "rest-hooks": "^6.4.0-beta.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "3.3.0-beta.1",
+  "version": "3.3.0-beta.2",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -103,8 +103,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/normalizr": "^9.0.0-beta.1",
-    "@rest-hooks/use-enhanced-reducer": "^1.1.5-beta.1",
+    "@rest-hooks/normalizr": "^9.0.0-beta.2",
+    "@rest-hooks/use-enhanced-reducer": "^1.1.5-beta.2",
     "flux-standard-action": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
+  "react-native": "legacy/index.js",
   "module": "legacy/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -4,6 +4,7 @@
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",
+  "react-native": "legacy/index.js",
   "module": "legacy/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -4,6 +4,7 @@
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
+  "react-native": "lib/index.js",
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "7.1.0-beta.1",
+  "version": "7.1.0-beta.2",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0-beta.2",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^3.0.0-beta.1"
+    "@rest-hooks/endpoint": "^3.0.0-beta.2"
   },
   "devDependencies": {
     "@babel/cli": "7.18.10",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -4,6 +4,7 @@
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",
+  "react-native": "legacy/index.js",
   "module": "legacy/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "3.0.6-beta.1",
+  "version": "3.0.6-beta.2",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -4,6 +4,7 @@
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
+  "react-native": "legacy/index.js",
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -4,6 +4,7 @@
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
+  "react-native": "lib/index.js",
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/img",
-  "version": "0.6.5-beta.1",
+  "version": "0.6.5-beta.2",
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -4,6 +4,7 @@
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",
+  "react-native": "legacy/index.js",
   "module": "legacy/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "4.4.0-beta.1",
+  "version": "4.4.0-beta.2",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -31,6 +31,7 @@
     "README.md"
   ],
   "main": "dist/normalizr.js",
+  "react-native": "legacy/index.js",
   "module": "legacy/index.js",
   "types": "lib/index.d.ts",
   "typesVersions": {

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "9.0.0-beta.1",
+  "version": "9.0.0-beta.2",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "6.4.0-beta.1",
+  "version": "6.4.0-beta.2",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -103,8 +103,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/core": "^3.3.0-beta.1",
-    "@rest-hooks/endpoint": "^3.0.0-beta.1"
+    "@rest-hooks/core": "^3.3.0-beta.2",
+    "@rest-hooks/endpoint": "^3.0.0-beta.2"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -4,6 +4,7 @@
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
+  "react-native": "legacy/index.js",
   "module": "legacy/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -4,6 +4,7 @@
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",
+  "react-native": "legacy/index.js",
   "module": "legacy/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "5.2.0-beta.1",
+  "version": "5.2.0-beta.2",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^3.0.0-beta.1"
+    "@rest-hooks/endpoint": "^3.0.0-beta.2"
   },
   "devDependencies": {
     "@babel/cli": "7.18.10",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/ssr",
-  "version": "0.2.7-beta.1",
+  "version": "0.2.7-beta.2",
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -4,6 +4,7 @@
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",
+  "react-native": "legacy/index.js",
   "module": "legacy/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -4,6 +4,7 @@
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",
+  "react-native": "legacy/browser.js",
   "module": "legacy/browser.js",
   "types": "lib/index.d.ts",
   "typesVersions": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "7.3.8-beta.1",
+  "version": "7.3.8-beta.2",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -4,6 +4,7 @@
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
+  "react-native": "lib/index.js",
   "module": "lib/index.js",
   "unpkg": "dist/index.umd.min.js",
   "types": "lib/index.d.ts",

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.1.5-beta.1",
+  "version": "1.1.5-beta.2",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,15 +3746,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/core@^3.3.0-beta.1, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
+"@rest-hooks/core@^3.3.0-beta.2, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/core@workspace:packages/core"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.1
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/normalizr": ^9.0.0-beta.1
-    "@rest-hooks/use-enhanced-reducer": ^1.1.5-beta.1
+    "@rest-hooks/normalizr": ^9.0.0-beta.2
+    "@rest-hooks/use-enhanced-reducer": ^1.1.5-beta.2
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
@@ -3776,7 +3776,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/endpoint@^3.0.0-beta.1, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
+"@rest-hooks/endpoint@^3.0.0-beta.2, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/endpoint@workspace:packages/endpoint"
   dependencies:
@@ -3798,7 +3798,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/experimental@^7.1.0-beta.1, @rest-hooks/experimental@workspace:packages/experimental":
+"@rest-hooks/experimental@^7.1.0-beta.2, @rest-hooks/experimental@workspace:packages/experimental":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/experimental@workspace:packages/experimental"
   dependencies:
@@ -3829,14 +3829,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/graphql@^0.2.0-beta.1, @rest-hooks/graphql@workspace:packages/graphql":
+"@rest-hooks/graphql@^0.2.0-beta.2, @rest-hooks/graphql@workspace:packages/graphql":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/graphql@workspace:packages/graphql"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.1
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^3.0.0-beta.1
+    "@rest-hooks/endpoint": ^3.0.0-beta.2
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -3851,7 +3851,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/hooks@^3.0.6-beta.1, @rest-hooks/hooks@workspace:packages/hooks":
+"@rest-hooks/hooks@^3.0.6-beta.2, @rest-hooks/hooks@workspace:packages/hooks":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/hooks@workspace:packages/hooks"
   dependencies:
@@ -3933,7 +3933,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/normalizr@^9.0.0-beta.1, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
+"@rest-hooks/normalizr@^9.0.0-beta.2, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/normalizr@workspace:packages/normalizr"
   dependencies:
@@ -3955,14 +3955,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/rest@^5.2.0-beta.1, @rest-hooks/rest@workspace:packages/rest":
+"@rest-hooks/rest@^5.2.0-beta.2, @rest-hooks/rest@workspace:packages/rest":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/rest@workspace:packages/rest"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.1
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^3.0.0-beta.1
+    "@rest-hooks/endpoint": ^3.0.0-beta.2
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -4060,7 +4060,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/use-enhanced-reducer@^1.1.5-beta.1, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
+"@rest-hooks/use-enhanced-reducer@^1.1.5-beta.2, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:
@@ -10466,12 +10466,12 @@ __metadata:
     "@linaria/core": 4.1.2
     "@linaria/react": 4.1.3
     "@linaria/shaker": 4.2.0
-    "@rest-hooks/core": ^3.3.0-beta.1
-    "@rest-hooks/endpoint": ^3.0.0-beta.1
-    "@rest-hooks/experimental": ^7.1.0-beta.1
-    "@rest-hooks/graphql": ^0.2.0-beta.1
-    "@rest-hooks/hooks": ^3.0.6-beta.1
-    "@rest-hooks/rest": ^5.2.0-beta.1
+    "@rest-hooks/core": ^3.3.0-beta.2
+    "@rest-hooks/endpoint": ^3.0.0-beta.2
+    "@rest-hooks/experimental": ^7.1.0-beta.2
+    "@rest-hooks/graphql": ^0.2.0-beta.2
+    "@rest-hooks/hooks": ^3.0.6-beta.2
+    "@rest-hooks/rest": ^5.2.0-beta.2
     "@types/eslint": 8.4.6
     "@types/parse-link-header": ^2.0.0
     "@types/prettier": 2.7.0
@@ -10496,7 +10496,7 @@ __metadata:
     rehype-highlight: ^5.0.2
     remark-gfm: ^3.0.1
     remark-remove-comments: ^0.2.0
-    rest-hooks: ^6.4.0-beta.1
+    rest-hooks: ^6.4.0-beta.2
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
     rollup-plugin-commonjs: ^10.1.0
@@ -15276,7 +15276,7 @@ __metadata:
     "@babel/node": 7.19.1
     "@octokit/rest": 19.0.4
     "@rest-hooks/endpoint": "workspace:^"
-    "@rest-hooks/normalizr": ^9.0.0-beta.1
+    "@rest-hooks/normalizr": ^9.0.0-beta.2
     "@types/babel__core": ^7
     inquirer: ^8.1.1
     redux: 4.2.0
@@ -18990,15 +18990,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rest-hooks@^6.4.0-beta.1, rest-hooks@workspace:^, rest-hooks@workspace:packages/rest-hooks":
+"rest-hooks@^6.4.0-beta.2, rest-hooks@workspace:^, rest-hooks@workspace:packages/rest-hooks":
   version: 0.0.0-use.local
   resolution: "rest-hooks@workspace:packages/rest-hooks"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.1
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/core": ^3.3.0-beta.1
-    "@rest-hooks/endpoint": ^3.0.0-beta.1
+    "@rest-hooks/core": ^3.3.0-beta.2
+    "@rest-hooks/endpoint": ^3.0.0-beta.2
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -20837,8 +20837,8 @@ __metadata:
     "@linaria/core": 4.1.2
     "@linaria/react": 4.1.3
     "@linaria/shaker": 4.2.0
-    "@rest-hooks/endpoint": ^3.0.0-beta.1
-    "@rest-hooks/rest": ^5.2.0-beta.1
+    "@rest-hooks/endpoint": ^3.0.0-beta.2
+    "@rest-hooks/rest": ^5.2.0-beta.2
     "@types/eslint": 8.4.6
     "@types/prettier": 2.7.0
     "@types/react-dom": 18.0.6
@@ -20853,7 +20853,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-refresh: 0.14.0
-    rest-hooks: ^6.4.0-beta.1
+    rest-hooks: ^6.4.0-beta.2
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
     rollup-plugin-commonjs: ^10.1.0


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #2178 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
react-native uses the 'main' field of package.json (at least in older versions). However, the commonjs builds sometimes did weird things with require in this environment.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Using es6 works best, and can be done with legacy metro setups by specifying a "react-native" field in the package.json.

Most likely future bundlers for RN will use 'exports' field and thus not have this problem.