### PR TITLE
enhance: Reduce bundlesize via custom Object.hasOwn polyfill

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,6 @@ module.exports = function (api) {
         {
           typing: 'typescript',
           loose: true,
-          useBuiltIns: 'entry',
           resolver: {
             extensions: ['.ts.', '.tsx', '.js', '.jsx', '.es', '.es6', '.mjs'],
             resolvePath(sourcePath, currentFile, opts) {

--- a/docs/core/getting-started/installation.md
+++ b/docs/core/getting-started/installation.md
@@ -108,6 +108,8 @@ coupled with importing [core-js](https://www.npmjs.com/package/core-js) at the e
 
 This ensures only the needed polyfills for your browser support targets are included in your application bundle.
 
+For instance `TypeError: Object.hasOwn is not a function`
+
 </details>
 <details><summary><b>Internet Explorer support</b></summary>
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,7 +106,6 @@
   "dependencies": {
     "@babel/runtime": "^7.17.0",
     "@rest-hooks/normalizr": "^9.3.2",
-    "core-js": "^3.17.0",
     "flux-standard-action": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,9 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
+
 export * as __INTERNAL__ from './internal.js';
 export type {
   NetworkError,

--- a/packages/core/src/manager/NetworkManager.ts
+++ b/packages/core/src/manager/NetworkManager.ts
@@ -1,4 +1,3 @@
-import 'core-js/es/object/has-own';
 import { RECEIVE_TYPE, FETCH_TYPE, RESET_TYPE } from '../actionTypes.js';
 import Controller from '../controller/Controller.js';
 import { initialState } from '../internal.js';

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -99,8 +99,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.0",
-    "core-js": "^3.17.0"
+    "@babel/runtime": "^7.17.0"
   },
   "devDependencies": {
     "@babel/cli": "7.19.3",

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -1,3 +1,9 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
+
 export type {
   EndpointInterface,
   ReadEndpoint,

--- a/packages/endpoint/src/schemas/All.ts
+++ b/packages/endpoint/src/schemas/All.ts
@@ -1,4 +1,3 @@
-import 'core-js/es/object/has-own';
 import { EntityTable } from '../interface.js';
 import { EntityInterface, EntityMap, SchemaFunction } from '../schema.js';
 import ArraySchema from './Array.js';

--- a/packages/endpoint/src/schemas/Entity.ts
+++ b/packages/endpoint/src/schemas/Entity.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import 'core-js/es/object/has-own';
+
 import type { Schema, NormalizedIndex, UnvisitFunction } from '../interface.js';
 import { AbstractInstanceType } from '../normal.js';
 import { isImmutable, denormalizeImmutable } from './ImmutableUtils.js';

--- a/packages/endpoint/src/schemas/Object.ts
+++ b/packages/endpoint/src/schemas/Object.ts
@@ -65,9 +65,7 @@ export function infer(
   entities: any,
 ) {
   const resultObject: any = {};
-  console.log('infer obj');
   for (const k of Object.keys(schema)) {
-    console.log('infer', k);
     resultObject[k] = recurse(schema[k], args, indexes, entities);
   }
   return resultObject;

--- a/packages/endpoint/src/schemas/validatRequired.ts
+++ b/packages/endpoint/src/schemas/validatRequired.ts
@@ -1,5 +1,3 @@
-import 'core-js/es/object/has-own';
-
 export default function validateRequired(
   processedEntity: any,
   requiredDefaults: Record<string, unknown>,

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -93,7 +93,6 @@
   "peerDependencies": {
     "@rest-hooks/react": "^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
-    "core-js": "^3.17.0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"
   },
   "peerDependenciesMeta": {

--- a/packages/legacy/src/endpoint/shapeToEndpoint.ts
+++ b/packages/legacy/src/endpoint/shapeToEndpoint.ts
@@ -2,7 +2,6 @@ import { Endpoint } from '@rest-hooks/endpoint';
 import type { EndpointInstance } from '@rest-hooks/endpoint';
 
 import type { FetchShape } from './shapes.js';
-import 'core-js/es/object/has-own';
 
 type ShapeTypeToSideEffect<T extends 'read' | 'mutate' | 'delete' | undefined> =
   T extends 'read' | undefined ? undefined : true;

--- a/packages/legacy/src/index.ts
+++ b/packages/legacy/src/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 export * from './resource/index.js';
 export { default as useStatefulResource } from './useStatefulResource.js';
 export * from './endpoint/index.js';

--- a/packages/legacy/src/resource/Entity.ts
+++ b/packages/legacy/src/resource/Entity.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { AbstractInstanceType, Schema, schema } from '@rest-hooks/endpoint';
-import 'core-js/es/object/has-own';
 
 import { isImmutable, denormalizeImmutable } from './ImmutableUtils.js';
 import SimpleRecord from './SimpleRecord.js';

--- a/packages/legacy/src/resource/SimpleRecord.ts
+++ b/packages/legacy/src/resource/SimpleRecord.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { AbstractInstanceType, Schema } from '@rest-hooks/endpoint';
-import 'core-js/es/object/has-own';
 
 import { normalize, infer } from './Object.js';
 import { NormalizedEntity } from './types.js';

--- a/packages/legacy/src/resource/SimpleResource.ts
+++ b/packages/legacy/src/resource/SimpleResource.ts
@@ -4,7 +4,6 @@ import type {
   EndpointExtraOptions,
   AbstractInstanceType,
 } from '@rest-hooks/endpoint';
-import 'core-js/es/object/has-own';
 
 import { ReadShape, MutateShape, DeleteShape } from '../rest-3/legacy.js';
 import Delete from './Delete.js';

--- a/packages/legacy/src/rest-3/SimpleResource.ts
+++ b/packages/legacy/src/rest-3/SimpleResource.ts
@@ -6,7 +6,6 @@ import type {
   SchemaList,
 } from '@rest-hooks/endpoint';
 import type { AbstractInstanceType } from '@rest-hooks/endpoint';
-import 'core-js/es/object/has-own';
 
 import EntityRecord from './EntityRecord.js';
 import { NotImplementedError } from './errors.js';

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -110,7 +110,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "core-js": "^3.17.0",
     "npm-run-all": "^4.1.5"
   }
 }

--- a/packages/normalizr/src/WeakListMap.ts
+++ b/packages/normalizr/src/WeakListMap.ts
@@ -1,4 +1,3 @@
-import 'core-js/es/object/has-own';
 /** Link in a chain */
 class Link<K extends object, V> {
   children = new WeakMap<K, Link<K, V>>();

--- a/packages/normalizr/src/denormalize.ts
+++ b/packages/normalizr/src/denormalize.ts
@@ -9,7 +9,6 @@ import type {
   DenormalizeCache,
 } from './types.js';
 import WeakListMap from './WeakListMap.js';
-import 'core-js/es/object/has-own';
 
 const DRAFT = Symbol('draft');
 

--- a/packages/normalizr/src/index.ts
+++ b/packages/normalizr/src/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 import { denormalize } from './denormalize.js';
 import { isEntity } from './isEntity.js';
 import { normalize } from './normalize.js';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -123,8 +123,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.0",
     "@rest-hooks/core": "^4.1.1",
-    "@rest-hooks/use-enhanced-reducer": "^1.2.1",
-    "core-js": "^3.17.0"
+    "@rest-hooks/use-enhanced-reducer": "^1.2.1"
   },
   "peerDependencies": {
     "@react-navigation/native": "^6.0.0",

--- a/packages/react/src/components/NetworkErrorBoundary.tsx
+++ b/packages/react/src/components/NetworkErrorBoundary.tsx
@@ -1,6 +1,5 @@
 import type { NetworkError } from '@rest-hooks/core';
 import React from 'react';
-import 'core-js/es/object/has-own';
 
 function isNetworkError(error: NetworkError | unknown): error is NetworkError {
   return Object.hasOwn(error as any, 'status');

--- a/packages/react/src/hooks/useCacheState.ts
+++ b/packages/react/src/hooks/useCacheState.ts
@@ -1,6 +1,5 @@
 import type { State } from '@rest-hooks/core';
 import React, { useContext } from 'react';
-import 'core-js/es/object/has-own';
 
 import { StateContext, StoreContext } from '../context.js';
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 export {
   PollingSubscription,
   DevToolsManager,

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -108,7 +108,6 @@
   "dependencies": {
     "@babel/runtime": "^7.17.0",
     "@rest-hooks/endpoint": "^3.2.4",
-    "core-js": "^3.17.0",
     "redux": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/rest-hooks/src/endpoint/adapter.ts
+++ b/packages/rest-hooks/src/endpoint/adapter.ts
@@ -1,7 +1,6 @@
 import type { EndpointInterface } from '@rest-hooks/react';
 
 import type { FetchShape } from './shapes.js';
-import 'core-js/es/object/has-own';
 
 type ShapeTypeToSideEffect<T extends 'read' | 'mutate' | 'delete' | undefined> =
   T extends 'read' | undefined ? undefined : true;

--- a/packages/rest-hooks/src/index.ts
+++ b/packages/rest-hooks/src/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 export { Endpoint, Index } from '@rest-hooks/endpoint';
 export type {
   EndpointExtraOptions as FetchOptions,

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -109,8 +109,6 @@
   "dependencies": {
     "@babel/runtime": "^7.17.0",
     "@rest-hooks/endpoint": "^3.2.4",
-    "copyfiles": "^2.4.1",
-    "core-js": "^3.17.0",
     "path-to-regexp": "^6.2.1"
   },
   "devDependencies": {
@@ -119,6 +117,7 @@
     "@types/babel__core": "^7",
     "@types/copyfiles": "^2",
     "@types/path-to-regexp": "^1.7.0",
+    "copyfiles": "^2.4.1",
     "downlevel-dts": "^0.10.0",
     "npm-run-all": "^4.1.5",
     "rollup": "2.79.1",

--- a/packages/rest/src/RestHelpers.ts
+++ b/packages/rest/src/RestHelpers.ts
@@ -1,5 +1,4 @@
 import { compile, PathFunction, parse } from 'path-to-regexp';
-import 'core-js/es/object/has-own';
 
 import { ShortenPath } from './pathTypes.js';
 

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 export { default as RestEndpoint } from './RestEndpoint.js';
 export type {
   GetEndpoint,

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -110,8 +110,7 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.0",
-    "core-js": "^3.17.0"
+    "@babel/runtime": "^7.17.0"
   },
   "peerDependencies": {
     "@rest-hooks/react": "^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0",

--- a/packages/ssr/src/index.ts
+++ b/packages/ssr/src/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 export { default as createPersistedStore } from './createPersistedStore.js';
 export * from './getInitialData.js';
 export { default as createServerDataComponent } from './createServerDataComponent.js';

--- a/packages/ssr/src/nextjs/RestHooksDocument.tsx
+++ b/packages/ssr/src/nextjs/RestHooksDocument.tsx
@@ -4,7 +4,6 @@ import Document, {
   DocumentContext,
   DocumentInitialProps,
 } from 'next/document.js';
-import 'core-js/es/object/has-own';
 
 import createPersistedStore from '../createPersistedStore.js';
 import createServerDataComponent from '../createServerDataComponent.js';

--- a/packages/ssr/src/nextjs/index.ts
+++ b/packages/ssr/src/nextjs/index.ts
@@ -1,2 +1,7 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 export { default as RestHooksDocument } from './RestHooksDocument.js';
 export { default as AppCacheProvider } from './AppCacheProvider.js';

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -99,8 +99,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@testing-library/react-hooks": "~8.0.0",
-    "core-js": "^3.17.0"
+    "@testing-library/react-hooks": "~8.0.0"
   },
   "peerDependencies": {
     "@rest-hooks/react": "^0.2.0 || ^0.3.0 || ^1.0.0 || ^6.0.0 || ^7.0.0",

--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -7,7 +7,6 @@ import {
 } from '@rest-hooks/react';
 import { useCallback, useContext, useMemo } from 'react';
 import React from 'react';
-import 'core-js/es/object/has-own';
 
 import { Fixture, dispatchFixture } from './mockState.js';
 

--- a/packages/test/src/browser.ts
+++ b/packages/test/src/browser.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 import MockProvider from './MockProvider.js';
 import mockInitialState from './mockState.js';
 export { default as MockResolver } from './MockResolver.js';

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -1,3 +1,8 @@
+Object.hasOwn =
+  Object.hasOwn ||
+  /* istanbul ignore next */ function hasOwn(it, key) {
+    return Object.prototype.hasOwnProperty.call(it, key);
+  };
 import makeRenderRestHook from './makeRenderRestHook.js';
 import MockProvider from './MockProvider.js';
 import mockInitialState from './mockState.js';

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
@@ -1183,13 +1183,13 @@ type FetchGet<A extends readonly any[] = [any], R = any> = (
 type GetEndpoint<
   UrlParams = any,
   S extends Schema | undefined = Schema | undefined,
-> = RestTypeNoBody<UrlParams, S, undefined, { path: string; body: undefined }>;
+> = RestTypeNoBody<UrlParams, S, undefined>;
 
 type MutateEndpoint<
   UrlParams = any,
   Body extends BodyInit | Record<string, any> = any,
   S extends Schema | undefined = Schema | undefined,
-> = RestTypeWithBody<UrlParams, S, true, Body, { path: string; body: Body }>;
+> = RestTypeWithBody<UrlParams, S, true, Body>;
 
 type Defaults<O, D> = {
   [K in keyof O | keyof D]: K extends keyof O

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -1,19 +1,19 @@
-import React, { useContext, useMemo, useReducer, useState, lazy } from 'react';
-import { LiveProvider, LiveProviderProps } from 'react-live';
-import clsx from 'clsx';
+import { usePrismTheme } from '@docusaurus/theme-common';
 import Translate from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import { usePrismTheme } from '@docusaurus/theme-common';
 import { FixtureEndpoint } from '@rest-hooks/test';
+import clsx from 'clsx';
+import React, { useContext, useMemo, useReducer, useState, lazy } from 'react';
+import { LiveProvider, LiveProviderProps } from 'react-live';
 
 import CodeTabContext from '../Demo/CodeTabContext';
-import styles from './styles.module.css';
+import Boundary from './Boundary';
 import FixturePreview from './FixturePreview';
 import Header from './Header';
-import PreviewWithHeader from './PreviewWithHeader';
-import Boundary from './Boundary';
-import PlaygroundEditor from './PlaygroundEditor';
 import MonacoPreloads from './MonacoPreloads';
+import PlaygroundEditor from './PlaygroundEditor';
+import PreviewWithHeader from './PreviewWithHeader';
+import styles from './styles.module.css';
 
 function HeaderTabs() {
   const { selectedValue, setSelectedValue, values } =

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2927,39 +2927,37 @@ __metadata:
 
 "@rest-hooks/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
   version: 4.1.1
-  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=a9d69c&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=e97d13&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^9.3.2
-    core-js: ^3.17.0
     flux-standard-action: ^2.1.1
-  checksum: 3e7c5be6acc21b36c9058978ba7320d1de53d561748520f29bbedadbcf427777df304e1504a818ec79fbf6670e2bc34f560a5e0e1a29bce4a06347e4bfc03c32
+  checksum: b446a404c05665c416d9dd3fbc0416eb806fe1f346ea78026246f96627aedf343714629606da5b6257b0f909a6dca2cc64ee7743697b230c88cc12f4809ace5b
   languageName: node
   linkType: hard
 
 "@rest-hooks/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.2.4
-  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=ee9a52&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=b7ec08&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-    core-js: ^3.17.0
-  checksum: d18ff42e66cc1cfb4a96e9871e9285deefd7aac84c55d373b2644e3a66648f68b94b2fa2c2c65f2a8f8924ddd43b96841dc9e1122ffb8b14e6dadddf6169d903
+  checksum: ba341f18c228e79fba5cd2947ca4349ed590ee14b37191c49767438e793cc6097ac0ea06df467b1e04482ddf0ae61b63d2e36a399c74ee17f1d060895449a641
   languageName: node
   linkType: hard
 
 "@rest-hooks/graphql@file:../packages/graphql::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.3.7
-  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=e89223&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/graphql@file:../packages/graphql#../packages/graphql::hash=7d0138&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.4
-  checksum: 57cafaea7febaa877bf4b98bbc25cbeb125478244e95e3ee23b81ba363c6f42db7babdf8050a3de29534517d2af4214a16ce2b2a8a7df4d1d2d0f3c1367666f2
+  checksum: 5fdd771e696df8db4da61582268c9cd1a7ea80568405ebd33e63130739f131dce2fd5cb0927e9c13234e574a5eaa258f038a420dcc08b0adbd04b3a691a329a1
   languageName: node
   linkType: hard
 
 "@rest-hooks/hooks@file:../packages/hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.1.1
-  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=de9b86&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/hooks@file:../packages/hooks#../packages/hooks::hash=459921&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
   peerDependencies:
@@ -2969,29 +2967,27 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: f0faa66c709fc484e8872c20d9bd133442b5d28f7cc68f31fc3274c351fd242a6f45e56ee21d8415db9fb2fedb2827a6fa5faa338f7a4adcb8da0afc9dcc9263
+  checksum: d9d560b5ece784b5e683deb654626e9a7ef77c4ea050d8bd59729b9e1bd06b4ea9b074cbb1ac382be2c6585a25bca9c1db6e51ad15660c6780a1c676481fca57
   languageName: node
   linkType: hard
 
 "@rest-hooks/normalizr@file:../packages/normalizr::locator=root-workspace-0b6124%40workspace%3A.":
   version: 9.3.2
-  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=554402&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=302eda&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-    core-js: ^3.17.0
     npm-run-all: ^4.1.5
-  checksum: a08c5d6131e05d11bb09775bc678fd21dcaaefcd697159e9c95fc3ba4ed4ffaf77a4e037126a811718a76174673f34b05e8cb793407948cfe1117708cc2c6ffe
+  checksum: b8259f31b8e82636de1a41afe3594575e311bfe9d6017813cf3a1f5a3ef7743e587f427b5953a0af27e80420c4be02f827c3e3bb6240e69c281887bde49972f1
   languageName: node
   linkType: hard
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.1.1
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=718ada&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=7b4ff7&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.1.1
     "@rest-hooks/use-enhanced-reducer": ^1.2.1
-    core-js: ^3.17.0
   peerDependencies:
     "@react-navigation/native": ^6.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0
@@ -3001,30 +2997,27 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 27c2b1fd780916210b0fce48054a2f2299da9a6f9d2cbcd51b6b5477711aedaba05c39ca13dd5192dcffd73b83b20914eef1850d116da77f603132e35c380f59
+  checksum: d9debb66c3096e2452295971bf8a3a080f85e6cbfe6328f98d84f105723efaff4bb2a926fd2a386b3961c775325cc5aba09896ca97525df18799bcbfff67e158
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
   version: 6.2.2
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=da66fb&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=235a3c&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.4
-    copyfiles: ^2.4.1
-    core-js: ^3.17.0
     path-to-regexp: ^6.2.1
-  checksum: 5dd04acf3d5cfde6470fb814514f4e0fc5dd12dcfa9ccc902a336c733a2b5a9ec0147089afc9906a979b6080fad6e3bc73395598f4de6a7457fb1293b0900869
+  checksum: 14511f8fee359bba84d20fd3a11c386ee72b1d6e86ab5610e0291ed9aab6eaa1ee900a3cef6417c38e225af48c5e460694d8c67e98201cf00f21ee46cd235a01
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 9.1.1
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=0c0a9d&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=320625&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react-hooks": ~8.0.0
-    core-js: ^3.17.0
   peerDependencies:
     "@rest-hooks/react": ^0.2.0 || ^0.3.0 || ^1.0.0 || ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
@@ -3032,7 +3025,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 4c7c24ffc270bbdfb9f385ba159a4ff037cdb59b34a38b7a4270db310a2b3adaefda0c54781b3d9c56043740142b8186d0fc560337e6ba0fd97ace7216a6b572
+  checksum: 4c4d11d80b07bc3f519c02e6bdf54599e672922294065b6623e213324f9533b6d274e15ed3068aa2e8d8d954efc51301fccbae4b1c40dbfc9968368bd757c242
   languageName: node
   linkType: hard
 
@@ -5645,24 +5638,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copyfiles@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "copyfiles@npm:2.4.1"
-  dependencies:
-    glob: ^7.0.5
-    minimatch: ^3.0.3
-    mkdirp: ^1.0.4
-    noms: 0.0.0
-    through2: ^2.0.1
-    untildify: ^4.0.0
-    yargs: ^16.1.0
-  bin:
-    copyfiles: copyfiles
-    copyup: copyfiles
-  checksum: aea69873bb99cc5f553967660cbfb70e4eeda198f572a36fb0f748b36877ff2c90fd906c58b1d540adbad8afa8ee82820172f1c18e69736f7ab52792c12745a7
-  languageName: node
-  linkType: hard
-
 "core-js-compat@npm:^3.25.1":
   version: 3.26.0
   resolution: "core-js-compat@npm:3.26.0"
@@ -5686,7 +5661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.17.0, core-js@npm:^3.21.0, core-js@npm:^3.23.3":
+"core-js@npm:^3.21.0, core-js@npm:^3.23.3":
   version: 3.26.1
   resolution: "core-js@npm:3.26.1"
   checksum: 0a01149f51ff1e9f41d1ea49cc4c9222047949ea597189ede7c4cf8cde3b097766b9c7615acc77c86fe65b4002f20b638a133dfba7b41dba830d707aeeed45ad
@@ -8074,7 +8049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.0.5, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -8835,7 +8810,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.0, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.0, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -10182,7 +10157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.1.2, minimatch@npm:^3.0.3, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
+"minimatch@npm:3.1.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -10490,16 +10465,6 @@ __metadata:
   version: 2.0.6
   resolution: "node-releases@npm:2.0.6"
   checksum: e86a926dc9fbb3b41b4c4a89d998afdf140e20a4e8dbe6c0a807f7b2948b42ea97d7fd3ad4868041487b6e9ee98409829c6e4d84a734a4215dff060a7fbeb4bf
-  languageName: node
-  linkType: hard
-
-"noms@npm:0.0.0":
-  version: 0.0.0
-  resolution: "noms@npm:0.0.0"
-  dependencies:
-    inherits: ^2.0.1
-    readable-stream: ~1.0.31
-  checksum: a05f056dabf764c86472b6b5aad10455f3adcb6971f366cdf36a72b559b29310a940e316bca30802f2804fdd41707941366224f4cba80c4f53071512245bf200
   languageName: node
   linkType: hard
 
@@ -12593,7 +12558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.1, readable-stream@npm:~2.3.6":
+"readable-stream@npm:^2.0.1":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
   dependencies:
@@ -12628,18 +12593,6 @@ __metadata:
     events: ^3.3.0
     process: ^0.11.10
   checksum: aa8447f781e6df90af78f6b0b9b9a77da2816dcf6c8220e7021c4de36e04f8129fed7ead81eac0baad2f42098209f9e7d7cd43169e1c156efcd2613828a37439
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:~1.0.31":
-  version: 1.0.34
-  resolution: "readable-stream@npm:1.0.34"
-  dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.1
-    isarray: 0.0.1
-    string_decoder: ~0.10.x
-  checksum: 85042c537e4f067daa1448a7e257a201070bfec3dd2706abdbd8ebc7f3418eb4d3ed4b8e5af63e2544d69f88ab09c28d5da3c0b77dc76185fddd189a59863b60
   languageName: node
   linkType: hard
 
@@ -13019,11 +12972,10 @@ __metadata:
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.0.2
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=d3a672&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=fe03f6&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.4
-    core-js: ^3.17.0
     redux: ^4.0.0
   peerDependencies:
     "@rest-hooks/react": ^6.0.0 || ^7.0.0
@@ -13032,7 +12984,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 5598c9cfcbebfffc3c7ced21384feac41d94a6987505b2b92d6e9177310c816f2ae9a7418c22ded910afc604359ad987bece937115acde4b9e155ee200983531
+  checksum: ba84d631ada4e75289e386c162ae8ffb027a2b52bb380c02926942c8b2098760d4d20da4c1a22009f52097d1bf98df1795097c0e61f8437603007d77d81ee57b
   languageName: node
   linkType: hard
 
@@ -13995,13 +13947,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:~0.10.x":
-  version: 0.10.31
-  resolution: "string_decoder@npm:0.10.31"
-  checksum: fe00f8e303647e5db919948ccb5ce0da7dea209ab54702894dd0c664edd98e5d4df4b80d6fabf7b9e92b237359d21136c95bf068b2f7760b772ca974ba970202
-  languageName: node
-  linkType: hard
-
 "string_decoder@npm:~1.1.1":
   version: 1.1.1
   resolution: "string_decoder@npm:1.1.1"
@@ -14281,16 +14226,6 @@ __metadata:
   dependencies:
     any-promise: ^1.0.0
   checksum: 84e1b804bfec49f3531215f17b4a6e50fd4397b5f7c1bccc427b9c656e1ecfb13ea79d899930184f78bc2f57285c54d9a50a590c8868f4f0cef5c1d9f898b05e
-  languageName: node
-  linkType: hard
-
-"through2@npm:^2.0.1":
-  version: 2.0.5
-  resolution: "through2@npm:2.0.5"
-  dependencies:
-    readable-stream: ~2.3.6
-    xtend: ~4.0.1
-  checksum: beb0f338aa2931e5660ec7bf3ad949e6d2e068c31f4737b9525e5201b824ac40cac6a337224856b56bd1ddd866334bbfb92a9f57cd6f66bc3f18d3d86fc0fe50
   languageName: node
   linkType: hard
 
@@ -14742,13 +14677,6 @@ __metadata:
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
-  languageName: node
-  linkType: hard
-
-"untildify@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "untildify@npm:4.0.0"
-  checksum: 39ced9c418a74f73f0a56e1ba4634b4d959422dff61f4c72a8e39f60b99380c1b45ed776fbaa0a4101b157e4310d873ad7d114e8534ca02609b4916bb4187fb9
   languageName: node
   linkType: hard
 
@@ -15455,7 +15383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.0, xtend@npm:^4.0.1, xtend@npm:^4.0.2, xtend@npm:~4.0.1":
+"xtend@npm:^4.0.0, xtend@npm:^4.0.1, xtend@npm:^4.0.2":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a
@@ -15483,32 +15411,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.2":
-  version: 20.2.9
-  resolution: "yargs-parser@npm:20.2.9"
-  checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^21.0.0":
   version: 21.0.0
   resolution: "yargs-parser@npm:21.0.0"
   checksum: 1e205fca1cb7a36a1585e2b94a64e641c12741b53627d338e12747f4dca3c3610cdd9bb235040621120548dd74c3ef03a8168d52a1eabfedccbe4a62462b6731
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^16.1.0":
-  version: 16.2.0
-  resolution: "yargs@npm:16.2.0"
-  dependencies:
-    cliui: ^7.0.2
-    escalade: ^3.1.1
-    get-caller-file: ^2.0.5
-    require-directory: ^2.1.1
-    string-width: ^4.2.0
-    y18n: ^5.0.5
-    yargs-parser: ^20.2.2
-  checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4100,7 +4100,6 @@ __metadata:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^9.3.2
     "@types/babel__core": ^7
-    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
     npm-run-all: ^4.1.5
@@ -4124,7 +4123,6 @@ __metadata:
     "@babel/core": 7.20.5
     "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
-    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
     rollup: 2.79.1
@@ -4267,7 +4265,6 @@ __metadata:
   peerDependencies:
     "@rest-hooks/react": ^0.1.0 || ^0.2.0 || ^6.0.0 || ^7.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
-    core-js: ^3.17.0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
     "@types/react":
@@ -4283,7 +4280,6 @@ __metadata:
     "@babel/core": 7.20.5
     "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
-    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     immutable: 4.1.0
     npm-run-all: ^4.1.5
@@ -4308,7 +4304,6 @@ __metadata:
     "@rest-hooks/core": ^4.1.1
     "@rest-hooks/use-enhanced-reducer": ^1.2.1
     "@types/babel__core": ^7
-    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
     rollup: 2.79.1
@@ -4375,7 +4370,6 @@ __metadata:
     "@types/copyfiles": ^2
     "@types/path-to-regexp": ^1.7.0
     copyfiles: ^2.4.1
-    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
     path-to-regexp: ^6.2.1
@@ -4398,7 +4392,6 @@ __metadata:
     "@babel/core": 7.20.5
     "@babel/runtime": ^7.17.0
     "@types/babel__core": ^7
-    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     next: ^13.0.4
     npm-run-all: ^4.1.5
@@ -4434,7 +4427,6 @@ __metadata:
     "@babel/runtime": ^7.17.0
     "@testing-library/react-hooks": ~8.0.0
     "@types/babel__core": ^7
-    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     rollup: 2.79.1
     rollup-plugin-babel: ^4.4.0
@@ -8375,7 +8367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:3.26.1, core-js@npm:^3.17.0, core-js@npm:^3.21.0, core-js@npm:^3.26.0":
+"core-js@npm:3.26.1, core-js@npm:^3.21.0, core-js@npm:^3.26.0":
   version: 3.26.1
   resolution: "core-js@npm:3.26.1"
   checksum: 0a01149f51ff1e9f41d1ea49cc4c9222047949ea597189ede7c4cf8cde3b097766b9c7615acc77c86fe65b4002f20b638a133dfba7b41dba830d707aeeed45ad
@@ -19887,7 +19879,6 @@ __metadata:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.4
     "@types/babel__core": ^7
-    core-js: ^3.17.0
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
     redux: ^4.0.0


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Turns out *just* [including the core-js hasOwn polyfill ](https://github.com/coinbase/rest-hooks/pull/2309) increased the [bundlesize by over 12kb](https://bundlephobia.com/package/@rest-hooks/core@4.1.1).

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Include a minimal polyfill at entrypoint of each library and remove core-js dependency:

```typescript
Object.hasOwn = Object.hasOwn || function hasOwn(it, key) {
  return Object.prototype.hasOwnProperty.call(it, key);
};
```

This is technically incomplete as Object.hasOwn will throw when its not passed a valid object. However, we do not care about doing that in our usage. Consider this a 'loose' implementation.

### Test plan

Beta release one version, then try to run on old node version (14) and find an old browser as well