### PR TITLE
enhance: Allow body-only RestEndpoint.extend()

### DIFF
--- a/docs/rest/api/RestEndpoint.md
+++ b/docs/rest/api/RestEndpoint.md
@@ -186,6 +186,25 @@ const getSite = new RestEndpoint({ path: 'https\\://site.com/:slug' });
 getSite({ slug: 'first' });
 ```
 
+:::info
+
+Types are inferred automatically from `path`.
+
+`body` can be used to set a second argument for mutation endpoints. The actual value is not
+used in any way so it does not matter.
+
+```ts
+const updateSite = new RestEndpoint({
+  path: 'https\\://site.com/:slug',
+  // highlight-next-line
+  body: {} as { url: string },
+});
+
+updateSite({ slug: 'cool' }, { url: 'https://resthooks.io/' })
+```
+
+:::
+
 ### urlPrefix: string = '' {#urlPrefix}
 
 Prepends this to the compiled [path](#path)
@@ -230,6 +249,34 @@ Takes the [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) 
 ### process(value, ...args): any {#process}
 
 Perform any transforms with the parsed result. Defaults to identity function.
+
+:::tip
+
+The return type of process can be used to set the return type of the endpoint fetch:
+
+```ts
+const getTodo = new RestEndpoint({
+  path: '/todos/:id',
+  // The identity function is the default value; so we aren't changing any runtime behavior
+  // highlight-next-line
+  process(value): TodoInterface {
+    return value;
+  },
+});
+
+interface TodoInterface {
+  id: string;
+  title: string;
+  completed: boolean;
+}
+```
+
+```ts
+// title is string
+const title = (await getTodo({ id })).title;
+```
+
+:::
 
 ## schema?: Schema {#schema}
 

--- a/docs/rest/api/createResource.md
+++ b/docs/rest/api/createResource.md
@@ -66,6 +66,8 @@ Passed to [RestEndpoint.urlPrefix](./RestEndpoint.md#urlPrefix)
 
 Class used to construct the members.
 
+### [EndpointExtraOptions](./RestEndpoint.md#endpoint-life-cycles)
+
 ## Members
 
 These provide the standard [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete)
@@ -87,6 +89,7 @@ Commonly used with [useSuspense()](/docs/api/useSuspense), [Controller.invalidat
   - Removes the last argument:
     ```ts
     createResource({path: '/:first/:second'}).getList.path === '/:first'
+    createResource({path: '/:first'}).getList.path === '/'
     ```
 - schema: `[schema]`
 
@@ -99,6 +102,7 @@ Commonly used with [useSuspense()](/docs/api/useSuspense), [Controller.invalidat
   - Removes the last argument:
     ```ts
     createResource({path: '/:first/:second'}).getList.path === '/:first'
+    createResource({path: '/:first'}).create.path === '/'
     ```
 - schema: `schema`
 

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -624,6 +624,32 @@ describe('RestEndpoint', () => {
           "username2": "charles",
         }
       `);
+
+      const newBody = getUser.extend({
+        body: {} as { title: string },
+      });
+      () => newBody({ group: 'hi', id: 'what' }, { title: 'cool' });
+      // @ts-expect-error
+      () => newBody({ id: 'what' }, { title: 'cool' });
+      // @ts-expect-error
+      () => newBody({ title: 'cool' });
+      // @ts-expect-error
+      () => newBody({ group: 'hi', id: 'what' });
+      // @ts-expect-error
+      () => newBody({ group: 'hi', id: 'what' }, { sdfsd: 'cool' });
+
+      const bodyNoParams = newBody
+        .extend({
+          path: '/',
+        })
+        .extend({ body: {} as { happy: string } });
+      () => bodyNoParams({ happy: 'cool' });
+      // @ts-expect-error
+      () => bodyNoParams({ group: 'hi', id: 'what' }, { happy: 'cool' });
+      // @ts-expect-error
+      () => bodyNoParams({ group: 'hi', id: 'what' }, { title: 'cool' });
+      // @ts-expect-error
+      () => bodyNoParams({ sdfd: 'cool' });
     });
   });
   it('extending with name should work', () => {

--- a/packages/rest/src/hookifyResource.ts
+++ b/packages/rest/src/hookifyResource.ts
@@ -1,6 +1,6 @@
 import { EndpointInterface } from '@rest-hooks/endpoint';
 
-interface HookableEndpointInterface extends EndpointInterface {
+export interface HookableEndpointInterface extends EndpointInterface {
   extend(...args: any): HookableEndpointInterface;
 }
 

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -14,7 +14,10 @@ export type {
 export { default as createResource } from './createResource.js';
 export type { Resource } from './createResource.js';
 export { default as hookifyResource } from './hookifyResource.js';
-export type { HookResource } from './hookifyResource.js';
+export type {
+  HookResource,
+  HookableEndpointInterface,
+} from './hookifyResource.js';
 export { default as NetworkError } from './NetworkError.js';
 export { default as paginationUpdate } from './paginationUpdate.js';
 

--- a/website/src/components/Demo/index.js
+++ b/website/src/components/Demo/index.js
@@ -64,7 +64,7 @@ render(<TodoDetail id={1} />);
       },
     ],
     endpointCode: `const gql = new GQLEndpoint('/');
-const todoDetail = gql.query(\`
+const getTodo = gql.query(\`
   query GetTodo($id: ID!) {
     todo(id: $id) {
       id
@@ -74,7 +74,7 @@ const todoDetail = gql.query(\`
   }
 \`);`,
     code: `function TodoDetail({ id }: { id: number }) {
-  const { todo } = useSuspense(todoDetail, { id });
+  const { todo } = useSuspense(getTodo, { id });
   return <div>{todo.title}</div>;
 }
 render(<TodoDetail id={1} />);


### PR DESCRIPTION
Fixes #2215

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Turns out this is easier than trying to ban 'body' without 'path'.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
I realized I can easily infer urlParams since it's either there or not

Let's also make the docs more clear about how to set types using the parameters