### PR TITLE
feat: Add Controller.getState()

### DIFF
--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -28,6 +28,7 @@ import createFetch from './createFetch.js';
 import createInvalidate from './createInvalidate.js';
 import selectMeta from '../state/selectors/selectMeta.js';
 import type { ActionTypes, State } from '../types.js';
+import { initialState } from '../state/createReducer.js';
 
 type RHDispatch = (value: ActionTypes) => Promise<void>;
 
@@ -210,10 +211,27 @@ export default class Controller {
   ): Promise<void>
   */
 
+  /**
+   * Gets the latest state snapshot that is fully committed.
+   *
+   * This can be useful for imperative use-cases like event handlers.
+   * This should *not* be used to render; instead useSuspense() or useCache()
+   * @see https://resthooks.io/docs/api/Controller#getState
+   */
+  getState = (): State<unknown> => {
+    // This is only the value until it is set by the CacheProvider
+    /* istanbul ignore next */
+    return initialState;
+  };
+
   snapshot = (state: State<unknown>, fetchedAt?: number): SnapshotInterface => {
     return new Snapshot(this, state, fetchedAt);
   };
 
+  /**
+   * Gets the error, if any, for a given endpoint. Returns undefined for no errors.
+   * @see https://resthooks.io/docs/api/Controller#getError
+   */
   getError = <
     E extends Pick<EndpointInterface, 'key'>,
     Args extends readonly [...Parameters<E['key']>] | readonly [null],
@@ -235,6 +253,10 @@ export default class Controller {
     return meta?.error as any;
   };
 
+  /**
+   * Gets the (globally referentially stable) response for a given endpoint/args pair from state given.
+   * @see https://resthooks.io/docs/api/Controller#getResponse
+   */
   getResponse = <
     E extends Pick<EndpointInterface, 'key' | 'schema' | 'invalidIfStale'>,
     Args extends readonly [...Parameters<E['key']>] | readonly [null],

--- a/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
+++ b/packages/core/src/react-integration/__tests__/__snapshots__/hooks-endpoint.web.tsx.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`useController().getState CacheProvider should eventually update 1`] = `
+CoolerArticle {
+  "author": null,
+  "content": "whatever",
+  "id": 1,
+  "tags": [
+    "a",
+    "best",
+    "react",
+  ],
+  "title": "hi ho",
+}
+`;
+
+exports[`useController().getState ExternalCacheProvider should eventually update 1`] = `
+CoolerArticle {
+  "author": null,
+  "content": "whatever",
+  "id": 1,
+  "tags": [
+    "a",
+    "best",
+    "react",
+  ],
+  "title": "hi ho",
+}
+`;
+
 exports[`useController.fetch should dispatch an action that fetches a create 1`] = `
 {
   "endpoint": [Function],

--- a/packages/core/src/react-integration/provider/CacheStore.tsx
+++ b/packages/core/src/react-integration/provider/CacheStore.tsx
@@ -28,11 +28,14 @@ function CacheStore({
 }: StoreProps) {
   const masterReducer = useMemo(() => createReducer(controller), [controller]);
 
-  const [state, dispatch] = useEnhancedReducer(
+  const [state, dispatch, getState] = useEnhancedReducer(
     masterReducer,
     initialState,
     middlewares,
   );
+  useMemo(() => {
+    controller.getState = getState;
+  }, [controller, getState]);
   const optimisticState = useMemo(
     () => state.optimistic.reduce(masterReducer, state),
     [masterReducer, state],

--- a/packages/rest-hooks/src/react-integration/provider/ExternalCacheProvider.tsx
+++ b/packages/rest-hooks/src/react-integration/provider/ExternalCacheProvider.tsx
@@ -41,6 +41,9 @@ export default function ExternalCacheProvider<S>({
     const state = selector(store.getState());
     return state.optimistic.reduce(masterReducer, state);
   }, [masterReducer, selector, store]);
+  useMemo(() => {
+    controller.getState = selectState;
+  }, [controller, selectState]);
 
   const [state, setState] = useState(selectState);
 


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #1468 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Imperative handlers sometimes need context to choose their next behavior. It's critical we don't lock this into the React lifecycle as that is an antipattern (the useEffect-trap) - not just annoying from a coding perspective.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We already have imperative access with middlewares, so use the same function to provide to controller.

It's important we do not hide [getState()](https://resthooks.io/docs/api/Controller#getState) inside any accessors, as it is critical to understand where state comes from so it always represents the expected value.

```ts
const controller = useController();

const updateHandler = useCallback(async (updatePayload) => {
  const response = controller.fetch(MyResource.update, { id }, updatePayload);
  const denormalized = controller.getResponse(MyResource.update, { id }, updatePayload, controller.getState());
  redirect(denormalized.getterUrl);
}, [id]);
```

### Open questions

[controller.getState()](https://resthooks.io/docs/api/Controller#getState) won't include updated state til the providers useEffect() is called. This means it could potentially not have the result. We might need another promise to listen to next state update to complete this functionality.

```ts
const denormalized = controller.getResponse(MyResource.update, { id }, updatePayload, await controller.getNextState());
```

Until this is resolved, one can likely just use a useIdleCallback() as the lower priority nature compared to useEffects should guarantee running after the update.