### PR TITLE
enhance: Include Object.hasOwn polyfill

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,7 @@ module.exports = function (api) {
         {
           typing: 'typescript',
           loose: true,
+          useBuiltIns: 'entry',
           resolver: {
             extensions: ['.ts.', '.tsx', '.js', '.jsx', '.es', '.es6', '.mjs'],
             resolvePath(sourcePath, currentFile, opts) {
@@ -26,10 +27,6 @@ module.exports = function (api) {
         },
       ],
     ],
-    plugins: [
-      process.env.BROWSERSLIST_ENV !== '2020' &&
-        'babel-plugin-transform-object-hasown',
-    ].filter(p => p),
     assumptions: {
       noDocumentAll: true,
       noClassCalls: true,

--- a/docs/core/getting-started/installation.md
+++ b/docs/core/getting-started/installation.md
@@ -100,7 +100,16 @@ export default function App({ Component, pageProps }: AppProps) {
 
 Alternatively [integrate state with redux](../guides/redux.md)
 
-<details><summary><b>Legacy (IE) browser support</b></summary>
+<details><summary><b>Older browser support</b></summary>
+
+If your application targets older browsers (a few years or more), be sure to load polyfills.
+Typically this is done with [@babel/preset-env useBuiltIns: 'entry'](https://babeljs.io/docs/en/babel-preset-env#usebuiltins),
+coupled with importing [https://www.npmjs.com/package/core-js] at the entrypoint of your application.
+
+This ensures only the needed polyfills for your browser support targets are included in your application bundle.
+
+</details>
+<details><summary><b>Internet Explorer support</b></summary>
 
 If you see `Uncaught TypeError: Class constructor Resource cannot be invoked without 'new'`,
 follow the instructions to [add legacy browser support to packages](../guides/legacy-browser)

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@types/react": "18.0.25",
     "@typescript-eslint/eslint-plugin": "5.44.0",
     "@typescript-eslint/parser": "5.44.0",
-    "babel-plugin-transform-object-hasown": "^1.1.0",
     "benchmark": "^2.1.4",
     "conventional-changelog-anansi": "^0.2.0",
     "copyfiles": "^2.4.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,8 +104,9 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0",
+    "@babel/runtime": "^7.17.0",
     "@rest-hooks/normalizr": "^9.3.1",
+    "core-js": "^3.17.0",
     "flux-standard-action": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/core/src/manager/NetworkManager.ts
+++ b/packages/core/src/manager/NetworkManager.ts
@@ -1,3 +1,4 @@
+import 'core-js/es/object/has-own';
 import { RECEIVE_TYPE, FETCH_TYPE, RESET_TYPE } from '../actionTypes.js';
 import Controller from '../controller/Controller.js';
 import { initialState } from '../internal.js';

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -99,7 +99,8 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0"
+    "@babel/runtime": "^7.17.0",
+    "core-js": "^3.17.0"
   },
   "devDependencies": {
     "@babel/cli": "7.19.3",

--- a/packages/endpoint/src/schemas/All.ts
+++ b/packages/endpoint/src/schemas/All.ts
@@ -1,3 +1,4 @@
+import 'core-js/es/object/has-own';
 import { EntityTable } from '../interface.js';
 import { EntityInterface, EntityMap, SchemaFunction } from '../schema.js';
 import ArraySchema from './Array.js';

--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import 'core-js/es/object/has-own';
 import type { Schema, NormalizedIndex, UnvisitFunction } from '../interface.js';
 import { AbstractInstanceType } from '../normal.js';
 import { isImmutable, denormalizeImmutable } from './ImmutableUtils.js';

--- a/packages/endpoint/src/schemas/validatRequired.ts
+++ b/packages/endpoint/src/schemas/validatRequired.ts
@@ -1,3 +1,5 @@
+import 'core-js/es/object/has-own';
+
 export default function validateRequired(
   processedEntity: any,
   requiredDefaults: Record<string, unknown>,

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -77,7 +77,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0",
+    "@babel/runtime": "^7.17.0",
     "@types/path-to-regexp": "^1.7.0",
     "path-to-regexp": "^6.2.0"
   },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -102,7 +102,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0",
+    "@babel/runtime": "^7.17.0",
     "@rest-hooks/endpoint": "^3.2.3"
   },
   "devDependencies": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -72,7 +72,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0"
+    "@babel/runtime": "^7.17.0"
   },
   "peerDependencies": {
     "@rest-hooks/endpoint": "^0.6.1 || ^1.0.0-0 || ^2.0.0-0 || ^3.0.0",

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -68,7 +68,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0"
+    "@babel/runtime": "^7.17.0"
   },
   "peerDependencies": {
     "@rest-hooks/endpoint": "^1.0.3 || ^2.0.0-0 || ^3.0.0",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -93,6 +93,7 @@
   "peerDependencies": {
     "@rest-hooks/react": "^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
+    "core-js": "^3.17.0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"
   },
   "peerDependenciesMeta": {

--- a/packages/legacy/src/endpoint/shapeToEndpoint.ts
+++ b/packages/legacy/src/endpoint/shapeToEndpoint.ts
@@ -2,6 +2,7 @@ import { Endpoint } from '@rest-hooks/endpoint';
 import type { EndpointInstance } from '@rest-hooks/endpoint';
 
 import type { FetchShape } from './shapes.js';
+import 'core-js/es/object/has-own';
 
 type ShapeTypeToSideEffect<T extends 'read' | 'mutate' | 'delete' | undefined> =
   T extends 'read' | undefined ? undefined : true;

--- a/packages/legacy/src/resource/Entity.ts
+++ b/packages/legacy/src/resource/Entity.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { AbstractInstanceType, Schema, schema } from '@rest-hooks/endpoint';
+import 'core-js/es/object/has-own';
 
 import { isImmutable, denormalizeImmutable } from './ImmutableUtils.js';
 import SimpleRecord from './SimpleRecord.js';

--- a/packages/legacy/src/resource/SimpleRecord.ts
+++ b/packages/legacy/src/resource/SimpleRecord.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { AbstractInstanceType, Schema } from '@rest-hooks/endpoint';
+import 'core-js/es/object/has-own';
 
 import { normalize, infer } from './Object.js';
 import { NormalizedEntity } from './types.js';

--- a/packages/legacy/src/resource/SimpleResource.ts
+++ b/packages/legacy/src/resource/SimpleResource.ts
@@ -4,6 +4,7 @@ import type {
   EndpointExtraOptions,
   AbstractInstanceType,
 } from '@rest-hooks/endpoint';
+import 'core-js/es/object/has-own';
 
 import { ReadShape, MutateShape, DeleteShape } from '../rest-3/legacy.js';
 import Delete from './Delete.js';

--- a/packages/legacy/src/rest-3/SimpleResource.ts
+++ b/packages/legacy/src/rest-3/SimpleResource.ts
@@ -6,6 +6,7 @@ import type {
   SchemaList,
 } from '@rest-hooks/endpoint';
 import type { AbstractInstanceType } from '@rest-hooks/endpoint';
+import 'core-js/es/object/has-own';
 
 import EntityRecord from './EntityRecord.js';
 import { NotImplementedError } from './errors.js';

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -109,7 +109,8 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0",
+    "@babel/runtime": "^7.17.0",
+    "core-js": "^3.17.0",
     "npm-run-all": "^4.1.5"
   }
 }

--- a/packages/normalizr/src/WeakListMap.ts
+++ b/packages/normalizr/src/WeakListMap.ts
@@ -1,3 +1,4 @@
+import 'core-js/es/object/has-own';
 /** Link in a chain */
 class Link<K extends object, V> {
   children = new WeakMap<K, Link<K, V>>();

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -9,6 +9,7 @@ import type {
   DenormalizeCache,
 } from './types.js';
 import WeakListMap from './WeakListMap.js';
+import 'core-js/es/object/has-own';
 
 const DRAFT = Symbol('draft');
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -121,9 +121,10 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0",
+    "@babel/runtime": "^7.17.0",
     "@rest-hooks/core": "^4.1.0",
-    "@rest-hooks/use-enhanced-reducer": "^1.2.0"
+    "@rest-hooks/use-enhanced-reducer": "^1.2.0",
+    "core-js": "^3.17.0"
   },
   "peerDependencies": {
     "@react-navigation/native": "^6.0.0",

--- a/packages/react/src/components/NetworkErrorBoundary.tsx
+++ b/packages/react/src/components/NetworkErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import type { NetworkError } from '@rest-hooks/core';
 import React from 'react';
+import 'core-js/es/object/has-own';
 
 function isNetworkError(error: NetworkError | unknown): error is NetworkError {
   return Object.hasOwn(error as any, 'status');

--- a/packages/react/src/hooks/useCacheState.ts
+++ b/packages/react/src/hooks/useCacheState.ts
@@ -1,5 +1,6 @@
 import type { State } from '@rest-hooks/core';
 import React, { useContext } from 'react';
+import 'core-js/es/object/has-own';
 
 import { StateContext, StoreContext } from '../context.js';
 

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -121,7 +121,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0"
+    "@babel/runtime": "^7.17.0"
   },
   "peerDependencies": {
     "@rest-hooks/react": "^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0",

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -106,8 +106,9 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0",
+    "@babel/runtime": "^7.17.0",
     "@rest-hooks/endpoint": "^3.2.3",
+    "core-js": "^3.17.0",
     "redux": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/rest-hooks/src/endpoint/adapter.ts
+++ b/packages/rest-hooks/src/endpoint/adapter.ts
@@ -1,6 +1,7 @@
 import type { EndpointInterface } from '@rest-hooks/react';
 
 import type { FetchShape } from './shapes.js';
+import 'core-js/es/object/has-own';
 
 type ShapeTypeToSideEffect<T extends 'read' | 'mutate' | 'delete' | undefined> =
   T extends 'read' | undefined ? undefined : true;

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -107,9 +107,10 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0",
+    "@babel/runtime": "^7.17.0",
     "@rest-hooks/endpoint": "^3.2.3",
     "copyfiles": "^2.4.1",
+    "core-js": "^3.17.0",
     "path-to-regexp": "^6.2.1"
   },
   "devDependencies": {

--- a/packages/rest/src/RestHelpers.ts
+++ b/packages/rest/src/RestHelpers.ts
@@ -1,4 +1,5 @@
 import { compile, PathFunction, parse } from 'path-to-regexp';
+import 'core-js/es/object/has-own';
 
 import { ShortenPath } from './pathTypes.js';
 

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -110,7 +110,8 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0"
+    "@babel/runtime": "^7.17.0",
+    "core-js": "^3.17.0"
   },
   "peerDependencies": {
     "@rest-hooks/react": "^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0",

--- a/packages/ssr/src/nextjs/RestHooksDocument.tsx
+++ b/packages/ssr/src/nextjs/RestHooksDocument.tsx
@@ -4,6 +4,7 @@ import Document, {
   DocumentContext,
   DocumentInitialProps,
 } from 'next/document.js';
+import 'core-js/es/object/has-own';
 
 import createPersistedStore from '../createPersistedStore.js';
 import createServerDataComponent from '../createServerDataComponent.js';

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -98,8 +98,9 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.0",
-    "@testing-library/react-hooks": "~8.0.0"
+    "@babel/runtime": "^7.17.0",
+    "@testing-library/react-hooks": "~8.0.0",
+    "core-js": "^3.17.0"
   },
   "peerDependencies": {
     "@rest-hooks/react": "^0.2.0 || ^0.3.0 || ^1.0.0 || ^6.0.0 || ^7.0.0",

--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -7,6 +7,7 @@ import {
 } from '@rest-hooks/react';
 import { useCallback, useContext, useMemo } from 'react';
 import React from 'react';
+import 'core-js/es/object/has-own';
 
 import { Fixture, dispatchFixture } from './mockState.js';
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1696,12 +1696,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.0, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.20.1
   resolution: "@babel/runtime@npm:7.20.1"
   dependencies:
     regenerator-runtime: ^0.13.10
   checksum: 00567a333d3357925742a6f5e39394dcc0af6e6029103fe188158bf7ae8b0b3ee3c6c0f68fccc217f0a6cfa455f6be252298baf56b3f5ff37b34313b170cd9f6
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.17.0":
+  version: 7.20.6
+  resolution: "@babel/runtime@npm:7.20.6"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 42a8504db21031b1859fbc0f52d698a3d2f5ada9519eb76c6f96a7e657d8d555732a18fe71ef428a67cc9fc81ca0d3562fb7afdc70549c5fec343190cbaa9b03
   languageName: node
   linkType: hard
 
@@ -2929,39 +2938,41 @@ __metadata:
 
 "@rest-hooks/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
   version: 4.1.0
-  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=0e6da9&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=597500&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^9.3.1
+    core-js: ^3.17.0
     flux-standard-action: ^2.1.1
-  checksum: e6cec9e5e6ce1d5fd8de161e8d1e487a513671daabc1cd62d1f1df493146088023788648d5fd2a17bde0f5268d4cdaa7684260e7b86dc8a25794b20cb7840c53
+  checksum: ecaae979631b30438ba8967b395ba0a5a3467e010115e869f394daccb43711da703439fcff5b1e17a6b0267d0a73f6a01cc10f71236e5d5cc68119349873cc75
   languageName: node
   linkType: hard
 
 "@rest-hooks/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.2.3
-  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=9025fa&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=288050&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    "@babel/runtime": ^7.13.0
-  checksum: 85a9604d87cd2cf3e6b3e9d6867089d50e48f9cde6c20968da771a29957e6d59046eaeb8d52464fce3bba9e744e72e1550745369b15948833e58a776eff02d75
+    "@babel/runtime": ^7.17.0
+    core-js: ^3.17.0
+  checksum: 71032536cc9d722d7943f862fa5d7340791ccb69a2165c133efa7e2c39c62a3132bc41245f4e9ff4dead93ac009f1506ed43c1bec32b9aadb6ae658acf406015
   languageName: node
   linkType: hard
 
 "@rest-hooks/graphql@file:../packages/graphql::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.3.6
-  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=0e9ca2&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=cf142f&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.3
-  checksum: 01cf10ad08ed2f57fd1328b28070afc348fe42a782c4cfc879a6bd46cc8a2d9695da16a505bb67537b235f7a6d5c752b9a2e7765a8a8243bf359d50705a69c5c
+  checksum: 900a042fe5d715f69692ea57501058bf516e901b05d71ff17b678614137432c814de029e0f4232bc9aaa2d0d991cd43f18c680ac111432629465a24441bb02d6
   languageName: node
   linkType: hard
 
 "@rest-hooks/hooks@file:../packages/hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.1.0
-  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=efa1ed&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=90d60b&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
   peerDependencies:
     "@rest-hooks/endpoint": ^0.6.1 || ^1.0.0-0 || ^2.0.0-0 || ^3.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
@@ -2969,27 +2980,29 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 1e8758a1aa1d6d3aaf22688ffc93f15faedee49b95626b682752833e1e5418a23164324cab887d02481c94fc666f042d8b02fc288a62895b44991c7f1390645b
+  checksum: 2de444a5c6c6f234c308b6ad10b56b1929fcadef49fa369ecf503681951e57e625124c500c2bde51a4087b3dec499df42cbc1ef86138e49730e9da3b30489184
   languageName: node
   linkType: hard
 
 "@rest-hooks/normalizr@file:../packages/normalizr::locator=root-workspace-0b6124%40workspace%3A.":
   version: 9.3.1
-  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=bfdc43&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=bb332c&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
+    core-js: ^3.17.0
     npm-run-all: ^4.1.5
-  checksum: 1885eb336c43dd81bde3fc3f54765992289b1e1a536077c122365d806bba2a166a24a659547f764e641999b87cda6513b36b2002b274b5e7014d14ad28a66629
+  checksum: 45446bc7f33ec1e88ab6ab5ab0b3feb2533f9e7e5df9dac9278fa2192054f7f7be06105462f24f2bdcd9061eb7709b4696ab0a82cb21b2d8314b10e816684705
   languageName: node
   linkType: hard
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.1.0
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=4a237a&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=6bcfb5&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.1.0
     "@rest-hooks/use-enhanced-reducer": ^1.2.0
+    core-js: ^3.17.0
   peerDependencies:
     "@react-navigation/native": ^6.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0
@@ -2999,28 +3012,30 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: ff1af526f06d4db58e516f0d3470b0d6e3a3b4b0b56c24968aaa4f3d54788b5632800e68b87a91dbc697586d40bb6e48e0bc589db020b83ad498987bbdc0632f
+  checksum: 8593a617524d041dc79ecec16a30605a25a52057a1a02bfc77dbeb7c781ad91e843f52ad3d4476a532eb16e1fe547831ec3abb142c05b47a873a452ea8caa2b2
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
   version: 6.2.1
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=b1689c&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=1cff94&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.3
     copyfiles: ^2.4.1
+    core-js: ^3.17.0
     path-to-regexp: ^6.2.1
-  checksum: 1343009bdad326c2e013d99010bc666c3bc9843f5a68ab814d864b4d7d30ff14297e9b3ea98a85e6a6755a8d58c71a81ac61a3d57dbdda6ac17ed4b6e8d09ffe
+  checksum: c36d8bb67de040ab8bcf8332903f10024667347cebe9761640cd17701c94b16515cf198921d3eb0d711fd069896d77d6720572bb2f6f099ae0d5b767f02c89d5
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 9.1.0
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=655a9d&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=8b3c4d&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@testing-library/react-hooks": ~8.0.0
+    core-js: ^3.17.0
   peerDependencies:
     "@rest-hooks/react": ^0.2.0 || ^0.3.0 || ^1.0.0 || ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
@@ -3028,20 +3043,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 0e044152eba3a929b9758bb98eed56fe6b2d3ee25026c66fda346b52208ca172b23fca1b03156251b55ef564b92b486e4cbcdafeded058e0aac2f02bcb7b53b0
+  checksum: 29b973819eb02c5d88655f62343b24cd8b889d43118cb8eca9448c3f845cf89d67863cf229b290864cde662a942028c2b8a2b4cabe432ff1f32c5ef2cee97feb
   languageName: node
   linkType: hard
 
 "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer::locator=root-workspace-0b6124%40workspace%3A.":
   version: 1.2.0
-  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=6e88cf&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=3230a6&locator=root-workspace-0b6124%40workspace%3A."
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: f261b80676d574df6913444565378740c18a978958b53701c2750a2e0782f6021657fd0b63fbb9486bf019b24f436cf24e310adc6157bfc0051693612d1d2395
+  checksum: 16b07dcf7514bdc6d2db550ae3047bba3693ab4cecd4e4568c0fd6c935e9b4f153ac89467e15b20536a0538acb9bdc16452346c5f2dbd9bf912445c58f4e03a5
   languageName: node
   linkType: hard
 
@@ -5702,6 +5717,13 @@ __metadata:
   version: 2.6.12
   resolution: "core-js@npm:2.6.12"
   checksum: 44fa9934a85f8c78d61e0c8b7b22436330471ffe59ec5076fe7f324d6e8cf7f824b14b1c81ca73608b13bdb0fef035bd820989bf059767ad6fa13123bb8bd016
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.17.0":
+  version: 3.26.1
+  resolution: "core-js@npm:3.26.1"
+  checksum: 0a01149f51ff1e9f41d1ea49cc4c9222047949ea597189ede7c4cf8cde3b097766b9c7615acc77c86fe65b4002f20b638a133dfba7b41dba830d707aeeed45ad
   languageName: node
   linkType: hard
 
@@ -12730,7 +12752,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.10, regenerator-runtime@npm:^0.13.4":
+"regenerator-runtime@npm:^0.13.10, regenerator-runtime@npm:^0.13.11, regenerator-runtime@npm:^0.13.4":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
@@ -13038,10 +13060,11 @@ __metadata:
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.0.1
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=2b8fe5&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=40c7be&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.3
+    core-js: ^3.17.0
     redux: ^4.0.0
   peerDependencies:
     "@rest-hooks/react": ^6.0.0 || ^7.0.0
@@ -13050,7 +13073,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: f2d7a092fd370b1296460d0708efc5ede4fa3ba91fb61b572def4693c26110179239bb1a1dd8d992e54b85b5c95b84f2c0337acbd4900804abaa6e3fefaa1ff7
+  checksum: 7513f6c4bb8e70e0df2ef39633f293d899b308defc0ffd32965d228598fc1a0878c2253aab00eef8b543d0e227f23aed0154299c67dcc87f952a63398c63ab0f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,21 +1955,21 @@ __metadata:
   linkType: hard
 
 "@babel/runtime-corejs3@npm:^7.10.2":
-  version: 7.18.3
-  resolution: "@babel/runtime-corejs3@npm:7.18.3"
+  version: 7.20.6
+  resolution: "@babel/runtime-corejs3@npm:7.20.6"
   dependencies:
-    core-js-pure: ^3.20.2
-    regenerator-runtime: ^0.13.4
-  checksum: 50319e107e4c3dc6662404daf1079ab1ecd1cb232577bf50e645c5051fa8977f6ce48a44aa1d158ce2beaec76a43df4fc404999bf4f03c66719c3f8b8fe50a4e
+    core-js-pure: ^3.25.1
+    regenerator-runtime: ^0.13.11
+  checksum: d533d432216509426c4f9dad56db2fe453112b7d738433111944372fba4abd0b07bee3261f19a218530b435de46592121b2a6a57b98c0c7c3452d552ba009c3e
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.10.5, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.0, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
-  version: 7.20.1
-  resolution: "@babel/runtime@npm:7.20.1"
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.10.4, @babel/runtime@npm:^7.10.5, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.0, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+  version: 7.20.6
+  resolution: "@babel/runtime@npm:7.20.6"
   dependencies:
-    regenerator-runtime: ^0.13.10
-  checksum: 00567a333d3357925742a6f5e39394dcc0af6e6029103fe188158bf7ae8b0b3ee3c6c0f68fccc217f0a6cfa455f6be252298baf56b3f5ff37b34313b170cd9f6
+    regenerator-runtime: ^0.13.11
+  checksum: 42a8504db21031b1859fbc0f52d698a3d2f5ada9519eb76c6f96a7e657d8d555732a18fe71ef428a67cc9fc81ca0d3562fb7afdc70549c5fec343190cbaa9b03
   languageName: node
   linkType: hard
 
@@ -4097,9 +4097,10 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^9.3.1
     "@types/babel__core": ^7
+    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
     npm-run-all: ^4.1.5
@@ -4121,8 +4122,9 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
+    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
     rollup: 2.79.1
@@ -4143,7 +4145,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
     "@types/path-to-regexp": ^1.7.0
     downlevel-dts: ^0.10.0
@@ -4174,7 +4176,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.3
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
@@ -4196,7 +4198,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     rollup: 2.79.1
@@ -4223,7 +4225,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     rollup: 2.79.1
@@ -4265,6 +4267,7 @@ __metadata:
   peerDependencies:
     "@rest-hooks/react": ^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
+    core-js: ^3.17.0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
     "@types/react":
@@ -4278,8 +4281,9 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
+    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     immutable: 4.1.0
     npm-run-all: ^4.1.5
@@ -4300,10 +4304,11 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.1.0
     "@rest-hooks/use-enhanced-reducer": ^1.2.0
     "@types/babel__core": ^7
+    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
     rollup: 2.79.1
@@ -4333,7 +4338,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -4364,12 +4369,13 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.3
     "@types/babel__core": ^7
     "@types/copyfiles": ^2
     "@types/path-to-regexp": ^1.7.0
     copyfiles: ^2.4.1
+    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
     path-to-regexp: ^6.2.1
@@ -4390,8 +4396,9 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
+    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     next: ^13.0.4
     npm-run-all: ^4.1.5
@@ -4424,9 +4431,10 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@testing-library/react-hooks": ~8.0.0
     "@types/babel__core": ^7
+    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     rollup: 2.79.1
     rollup-plugin-babel: ^4.4.0
@@ -6760,13 +6768,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-transform-object-hasown@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "babel-plugin-transform-object-hasown@npm:1.1.0"
-  checksum: 5cdde8b784ebc2364324da16c48cbc75de63d9529be02ceff6a44a86f0681e41a771fdc857b01828e46bf3d2b0228cfae27f436678f19db9e54172e9a79ef4bf
-  languageName: node
-  linkType: hard
-
 "babel-plugin-transform-react-remove-prop-types@npm:^0.4.24":
   version: 0.4.24
   resolution: "babel-plugin-transform-react-remove-prop-types@npm:0.4.24"
@@ -7492,9 +7493,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001406, caniuse-lite@npm:^1.0.30001426":
-  version: 1.0.30001431
-  resolution: "caniuse-lite@npm:1.0.30001431"
-  checksum: bc8ab55cd194e240152946b54bfaff7456180cc018674fc7ed134f4f502192405f6643f422feaa0a5e7cc02b5bac564cfac7771ac6d29f5d129482fcfe335ba1
+  version: 1.0.30001435
+  resolution: "caniuse-lite@npm:1.0.30001435"
+  checksum: ec88b9c37f66095e26ddb8b43110e9564ebccb6de77e495b8e8b9d64fdbfe37f7762be8fd2578c3ecc181a183a159578c9bd8e9b90eb15b44b78e8a6d0e92530
   languageName: node
   linkType: hard
 
@@ -8359,22 +8360,22 @@ __metadata:
   linkType: hard
 
 "core-js-compat@npm:^3.23.5, core-js-compat@npm:^3.25.1":
-  version: 3.25.1
-  resolution: "core-js-compat@npm:3.25.1"
+  version: 3.26.1
+  resolution: "core-js-compat@npm:3.26.1"
   dependencies:
-    browserslist: ^4.21.3
-  checksum: 34dbec657adc2f660f4cd701709c9c5e27cbd608211c65df09458f80f3e357b9492ba1c5173e17cca72d889dcc6da01268cadf88fb407cf1726e76d301c6143e
+    browserslist: ^4.21.4
+  checksum: f222bce0002eae405327d68286e1d566037e8ac21906a47d7ecd15858adca7b12e82140db11dc43c8cc1fc066c5306120f3c27bfb2d7dbc2d20a72a2d90d38dc
   languageName: node
   linkType: hard
 
-"core-js-pure@npm:^3.20.2, core-js-pure@npm:^3.23.3":
-  version: 3.25.5
-  resolution: "core-js-pure@npm:3.25.5"
-  checksum: e48799a8ab28f00ef3db18377142ff2c578574ab2b18ebddde6cbf12823e0181a57c80e3caa6046ce2a2e439d603a252be767583ddc54248e3d1060bc5012127
+"core-js-pure@npm:^3.23.3, core-js-pure@npm:^3.25.1":
+  version: 3.26.1
+  resolution: "core-js-pure@npm:3.26.1"
+  checksum: d88c40e5e29e413c11d1ef991a8d5b6a63f00bd94707af0f649d3fc18b3524108b202f4ae75ce77620a1557d1ba340bc3362b4f25d590eccc37cf80fc75f7cd4
   languageName: node
   linkType: hard
 
-"core-js@npm:3.26.1, core-js@npm:^3.21.0, core-js@npm:^3.26.0":
+"core-js@npm:3.26.1, core-js@npm:^3.17.0, core-js@npm:^3.21.0, core-js@npm:^3.26.0":
   version: 3.26.1
   resolution: "core-js@npm:3.26.1"
   checksum: 0a01149f51ff1e9f41d1ea49cc4c9222047949ea597189ede7c4cf8cde3b097766b9c7615acc77c86fe65b4002f20b638a133dfba7b41dba830d707aeeed45ad
@@ -19514,7 +19515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.10, regenerator-runtime@npm:^0.13.11, regenerator-runtime@npm:^0.13.2, regenerator-runtime@npm:^0.13.4":
+"regenerator-runtime@npm:^0.13.11, regenerator-runtime@npm:^0.13.2":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
@@ -19883,9 +19884,10 @@ __metadata:
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
-    "@babel/runtime": ^7.13.0
+    "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.3
     "@types/babel__core": ^7
+    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
     redux: ^4.0.0
@@ -20156,7 +20158,6 @@ __metadata:
     "@types/react": 18.0.25
     "@typescript-eslint/eslint-plugin": 5.44.0
     "@typescript-eslint/parser": 5.44.0
-    babel-plugin-transform-object-hasown: ^1.1.0
     benchmark: ^2.1.4
     conventional-changelog-anansi: ^0.2.0
     copyfiles: ^2.4.1


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #2304 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Our `exports` target is currently 2020 and later browsers. Sadly Safari is late to the party, so we still need Object.hasOwn.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
- Remove 'babel-plugin-transform-object-hasown' even for legacy builds as this copies a function in multiple places
- Add relevant core-js import to files that use Object.hasOwn
- Use `entry` in babel config to ensure these core-js imports are only added when necessary.
- Add core-js as a dependency on a version that includes said polyfill
- Slightly move up @babel/runtime version
- Add note about polyfills to install docs
