### PR TITLE
internal: publish

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.4.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.3.2...@rest-hooks/core@3.4.0) (2022-11-06)
+
+### 🚀 Features
+
+* Add Controller.getState() ([#2252](https://github.com/coinbase/rest-hooks/issues/2252)) ([20aa9e4](https://github.com/coinbase/rest-hooks/commit/20aa9e42fa7777baeef208b8f880411c0b1e6862))
+* Add Query and schema.All ([#2229](https://github.com/coinbase/rest-hooks/issues/2229)) ([ddc03ff](https://github.com/coinbase/rest-hooks/commit/ddc03ff39b7ce8415db37b735bb81aa862807bb2))
+* Support React 18 preload-free-SSR like in NextJS ([#2253](https://github.com/coinbase/rest-hooks/issues/2253)) ([589030c](https://github.com/coinbase/rest-hooks/commit/589030c60481a7a502700773b67beeb684d527fe))
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
+### 📝 Documentation
+
+* Add diagram blog post ([#2254](https://github.com/coinbase/rest-hooks/issues/2254)) ([13b260f](https://github.com/coinbase/rest-hooks/commit/13b260f3b610983008ed051928516adee894c55d))
+
 ### [3.3.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@3.3.1...@rest-hooks/core@3.3.2) (2022-10-28)
 
 ### 💅 Enhancement

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -107,8 +107,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/normalizr": "^9.1.0",
-    "@rest-hooks/use-enhanced-reducer": "^1.1.7",
+    "@rest-hooks/normalizr": "^9.2.0",
+    "@rest-hooks/use-enhanced-reducer": "^1.2.0",
     "flux-standard-action": "^2.1.1"
   },
   "peerDependencies": {

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@3.1.0...@rest-hooks/endpoint@3.2.0) (2022-11-06)
+
+### 🚀 Features
+
+* Add Query and schema.All ([#2229](https://github.com/coinbase/rest-hooks/issues/2229)) ([ddc03ff](https://github.com/coinbase/rest-hooks/commit/ddc03ff39b7ce8415db37b735bb81aa862807bb2))
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ## [3.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@3.0.1...@rest-hooks/endpoint@3.1.0) (2022-10-28)
 
 ### 🚀 Features

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [8.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@8.0.1...@rest-hooks/experimental@8.0.2) (2022-11-06)
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ### [8.0.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@8.0.0...@rest-hooks/experimental@8.0.1) (2022-10-28)
 
 ### 📦 Package

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.3.2...@rest-hooks/graphql@0.3.3) (2022-11-06)
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ### [0.3.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.3.1...@rest-hooks/graphql@0.3.2) (2022-10-28)
 
 ### 📦 Package

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^3.1.0"
+    "@rest-hooks/endpoint": "^3.2.0"
   },
   "devDependencies": {
     "@babel/cli": "7.19.3",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.0.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.8...@rest-hooks/hooks@3.0.9) (2022-11-06)
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ### [3.0.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.7...@rest-hooks/hooks@3.0.8) (2022-10-28)
 
 ### 📦 Package

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/img/CHANGELOG.md
+++ b/packages/img/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.6.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.7...@rest-hooks/img@0.6.8) (2022-11-06)
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ### [0.6.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.6.6...@rest-hooks/img@0.6.7) (2022-10-28)
 
 ### 📦 Package

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/img",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.5.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.4.2...@rest-hooks/legacy@4.5.0) (2022-11-06)
+
+### 🚀 Features
+
+* Add Query and schema.All ([#2229](https://github.com/coinbase/rest-hooks/issues/2229)) ([ddc03ff](https://github.com/coinbase/rest-hooks/commit/ddc03ff39b7ce8415db37b735bb81aa862807bb2))
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ### [4.4.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@4.4.1...@rest-hooks/legacy@4.4.2) (2022-10-28)
 
 ### 📦 Package

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@9.1.0...@rest-hooks/normalizr@9.2.0) (2022-11-06)
+
+### 🚀 Features
+
+* Add Query and schema.All ([#2229](https://github.com/coinbase/rest-hooks/issues/2229)) ([ddc03ff](https://github.com/coinbase/rest-hooks/commit/ddc03ff39b7ce8415db37b735bb81aa862807bb2))
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ## [9.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@9.0.1...@rest-hooks/normalizr@9.1.0) (2022-10-28)
 
 ### 🚀 Features

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.5.0](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.4.2...rest-hooks@6.5.0) (2022-11-06)
+
+### 🚀 Features
+
+* Add Controller.getState() ([#2252](https://github.com/coinbase/rest-hooks/issues/2252)) ([20aa9e4](https://github.com/coinbase/rest-hooks/commit/20aa9e42fa7777baeef208b8f880411c0b1e6862))
+* Support React 18 preload-free-SSR like in NextJS ([#2253](https://github.com/coinbase/rest-hooks/issues/2253)) ([589030c](https://github.com/coinbase/rest-hooks/commit/589030c60481a7a502700773b67beeb684d527fe))
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+* Update docusaurus monorepo to v2.2.0 ([#2242](https://github.com/coinbase/rest-hooks/issues/2242)) ([dcdc24a](https://github.com/coinbase/rest-hooks/commit/dcdc24a8f1c9644ad9e991ef9476d1c12eccb3de))
+
+### 📝 Documentation
+
+* Add diagram blog post ([#2254](https://github.com/coinbase/rest-hooks/issues/2254)) ([13b260f](https://github.com/coinbase/rest-hooks/commit/13b260f3b610983008ed051928516adee894c55d))
+
 ### [6.4.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@6.4.1...rest-hooks@6.4.2) (2022-10-28)
 
 ### 📦 Package

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -107,8 +107,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/core": "^3.3.2",
-    "@rest-hooks/endpoint": "^3.1.0"
+    "@rest-hooks/core": "^3.4.0",
+    "@rest-hooks/endpoint": "^3.2.0"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@6.0.2...@rest-hooks/rest@6.1.0) (2022-11-06)
+
+### 🚀 Features
+
+* Exporting schema.All and Query ([e710e61](https://github.com/coinbase/rest-hooks/commit/e710e619adf23e23d83350df47e9e08eb43307dc))
+
+### 💅 Enhancement
+
+* Get rid of extraneous type BaseResource ([#2251](https://github.com/coinbase/rest-hooks/issues/2251)) ([fa5b457](https://github.com/coinbase/rest-hooks/commit/fa5b4573240d7d77d74aa824cdd2cfc05040078f))
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
+### 📝 Documentation
+
+* More random docs updates ([#2245](https://github.com/coinbase/rest-hooks/issues/2245)) ([361082a](https://github.com/coinbase/rest-hooks/commit/361082a3f6994f365712a4beb15f642ac24bc7ee))
+
 ### [6.0.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@6.0.1...@rest-hooks/rest@6.0.2) (2022-10-28)
 
 ### 📦 Package

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -55,6 +55,13 @@ const article = useSuspense(ArticleResource.get, { id: 5 });
 const articles = useSuspense(ArticleResource.getList);
 ```
 
+```typescript
+const [article, setArticle] = useState();
+useEffect(() => {
+  setArticle(await ArticleResource.get({ id: 5 }));
+}, []);
+```
+
 #### Mutates
 
 ```typescript

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "6.0.2",
+  "version": "6.1.0",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.0",
-    "@rest-hooks/endpoint": "^3.1.0",
+    "@rest-hooks/endpoint": "^3.2.0",
     "copyfiles": "^2.4.1",
     "path-to-regexp": "^6.2.1"
   },

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.9...@rest-hooks/ssr@0.3.0) (2022-11-06)
+
+### 🚀 Features
+
+* Support React 18 preload-free-SSR like in NextJS ([#2253](https://github.com/coinbase/rest-hooks/issues/2253)) ([589030c](https://github.com/coinbase/rest-hooks/commit/589030c60481a7a502700773b67beeb684d527fe))
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ### [0.2.9](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.2.8...@rest-hooks/ssr@0.2.9) (2022-10-28)
 
 ### 📦 Package

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/ssr",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.4.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.4.1...@rest-hooks/test@7.4.2) (2022-11-06)
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ### [7.4.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@7.4.0...@rest-hooks/test@7.4.1) (2022-10-28)
 
 ### 📦 Package

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/use-enhanced-reducer/CHANGELOG.md
+++ b/packages/use-enhanced-reducer/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.7...@rest-hooks/use-enhanced-reducer@1.2.0) (2022-11-06)
+
+### 🚀 Features
+
+* Return getState method as third arg ([#2250](https://github.com/coinbase/rest-hooks/issues/2250)) ([c46ce8d](https://github.com/coinbase/rest-hooks/commit/c46ce8dae8d9e1aaf8d149fb3777c9b7c756097a))
+
+### 📦 Package
+
+* Update babel packages ([#2255](https://github.com/coinbase/rest-hooks/issues/2255)) ([4d739a9](https://github.com/coinbase/rest-hooks/commit/4d739a9dbe2d9796f21e24ebb2022e10575bd0c4))
+
 ### [1.1.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.6...@rest-hooks/use-enhanced-reducer@1.1.7) (2022-10-28)
 
 ### 📦 Package

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3892,15 +3892,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/core@^3.3.1, @rest-hooks/core@^3.3.2, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
+"@rest-hooks/core@^3.3.1, @rest-hooks/core@^3.4.0, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/core@workspace:packages/core"
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.2
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/normalizr": ^9.1.0
-    "@rest-hooks/use-enhanced-reducer": ^1.1.7
+    "@rest-hooks/normalizr": ^9.2.0
+    "@rest-hooks/use-enhanced-reducer": ^1.2.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
@@ -3923,7 +3923,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/endpoint@^3.0.1, @rest-hooks/endpoint@^3.1.0, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
+"@rest-hooks/endpoint@^3.0.1, @rest-hooks/endpoint@^3.2.0, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/endpoint@workspace:packages/endpoint"
   dependencies:
@@ -3983,7 +3983,7 @@ __metadata:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.2
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^3.1.0
+    "@rest-hooks/endpoint": ^3.2.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -4080,7 +4080,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/normalizr@^9.0.1, @rest-hooks/normalizr@^9.1.0, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
+"@rest-hooks/normalizr@^9.0.1, @rest-hooks/normalizr@^9.2.0, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/normalizr@workspace:packages/normalizr"
   dependencies:
@@ -4109,7 +4109,7 @@ __metadata:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.2
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/endpoint": ^3.1.0
+    "@rest-hooks/endpoint": ^3.2.0
     "@types/babel__core": ^7
     "@types/copyfiles": ^2
     "@types/path-to-regexp": ^1.7.0
@@ -4190,7 +4190,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/use-enhanced-reducer@^1.1.7, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
+"@rest-hooks/use-enhanced-reducer@^1.2.0, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:
@@ -19469,8 +19469,8 @@ __metadata:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.2
     "@babel/runtime": ^7.13.0
-    "@rest-hooks/core": ^3.3.2
-    "@rest-hooks/endpoint": ^3.1.0
+    "@rest-hooks/core": ^3.4.0
+    "@rest-hooks/endpoint": ^3.2.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5


### PR DESCRIPTION
 - @rest-hooks/core: 3.3.2 => 3.4.0
 - @rest-hooks/endpoint: 3.1.0 => 3.2.0
 - @rest-hooks/experimental: 8.0.1 => 8.0.2
 - @rest-hooks/graphql: 0.3.2 => 0.3.3
 - @rest-hooks/hooks: 3.0.8 => 3.0.9
 - @rest-hooks/img: 0.6.7 => 0.6.8
 - @rest-hooks/legacy: 4.4.2 => 4.5.0
 - @rest-hooks/normalizr: 9.1.0 => 9.2.0
 - rest-hooks: 6.4.2 => 6.5.0
 - @rest-hooks/rest: 6.0.2 => 6.1.0
 - @rest-hooks/ssr: 0.2.9 => 0.3.0
 - @rest-hooks/test: 7.4.1 => 7.4.2
 - @rest-hooks/use-enhanced-reducer: 1.1.7 => 1.2.0