### PR TITLE
fix: Network down/ CORS errors should be 'soft' by default

### DIFF
--- a/packages/graphql/src/GQLEndpoint.ts
+++ b/packages/graphql/src/GQLEndpoint.ts
@@ -68,7 +68,7 @@ export default class GQLEndpoint<
       .catch(error => {
         // ensure CORS, network down, and parse errors are still caught by NetworkErrorBoundary
         if (error instanceof TypeError) {
-          (error as any).status = 400;
+          (error as any).status = 500;
         }
         throw error;
       });

--- a/packages/rest/src/RestEndpoint.js
+++ b/packages/rest/src/RestEndpoint.js
@@ -106,7 +106,7 @@ export default class RestEndpoint extends Endpoint {
       .catch(error => {
         // ensure CORS, network down, and parse errors are still caught by NetworkErrorBoundary
         if (error instanceof TypeError) {
-          error.status = 400;
+          error.status = 500;
         }
         throw error;
       });

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -991,7 +991,7 @@ describe('RestEndpoint.fetch()', () => {
       error = e;
     }
     expect(error).toBeDefined();
-    expect(error.status).toBe(400);
+    expect(error.status).toBe(500);
 
     // eslint-disable-next-line require-atomic-updates
     console.error = oldError;


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
These are potentially recoverable so we want to retry when that logic is added, but also keep existing data if it is still valid.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Change artificial status from 400 to 500