### PR TITLE
feat: Move from rest-hooks to @rest-hooks/react pkg

### DIFF
--- a/packages/experimental/src/__tests__/useController.tsx
+++ b/packages/experimental/src/__tests__/useController.tsx
@@ -1,4 +1,5 @@
 import { useCache, useSuspense, useFetch } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { FixtureEndpoint } from '@rest-hooks/test/mockState';
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
@@ -8,11 +9,7 @@ import nock from 'nock';
 import { Suspense, useEffect } from 'react';
 
 import { useController } from '..';
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  MockNetworkManager,
-} from '../../../test';
+import { makeRenderRestHook, MockNetworkManager } from '../../../test';
 
 export const payload = {
   id: 5,

--- a/packages/experimental/src/hooks/__tests__/subscriptions.tsx
+++ b/packages/experimental/src/hooks/__tests__/subscriptions.tsx
@@ -4,6 +4,8 @@ import {
   ControllerContext,
   useCache,
 } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { renderHook } from '@testing-library/react-hooks';
 import {
   PollingArticleResource,
@@ -13,11 +15,7 @@ import {
 import nock from 'nock';
 import React from 'react';
 
-import {
-  makeCacheProvider,
-  makeExternalCacheProvider,
-  makeRenderRestHook,
-} from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import useSubscription from '../useSubscription';
 
 let mynock: nock.Scope;

--- a/packages/experimental/src/rest/__tests__/Resource.test.ts
+++ b/packages/experimental/src/rest/__tests__/Resource.test.ts
@@ -1,9 +1,10 @@
 import { Entity, Schema, schema } from '@rest-hooks/endpoint';
 import { useController, useSuspense } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import nock from 'nock';
 
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import createResource from '../createResource';
 import RestEndpoint from '../RestEndpoint';
 import {

--- a/packages/experimental/src/rest/__tests__/RestEndpoint.ts
+++ b/packages/experimental/src/rest/__tests__/RestEndpoint.ts
@@ -1,9 +1,10 @@
 import { Entity } from '@rest-hooks/endpoint';
 import { useController, useSuspense } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import nock from 'nock';
 
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import RestEndpoint, {
   Defaults,
   RestEndpointConstructorOptions,

--- a/packages/experimental/src/rest/__tests__/createResource.test.ts
+++ b/packages/experimental/src/rest/__tests__/createResource.test.ts
@@ -1,6 +1,7 @@
 import { Entity, Schema, schema } from '@rest-hooks/endpoint';
 import { useCache, useController, useSuspense } from '@rest-hooks/react';
-import { makeRenderRestHook, makeCacheProvider } from '@rest-hooks/test';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import { makeRenderRestHook } from '@rest-hooks/test';
 import { act } from '@testing-library/react-hooks';
 import nock from 'nock';
 

--- a/packages/img/src/__tests__/fixtures.ts
+++ b/packages/img/src/__tests__/fixtures.ts
@@ -3,16 +3,16 @@ import { getImage } from '..';
 export default {
   found: [
     {
-      request: getImage,
-      params: { src: 'http://test.com/myimage.png' },
-      result: 'http://test.com/myimage.png',
+      endpoint: getImage,
+      args: [{ src: 'http://test.com/myimage.png' }],
+      response: 'http://test.com/myimage.png',
     },
   ],
   error: [
     {
-      request: getImage,
-      params: { src: 'http://test.com/myimage.png' },
-      result: { message: 'Bad request', status: 400, name: 'Not Found' },
+      endpoint: getImage,
+      args: [{ src: 'http://test.com/myimage.png' }],
+      response: { message: 'Bad request', status: 400, name: 'Not Found' },
       error: true,
     },
   ],

--- a/packages/legacy/src/__tests__/useStatefulResource.tsx
+++ b/packages/legacy/src/__tests__/useStatefulResource.tsx
@@ -1,4 +1,5 @@
-import { makeRenderRestHook, makeCacheProvider } from '@rest-hooks/test';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import { makeRenderRestHook } from '@rest-hooks/test';
 import { CoolerArticleResource as LegacyArticle } from '__tests__/legacy';
 import {
   CoolerArticleResource,

--- a/packages/react/src/__tests__/endpoint-types.web.tsx
+++ b/packages/react/src/__tests__/endpoint-types.web.tsx
@@ -1,11 +1,9 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { TypedArticleResource } from '__tests__/new';
 import nock from 'nock';
 
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  makeExternalCacheProvider,
-} from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import { useController, useSuspense } from '../hooks';
 import { payload, createPayload, users, nested } from '../test-fixtures';
 

--- a/packages/react/src/__tests__/hooks-endpoint.web.tsx
+++ b/packages/react/src/__tests__/hooks-endpoint.web.tsx
@@ -1,4 +1,6 @@
 import { State, ActionTypes, Controller, actionTypes } from '@rest-hooks/core';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { render, act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { CoolerArticleResource, PaginatedArticleResource } from '__tests__/new';
@@ -7,12 +9,7 @@ import React, { Suspense, useContext, useEffect } from 'react';
 
 // relative imports to avoid circular dependency in tsconfig references
 
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  mockInitialState,
-  makeExternalCacheProvider,
-} from '../../../test';
+import { makeRenderRestHook, mockInitialState } from '../../../test';
 import { ControllerContext, DispatchContext, StateContext } from '../context';
 import { useController, useSuspense } from '../hooks';
 import { articlesPages, createPayload, payload } from '../test-fixtures';

--- a/packages/react/src/__tests__/integration-endpoint.web.tsx
+++ b/packages/react/src/__tests__/integration-endpoint.web.tsx
@@ -1,6 +1,8 @@
 import { schema, Entity, Query } from '@rest-hooks/endpoint';
 import { Endpoint } from '@rest-hooks/endpoint';
 import { SimpleRecord } from '@rest-hooks/legacy';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import {
   CoolerArticleResource,
@@ -16,13 +18,10 @@ import {
   PaginatedArticle,
 } from '__tests__/new';
 import nock from 'nock';
+
 // relative imports to avoid circular dependency in tsconfig references
 
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  makeExternalCacheProvider,
-} from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import { useCache, useController, useFetch, useSuspense } from '../hooks';
 import {
   payload,
@@ -327,9 +326,9 @@ describe.each([
       {
         results: [
           {
-            request: unionEndpoint,
-            params: {},
-            result: [
+            endpoint: unionEndpoint,
+            args: [{}],
+            response: [
               { id: '1', type: 'users', username: 'bob' },
               { id: '2', type: 'groups', grouname: 'fast', memberCount: 5 },
             ],

--- a/packages/react/src/__tests__/integration-index-endpoint.web.tsx
+++ b/packages/react/src/__tests__/integration-index-endpoint.web.tsx
@@ -1,14 +1,11 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import { IndexedUserResource, User } from '__tests__/new';
 import nock from 'nock';
 import { useContext } from 'react';
 
 // relative imports to avoid circular dependency in tsconfig references
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  makeExternalCacheProvider,
-} from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import { StateContext } from '../context';
 import { useCache, useSuspense, useController } from '../hooks';
 import {

--- a/packages/react/src/__tests__/integration-nesting.web.tsx
+++ b/packages/react/src/__tests__/integration-nesting.web.tsx
@@ -1,3 +1,5 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import {
   CoauthoredArticle,
@@ -6,11 +8,7 @@ import {
 } from '__tests__/new';
 import nock from 'nock';
 
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  makeExternalCacheProvider,
-} from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import { useCache, useSuspense, useController } from '../hooks';
 import { coAuthored } from '../test-fixtures';
 

--- a/packages/react/src/__tests__/integration-optimistic-endpoint.web.tsx
+++ b/packages/react/src/__tests__/integration-optimistic-endpoint.web.tsx
@@ -1,6 +1,8 @@
 import { jest } from '@jest/globals';
 import { Endpoint, Entity } from '@rest-hooks/endpoint';
 import { AbortOptimistic } from '@rest-hooks/endpoint';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import {
   CoolerArticleResource,
@@ -16,11 +18,7 @@ import { SpyInstance } from 'jest-mock';
 import nock from 'nock';
 import { useContext } from 'react';
 
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  makeExternalCacheProvider,
-} from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import { StateContext } from '../context';
 import { useCache, useController, useSuspense } from '../hooks';
 import { useError } from '../hooks';

--- a/packages/react/src/__tests__/integration.node.tsx
+++ b/packages/react/src/__tests__/integration.node.tsx
@@ -1,9 +1,10 @@
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import { CoolerArticleResource, CoolerArticleDetail } from '__tests__/new';
 import nock from 'nock';
-// relative imports to avoid circular dependency in tsconfig references
 
-import { makeRenderRestHook, makeExternalCacheProvider } from '../../../test';
+// relative imports to avoid circular dependency in tsconfig references
+import { makeRenderRestHook } from '../../../test';
 import { useCache, useSuspense } from '../hooks';
 import { useController } from '../hooks';
 import {

--- a/packages/react/src/__tests__/optional-members.tsx
+++ b/packages/react/src/__tests__/optional-members.tsx
@@ -1,12 +1,8 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { createResource, Entity } from '@rest-hooks/rest';
 
 import { useSuspense, useCache } from '../';
-import {
-  Fixture,
-  FixtureEndpoint,
-  makeCacheProvider,
-  makeRenderRestHook,
-} from '../../../test';
+import { Fixture, FixtureEndpoint, makeRenderRestHook } from '../../../test';
 
 class Nested extends Entity {
   id = '';

--- a/packages/react/src/__tests__/subscriptions-endpoint.tsx
+++ b/packages/react/src/__tests__/subscriptions-endpoint.tsx
@@ -1,4 +1,6 @@
 import { Controller } from '@rest-hooks/core';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { renderHook } from '@testing-library/react-hooks';
 import {
   PollingArticleResource,
@@ -8,11 +10,7 @@ import {
 import nock from 'nock';
 import React from 'react';
 
-import {
-  makeCacheProvider,
-  makeExternalCacheProvider,
-  makeRenderRestHook,
-} from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import { ControllerContext } from '../context';
 import { useSubscription, useCache } from '../hooks';
 

--- a/packages/react/src/__tests__/useCache-endpoint.tsx
+++ b/packages/react/src/__tests__/useCache-endpoint.tsx
@@ -1,3 +1,4 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import {
   CoolerArticleResource,
   PaginatedArticleResource,
@@ -10,7 +11,7 @@ import {
 import React, { useEffect } from 'react';
 
 // relative imports to avoid circular dependency in tsconfig references
-import { makeRenderRestHook, makeCacheProvider } from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import { useCache } from '../hooks';
 import { articlesPages, payload, nested } from '../test-fixtures';
 
@@ -83,9 +84,9 @@ describe('useCache()', () => {
   it('should select singles', () => {
     const results = [
       {
-        request: CoolerArticleResource.get,
-        params: payload,
-        result: payload,
+        endpoint: CoolerArticleResource.get,
+        args: [payload],
+        response: payload,
       },
     ];
     const { result } = renderRestHook(
@@ -104,9 +105,9 @@ describe('useCache()', () => {
     Date.now = jest.fn(() => 999999999);
     const results = [
       {
-        request: InvalidIfStaleArticleResource.get,
-        params: payload,
-        result: payload,
+        endpoint: InvalidIfStaleArticleResource.get,
+        args: [payload],
+        response: payload,
       },
     ];
     const { result, rerender } = renderRestHook(

--- a/packages/react/src/__tests__/useError-endpoint.tsx
+++ b/packages/react/src/__tests__/useError-endpoint.tsx
@@ -1,7 +1,8 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { CoolerArticleResource } from '__tests__/new';
 
 // relative imports to avoid circular dependency in tsconfig references
-import { makeRenderRestHook, makeCacheProvider } from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import { useError } from '../hooks';
 import { payload } from '../test-fixtures';
 

--- a/packages/react/src/hooks/__tests__/subscriptions.tsx
+++ b/packages/react/src/hooks/__tests__/subscriptions.tsx
@@ -1,4 +1,6 @@
 import { actionTypes, Controller } from '@rest-hooks/core';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { renderHook } from '@testing-library/react-hooks';
 import {
   PollingArticleResource,
@@ -8,11 +10,7 @@ import {
 import nock from 'nock';
 import React from 'react';
 
-import {
-  makeCacheProvider,
-  makeExternalCacheProvider,
-  makeRenderRestHook,
-} from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import { ControllerContext } from '../../context';
 import useCache from '../useCache';
 import useSubscription from '../useSubscription';

--- a/packages/react/src/hooks/__tests__/useCache.tsx
+++ b/packages/react/src/hooks/__tests__/useCache.tsx
@@ -1,3 +1,4 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { GetEndpoint } from '@rest-hooks/rest';
 import {
   CoolerArticleResource,
@@ -9,10 +10,9 @@ import {
   PaginatedArticle,
 } from '__tests__/new';
 import React, { useEffect } from 'react';
-
 // relative imports to avoid circular dependency in tsconfig references
 
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import { articlesPages, payload, nested } from '../test-fixtures';
 import useCache from '../useCache';
 

--- a/packages/react/src/hooks/__tests__/useController/fetch.tsx
+++ b/packages/react/src/hooks/__tests__/useController/fetch.tsx
@@ -1,16 +1,13 @@
 import { ResolveType } from '@rest-hooks/core';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import { CoolerArticle, FutureArticleResource } from '__tests__/new';
 import nock from 'nock';
 
 import { useCache, useController, useSuspense } from '../..';
 // relative imports to avoid circular dependency in tsconfig references
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  makeExternalCacheProvider,
-  FixtureEndpoint,
-} from '../../../../../test';
+import { makeRenderRestHook, FixtureEndpoint } from '../../../../../test';
 
 export const payload = {
   id: 5,

--- a/packages/react/src/hooks/__tests__/useController/invalidate.tsx
+++ b/packages/react/src/hooks/__tests__/useController/invalidate.tsx
@@ -1,3 +1,4 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { FixtureEndpoint } from '@rest-hooks/test/mockState';
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from '@testing-library/react-hooks';
@@ -6,7 +7,7 @@ import nock from 'nock';
 import { useEffect } from 'react';
 
 import { useCache, useController } from '../..';
-import { makeRenderRestHook, makeCacheProvider } from '../../../../../test';
+import { makeRenderRestHook } from '../../../../../test';
 
 export const payload = {
   id: 5,

--- a/packages/react/src/hooks/__tests__/useController/receive.tsx
+++ b/packages/react/src/hooks/__tests__/useController/receive.tsx
@@ -1,16 +1,11 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { FixtureEndpoint } from '@rest-hooks/test/mockState';
-import { renderHook } from '@testing-library/react-hooks';
 import { act } from '@testing-library/react-hooks';
-import {
-  CoolerArticle,
-  CoolerArticleDetail,
-  FutureArticleResource,
-} from '__tests__/new';
+import { CoolerArticle, FutureArticleResource } from '__tests__/new';
 import nock from 'nock';
-import { useEffect } from 'react';
 
 import { useCache, useController, useError } from '../..';
-import { makeRenderRestHook, makeCacheProvider } from '../../../../../test';
+import { makeRenderRestHook } from '../../../../../test';
 
 export const payload = {
   id: 5,

--- a/packages/react/src/hooks/__tests__/useController/reset.tsx
+++ b/packages/react/src/hooks/__tests__/useController/reset.tsx
@@ -1,4 +1,5 @@
-import { makeRenderRestHook, makeCacheProvider } from '@rest-hooks/test';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import { makeRenderRestHook } from '@rest-hooks/test';
 import { FixtureEndpoint } from '@rest-hooks/test/mockState';
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from '@testing-library/react-hooks';

--- a/packages/react/src/hooks/__tests__/useController/subscribe.tsx
+++ b/packages/react/src/hooks/__tests__/useController/subscribe.tsx
@@ -1,9 +1,10 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { FixtureEndpoint } from '@rest-hooks/test/mockState';
 import { act } from '@testing-library/react-hooks';
 import { FutureArticleResource } from '__tests__/new';
 import nock from 'nock';
 
-import { makeRenderRestHook, makeCacheProvider } from '../../../../../test';
+import { makeRenderRestHook } from '../../../../../test';
 import useCache from '../../useCache';
 import useController from '../../useController';
 

--- a/packages/react/src/hooks/__tests__/useDLE.tsx
+++ b/packages/react/src/hooks/__tests__/useDLE.tsx
@@ -1,4 +1,5 @@
-import { makeRenderRestHook, makeCacheProvider } from '@rest-hooks/test';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import { makeRenderRestHook } from '@rest-hooks/test';
 import {
   CoolerArticle,
   CoolerArticleResource,

--- a/packages/react/src/hooks/__tests__/useError.tsx
+++ b/packages/react/src/hooks/__tests__/useError.tsx
@@ -1,7 +1,8 @@
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { CoolerArticleResource } from '__tests__/new';
 
 // relative imports to avoid circular dependency in tsconfig references
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import { payload } from '../test-fixtures';
 import useError from '../useError';
 

--- a/packages/react/src/hooks/__tests__/useFetch.web.tsx
+++ b/packages/react/src/hooks/__tests__/useFetch.web.tsx
@@ -1,13 +1,13 @@
 import { initialState, State, ActionTypes, Controller } from '@rest-hooks/core';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { CoolerArticleResource, StaticArticleResource } from '__tests__/new';
 import nock from 'nock';
 import React, { Suspense } from 'react';
-
 // relative imports to avoid circular dependency in tsconfig references
 
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import { StateContext, ControllerContext } from '../../context';
 import { users, payload } from '../test-fixtures';
 import useFetch from '../useFetch';

--- a/packages/react/src/hooks/__tests__/useSuspense.native.tsx
+++ b/packages/react/src/hooks/__tests__/useSuspense.native.tsx
@@ -11,11 +11,8 @@ import {
 import { FetchAction } from '@rest-hooks/core';
 import { Endpoint, FetchFunction, ReadEndpoint } from '@rest-hooks/endpoint';
 import { normalize } from '@rest-hooks/normalizr';
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  mockInitialState,
-} from '@rest-hooks/test';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import { makeRenderRestHook, mockInitialState } from '@rest-hooks/test';
 import { render, act, screen, waitFor } from '@testing-library/react-native';
 import {
   CoolerArticleResource,

--- a/packages/react/src/hooks/__tests__/useSuspense.web.tsx
+++ b/packages/react/src/hooks/__tests__/useSuspense.web.tsx
@@ -9,6 +9,7 @@ import {
 import { FetchAction } from '@rest-hooks/core';
 import { Endpoint, FetchFunction, ReadEndpoint } from '@rest-hooks/endpoint';
 import { normalize } from '@rest-hooks/normalizr';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { render, act } from '@testing-library/react';
 import {
   CoolerArticleResource,
@@ -37,11 +38,7 @@ import {
   ControllerContext,
   StateContext,
 } from '../..';
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  mockInitialState,
-} from '../../../../test';
+import { makeRenderRestHook, mockInitialState } from '../../../../test';
 import { articlesPages, payload, users, nested } from '../test-fixtures';
 import useSuspense from '../useSuspense';
 

--- a/packages/rest-hooks/src/hooks/__tests__/hooks.web.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/hooks.web.tsx
@@ -1,3 +1,4 @@
+import { shapeToEndpoint } from '@rest-hooks/legacy';
 import {
   DispatchContext,
   StateContext,
@@ -6,6 +7,7 @@ import {
   actionTypes,
   __INTERNAL__,
 } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { render } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import {
@@ -16,15 +18,10 @@ import {
 } from '__tests__/legacy-3';
 import nock from 'nock';
 import React, { Suspense, useEffect } from 'react';
-
 // relative imports to avoid circular dependency in tsconfig references
 
 import { useFetcher, useRetrieve, useInvalidator, useResetter } from '..';
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  mockInitialState,
-} from '../../../../test';
+import { makeRenderRestHook, mockInitialState } from '../../../../test';
 import { users, articlesPages, payload } from '../test-fixtures';
 
 const { initialState } = __INTERNAL__;
@@ -220,9 +217,9 @@ describe('useInvalidate', () => {
   it('should not invalidate anything if params is null', () => {
     const state = mockInitialState([
       {
-        request: PaginatedArticleResource.listShape(),
-        params: {},
-        result: articlesPages,
+        endpoint: shapeToEndpoint(PaginatedArticleResource.listShape()),
+        args: [{}],
+        response: articlesPages,
       },
     ]);
     const dispatch = jest.fn();
@@ -240,9 +237,9 @@ describe('useInvalidate', () => {
   it('should return a function that dispatches an action to invalidate a resource', () => {
     const state = mockInitialState([
       {
-        request: PaginatedArticleResource.listShape(),
-        params: {},
-        result: articlesPages,
+        endpoint: shapeToEndpoint(PaginatedArticleResource.listShape()),
+        args: [{}],
+        response: articlesPages,
       },
     ]);
     const dispatch = jest.fn();
@@ -285,9 +282,9 @@ describe('useResetter', () => {
     jest.useFakeTimers();
     const state = mockInitialState([
       {
-        request: PaginatedArticleResource.listShape(),
-        params: {},
-        result: articlesPages,
+        endpoint: shapeToEndpoint(PaginatedArticleResource.listShape()),
+        args: [{}],
+        response: articlesPages,
       },
     ]);
     const dispatch = jest.fn();
@@ -388,9 +385,9 @@ describe('useRetrieve', () => {
     mynock.get(`/article-cooler/${payload.id}`).reply(200, fetchMock).persist();
     const results: any[] = [
       {
-        request: CoolerArticleResource.detailShape(),
-        params: payload,
-        result: payload,
+        endpoint: shapeToEndpoint(CoolerArticleResource.detailShape()),
+        args: [payload],
+        response: payload,
       },
     ];
     const { result, rerender } = renderRestHook(

--- a/packages/rest-hooks/src/hooks/__tests__/integration-legacy.web.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/integration-legacy.web.tsx
@@ -1,11 +1,10 @@
 import { jest } from '@jest/globals';
 // relative imports to avoid circular dependency in tsconfig references
 import { SimpleRecord } from '@rest-hooks/legacy';
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  makeExternalCacheProvider,
-} from '@rest-hooks/test';
+import { shapeToEndpoint } from '@rest-hooks/legacy';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
+import { makeRenderRestHook } from '@rest-hooks/test';
 import { act } from '@testing-library/react-hooks';
 import {
   CoolerArticleResource,
@@ -422,9 +421,9 @@ describe.each([
         {
           results: [
             {
-              request: CoolerArticleResource.detailShape(),
-              params,
-              result: payload,
+              endpoint: shapeToEndpoint(CoolerArticleResource.detailShape()),
+              args: [params],
+              response: payload,
             },
           ],
         },
@@ -463,9 +462,9 @@ describe.each([
         {
           results: [
             {
-              request: CoolerArticleResource.listShape(),
-              params: {},
-              result: [payload],
+              endpoint: shapeToEndpoint(CoolerArticleResource.listShape()),
+              args: [{}],
+              response: [payload],
             },
           ],
         },
@@ -512,9 +511,11 @@ describe.each([
         {
           results: [
             {
-              request: ArticleResourceWithOtherListUrl.otherListShape(),
-              params: {},
-              result: [{ id: 100, content: 'something' }],
+              endpoint: shapeToEndpoint(
+                ArticleResourceWithOtherListUrl.otherListShape(),
+              ),
+              args: [{}],
+              response: [{ id: 100, content: 'something' }],
             },
           ],
         },
@@ -580,9 +581,9 @@ describe.each([
         {
           results: [
             {
-              request: CoolerArticleResource.detailShape(),
-              params,
-              result: payload,
+              endpoint: shapeToEndpoint(CoolerArticleResource.detailShape()),
+              args: [params],
+              response: payload,
             },
           ],
         },

--- a/packages/rest-hooks/src/hooks/__tests__/integration-optimistic-legacy-endpoint.web.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/integration-optimistic-legacy-endpoint.web.tsx
@@ -1,4 +1,6 @@
 import { jest } from '@jest/globals';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import {
   CoolerArticleResource,
   ArticleResourceWithOtherListUrl,
@@ -7,11 +9,7 @@ import {
 import nock from 'nock';
 
 import { useResource, useFetcher, useCache } from '..';
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  makeExternalCacheProvider,
-} from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import {
   payload,
   createPayload,
@@ -107,9 +105,9 @@ describe.each([
         {
           results: [
             {
-              request: CoolerArticleResource.detail(),
-              params,
-              result: payload,
+              endpoint: CoolerArticleResource.detail(),
+              args: [params],
+              response: payload,
             },
           ],
         },
@@ -148,9 +146,9 @@ describe.each([
         {
           results: [
             {
-              request: CoolerArticleResource.list(),
-              params: {},
-              result: [payload],
+              endpoint: CoolerArticleResource.list(),
+              args: [{}],
+              response: [payload],
             },
           ],
         },
@@ -190,9 +188,9 @@ describe.each([
         {
           results: [
             {
-              request: ArticleResourceWithOtherListUrl.otherList(),
-              params: {},
-              result: [{ id: 100, content: 'something' }],
+              endpoint: ArticleResourceWithOtherListUrl.otherList(),
+              args: [{}],
+              response: [{ id: 100, content: 'something' }],
             },
           ],
         },

--- a/packages/rest-hooks/src/hooks/__tests__/subscriptions.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/subscriptions.tsx
@@ -3,6 +3,8 @@ import {
   ControllerContext,
   Controller,
 } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import makeExternalCacheProvider from '@rest-hooks/redux/makeCacheProvider';
 import { renderHook } from '@testing-library/react-hooks';
 import { PollingArticleResource } from '__tests__/legacy-3';
 import nock from 'nock';
@@ -11,11 +13,7 @@ import React from 'react';
 // relative imports to avoid circular dependency in tsconfig references
 
 import { useSubscription, useCache } from '..';
-import {
-  makeCacheProvider,
-  makeExternalCacheProvider,
-  makeRenderRestHook,
-} from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 
 let mynock: nock.Scope;
 

--- a/packages/rest-hooks/src/hooks/__tests__/useCache.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/useCache.tsx
@@ -1,3 +1,5 @@
+import { shapeToEndpoint } from '@rest-hooks/legacy';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import {
   CoolerArticleResource,
   PaginatedArticleResource,
@@ -8,7 +10,7 @@ import React, { useEffect } from 'react';
 
 // relative imports to avoid circular dependency in tsconfig references
 import { useCache } from '..';
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import { articlesPages, payload } from '../test-fixtures';
 
 describe('useCache()', () => {
@@ -37,9 +39,9 @@ describe('useCache()', () => {
   it('should select singles', () => {
     const results = [
       {
-        request: CoolerArticleResource.detailShape(),
-        params: payload,
-        result: payload,
+        endpoint: shapeToEndpoint(CoolerArticleResource.detailShape()),
+        args: [payload],
+        response: payload,
       },
     ];
     const { result } = renderRestHook(
@@ -58,9 +60,9 @@ describe('useCache()', () => {
     Date.now = jest.fn(() => 999999999);
     const results = [
       {
-        request: InvalidIfStaleArticleResource.detailShape(),
-        params: payload,
-        result: payload,
+        endpoint: shapeToEndpoint(InvalidIfStaleArticleResource.detailShape()),
+        args: [payload],
+        response: payload,
       },
     ];
     const { result, rerender } = renderRestHook(
@@ -84,9 +86,9 @@ describe('useCache()', () => {
   it('should select paginated results', () => {
     const results = [
       {
-        request: PaginatedArticleResource.listShape(),
-        params: {},
-        result: articlesPages,
+        endpoint: shapeToEndpoint(PaginatedArticleResource.listShape()),
+        args: [{}],
+        response: articlesPages,
       },
     ];
     const { result } = renderRestHook(
@@ -107,9 +109,9 @@ describe('useCache()', () => {
   it('should return identical value no matter how many re-renders', () => {
     const results = [
       {
-        request: PaginatedArticleResource.listShape(),
-        params: {},
-        result: articlesPages,
+        endpoint: shapeToEndpoint(PaginatedArticleResource.listShape()),
+        args: [{}],
+        response: articlesPages,
       },
     ];
     const track = jest.fn();
@@ -144,9 +146,9 @@ describe('useCache()', () => {
     it('should find results', () => {
       const results = [
         {
-          request: PaginatedArticleResource.listShape(),
-          params: {},
-          result: articlesPages,
+          endpoint: shapeToEndpoint(PaginatedArticleResource.listShape()),
+          args: [{}],
+          response: articlesPages,
         },
       ];
       const { result } = renderRestHook(
@@ -168,9 +170,9 @@ describe('useCache()', () => {
     it('should return identical value no matter how many re-renders', () => {
       const results = [
         {
-          request: PaginatedArticleResource.listShape(),
-          params: {},
-          result: articlesPages,
+          endpoint: shapeToEndpoint(PaginatedArticleResource.listShape()),
+          args: [{}],
+          response: articlesPages,
         },
       ];
       const track = jest.fn();

--- a/packages/rest-hooks/src/hooks/__tests__/useError.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/useError.tsx
@@ -1,8 +1,10 @@
+import { shapeToEndpoint } from '@rest-hooks/legacy';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { CoolerArticleResource } from '__tests__/legacy-3';
 
 // relative imports to avoid circular dependency in tsconfig references
 import { useError } from '..';
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import { payload } from '../test-fixtures';
 
 describe('useError()', () => {
@@ -14,9 +16,9 @@ describe('useError()', () => {
   it('should return undefined when cache not ready and no error in meta', () => {
     const results = [
       {
-        request: CoolerArticleResource.detailShape(),
-        params: payload,
-        result: payload,
+        endpoint: shapeToEndpoint(CoolerArticleResource.detailShape()),
+        args: [payload],
+        response: payload,
       },
     ];
     const { result } = renderRestHook(

--- a/packages/rest-hooks/src/hooks/__tests__/useExpiresAt.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/useExpiresAt.tsx
@@ -1,13 +1,13 @@
 import { Endpoint, Entity } from '@rest-hooks/endpoint';
 import { StateContext } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 
 // relative imports to avoid circular dependency in tsconfig references
-
 import { useExpiresAt } from '..';
 import { State, useDenormalized } from '../..';
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 
 export default class IDEntity extends Entity {
   readonly id: string | number | undefined = undefined;

--- a/packages/rest-hooks/src/hooks/__tests__/useMeta-endpoint.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/useMeta-endpoint.tsx
@@ -1,12 +1,8 @@
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  Fixture,
-} from '@rest-hooks/test';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import { makeRenderRestHook, Fixture } from '@rest-hooks/test';
 import { TypedArticleResource } from '__tests__/new';
 
 // relative imports to avoid circular dependency in tsconfig references
-
 import { useMeta } from '..';
 import { payload } from '../test-fixtures';
 

--- a/packages/rest-hooks/src/hooks/__tests__/useResource-legacy.web.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/useResource-legacy.web.tsx
@@ -1,10 +1,11 @@
 import { ReadShape } from '@rest-hooks/core';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { CoolerArticleResource } from '__tests__/legacy';
 import nock from 'nock';
 
 // relative imports to avoid circular dependency in tsconfig references
 import { useResource } from '..';
-import { makeRenderRestHook, makeCacheProvider } from '../../../../test';
+import { makeRenderRestHook } from '../../../../test';
 import { payload, users, nested } from '../test-fixtures';
 
 describe('useResource()', () => {

--- a/packages/rest-hooks/src/hooks/__tests__/useResource.web.tsx
+++ b/packages/rest-hooks/src/hooks/__tests__/useResource.web.tsx
@@ -1,10 +1,9 @@
 import { State, ReadShape } from '@rest-hooks/core';
 import { initialState } from '@rest-hooks/core';
-
-// relative imports to avoid circular dependency in tsconfig references
-
+import { shapeToEndpoint } from '@rest-hooks/legacy';
 import { normalize } from '@rest-hooks/normalizr';
 import { DispatchContext, StateContext } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { render } from '@testing-library/react';
 import {
   CoolerArticleResource,
@@ -18,12 +17,9 @@ import { createEntityMeta } from '__tests__/utils';
 import nock from 'nock';
 import React, { Suspense } from 'react';
 
+// relative imports to avoid circular dependency in tsconfig references
 import { useResource } from '..';
-import {
-  makeRenderRestHook,
-  makeCacheProvider,
-  mockInitialState,
-} from '../../../../test';
+import { makeRenderRestHook, mockInitialState } from '../../../../test';
 import { payload, users, nested } from '../test-fixtures';
 
 async function testDispatchFetch(
@@ -231,9 +227,9 @@ describe('useResource()', () => {
   it('should NOT suspend if result already in cache and options.invalidIfStale is false', () => {
     const state: State<unknown> = mockInitialState([
       {
-        request: CoolerArticleResource.detailShape(),
-        params: payload,
-        result: payload,
+        endpoint: shapeToEndpoint(CoolerArticleResource.detailShape()),
+        args: [payload],
+        response: payload,
       },
     ]) as any;
 
@@ -395,11 +391,13 @@ describe('useResource()', () => {
       {
         results: [
           {
-            request: FS,
-            params: {
-              id: '0',
-            },
-            result: error,
+            endpoint: shapeToEndpoint(FS),
+            args: [
+              {
+                id: '0',
+              },
+            ],
+            response: error,
             error: true,
           },
         ],
@@ -428,11 +426,13 @@ describe('useResource()', () => {
       {
         results: [
           {
-            request: expiredShape,
-            params: {
-              id: '0',
-            },
-            result: error,
+            endpoint: shapeToEndpoint(expiredShape),
+            args: [
+              {
+                id: '0',
+              },
+            ],
+            response: error,
             error: true,
           },
         ],
@@ -478,11 +478,11 @@ describe('useResource()', () => {
       {
         results: [
           {
-            request: expiredShape,
-            params: {
+            endpoint: shapeToEndpoint(expiredShape,
+            args: [{
               id: '4000',
             },
-            result: { data: null },
+            response: { data: null },
           },
         ],
       },

--- a/packages/rest/src/__tests__/Resource.test.ts
+++ b/packages/rest/src/__tests__/Resource.test.ts
@@ -1,10 +1,11 @@
 import { Entity, Schema } from '@rest-hooks/endpoint';
 import { useController } from '@rest-hooks/react';
 import { useSuspense } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import nock from 'nock';
 
-import { makeRenderRestHook, makeCacheProvider } from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import createResource from '../createResource';
 import RestEndpoint from '../RestEndpoint';
 import {

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -1,11 +1,12 @@
 import { Entity } from '@rest-hooks/endpoint';
 import { useController } from '@rest-hooks/react';
 import { useSuspense } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { act } from '@testing-library/react-hooks';
 import { CoolerArticle, CoolerArticleResource } from '__tests__/new';
 import nock from 'nock';
 
-import { makeRenderRestHook, makeCacheProvider } from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import RestEndpoint, {
   Defaults,
   RestEndpointConstructorOptions,

--- a/packages/rest/src/__tests__/createResource.test.ts
+++ b/packages/rest/src/__tests__/createResource.test.ts
@@ -1,6 +1,7 @@
 import { Entity, schema } from '@rest-hooks/endpoint';
 import { useCache, useController, useSuspense } from '@rest-hooks/react';
-import { makeRenderRestHook, makeCacheProvider } from '@rest-hooks/test';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
+import { makeRenderRestHook } from '@rest-hooks/test';
 import { act } from '@testing-library/react-hooks';
 import nock from 'nock';
 

--- a/packages/rest/src/__tests__/hookifyResource.ts
+++ b/packages/rest/src/__tests__/hookifyResource.ts
@@ -1,8 +1,9 @@
 import { useController, useSuspense } from '@rest-hooks/react';
+import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';
 import { CoolerArticleResource, CoolerArticle, User } from '__tests__/new';
 import nock from 'nock';
 
-import { makeRenderRestHook, makeCacheProvider } from '../../../test';
+import { makeRenderRestHook } from '../../../test';
 import hookifyResource from '../hookifyResource';
 
 const CoolerArticleHookResource = hookifyResource(

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -102,9 +102,9 @@
     "@testing-library/react-hooks": "~8.0.0"
   },
   "peerDependencies": {
+    "@rest-hooks/react": "^0.2.0 || ^0.3.0 || ^1.0.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
-    "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
-    "rest-hooks": "^6.6.0"
+    "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/test/src/MockProvider.tsx
+++ b/packages/test/src/MockProvider.tsx
@@ -1,6 +1,6 @@
+import { StateContext, DispatchContext, actionTypes } from '@rest-hooks/react';
+import type { ActionTypes } from '@rest-hooks/react';
 import React from 'react';
-import { StateContext, DispatchContext, actionTypes } from 'rest-hooks';
-import type { ActionTypes } from 'rest-hooks';
 
 import mockState, { Fixture } from './mockState.js';
 
@@ -14,14 +14,14 @@ for which there is no matching fixture.
 If you were expecting to see results, it is likely due to data not being found in fixtures.
 Double check your params and FetchShape match. For example:
 
-useResource(ArticleResource.listShape(), { maxResults: 10 });
+useSuspense(ArticleResource.getList, { maxResults: 10 });
 
 and
 
 {
-request: ArticleResource.listShape(),
-params: { maxResults: 10 },
-result: [],
+endpoint: ArticleResource.getList,
+args: [{ maxResults: 10 }],
+response: [],
 }`,
     );
   }

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -11,6 +11,5 @@ export type {
   SuccessFixture,
   ErrorFixture,
 } from './mockState.js';
-export { makeExternalCacheProvider, makeCacheProvider } from 'rest-hooks';
 
 export { makeRenderRestHook, MockProvider, mockInitialState };

--- a/packages/test/src/makeRenderRestHook.tsx
+++ b/packages/test/src/makeRenderRestHook.tsx
@@ -1,6 +1,6 @@
+import { State, Manager, SubscriptionManager } from '@rest-hooks/react';
 import { renderHook } from '@testing-library/react-hooks';
 import React, { memo, Suspense } from 'react';
-import { State, Manager, SubscriptionManager } from 'rest-hooks';
 
 import { MockNetworkManager, MockPollingSubscription } from './managers.js';
 import MockResolver from './MockResolver.js';

--- a/packages/test/src/managers.ts
+++ b/packages/test/src/managers.ts
@@ -1,6 +1,6 @@
+import { NetworkManager, PollingSubscription } from '@rest-hooks/react';
+import type { ReceiveAction } from '@rest-hooks/react';
 import { act } from '@testing-library/react-hooks';
-import { NetworkManager, PollingSubscription } from 'rest-hooks';
-import type { ReceiveAction } from 'rest-hooks';
 
 export class MockNetworkManager extends NetworkManager {
   handleFetch(

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -6,6 +6,6 @@
   },
   "include": ["src"],
   "references": [
-    { "path": "../rest-hooks" }
+    { "path": "../react" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4350,9 +4350,9 @@ __metadata:
     rollup-plugin-replace: ^2.2.0
     rollup-plugin-terser: ^7.0.2
   peerDependencies:
+    "@rest-hooks/react": ^0.2.0 || ^0.3.0 || ^1.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
-    rest-hooks: ^6.6.0
   peerDependenciesMeta:
     "@types/react":
       optional: true


### PR DESCRIPTION
BREAKING CHANGE:
- Requires @rest-hooks/react instead of rest-hooks
- No longer support shape-based fixtures
  - use shapeToEndpoint from @rest-hooks/legacy to convert
- import makeCacheProvider from '@rest-hooks/react/makeCacheProvider';

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Moving people toward @rest-hooks/react - so we need it as peerdep

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
