### PR TITLE
docs: Random improvements and robots.txt again

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,6 +15,8 @@ assignees: ''
 
 **Package manager version** (e.g., yarn 2, npm 8)
 
+**Environment version** (e.g., chrome 108, react-native 0.70.6 android)
+
 **Node version** (e.g., 16.13.2)
 
 **Describe the bug**

--- a/docs/core/api/AsyncBoundary.md
+++ b/docs/core/api/AsyncBoundary.md
@@ -1,5 +1,5 @@
 ---
-title: "<AsyncBoundary />"
+title: '<AsyncBoundary />'
 ---
 
 <head>
@@ -10,16 +10,47 @@ title: "<AsyncBoundary />"
 Handles loading and error conditions of Suspense.
 
 ```tsx
-function AsyncBoundary({ children, errorComponent, fallback, }: {
-    children: React.ReactNode;
-    fallback?: React.ReactNode;
-    errorComponent?: React.ComponentType<{
-        error: NetworkError;
-    }>;
+function AsyncBoundary({
+  children,
+  errorComponent,
+  fallback,
+}: {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+  errorComponent?: React.ComponentType<{
+    error: NetworkError;
+  }>;
 }): JSX.Element;
 ```
 
-Custom fallback usage example:
+:::tip
+
+Learn more about boundary placement by learning how to [co-locate data dependencies](../getting-started/data-dependency.md)
+
+:::
+
+## Example
+
+```tsx
+import React from 'react';
+import { AsyncBoundary } from '@rest-hooks/react';
+
+export default function MyPage() {
+  return (
+    <AsyncBoundary>
+      <SuspendingComponent />
+    </AsyncBoundary>
+  );
+}
+
+function SuspendingComponent() {
+  const data = useSuspense(MyEndpoint);
+
+  return <div>{data.text}</div>
+}
+```
+
+## Custom fallback example {#custom-fallback}
 
 ```tsx
 import React from 'react';
@@ -33,7 +64,7 @@ function ErrorPage({ error }: { error: NetworkError }) {
   );
 }
 
-export default function App(): React.ReactElement {
+export default function App() {
   return (
     <CacheProvider>
       <AsyncBoundary fallback="loading" errorComponent={ErrorPage}>

--- a/docs/core/api/Manager.md
+++ b/docs/core/api/Manager.md
@@ -5,6 +5,11 @@ title: Manager
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+<head>
+  <title>Manager - Powerful middlewares with global store knowledge</title>
+  <meta name="docsearch:pagerank" content="20"/>
+</head>
+
 Managers are singletons that orchestrate the complex asynchronous behavior of `rest-hooks`.
 Several managers are provided by `rest-hooks` and used by default; however there is nothing
 stopping other compatible managers to be built that expand the functionality. We encourage
@@ -173,7 +178,7 @@ export default class LoggingManager implements Manager {
 }
 ```
 
-### Middleware data stream
+### Middleware data stream (with websockets) {#data-stream}
 
 ```typescript
 import type { Manager, Middleware } from '@rest-hooks/core';

--- a/docs/core/api/SubscriptionManager.md
+++ b/docs/core/api/SubscriptionManager.md
@@ -7,7 +7,7 @@ sidebar_label: SubscriptionManager
 class SubscriptionManager<S extends SubscriptionConstructable> implements Manager
 ```
 
-Keeps track of all resource subscriptions.
+Orchestrates all subscriptions; ensuring fresh data without overfetching.
 
 ## constructor(Subscription: S)
 

