### PR TITLE
enhance: Use process() option to infer return type of RestEndpoint

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -363,6 +363,21 @@ export const FutureArticleResource = {
     },
   }),
   create: CoolerArticleResource.create.extend({
+    path: '',
+    body: {} as {
+      id?: number;
+      title?: string;
+      content?: string;
+      tags?: string[];
+    },
+    process(value: any): {
+      id: number;
+      title: string;
+      content: string;
+      tags: string[];
+    } {
+      return value;
+    },
     update: (newid: string) => ({
       [CoolerArticleResource.getList.key()]: (existing: string[] = []) => [
         newid,

--- a/docs/rest/usage.md
+++ b/docs/rest/usage.md
@@ -35,7 +35,8 @@ export class Article extends Entity {
 }
 
 export const ArticleResource = createResource({
-  path: 'http\\://test.com/article/:id',
+  urlPrefix: 'http://test.com',
+  path: '/article/:id',
   schema: Article,
 });
 ```
@@ -55,7 +56,8 @@ export class Article extends Entity {
   }
 }
 export const ArticleResource = createResource({
-  path: 'http\\://test.com/article/:id',
+  urlPrefix: 'http://test.com',
+  path: '/article/:id',
   schema: Article,
 });
 ```

--- a/packages/core/src/controller/__tests__/fetch.tsx
+++ b/packages/core/src/controller/__tests__/fetch.tsx
@@ -193,9 +193,17 @@ describe.each([
       );
       await waitForNextUpdate();
       await act(async () => {
-        await result.current.fetch(FutureArticleResource.create, {
-          id: 1,
-        });
+        const article = await result.current.fetch(
+          FutureArticleResource.create,
+          {
+            id: 1,
+          },
+        );
+        article.content;
+        // @ts-expect-error
+        article.asdf;
+        // @ts-expect-error
+        article.pk;
       });
 
       expect(result.current.articles.map(({ id }) => id)).toEqual([1, 5, 3]);

--- a/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
+++ b/packages/core/src/react-integration/__tests__/integration-optimistic-endpoint.web.tsx
@@ -260,7 +260,10 @@ describe.each([
       expect(result.current.articles.map(({ id }) => id)).toEqual([5, 3]);
 
       const createOptimistic = FutureArticleResource.create.extend({
-        getOptimisticResponse: (snap, body) => ({ id: Math.random(), ...body }),
+        getOptimisticResponse: (snap, body) => ({
+          id: Math.random(),
+          ...(body as any),
+        }),
       });
       act(() => {
         result.current.fetch(createOptimistic, {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
We can extrapolate the denormalized type from schema, but there is currently no way to set the return type of fetch, which will often be slightly different.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
```ts
const getArticle = new RestEndpoint({
  path: 'http\\://test.com/article-cooler/:id',
  process(value): ArticleInterface {
    return value;
  },
});
```

Now when we simply call the function we will get autocomplete.

```ts
const article = await getArticle({ id: '5' });
```

This can also be useful in mutations when doing something with the result

```ts
const newArticle = controller.fetch(createArticle, { title: 'yay' });
router.push(`/article/${newArticle.id}`);
```