### PR TITLE
feat: Support infer for Endpoints with string or number args

### DIFF
--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -307,6 +307,9 @@ First three members: ${JSON.stringify(input.slice(0, 3), null, 2)}`;
     recurse: any,
   ): any {
     if (!args[0]) return undefined;
+    if (['string', 'number'].includes(typeof args[0])) {
+      return `${args[0]}`;
+    }
     const id = this.pk(args[0], undefined, '');
     // Was able to infer the entity's primary key from params
     if (id !== undefined && id !== '') return id;

--- a/packages/normalizr/src/__tests__/inferResults.ts
+++ b/packages/normalizr/src/__tests__/inferResults.ts
@@ -16,6 +16,28 @@ describe('inferResults()', () => {
     });
   });
 
+  it('should work with number argument', () => {
+    const schema = new schemas.Object({
+      data: new schemas.Object({
+        article: CoolerArticle,
+      }),
+    });
+    expect(buildInferredResults(schema, [5], {})).toEqual({
+      data: { article: '5' },
+    });
+  });
+
+  it('should work with string argument', () => {
+    const schema = new schemas.Object({
+      data: new schemas.Object({
+        article: CoolerArticle,
+      }),
+    });
+    expect(buildInferredResults(schema, ['5'], {})).toEqual({
+      data: { article: '5' },
+    });
+  });
+
   it('should work with SimpleRecord', () => {
     class Data extends SimpleRecord {
       readonly article = CoolerArticle.fromJS();


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Supporting non-object arguments for an endpoint like so:

```ts
const data = useSuspense(getThing, id);
```

Longer:

```ts
const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))

class Item extends Entity {
  readonly id: string = ''
  readonly name: string = ''

  public pk() {
    console.log('creating item with id', this.id)
    return this.id
  }
}

const listEndpoint = new Endpoint(
  async () => {
    console.log('fetching items')
    await delay(1000)
    return [
      { id: 'A', name: 'Name A' },
      { id: 'B', name: 'Name B' },
      { id: 'C', name: 'Name C' },
    ]
  },
  {
    name: `${Item.name}.getList`,
    schema: [Item],
  },
)

const detailEndpoint = listEndpoint.extend({
  async fetch(id: string) {
    console.log('fetching item', id)
    await delay(500)
    return { id, name: `Name ${id}` }
  },
  name: `${Item.name}.getById`,
  schema: Item,
})
```

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Detect the first argument and if it's a number or string treat it as the pk.