### PR TITLE
enhance: Block dispatches after unmount

### DIFF
--- a/packages/react/src/components/CacheStore.tsx
+++ b/packages/react/src/components/CacheStore.tsx
@@ -47,6 +47,19 @@ function CacheStore({
       managers[i].init?.(state);
     }
     return () => {
+      // dispatching after unmount should be ignored
+      /* istanbul ignore else */
+      if (process.env.NODE_ENV !== 'production') {
+        (controller as any).dispatch = (action: any) => {
+          console.debug(
+            'Action dispatched after CacheProvider unmounted. This will be ignored.',
+          );
+          console.debug(JSON.stringify(action, undefined, 2));
+          return Promise.resolve();
+        };
+      } else {
+        (controller as any).dispatch = () => Promise.resolve();
+      }
       for (let i = 0; i < managers.length; ++i) {
         managers[i].cleanup();
       }

--- a/packages/react/src/components/__tests__/provider.tsx
+++ b/packages/react/src/components/__tests__/provider.tsx
@@ -24,7 +24,7 @@ describe('<CacheProvider />', () => {
   let debugspy: jest.SpyInstance;
   beforeEach(() => {
     warnspy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
-    debugspy = jest.spyOn(global.console, 'info').mockImplementation(() => {});
+    debugspy = jest.spyOn(global.console, 'debug').mockImplementation(() => {});
   });
   afterEach(() => {
     warnspy.mockRestore();

--- a/packages/react/src/components/__tests__/provider.tsx
+++ b/packages/react/src/components/__tests__/provider.tsx
@@ -3,6 +3,9 @@ import {
   NetworkManager,
   actionTypes,
   SubscriptionManager,
+  Manager,
+  Middleware,
+  Controller,
 } from '@rest-hooks/core';
 import { act, render } from '@testing-library/react';
 import { CoolerArticle, CoolerArticleResource } from '__tests__/new';
@@ -18,11 +21,14 @@ const { RECEIVE_TYPE } = actionTypes;
 
 describe('<CacheProvider />', () => {
   let warnspy: jest.SpyInstance;
+  let debugspy: jest.SpyInstance;
   beforeEach(() => {
-    warnspy = jest.spyOn(global.console, 'warn');
+    warnspy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+    debugspy = jest.spyOn(global.console, 'info').mockImplementation(() => {});
   });
   afterEach(() => {
     warnspy.mockRestore();
+    debugspy.mockRestore();
   });
 
   beforeAll(() => {
@@ -149,5 +155,62 @@ describe('<CacheProvider />', () => {
       manager => manager instanceof SubscriptionManager,
     );
     expect(subManagers.length).toBe(1);
+  });
+
+  it('should ignore dispatches after unmount', async () => {
+    class InjectorManager implements Manager {
+      protected declare middleware: Middleware;
+      declare controller: Controller;
+
+      constructor() {
+        this.middleware = controller => {
+          this.controller = controller;
+          return next => async action => {
+            await next(action);
+          };
+        };
+      }
+
+      cleanup() {}
+
+      getMiddleware() {
+        return this.middleware;
+      }
+    }
+    const injector = new InjectorManager();
+    const managers = [injector, ...CacheProvider.defaultProps.managers];
+    let resolve: (r: any) => void = () => {};
+    const endpoint = CoolerArticleResource.get.extend({
+      fetch() {
+        return new Promise(res => {
+          resolve = res;
+        });
+      },
+    });
+    const Component = () => {
+      const article = useSuspense(endpoint, { id: 5 });
+      return <div>{article.title}</div>;
+    };
+    const tree = (
+      <CacheProvider managers={managers}>
+        <Suspense fallback="loading">
+          <Component />
+        </Suspense>
+      </CacheProvider>
+    );
+    const { getByText, unmount } = render(tree);
+    const msg = getByText('loading');
+    expect(msg).toBeDefined();
+    unmount();
+    expect(debugspy).not.toHaveBeenCalled();
+    await act(() =>
+      injector.controller.receive(endpoint, { id: 5 }, { id: 5, title: 'hi' }),
+    );
+    expect(debugspy).toHaveBeenCalled();
+    expect(debugspy.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        "Action dispatched after CacheProvider unmounted. This will be ignored.",
+      ]
+    `);
   });
 });


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
User-land managers might call dispatchers after unmount. Forcing users to think about this is unnecessary complexity and learning curve.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Simply ignore them. In dev mode we will log at debug level as this is not considered a bug. But it may be useful if one is expecting dispatches to know where they went.