### PR TITLE
internal: publish

### DIFF
--- a/examples/benchmark/CHANGELOG.md
+++ b/examples/benchmark/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.0](https://github.com/coinbase/rest-hooks/compare/example-benchmark@0.3.0...example-benchmark@0.4.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2175](https://github.com/coinbase/rest-hooks/issues/2175)) ([d2fb0cc](https://github.com/coinbase/rest-hooks/commit/d2fb0ccb0d46cd2c25d16da36c69200a02fae0bd))
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [0.4.0-beta.1](https://github.com/coinbase/rest-hooks/compare/example-benchmark@0.3.0...example-benchmark@0.4.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-benchmark",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0",
   "description": "Benchmark for normalizr",
   "main": "index.js",
   "author": "Nathaniel Tucker",

--- a/examples/github-app/CHANGELOG.md
+++ b/examples/github-app/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.4.1](https://github.com/coinbase/rest-hooks/compare/github-app@0.4.0...github-app@0.4.1) (2022-09-19)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2175](https://github.com/coinbase/rest-hooks/issues/2175)) ([d2fb0cc](https://github.com/coinbase/rest-hooks/commit/d2fb0ccb0d46cd2c25d16da36c69200a02fae0bd))
+* Update all non-major dependencies ([#2179](https://github.com/coinbase/rest-hooks/issues/2179)) ([07ab6c3](https://github.com/coinbase/rest-hooks/commit/07ab6c3f8cc868e41605af220dbc64f9f1da4ad8))
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+* Update linting packages ([#2173](https://github.com/coinbase/rest-hooks/issues/2173)) ([40a9937](https://github.com/coinbase/rest-hooks/commit/40a99370212b66b387c50b7787f7c569772dceac))
+
 ### [0.4.1-beta.1](https://github.com/coinbase/rest-hooks/compare/github-app@0.4.0...github-app@0.4.1-beta.1) (2022-09-17)
 
 ### 📦 Package

--- a/examples/github-app/package.json
+++ b/examples/github-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-app",
-  "version": "0.4.1-beta.2",
+  "version": "0.4.1",
   "description": "github-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -61,12 +61,12 @@
   "dependencies": {
     "@anansi/router": "0.6.23",
     "@ant-design/icons": "^4.7.0",
-    "@rest-hooks/core": "^3.3.0-beta.2",
-    "@rest-hooks/endpoint": "^3.0.0-beta.2",
-    "@rest-hooks/experimental": "^7.1.0-beta.2",
-    "@rest-hooks/graphql": "^0.2.0-beta.2",
-    "@rest-hooks/hooks": "^3.0.6-beta.2",
-    "@rest-hooks/rest": "^5.2.0-beta.2",
+    "@rest-hooks/core": "^3.3.0",
+    "@rest-hooks/endpoint": "^3.0.0",
+    "@rest-hooks/experimental": "^7.1.0",
+    "@rest-hooks/graphql": "^0.2.0",
+    "@rest-hooks/hooks": "^3.0.6",
+    "@rest-hooks/rest": "^5.2.0",
     "antd": "4.23.2",
     "parse-link-header": "^2.0.0",
     "react": "18.2.0",
@@ -76,7 +76,7 @@
     "rehype-highlight": "^5.0.2",
     "remark-gfm": "^3.0.1",
     "remark-remove-comments": "^0.2.0",
-    "rest-hooks": "^6.4.0-beta.2",
+    "rest-hooks": "^6.4.0",
     "uuid": "^8.3.2"
   }
 }

--- a/examples/normalizr-github/CHANGELOG.md
+++ b/examples/normalizr-github/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.0](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.14...normalizr-github-example@0.1.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [0.1.0-beta.1](https://github.com/coinbase/rest-hooks/compare/normalizr-github-example@0.0.14...normalizr-github-example@0.1.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/examples/normalizr-github/package.json
+++ b/examples/normalizr-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-github-example",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0",
   "description": "And example of using Normalizr with github",
   "main": "index.js",
   "author": "Paul Armstrong",

--- a/examples/normalizr-redux/CHANGELOG.md
+++ b/examples/normalizr-redux/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.0](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.14...normalizr-redux-example@0.1.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [0.1.0-beta.1](https://github.com/coinbase/rest-hooks/compare/normalizr-redux-example@0.0.14...normalizr-redux-example@0.1.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/examples/normalizr-redux/package.json
+++ b/examples/normalizr-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-redux-example",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0",
   "description": "And example of using Normalizr with Redux",
   "main": "index.js",
   "author": "Paul Armstrong",
@@ -13,7 +13,7 @@
     "@babel/core": "7.19.1",
     "@babel/node": "7.19.1",
     "@octokit/rest": "19.0.4",
-    "@rest-hooks/normalizr": "^9.0.0-beta.2",
+    "@rest-hooks/normalizr": "^9.0.0",
     "@types/babel__core": "^7",
     "inquirer": "^8.1.1",
     "redux": "4.2.0",

--- a/examples/normalizr-relationships/CHANGELOG.md
+++ b/examples/normalizr-relationships/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.0](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.14...normalizr-relationships@0.1.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [0.1.0-beta.1](https://github.com/coinbase/rest-hooks/compare/normalizr-relationships@0.0.14...normalizr-relationships@0.1.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/examples/normalizr-relationships/package.json
+++ b/examples/normalizr-relationships/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normalizr-relationships",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0",
   "description": "And example of using Normalizr with relationships",
   "main": "index.js",
   "author": "Paul Armstrong",

--- a/examples/todo-app/CHANGELOG.md
+++ b/examples/todo-app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.11](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.10...todo-app@0.2.11) (2022-09-19)
+
+### 📦 Package
+
+* Update all non-major dependencies ([#2179](https://github.com/coinbase/rest-hooks/issues/2179)) ([07ab6c3](https://github.com/coinbase/rest-hooks/commit/07ab6c3f8cc868e41605af220dbc64f9f1da4ad8))
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+* Update linting packages ([#2173](https://github.com/coinbase/rest-hooks/issues/2173)) ([40a9937](https://github.com/coinbase/rest-hooks/commit/40a99370212b66b387c50b7787f7c569772dceac))
+
 ### [0.2.11-beta.1](https://github.com/coinbase/rest-hooks/compare/todo-app@0.2.10...todo-app@0.2.11-beta.1) (2022-09-17)
 
 ### 📦 Package

--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-app",
-  "version": "0.2.11-beta.2",
+  "version": "0.2.11",
   "description": "todo-app - A rest hooks example",
   "scripts": {
     "lint": "eslint src --ext .ts,.tsx",
@@ -56,10 +56,10 @@
     "webpack-dev-server": "4.11.0"
   },
   "dependencies": {
-    "@rest-hooks/endpoint": "^3.0.0-beta.2",
-    "@rest-hooks/rest": "^5.2.0-beta.2",
+    "@rest-hooks/endpoint": "^3.0.0",
+    "@rest-hooks/rest": "^5.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "rest-hooks": "^6.4.0-beta.2"
+    "rest-hooks": "^6.4.0"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.11...@rest-hooks/core@3.3.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 💅 Enhancement
+
+* Object.prototype.hasOwnProperty -> Object.hasOwn ([bdbc6a4](https://github.com/coinbase/rest-hooks/commit/bdbc6a49350cae24a9d8cda0d4e360ce20cb91cd))
+* **types:** Handle endpoint without schema ([e33df29](https://github.com/coinbase/rest-hooks/commit/e33df29dc79fc23dc5635618797a7bb6fed62cd7))
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+* Types no longer try importing from /lib inside package ([fee559d](https://github.com/coinbase/rest-hooks/commit/fee559d69261620f9fe90ab2e109714e796d3023))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [3.3.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.2.11...@rest-hooks/core@3.3.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "3.3.0-beta.2",
+  "version": "3.3.0",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -103,8 +103,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/normalizr": "^9.0.0-beta.2",
-    "@rest-hooks/use-enhanced-reducer": "^1.1.5-beta.2",
+    "@rest-hooks/normalizr": "^9.0.0",
+    "@rest-hooks/use-enhanced-reducer": "^1.1.5",
     "flux-standard-action": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.3.1...@rest-hooks/endpoint@3.0.0) (2022-09-19)
+
+### ⚠ 💥 BREAKING CHANGES
+
+* Requires handling endpoints without schema
+
+### 🚀 Features
+
+* Entity.denormalize handles symbol input ([0817c1e](https://github.com/coinbase/rest-hooks/commit/0817c1e56132ef02c38dfc7c226ba84dc272fce5))
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 💅 Enhancement
+
+* Get rid of legacy _schema member type ([7a42da4](https://github.com/coinbase/rest-hooks/commit/7a42da4f5c3357eb1963d8fd990851a554034671))
+* Object.prototype.hasOwnProperty -> Object.hasOwn ([bdbc6a4](https://github.com/coinbase/rest-hooks/commit/bdbc6a49350cae24a9d8cda0d4e360ce20cb91cd))
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [3.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@2.3.1...@rest-hooks/endpoint@3.0.0-beta.1) (2022-09-17)
 
 ### ⚠ 💥 BREAKING CHANGES

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@7.0.0...@rest-hooks/experimental@7.1.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 💅 Enhancement
+
+* Object.prototype.hasOwnProperty -> Object.hasOwn ([bdbc6a4](https://github.com/coinbase/rest-hooks/commit/bdbc6a49350cae24a9d8cda0d4e360ce20cb91cd))
+* **types:** Handle endpoint without schema ([e33df29](https://github.com/coinbase/rest-hooks/commit/e33df29dc79fc23dc5635618797a7bb6fed62cd7))
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [7.1.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@7.0.0...@rest-hooks/experimental@7.1.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "7.1.0-beta.2",
+  "version": "7.1.0",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.12...@rest-hooks/graphql@0.2.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [0.2.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.1.12...@rest-hooks/graphql@0.2.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^3.0.0-beta.2"
+    "@rest-hooks/endpoint": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.18.10",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.5...@rest-hooks/hooks@3.0.6) (2022-09-19)
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ### [3.0.6-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.5...@rest-hooks/hooks@3.0.6-beta.1) (2022-09-17)
 
 ### 📦 Package

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "3.0.6-beta.2",
+  "version": "3.0.6",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/img/CHANGELOG.md
+++ b/packages/img/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.6.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.4...@rest-hooks/img@0.6.5) (2022-09-19)
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ### [0.6.5-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.4...@rest-hooks/img@0.6.5-beta.1) (2022-09-17)
 
 ### 📦 Package

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/img",
-  "version": "0.6.5-beta.2",
+  "version": "0.6.5",
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.4.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.9...@rest-hooks/legacy@4.4.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 💅 Enhancement
+
+* Object.prototype.hasOwnProperty -> Object.hasOwn ([bdbc6a4](https://github.com/coinbase/rest-hooks/commit/bdbc6a49350cae24a9d8cda0d4e360ce20cb91cd))
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [4.4.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.3.9...@rest-hooks/legacy@4.4.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "4.4.0-beta.2",
+  "version": "4.4.0",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.3.1...@rest-hooks/normalizr@9.0.0) (2022-09-19)
+
+### ⚠ 💥 BREAKING CHANGES
+
+* Use @rest-hooks/endpoint for schema implementations
+
+### 🚀 Features
+
+* Entity.denormalize handles symbol input ([0817c1e](https://github.com/coinbase/rest-hooks/commit/0817c1e56132ef02c38dfc7c226ba84dc272fce5))
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+* Remove schema implementations from normalizr ([86dacae](https://github.com/coinbase/rest-hooks/commit/86dacae3bcdc49bb9da2fc12e5e989c802d19460))
+
+### 💅 Enhancement
+
+* Object.prototype.hasOwnProperty -> Object.hasOwn ([bdbc6a4](https://github.com/coinbase/rest-hooks/commit/bdbc6a49350cae24a9d8cda0d4e360ce20cb91cd))
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [9.0.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@8.3.1...@rest-hooks/normalizr@9.0.0-beta.1) (2022-09-17)
 
 ### ⚠ 💥 BREAKING CHANGES

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "9.0.0-beta.2",
+  "version": "9.0.0",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.4.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.11...rest-hooks@6.4.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 💅 Enhancement
+
+* Object.prototype.hasOwnProperty -> Object.hasOwn ([bdbc6a4](https://github.com/coinbase/rest-hooks/commit/bdbc6a49350cae24a9d8cda0d4e360ce20cb91cd))
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [6.4.0-beta.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.3.11...rest-hooks@6.4.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "6.4.0-beta.2",
+  "version": "6.4.0",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -103,8 +103,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/core": "^3.3.0-beta.2",
-    "@rest-hooks/endpoint": "^3.0.0-beta.2"
+    "@rest-hooks/core": "^3.3.0",
+    "@rest-hooks/endpoint": "^3.0.0"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.1.1...@rest-hooks/rest@5.2.0) (2022-09-19)
+
+### 🚀 Features
+
+* Move schema implementations to @rest-hooks/endpoint ([#2159](https://github.com/coinbase/rest-hooks/issues/2159)) ([a4be8c0](https://github.com/coinbase/rest-hooks/commit/a4be8c08ea515a27254ea480da2baffa1534b09d))
+
+### 💅 Enhancement
+
+* Object.prototype.hasOwnProperty -> Object.hasOwn ([bdbc6a4](https://github.com/coinbase/rest-hooks/commit/bdbc6a49350cae24a9d8cda0d4e360ce20cb91cd))
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ## [5.2.0-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@5.1.1...@rest-hooks/rest@5.2.0-beta.1) (2022-09-17)
 
 ### 🚀 Features

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "5.2.0-beta.2",
+  "version": "5.2.0",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^3.0.0-beta.2"
+    "@rest-hooks/endpoint": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.18.10",

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.2.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.6...@rest-hooks/ssr@0.2.7) (2022-09-19)
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ### [0.2.7-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.6...@rest-hooks/ssr@0.2.7-beta.1) (2022-09-17)
 
 ### 📦 Package

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/ssr",
-  "version": "0.2.7-beta.2",
+  "version": "0.2.7",
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.3.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.7...@rest-hooks/test@7.3.8) (2022-09-19)
+
+### 💅 Enhancement
+
+* Object.prototype.hasOwnProperty -> Object.hasOwn ([bdbc6a4](https://github.com/coinbase/rest-hooks/commit/bdbc6a49350cae24a9d8cda0d4e360ce20cb91cd))
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ### [7.3.8-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.3.7...@rest-hooks/test@7.3.8-beta.1) (2022-09-17)
 
 ### 💅 Enhancement

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "7.3.8-beta.2",
+  "version": "7.3.8",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/use-enhanced-reducer/CHANGELOG.md
+++ b/packages/use-enhanced-reducer/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.1.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.4...@rest-hooks/use-enhanced-reducer@1.1.5) (2022-09-19)
+
+### 🐛 Bug Fix
+
+* React native to use es6 modules ([#2180](https://github.com/coinbase/rest-hooks/issues/2180)) ([31524ea](https://github.com/coinbase/rest-hooks/commit/31524ea2cbe6ab4bf4cfe77659ac5e69b0319763))
+
+### 📦 Package
+
+* Update babel packages ([#2174](https://github.com/coinbase/rest-hooks/issues/2174)) ([dab7ac7](https://github.com/coinbase/rest-hooks/commit/dab7ac798850fc0519ffe5793601757b10d949b2))
+
 ### [1.1.5-beta.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.4...@rest-hooks/use-enhanced-reducer@1.1.5-beta.1) (2022-09-17)
 
 ### 📦 Package

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.1.5-beta.2",
+  "version": "1.1.5",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,15 +3746,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/core@^3.3.0-beta.2, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
+"@rest-hooks/core@^3.3.0, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/core@workspace:packages/core"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.1
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/normalizr": ^9.0.0-beta.2
-    "@rest-hooks/use-enhanced-reducer": ^1.1.5-beta.2
+    "@rest-hooks/normalizr": ^9.0.0
+    "@rest-hooks/use-enhanced-reducer": ^1.1.5
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
@@ -3776,7 +3776,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/endpoint@^3.0.0-beta.2, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
+"@rest-hooks/endpoint@^3.0.0, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/endpoint@workspace:packages/endpoint"
   dependencies:
@@ -3798,7 +3798,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/experimental@^7.1.0-beta.2, @rest-hooks/experimental@workspace:packages/experimental":
+"@rest-hooks/experimental@^7.1.0, @rest-hooks/experimental@workspace:packages/experimental":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/experimental@workspace:packages/experimental"
   dependencies:
@@ -3829,14 +3829,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/graphql@^0.2.0-beta.2, @rest-hooks/graphql@workspace:packages/graphql":
+"@rest-hooks/graphql@^0.2.0, @rest-hooks/graphql@workspace:packages/graphql":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/graphql@workspace:packages/graphql"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.1
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^3.0.0-beta.2
+    "@rest-hooks/endpoint": ^3.0.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -3851,7 +3851,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/hooks@^3.0.6-beta.2, @rest-hooks/hooks@workspace:packages/hooks":
+"@rest-hooks/hooks@^3.0.6, @rest-hooks/hooks@workspace:packages/hooks":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/hooks@workspace:packages/hooks"
   dependencies:
@@ -3933,7 +3933,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/normalizr@^9.0.0-beta.2, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
+"@rest-hooks/normalizr@^9.0.0, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/normalizr@workspace:packages/normalizr"
   dependencies:
@@ -3955,14 +3955,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/rest@^5.2.0-beta.2, @rest-hooks/rest@workspace:packages/rest":
+"@rest-hooks/rest@^5.2.0, @rest-hooks/rest@workspace:packages/rest":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/rest@workspace:packages/rest"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.1
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^3.0.0-beta.2
+    "@rest-hooks/endpoint": ^3.0.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -4007,28 +4007,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/test@npm:^7.2.1":
-  version: 7.3.7
-  resolution: "@rest-hooks/test@npm:7.3.7"
-  dependencies:
-    "@babel/runtime": ^7.13.0
-    "@testing-library/react-hooks": ~8.0.0
-  peerDependencies:
-    "@rest-hooks/core": ^1.0.0-0 || ^2.0.0-0 || ^3.0.0-0
-    "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
-    react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
-    redux: ^4.0.0
-    rest-hooks: ^5.0.11 || ^6.0.0-0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    redux:
-      optional: true
-  checksum: 228fe938e7ab9dadb1100b434e6c2f76137c5d6ef81089ff6701952a84b6461e8eb430666b5f5978737ebb9fade371b264756498e64bbf414d04cb4a0a2b2910
-  languageName: node
-  linkType: hard
-
-"@rest-hooks/test@workspace:packages/test":
+"@rest-hooks/test@^7.2.1, @rest-hooks/test@workspace:packages/test":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/test@workspace:packages/test"
   dependencies:
@@ -4060,7 +4039,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/use-enhanced-reducer@^1.1.5-beta.2, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
+"@rest-hooks/use-enhanced-reducer@^1.1.5, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:
@@ -10466,12 +10445,12 @@ __metadata:
     "@linaria/core": 4.1.2
     "@linaria/react": 4.1.3
     "@linaria/shaker": 4.2.0
-    "@rest-hooks/core": ^3.3.0-beta.2
-    "@rest-hooks/endpoint": ^3.0.0-beta.2
-    "@rest-hooks/experimental": ^7.1.0-beta.2
-    "@rest-hooks/graphql": ^0.2.0-beta.2
-    "@rest-hooks/hooks": ^3.0.6-beta.2
-    "@rest-hooks/rest": ^5.2.0-beta.2
+    "@rest-hooks/core": ^3.3.0
+    "@rest-hooks/endpoint": ^3.0.0
+    "@rest-hooks/experimental": ^7.1.0
+    "@rest-hooks/graphql": ^0.2.0
+    "@rest-hooks/hooks": ^3.0.6
+    "@rest-hooks/rest": ^5.2.0
     "@types/eslint": 8.4.6
     "@types/parse-link-header": ^2.0.0
     "@types/prettier": 2.7.0
@@ -10496,7 +10475,7 @@ __metadata:
     rehype-highlight: ^5.0.2
     remark-gfm: ^3.0.1
     remark-remove-comments: ^0.2.0
-    rest-hooks: ^6.4.0-beta.2
+    rest-hooks: ^6.4.0
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
     rollup-plugin-commonjs: ^10.1.0
@@ -15276,7 +15255,7 @@ __metadata:
     "@babel/node": 7.19.1
     "@octokit/rest": 19.0.4
     "@rest-hooks/endpoint": "workspace:^"
-    "@rest-hooks/normalizr": ^9.0.0-beta.2
+    "@rest-hooks/normalizr": ^9.0.0
     "@types/babel__core": ^7
     inquirer: ^8.1.1
     redux: 4.2.0
@@ -18990,15 +18969,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rest-hooks@^6.4.0-beta.2, rest-hooks@workspace:^, rest-hooks@workspace:packages/rest-hooks":
+"rest-hooks@^6.4.0, rest-hooks@workspace:^, rest-hooks@workspace:packages/rest-hooks":
   version: 0.0.0-use.local
   resolution: "rest-hooks@workspace:packages/rest-hooks"
   dependencies:
     "@babel/cli": 7.18.10
     "@babel/core": 7.19.1
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/core": ^3.3.0-beta.2
-    "@rest-hooks/endpoint": ^3.0.0-beta.2
+    "@rest-hooks/core": ^3.3.0
+    "@rest-hooks/endpoint": ^3.0.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -20837,8 +20816,8 @@ __metadata:
     "@linaria/core": 4.1.2
     "@linaria/react": 4.1.3
     "@linaria/shaker": 4.2.0
-    "@rest-hooks/endpoint": ^3.0.0-beta.2
-    "@rest-hooks/rest": ^5.2.0-beta.2
+    "@rest-hooks/endpoint": ^3.0.0
+    "@rest-hooks/rest": ^5.2.0
     "@types/eslint": 8.4.6
     "@types/prettier": 2.7.0
     "@types/react-dom": 18.0.6
@@ -20853,7 +20832,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-refresh: 0.14.0
-    rest-hooks: ^6.4.0-beta.2
+    rest-hooks: ^6.4.0
     rollup: 2.79.0
     rollup-plugin-babel: ^4.4.0
     rollup-plugin-commonjs: ^10.1.0


### PR DESCRIPTION
 - @rest-hooks/core@3.3.0
 - @rest-hooks/endpoint@3.0.0
 - @rest-hooks/experimental@7.1.0
 - @rest-hooks/graphql@0.2.0
 - @rest-hooks/hooks@3.0.6
 - @rest-hooks/img@0.6.5
 - @rest-hooks/legacy@4.4.0
 - @rest-hooks/normalizr@9.0.0
 - rest-hooks@6.4.0
 - @rest-hooks/rest@5.2.0
 - @rest-hooks/ssr@0.2.7
 - @rest-hooks/test@7.3.8
 - @rest-hooks/use-enhanced-reducer@1.1.5