--- a/docs/core/api/useDLE.md
+++ b/docs/core/api/useDLE.md
@@ -44,6 +44,8 @@ function useDLE<
 
 In case you cannot use [suspense](../getting-started/data-dependency.md#async-fallbacks), useDLE() is just like [useSuspense()](./useSuspense.md) but returns [D]ata [L]oading [E]rror values.
 
+<ConditionalDependencies hook="useDLE" />
+
 ## Hook usage
 
 <HooksPlayground fixtures={[
@@ -99,4 +101,3 @@ render(<ProfileList />);
 
 </HooksPlayground>
 
-<ConditionalDependencies hook="useDLE" />

--- a/docs/core/api/useError.md
+++ b/docs/core/api/useError.md
@@ -2,6 +2,10 @@
 title: useError()
 ---
 
+<head>
+  <title>useError() - Accessing error metadata</title>
+</head>
+
 ```typescript
 export interface SyntheticError extends Error {
   status: number;

--- a/docs/core/api/useFetch.md
+++ b/docs/core/api/useFetch.md
@@ -3,6 +3,7 @@ title: useFetch()
 ---
 
 import GenericsTabs from '@site/src/components/GenericsTabs';
+import ConditionalDependencies from '../shared/\_conditional_dependencies.mdx';
 
 <head>
   <title>useFetch() - Declarative fetch triggers</title>
@@ -56,6 +57,8 @@ Use in combination with a data-binding hook ([useCache()](./useCache.md), [useSu
 in another component.
 
 :::
+
+<ConditionalDependencies hook="useFetch" />
 
 ## Example
 

--- a/docs/core/getting-started/installation.md
+++ b/docs/core/getting-started/installation.md
@@ -104,7 +104,7 @@ Alternatively [integrate state with redux](../guides/redux.md)
 
 If your application targets older browsers (a few years or more), be sure to load polyfills.
 Typically this is done with [@babel/preset-env useBuiltIns: 'entry'](https://babeljs.io/docs/en/babel-preset-env#usebuiltins),
-coupled with importing [https://www.npmjs.com/package/core-js] at the entrypoint of your application.
+coupled with importing [core-js](https://www.npmjs.com/package/core-js) at the entrypoint of your application.
 
 This ensures only the needed polyfills for your browser support targets are included in your application bundle.
 

--- a/docs/graphql/auth.md
+++ b/docs/graphql/auth.md
@@ -61,3 +61,9 @@ function Auth() {
   return <AuthForm onSubmit={handleLogin} />;
 }
 ```
+
+## 401 Logout Handling
+
+In case a users authorization expires, the server will typically responsd to indicate
+as such. The standard way of doing this is with a 401. [LogoutManager](/docs/api/LogoutManager)
+can be used to easily trigger any de-authorization cleanup.

--- a/docs/rest/guides/auth.md
+++ b/docs/rest/guides/auth.md
@@ -154,7 +154,7 @@ export const MyResource = createResource({
 
 ## Auth Headers from React Context
 
-:::warning
+:::caution
 
 Using React Context for state that is not displayed (like auth tokens) is not recommended.
 This will result in unnecessary re-renders and application complexity.

--- a/docs/rest/guides/computed-properties.md
+++ b/docs/rest/guides/computed-properties.md
@@ -38,3 +38,32 @@ class User extends Entity {
   });
 }
 ```
+
+:::tip
+
+If you simply want to [deserialize a field](./network-transform.md#deserializing-fields) to a more useful form like [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) or [BigNumber](https://github.com/MikeMcl/bignumber.js), you can use
+the declarative [static schema](./network-transform.md#deserializing-fields).
+
+
+```typescript
+import { Entity } from '@rest-hooks/rest';
+
+class User extends Entity {
+  id = '';
+  firstName = '';
+  lastName = '';
+  createdAt = new Date(0);
+
+  pk() {
+    return this.id;
+  }
+
+  // highlight-start
+  static schema = {
+    createdAt: Date,
+  };
+  // highlight-end
+}
+```
+
+:::

--- a/packages/react/src/__tests__/integration-endpoint.web.tsx
+++ b/packages/react/src/__tests__/integration-endpoint.web.tsx
@@ -445,8 +445,7 @@ describe.each([
       await fetch(CoolerArticleResource.delete, { id: temppayload.id });
     });
     expect(throws.length).toBeGreaterThanOrEqual(2); //TODO: delete seems to have receive process multiple times. we suspect this is because of test+act integration.
-    await waitForNextUpdate();
-    await throws[throws.length - 1];
+    await Promise.race([waitForNextUpdate(), throws[throws.length - 1]]);
     [data, fetch] = result.current;
     expect(data).toBeInstanceOf(CoolerArticle);
     expect(data.title).toBe('othertitle');

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,7 +8,7 @@ const isDev = process.env.NODE_ENV === 'development';
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
   title: 'Rest Hooks',
-  tagline: 'Declarative Async State Management for React',
+  tagline: 'The Relational Data Client (for React)',
   url: 'https://resthooks.io',
   baseUrl: '/',
   organizationName: 'coinbase',
@@ -459,6 +459,10 @@ module.exports = {
               {
                 label: 'Demo (Todo)',
                 to: 'https://stackblitz.com/github/coinbase/rest-hooks/tree/master/examples/todo-app?file=src%2Fpages%2FHome%2FTodoListComponent.tsx',
+              },
+              {
+                label: 'Demo (NextJS)',
+                to: 'https://stackblitz.com/github/coinbase/rest-hooks/tree/master/examples/nextjs?file=pages%2FAssetPrice.tsx',
               },
               /*{
               html: `<iframe

--- a/website/src/components/Demo/index.js
+++ b/website/src/components/Demo/index.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import clsx from 'clsx';
-import { Link } from 'react-router-dom';
 import { GQLEndpoint } from '@rest-hooks/graphql';
+import clsx from 'clsx';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
 import { TODOS } from '../../mocks/handlers';
 import CodeEditor from './CodeEditor';
@@ -235,6 +235,7 @@ export const TodoResource = {
   ...BaseTodoResource,
   getList: BaseTodoResource.getList.extend({
     process(todos) {
+      // for demo purposes we'll only use the first seven
       return todos.slice(0, 7);
     },
   }),

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,14 +1,14 @@
-import React from 'react';
-import clsx from 'clsx';
-import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Layout from '@theme/Layout';
+import ThemedImage from '@theme/ThemedImage';
+import clsx from 'clsx';
+import React from 'react';
 
-import styles from './index.module.css';
-import HomepageFeatures from '../components/HomepageFeatures';
 import Demo from '../components/Demo/index';
+import HomepageFeatures from '../components/HomepageFeatures';
+import styles from './index.module.css';
 
 const ProjectTitle = () => {
   const sources = {
@@ -65,7 +65,7 @@ export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`Declarative Async State Management for React`}
+      title={`The Relational Data Client (for React)`}
       description="Making dynamic sites performant, scalable, simple to build with any API design. ...all typed ...fast ...and consistent"
     >
       <HomepageHeader />

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /assets/js/*


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
#2295 was supposed to have robots.txt but that was somehow lost on the final commit.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Various other docs tweaks

#### Block googlebot from JS assets

Googlebot has limited download resources. Since we SSR everything blocking it from loading the JS saves a lot of resources, avoiding quota limits that cause inconsistent 'mobile usability' issues. When quota limits are hit google simply stops mid-way through, but still evaluates the page, which means random resources aren't loaded. This potentially also allows googlebot to crawl pages with more frequency.