### PR TITLE
enhance: Detect html bad responses

### DIFF
--- a/docs/core/api/useLive.md
+++ b/docs/core/api/useLive.md
@@ -3,7 +3,7 @@ title: useLive()
 ---
 
 <head>
-  <title>useLive() - Use the data that is always fresh</title>
+  <title>useLive() - Use data that is always fresh</title>
   <meta name="docsearch:pagerank" content="10"/>
 </head>
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@4.1.0...@rest-hooks/core@4.1.1) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ## [4.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@4.0.2...@rest-hooks/core@4.1.0) (2022-11-22)
 
 ### 🚀 Features

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Normalized Asynchronous data framework. Protocol and View agnostic.",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -105,7 +105,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/normalizr": "^9.3.1",
+    "@rest-hooks/normalizr": "^9.3.2",
     "core-js": "^3.17.0",
     "flux-standard-action": "^2.1.1"
   },

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@3.2.3...@rest-hooks/endpoint@3.2.4) (2022-12-05)
+
+### 💅 Enhancement
+
+* Detect html bad responses ([#2311](https://github.com/coinbase/rest-hooks/issues/2311)) ([674001b](https://github.com/coinbase/rest-hooks/commit/674001bb697017c925d9f138744e94826fa1c519))
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+* Update doc link in normalize error ([042237a](https://github.com/coinbase/rest-hooks/commit/042237a0196c9ec3d9e00d1ad0f12334daf3f3df))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ### [3.2.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@3.2.2...@rest-hooks/endpoint@3.2.3) (2022-11-22)
 
 ### 📦 Package

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/endpoint/src/schemas/__tests__/Delete.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Delete.test.ts
@@ -36,6 +36,9 @@ describe(`${schema.Delete.name} normalization`, () => {
   test('normalizes already processed entities', () => {
     class MyEntity extends IDEntity {}
     expect(normalize('1', new schema.Delete(MyEntity))).toMatchSnapshot();
+    expect(
+      normalize(['1', '2'], new schema.Array(new schema.Delete(MyEntity))),
+    ).toMatchSnapshot();
   });
 
   test('does not infer', () => {

--- a/packages/endpoint/src/schemas/__tests__/Entity.test.ts
+++ b/packages/endpoint/src/schemas/__tests__/Entity.test.ts
@@ -69,7 +69,20 @@ describe(`${Entity.name} normalization`, () => {
 
   test('normalizes already processed entities', () => {
     class MyEntity extends IDEntity {}
-    expect(normalize('1', MyEntity)).toMatchSnapshot();
+    class Nested extends IDEntity {
+      title = '';
+      nest = MyEntity.fromJS();
+      static schema = {
+        nest: MyEntity,
+      };
+    }
+    expect(normalize(['1'], new schema.Array(MyEntity))).toMatchSnapshot();
+    expect(
+      normalize({ data: '1' }, new schema.Object({ data: MyEntity })),
+    ).toMatchSnapshot();
+    expect(
+      normalize({ title: 'hi', id: '5', nest: '10' }, Nested),
+    ).toMatchSnapshot();
   });
 
   it('should throw a custom error if data does not include pk', () => {

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/All.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/All.test.ts.snap
@@ -280,7 +280,7 @@ exports[`AllSchema normalization (%s) should throw a custom error if data loads 
 
 Parsing this input string as JSON worked. This likely indicates fetch function did not parse
 the JSON. By default, this only happens if "content-type" header includes "json".
-See https://resthooks.io/docs/guides/custom-networking for more information
+See https://resthooks.io/rest/api/RestEndpoint#parseResponse for more information
 
   Schema: [
   {

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -1690,7 +1690,7 @@ exports[`ArraySchema normalization (plain) Object should throw a custom error if
 
 Parsing this input string as JSON worked. This likely indicates fetch function did not parse
 the JSON. By default, this only happens if "content-type" header includes "json".
-See https://resthooks.io/docs/guides/custom-networking for more information
+See https://resthooks.io/rest/api/RestEndpoint#parseResponse for more information
 
   Schema: [
   {
@@ -2155,7 +2155,7 @@ exports[`ArraySchema normalization (schema) Object should throw a custom error i
 
 Parsing this input string as JSON worked. This likely indicates fetch function did not parse
 the JSON. By default, this only happens if "content-type" header includes "json".
-See https://resthooks.io/docs/guides/custom-networking for more information
+See https://resthooks.io/rest/api/RestEndpoint#parseResponse for more information
 
   Schema: [
   {

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Delete.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Delete.test.ts.snap
@@ -145,6 +145,18 @@ exports[`Delete normalization normalizes already processed entities 1`] = `
 }
 `;
 
+exports[`Delete normalization normalizes already processed entities 2`] = `
+{
+  "entities": {},
+  "entityMeta": {},
+  "indexes": {},
+  "result": [
+    "1",
+    "2",
+  ],
+}
+`;
+
 exports[`Delete normalization normalizes an object 1`] = `
 {
   "entities": {

--- a/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
+++ b/packages/endpoint/src/schemas/__tests__/__snapshots__/Entity.test.ts.snap
@@ -381,7 +381,45 @@ exports[`Entity normalization normalizes already processed entities 1`] = `
   "entities": {},
   "entityMeta": {},
   "indexes": {},
-  "result": "1",
+  "result": [
+    "1",
+  ],
+}
+`;
+
+exports[`Entity normalization normalizes already processed entities 2`] = `
+{
+  "entities": {},
+  "entityMeta": {},
+  "indexes": {},
+  "result": {
+    "data": "1",
+  },
+}
+`;
+
+exports[`Entity normalization normalizes already processed entities 3`] = `
+{
+  "entities": {
+    "Nested": {
+      "5": {
+        "id": "5",
+        "nest": "10",
+        "title": "hi",
+      },
+    },
+  },
+  "entityMeta": {
+    "Nested": {
+      "5": {
+        "date": 1557831718135,
+        "expiresAt": Infinity,
+        "fetchedAt": 0,
+      },
+    },
+  },
+  "indexes": {},
+  "result": "5",
 }
 `;
 

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [9.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@9.2.1...@rest-hooks/experimental@9.2.2) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ### [9.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@9.2.0...@rest-hooks/experimental@9.2.1) (2022-11-22)
 
 ### 📦 Package

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.3.6...@rest-hooks/graphql@0.3.7) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 🐛 Bug Fix
+
+* Network down/ CORS errors should be 'soft' by default ([#2302](https://github.com/coinbase/rest-hooks/issues/2302)) ([2545ce8](https://github.com/coinbase/rest-hooks/commit/2545ce8164e69905773738d7da0e170b3810a48e))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ### [0.3.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.3.5...@rest-hooks/graphql@0.3.6) (2022-11-22)
 
 **Note:** Version bump only for package @rest-hooks/graphql

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/endpoint": "^3.2.3"
+    "@rest-hooks/endpoint": "^3.2.4"
   },
   "devDependencies": {
     "@babel/cli": "7.19.3",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.1.0...@rest-hooks/hooks@3.1.1) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ## [3.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.0.9...@rest-hooks/hooks@3.1.0) (2022-11-13)
 
 ### 🚀 Features

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/img/CHANGELOG.md
+++ b/packages/img/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.8.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.8.0...@rest-hooks/img@0.8.1) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ## [0.8.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/img@0.7.2...@rest-hooks/img@0.8.0) (2022-11-16)
 
 ### 🚀 Features

--- a/packages/img/package.json
+++ b/packages/img/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/img",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Suspenseful images",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@5.2.0...@rest-hooks/legacy@5.2.1) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ## [5.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@5.1.0...@rest-hooks/legacy@5.2.0) (2022-11-16)
 
 ### 🚀 Features

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [9.3.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@9.3.1...@rest-hooks/normalizr@9.3.2) (2022-12-05)
+
+### 💅 Enhancement
+
+* Detect html bad responses ([#2311](https://github.com/coinbase/rest-hooks/issues/2311)) ([674001b](https://github.com/coinbase/rest-hooks/commit/674001bb697017c925d9f138744e94826fa1c519))
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+* Update doc link in normalize error ([042237a](https://github.com/coinbase/rest-hooks/commit/042237a0196c9ec3d9e00d1ad0f12334daf3f3df))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ### [9.3.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@9.3.0...@rest-hooks/normalizr@9.3.1) (2022-11-13)
 
 **Note:** Version bump only for package @rest-hooks/normalizr

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://github.com/coinbase/rest-hooks/tree/master/packages/normalizr#readme",
   "bugs": {

--- a/packages/normalizr/src/__tests__/index.test.js
+++ b/packages/normalizr/src/__tests__/index.test.js
@@ -1,5 +1,5 @@
 // eslint-env jest
-import { Entity } from '@rest-hooks/endpoint';
+import { Entity, schema } from '@rest-hooks/endpoint';
 import { fromJS } from 'immutable';
 
 import { normalize } from '../';
@@ -30,7 +30,7 @@ afterAll(() => {
 });
 
 describe('normalize', () => {
-  test.each([42, null, undefined, () => {}])(
+  test.each([42, null, undefined, '42', () => {}])(
     `cannot normalize input that == %s`,
     input => {
       class Test extends IDEntity {}
@@ -47,7 +47,7 @@ describe('normalize', () => {
 
   test('can normalize strings for entity (already processed)', () => {
     class Test extends IDEntity {}
-    expect(normalize('42', Test).result).toEqual('42');
+    expect(normalize(['42'], new schema.Array(Test)).result).toEqual(['42']);
   });
 
   test('passthrough with undefined schema', () => {

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -213,7 +213,12 @@ export const normalize = <
   if (
     input === null ||
     (typeof input !== schemaType &&
-      !((schema as any).key !== undefined && typeof input === 'string'))
+      // we will allow a Delete schema to be a string or object
+      !(
+        (schema as any).key !== undefined &&
+        (schema as any).pk === undefined &&
+        typeof input === 'string'
+      ))
   ) {
     /* istanbul ignore else */
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/normalizr/src/normalize.ts
+++ b/packages/normalizr/src/normalize.ts
@@ -234,7 +234,7 @@ export const normalize = <
 
 Parsing this input string as JSON worked. This likely indicates fetch function did not parse
 the JSON. By default, this only happens if "content-type" header includes "json".
-See https://resthooks.io/docs/guides/custom-networking for more information
+See https://resthooks.io/rest/api/RestEndpoint#parseResponse for more information
 
   Schema: ${JSON.stringify(schema, undefined, 2)}
   Input: "${input}"`);

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/react@7.1.0...@rest-hooks/react@7.1.1) (2022-12-05)
+
+### 💅 Enhancement
+
+* Block dispatches after unmount ([#2307](https://github.com/coinbase/rest-hooks/issues/2307)) ([55af3e6](https://github.com/coinbase/rest-hooks/commit/55af3e693c310f81511b254c1c2451d3bcbd7342))
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
+### 📝 Documentation
+
+* Lots of fixes ([#2295](https://github.com/coinbase/rest-hooks/issues/2295)) ([2d151e8](https://github.com/coinbase/rest-hooks/commit/2d151e824bac674f35b20f684defffd26c1409a1))
+
 ## [7.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/react@7.0.0...@rest-hooks/react@7.1.0) (2022-11-22)
 
 ### 🚀 Features

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/react",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "Asynchronous data framework for React",
   "sideEffects": [
     "./lib/hooks/useFocusEffect.native.js"
@@ -122,8 +122,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/core": "^4.1.0",
-    "@rest-hooks/use-enhanced-reducer": "^1.2.0",
+    "@rest-hooks/core": "^4.1.1",
+    "@rest-hooks/use-enhanced-reducer": "^1.2.1",
     "core-js": "^3.17.0"
   },
   "peerDependencies": {

--- a/packages/redux/CHANGELOG.md
+++ b/packages/redux/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/redux@6.2.0...@rest-hooks/redux@6.2.1) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ## [6.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/redux@6.1.0...@rest-hooks/redux@6.2.0) (2022-11-22)
 
 ### 🚀 Features

--- a/packages/redux/package.json
+++ b/packages/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/redux",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.0.2](https://github.com/coinbase/rest-hooks/compare/rest-hooks@7.0.1...rest-hooks@7.0.2) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
+### 📝 Documentation
+
+* Lots of fixes ([#2295](https://github.com/coinbase/rest-hooks/issues/2295)) ([2d151e8](https://github.com/coinbase/rest-hooks/commit/2d151e824bac674f35b20f684defffd26c1409a1))
+
 ### [7.0.1](https://github.com/coinbase/rest-hooks/compare/rest-hooks@7.0.0...rest-hooks@7.0.1) (2022-11-22)
 
 ### 📝 Documentation

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/endpoint": "^3.2.3",
+    "@rest-hooks/endpoint": "^3.2.4",
     "core-js": "^3.17.0",
     "redux": "^4.0.0"
   },

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.2.2](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@6.2.1...@rest-hooks/rest@6.2.2) (2022-12-05)
+
+### 💅 Enhancement
+
+* Detect html bad responses ([#2311](https://github.com/coinbase/rest-hooks/issues/2311)) ([674001b](https://github.com/coinbase/rest-hooks/commit/674001bb697017c925d9f138744e94826fa1c519))
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 🐛 Bug Fix
+
+* Network down/ CORS errors should be 'soft' by default ([#2302](https://github.com/coinbase/rest-hooks/issues/2302)) ([2545ce8](https://github.com/coinbase/rest-hooks/commit/2545ce8164e69905773738d7da0e170b3810a48e))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ### [6.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@6.2.0-beta.0...@rest-hooks/rest@6.2.1) (2022-11-22)
 
 **Note:** Version bump only for package @rest-hooks/rest

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/endpoint": "^3.2.3",
+    "@rest-hooks/endpoint": "^3.2.4",
     "copyfiles": "^2.4.1",
     "core-js": "^3.17.0",
     "path-to-regexp": "^6.2.1"

--- a/packages/rest/src/__tests__/__snapshots__/RestEndpoint.ts.snap
+++ b/packages/rest/src/__tests__/__snapshots__/RestEndpoint.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RestEndpoint.fetch() should reject if content-type does not exist with schema 1`] = `
+[NetworkError: Unexpected text response for schema class CoolerArticle extends Article {
+  get things() {
+    return \`\${this.title} five\`;
+  }
+}]
+`;
+
+exports[`RestEndpoint.fetch() should reject if content-type is not json with schema 1`] = `
+[NetworkError: Unexpected html response for schema class CoolerArticle extends Article {
+  get things() {
+    return \`\${this.title} five\`;
+  }
+}
+This likely means no API endpoint was configured for this request, resulting in an HTML fallback.
+
+Response (first 300 characters): <body>this is html</body>]
+`;
+
+exports[`RestEndpoint.fetch() should reject with custom message if content type is set but json parsable 1`] = `
+[NetworkError: "content-type" header does not include "json", but JSON response found.
+See https://www.rfc-editor.org/rfc/rfc4627 for information on JSON responses
+
+Using parsed JSON.
+If text content was expected see https://resthooks.io/rest/api/RestEndpoint#parseResponse]
+`;

--- a/packages/ssr/CHANGELOG.md
+++ b/packages/ssr/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.7.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.7.0...@rest-hooks/ssr@0.7.1) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ## [0.7.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/ssr@0.6.0...@rest-hooks/ssr@0.7.0) (2022-11-22)
 
 ### 🚀 Features

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/ssr",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Server Side Rendering helpers for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [9.1.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@9.1.0...@rest-hooks/test@9.1.1) (2022-12-05)
+
+### 💅 Enhancement
+
+* Include Object.hasOwn polyfill ([#2309](https://github.com/coinbase/rest-hooks/issues/2309)) ([14b93f6](https://github.com/coinbase/rest-hooks/commit/14b93f67f0589df5813909e0c1acd4cacad0a3ee))
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ## [9.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@9.0.0...@rest-hooks/test@9.1.0) (2022-11-16)
 
 ### 🚀 Features

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/use-enhanced-reducer/CHANGELOG.md
+++ b/packages/use-enhanced-reducer/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.1](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.2.0...@rest-hooks/use-enhanced-reducer@1.2.1) (2022-12-05)
+
+### 📦 Package
+
+* Update babel packages ([#2308](https://github.com/coinbase/rest-hooks/issues/2308)) ([e3ee5ee](https://github.com/coinbase/rest-hooks/commit/e3ee5ee57431971ba4bdb47b48ed89933412374c))
+
 ## [1.2.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.1.7...@rest-hooks/use-enhanced-reducer@1.2.0) (2022-11-06)
 
 ### 🚀 Features

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/website/src/components/Playground/editor-types/@rest-hooks/core.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/core.d.ts
@@ -1058,15 +1058,24 @@ declare class DevToolsManager implements Manager {
     getMiddleware(): Middleware$2<any>;
 }
 
-type Dispatch = (value: CombinedActionTypes) => Promise<void>;
-type Middleware = <C extends Controller<Dispatch>>(controller: C) => (next: C['dispatch']) => C['dispatch'];
+/** Handling network unauthorized indicators like HTTP 401
+ *
+ * @see https://resthooks.io/docs/api/LogoutManager
+ */
 declare class LogoutManager implements Manager<CombinedActionTypes> {
     protected middleware: Middleware;
-    constructor();
+    constructor({ handleLogout, shouldLogout }?: Props);
     cleanup(): void;
     getMiddleware(): Middleware;
     protected shouldLogout(error: UnknownError): boolean;
     handleLogout(controller: Controller<Dispatch>): void;
+}
+type Dispatch = (value: CombinedActionTypes) => Promise<void>;
+type Middleware = <C extends Controller<Dispatch>>(controller: C) => (next: C['dispatch']) => C['dispatch'];
+type HandleLogout = (controller: Controller<Dispatch>) => void;
+interface Props {
+    handleLogout?: HandleLogout;
+    shouldLogout?: (error: UnknownError) => boolean;
 }
 
 export { AbstractInstanceType, ActionTypes, BodyFromShape, CombinedActionTypes, ConnectionListener, Controller, DefaultConnectionListener, DeleteShape, Denormalize, DenormalizeCache, DenormalizeNullable, DevToolsConfig, DevToolsManager, Dispatch$1 as Dispatch, EndpointExtraOptions, EndpointInterface, EndpointUpdateFunction, EntityInterface, ErrorTypes, ExpiryStatus, FetchAction, FetchFunction, FetchShape, GCAction, InvalidateAction, LogoutManager, Manager, Middleware$2 as Middleware, MiddlewareAPI$1 as MiddlewareAPI, MutateShape, NetworkError, NetworkManager, Normalize, NormalizeNullable, OldActionTypes, OptimisticAction, PK, ParamsFromShape, PollingSubscription, ReadShape, ReceiveAction, ReceiveTypes, ResetAction, ResetError, ResolveType, ResponseActions, ResultEntry, ReturnFromShape, Schema, SetShapeParams, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, internal_d as __INTERNAL__, actionTypes_d as actionTypes, applyManager, createReducer, initialState, index_d as legacyActions, newActions, reducer };

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2927,39 +2927,39 @@ __metadata:
 
 "@rest-hooks/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
   version: 4.1.0
-  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=100da5&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=165627&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^9.3.1
     core-js: ^3.17.0
     flux-standard-action: ^2.1.1
-  checksum: 57ca4940d67f843a3481c58e4e67addca317951f8aba61f8379951ffa9bf6c1933594f328e6c13f21792f73be2ff201a23850223c2e73307bc61851fc8735e80
+  checksum: 6cb99d8fee1a6022f8d6171ed5c9897f557e18e93e865127ffa488b2817bb8ed0dedd1628b3ee43e1099a86b9e69b9c27b0142556b359ef3eb5c3d8099eabe4d
   languageName: node
   linkType: hard
 
 "@rest-hooks/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.2.3
-  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=efe602&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=40fd80&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     core-js: ^3.17.0
-  checksum: d4a73c3bcb97a94cd812294eff09143e36c206b13567785481202bd8c0a7bb03f7a832712cf3414f9ce434b24f97d674766ad6d7ac79f065b6d5ba4ed0ac6ea2
+  checksum: 9610c494b8549a2eb513c1224719614d1a311b663e8ca2cc6802797578e5031f28fb809abd6363f8bee4a78e10e7fdd74822d579a49db619ee39bbfda2b7739a
   languageName: node
   linkType: hard
 
 "@rest-hooks/graphql@file:../packages/graphql::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.3.6
-  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=bf5178&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=8e3925&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.3
-  checksum: 840105a5b88a077de5ec0282ef871a229377259f3eb9a3e5eefcc091eae583aa19d89d6aa860bbc4aaeb53c75a7704d7616e7b0a59c348f66193b8077775b165
+  checksum: ae82240ef6af1211a5243f2c3e3091569653009db9f89dd438eaee6903ae74335ee0da1dd4644d51925da450df17f252947122d8d5e47939c13e184a79e28243
   languageName: node
   linkType: hard
 
 "@rest-hooks/hooks@file:../packages/hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.1.0
-  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=e07f1a&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=3a7721&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
   peerDependencies:
@@ -2969,24 +2969,24 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 82bd62115812deed144e4391e7f37ec6726811dbccf28bed67bfbcb0b119dd6c14229db4869c5af7f3846f5b7f0bacb886058d609df1c7905ef760b327cff934
+  checksum: 8fc8b3fee16a5bd576148e2a01d59e08016eaa9d7c05f0a802dcf61215d28dff383ce1bf9c73138918608b80a79498026e4b5f6c38107dcbd46cfb1abdc0d67f
   languageName: node
   linkType: hard
 
 "@rest-hooks/normalizr@file:../packages/normalizr::locator=root-workspace-0b6124%40workspace%3A.":
   version: 9.3.1
-  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=20bd9b&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=21b5c5&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     core-js: ^3.17.0
     npm-run-all: ^4.1.5
-  checksum: 6aee80c9dab4632ead2878c5d7af09eb2919c740e0efde1fe981116330371b6e1b57c65da5a960f54854c34e4b6ca9c835ecc06a41cb781a2ef65ee198e69fe1
+  checksum: 39315cc2e0e4c69ddc2d519512403153e67874af281f25a857c3bfc8dc9d6ca7049aa78dc56469105c3b9777e550e6e78d8bcb1008bd9a6b019a9a487b942b64
   languageName: node
   linkType: hard
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.1.0
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=7393af&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=c6af7b&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.1.0
@@ -3001,26 +3001,26 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 30541525039e89c5c8ba42a288884956d6db90d15141faa63972547cfd6c1729f2a52b1b27bb6cfca9bbd2b49f3f476e6ce35a3e8cde7062f0fee5f006eaf2d7
+  checksum: 8a2526d66ebf26992cb603c44abfab9f4d9bed5b088245b32dd10ec8e9a724fa331a042882716f2de749ae001c27a337b7675880fc02787ee0c8a57557fefb2a
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
   version: 6.2.1
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=84392f&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=de50f1&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.3
     copyfiles: ^2.4.1
     core-js: ^3.17.0
     path-to-regexp: ^6.2.1
-  checksum: 268c50399a2e745e5a72c8b5619dd5eae5d24eaff481f5ee302c91cc73705fa88eb9841727da6421b23d3c1ad5f5e6bd65a2c930830afbdb4e9a566676754a9b
+  checksum: 17f0c832a48225b9ddf07705c4c90dfe9e438e9a9f7216a20e9b7228ab916cc41f3c394394153bb647a88672c4cf660735afd6ed42e05776a411108878dd0c38
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 9.1.0
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=ff852f&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=8f58b4&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react-hooks": ~8.0.0
@@ -3032,20 +3032,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 64f336476d6a242fc8a85e79efa557d9b343c218a650c6185993b16c485fe96a6b009ab78e153474d0e4147a190b7f450dfcfbc4a968e87c38fd0b83f0d4f273
+  checksum: 26e8cfa622549778045730a6932fe93537ab46d0938f683ef6404feb1a5a742258079f842e4c882163d638a16b26f7408cf05b7c144f928d3d348704bda63f61
   languageName: node
   linkType: hard
 
 "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer::locator=root-workspace-0b6124%40workspace%3A.":
   version: 1.2.0
-  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=4433b8&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=0f499c&locator=root-workspace-0b6124%40workspace%3A."
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 8b6eefabfeb4194655963d7e8b21f0ddd6f10466708b1f490676b4b9d35bae95935067b0e58d7e27b87edfe403ae673241312254475e8310db08ad2860381809
+  checksum: 733b68a32e24dcb24ebc2f3c3fadf15975aec11ba703fb40da0d9dc6c17f12c89580464ad4d90c5a31cdeda2c30b961d971fd7021375745049b7ed4e9926da96
   languageName: node
   linkType: hard
 
@@ -13019,7 +13019,7 @@ __metadata:
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.0.1
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=20d7ba&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=89570f&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.3
@@ -13032,7 +13032,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 0451d41c7c6219ac6cecf00006293a3d227908781d3e383593f475f0905b4158ea1be0e46ce2206e6902157f83e900cb5de936ddd6429da6fda100537b78f7a5
+  checksum: 100954f2506ee34f8aa33d0d5a066f352eb4e7d690552170f6ec6ac8f000493ec609ffc665d851b0e59700740849f1bfc344dff68ddaf8f08019905c4514d43f
   languageName: node
   linkType: hard
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2926,40 +2926,40 @@ __metadata:
   linkType: hard
 
 "@rest-hooks/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 4.1.0
-  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=165627&locator=root-workspace-0b6124%40workspace%3A."
+  version: 4.1.1
+  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=f46bf3&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/normalizr": ^9.3.1
+    "@rest-hooks/normalizr": ^9.3.2
     core-js: ^3.17.0
     flux-standard-action: ^2.1.1
-  checksum: 6cb99d8fee1a6022f8d6171ed5c9897f557e18e93e865127ffa488b2817bb8ed0dedd1628b3ee43e1099a86b9e69b9c27b0142556b359ef3eb5c3d8099eabe4d
+  checksum: b9ed6161df08d71cc4a2c776dfec70364f81fd8fe8b17ccf65eb0cb91f0d6f014f3dc25ceca27bbc13fdd42a4e92e4d8e178d14cec0d6256d7c87854b379456a
   languageName: node
   linkType: hard
 
 "@rest-hooks/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 3.2.3
-  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=40fd80&locator=root-workspace-0b6124%40workspace%3A."
+  version: 3.2.4
+  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=856d29&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     core-js: ^3.17.0
-  checksum: 9610c494b8549a2eb513c1224719614d1a311b663e8ca2cc6802797578e5031f28fb809abd6363f8bee4a78e10e7fdd74822d579a49db619ee39bbfda2b7739a
+  checksum: 124fa583f1fd86b7b4c9de3f463b9666aacf0ba01386959984ce2f92d93bf67183c57dc88858673c79b274267045f1f4a1c9892f4b94a96421c582bccbbc775d
   languageName: node
   linkType: hard
 
 "@rest-hooks/graphql@file:../packages/graphql::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 0.3.6
-  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=8e3925&locator=root-workspace-0b6124%40workspace%3A."
+  version: 0.3.7
+  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=e1e0c4&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/endpoint": ^3.2.3
-  checksum: ae82240ef6af1211a5243f2c3e3091569653009db9f89dd438eaee6903ae74335ee0da1dd4644d51925da450df17f252947122d8d5e47939c13e184a79e28243
+    "@rest-hooks/endpoint": ^3.2.4
+  checksum: 52e45330fe8e861e13a5cff5fdddae73e901fecd7823b9b18aa4bf52b694a38f7c372f9779c3b9bc3d7b7c84b9a39063ef11fc879ec0d3c90027f793eceb0dd6
   languageName: node
   linkType: hard
 
 "@rest-hooks/hooks@file:../packages/hooks::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 3.1.0
-  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=3a7721&locator=root-workspace-0b6124%40workspace%3A."
+  version: 3.1.1
+  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=2eeef8&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
   peerDependencies:
@@ -2969,28 +2969,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 8fc8b3fee16a5bd576148e2a01d59e08016eaa9d7c05f0a802dcf61215d28dff383ce1bf9c73138918608b80a79498026e4b5f6c38107dcbd46cfb1abdc0d67f
+  checksum: f947ded092c070369b1c39a2cb8a8b6d27dca3268ae02ec4dc6f25645546234507b337aa566b9c3a8ae75258ad28fc67ef19889b5ecfac5df819407be2b2185d
   languageName: node
   linkType: hard
 
 "@rest-hooks/normalizr@file:../packages/normalizr::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 9.3.1
-  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=21b5c5&locator=root-workspace-0b6124%40workspace%3A."
+  version: 9.3.2
+  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=f51993&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     core-js: ^3.17.0
     npm-run-all: ^4.1.5
-  checksum: 39315cc2e0e4c69ddc2d519512403153e67874af281f25a857c3bfc8dc9d6ca7049aa78dc56469105c3b9777e550e6e78d8bcb1008bd9a6b019a9a487b942b64
+  checksum: 745d94113ef11e321b0df0c45a4bf0ff2a38aa48722f43804e2be2ce4ccffbed767d00c1adfbf48a92d1d149bc916345a6e43a93a3d3560216ab8b1a9c4e5719
   languageName: node
   linkType: hard
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 7.1.0
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=c6af7b&locator=root-workspace-0b6124%40workspace%3A."
+  version: 7.1.1
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=4faf33&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/core": ^4.1.0
-    "@rest-hooks/use-enhanced-reducer": ^1.2.0
+    "@rest-hooks/core": ^4.1.1
+    "@rest-hooks/use-enhanced-reducer": ^1.2.1
     core-js: ^3.17.0
   peerDependencies:
     "@react-navigation/native": ^6.0.0
@@ -3001,26 +3001,26 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 8a2526d66ebf26992cb603c44abfab9f4d9bed5b088245b32dd10ec8e9a724fa331a042882716f2de749ae001c27a337b7675880fc02787ee0c8a57557fefb2a
+  checksum: 4b8b705c301dbe123d69285c1e3148df38d1eaf72eeb0534ca0224ab553400c92c98f28e735af649c175309fd71df7273b8132d22984310011ee50e2f5ba5b22
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 6.2.1
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=de50f1&locator=root-workspace-0b6124%40workspace%3A."
+  version: 6.2.2
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=7e2d50&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/endpoint": ^3.2.3
+    "@rest-hooks/endpoint": ^3.2.4
     copyfiles: ^2.4.1
     core-js: ^3.17.0
     path-to-regexp: ^6.2.1
-  checksum: 17f0c832a48225b9ddf07705c4c90dfe9e438e9a9f7216a20e9b7228ab916cc41f3c394394153bb647a88672c4cf660735afd6ed42e05776a411108878dd0c38
+  checksum: 6508fc3a50ea7c6daf46ad2d30b8de46679bd449516530eb7b5cca5abeb3d26400977126e0da72f2204d5ed97ccb8931dd8bfab356422451063115101aa21412
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 9.1.0
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=8f58b4&locator=root-workspace-0b6124%40workspace%3A."
+  version: 9.1.1
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=5d2408&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react-hooks": ~8.0.0
@@ -3032,20 +3032,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 26e8cfa622549778045730a6932fe93537ab46d0938f683ef6404feb1a5a742258079f842e4c882163d638a16b26f7408cf05b7c144f928d3d348704bda63f61
+  checksum: c4417fc6f2340d54dd5c8e2c2d66e620679fa2203f99bf9f37ef04b68bdddfe3d4af598ed8830036788da03b64cc3563641e1688f74e7bb7e2d0cb965bebc1d4
   languageName: node
   linkType: hard
 
 "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 1.2.0
-  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=0f499c&locator=root-workspace-0b6124%40workspace%3A."
+  version: 1.2.1
+  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=95bad6&locator=root-workspace-0b6124%40workspace%3A."
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 733b68a32e24dcb24ebc2f3c3fadf15975aec11ba703fb40da0d9dc6c17f12c89580464ad4d90c5a31cdeda2c30b961d971fd7021375745049b7ed4e9926da96
+  checksum: d970110fba8ea54888b6bc8619b6633984fab818b9f1d48f74a64e293496b18edaf7ced29fb281c0cadf816260ea8639cf8ed93692ba32bb77c8582776b3134c
   languageName: node
   linkType: hard
 
@@ -13018,11 +13018,11 @@ __metadata:
   linkType: hard
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 7.0.1
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=89570f&locator=root-workspace-0b6124%40workspace%3A."
+  version: 7.0.2
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=23b04e&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/endpoint": ^3.2.3
+    "@rest-hooks/endpoint": ^3.2.4
     core-js: ^3.17.0
     redux: ^4.0.0
   peerDependencies:
@@ -13032,7 +13032,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 100954f2506ee34f8aa33d0d5a066f352eb4e7d690552170f6ec6ac8f000493ec609ffc665d851b0e59700740849f1bfc344dff68ddaf8f08019905c4514d43f
+  checksum: e74dfc5d5826013da43df6e818363bad2d38c5fcf4f7b89497683eef1047634f1205e05c7fbad637004ac74d3ff4785b7df61058333a558cd0165827a35b1f23
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4091,14 +4091,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/core@^4.1.0, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
+"@rest-hooks/core@^4.1.1, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/core@workspace:packages/core"
   dependencies:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/normalizr": ^9.3.1
+    "@rest-hooks/normalizr": ^9.3.2
     "@types/babel__core": ^7
     core-js: ^3.17.0
     downlevel-dts: ^0.10.0
@@ -4116,7 +4116,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/endpoint@^3.0.1, @rest-hooks/endpoint@^3.2.3, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
+"@rest-hooks/endpoint@^3.0.1, @rest-hooks/endpoint@^3.2.4, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/endpoint@workspace:packages/endpoint"
   dependencies:
@@ -4177,7 +4177,7 @@ __metadata:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/endpoint": ^3.2.3
+    "@rest-hooks/endpoint": ^3.2.4
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -4275,7 +4275,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/normalizr@^9.0.1, @rest-hooks/normalizr@^9.3.1, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
+"@rest-hooks/normalizr@^9.0.1, @rest-hooks/normalizr@^9.3.2, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/normalizr@workspace:packages/normalizr"
   dependencies:
@@ -4305,8 +4305,8 @@ __metadata:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/core": ^4.1.0
-    "@rest-hooks/use-enhanced-reducer": ^1.2.0
+    "@rest-hooks/core": ^4.1.1
+    "@rest-hooks/use-enhanced-reducer": ^1.2.1
     "@types/babel__core": ^7
     core-js: ^3.17.0
     downlevel-dts: ^0.10.0
@@ -4370,7 +4370,7 @@ __metadata:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/endpoint": ^3.2.3
+    "@rest-hooks/endpoint": ^3.2.4
     "@types/babel__core": ^7
     "@types/copyfiles": ^2
     "@types/path-to-regexp": ^1.7.0
@@ -4475,7 +4475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/use-enhanced-reducer@^1.2.0, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
+"@rest-hooks/use-enhanced-reducer@^1.2.1, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:
@@ -19885,7 +19885,7 @@ __metadata:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/endpoint": ^3.2.3
+    "@rest-hooks/endpoint": ^3.2.4
     "@types/babel__core": ^7
     core-js: ^3.17.0
     downlevel-dts: ^0.10.0


### PR DESCRIPTION
<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes #2299 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
It's extremely common to have endpoint typos or forgetting to implement something such that you hit the wrong response. We want to ensure we can properly normalize, and also give helpful messages for common reasons why this could exist.

In the future we will want optionality to be explicit to avoid mismatches between types and responses allowed. However, in the meantime we can ensure common mismatches responses are quickly diagnosed.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We had previously done this basic detection in the root normalize; However, this limits flexibility in optionality and id based responses. When we had expanded this functionality we ended up passing through these issues. Here we provide the most robust layer of detection at the Endpoint-level, as it has the most context to diagnose why. However, we will also do what we can in normalize while maintaining the flexibility we desired.

- Back to disallowing string for base entity response
  - If this is the *only* thing returned, it is guaranteed to not contain entities, which means it could only resolve properly if the entity already exists in the store. This is unrealistic as the use case for string responses are for joins - but being at root level means we're simply gathering that entity.
- Add explicit check to RestEndpoint for text/html response when schema is set. This will be the most reliable catch-all of misconfigured endpoints.
  - Only valid schemas are a string type, undefined, or null.
  - Count as status = 404 as this is usually due to hitting HTML fallbacks. This also ensures it is not a 'soft' error by default.