### PR TITLE
feat: Add ctrl.setResponse, ctrl.setError

### DIFF
--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -457,7 +457,7 @@ export default class StreamManager implements Manager {
         try {
           const msg = JSON.parse(event.data);
           if (msg.type in this.endpoints)
-            controller.receive(this.endpoints[msg.type], ...msg.args, msg.data);
+            controller.setResponse(this.endpoints[msg.type], ...msg.args, msg.data);
         } catch (e) {
           console.error('Failed to handle message');
           console.error(e);

--- a/docs/core/api/Controller.md
+++ b/docs/core/api/Controller.md
@@ -17,8 +17,8 @@ class Controller {
   fetch(endpoint, ...args) => ReturnType<E>;
   invalidate(endpoint, ...args) => Promise<void>;
   resetEntireStore: () => Promise<void>;
-  receive(endpoint, ...args, response) => Promise<void>;
-  receiveError(endpoint, ...args, error) => Promise<void>;
+  setResponse(endpoint, ...args, response) => Promise<void>;
+  setError(endpoint, ...args, error) => Promise<void>;
   resolve(endpoint, { args, response, fetchedAt, error }) => Promise<void>;
   subscribe(endpoint, ...args) => Promise<void>;
   unsubscribe(endpoint, ...args) => Promise<void>;
@@ -197,7 +197,11 @@ function UserName() {
 }
 ```
 
-## receive(endpoint, ...args, response) {#receive}
+## receive() {#receive}
+
+Another name for setResponse()
+
+## setResponse(endpoint, ...args, response) {#setResponse}
 
 Stores `response` in cache for given [Endpoint](/rest/api/Endpoint) and args.
 
@@ -212,7 +216,7 @@ useEffect(() => {
   const websocket = new Websocket(url);
 
   websocket.onmessage = event =>
-    ctrl.receive(EndpointLookup[event.endpoint], ...event.args, event.data);
+    ctrl.setResponse(EndpointLookup[event.endpoint], ...event.args, event.data);
 
   return () => websocket.close();
 });
@@ -221,7 +225,11 @@ useEffect(() => {
 This shows a proof of concept in React; however a [Manager websockets implementation](./Manager.md#data-stream)
 would be much more robust.
 
-## receiveError(endpoint, ...args, error) {#receiveError}
+## receiveError() {#receiveError}
+
+Another name for setError()
+
+## setError(endpoint, ...args, error) {#setError}
 
 Stores the result of [Endpoint](/rest/api/Endpoint) and args as the error provided.
 
@@ -229,7 +237,7 @@ Stores the result of [Endpoint](/rest/api/Endpoint) and args as the error provid
 
 Resolves a specific fetch, storing the `response` in cache.
 
-This is similar to receive, except it triggers resolution of an inflight fetch.
+This is similar to setResponse, except it triggers resolution of an inflight fetch.
 This means the corresponding optimistic update will no longer be applies.
 
 This is used in [NetworkManager](./NetworkManager.md), and should be used when

--- a/docs/core/api/Manager.md
+++ b/docs/core/api/Manager.md
@@ -207,7 +207,7 @@ export default class StreamManager implements Manager {
         try {
           const msg = JSON.parse(event.data);
           if (msg.type in this.endpoints)
-            controller.receive(this.endpoints[msg.type], ...msg.args, msg.data);
+            controller.setResponse(this.endpoints[msg.type], ...msg.args, msg.data);
         } catch (e) {
           console.error('Failed to handle message');
           console.error(e);
@@ -228,5 +228,5 @@ export default class StreamManager implements Manager {
 }
 ```
 
-[Controller.receive()](./Controller.md#receive) updates the Rest Hooks store
+[Controller.setResponse()](./Controller.md#setResponse) updates the Rest Hooks store
 with `event.data`.

--- a/docs/core/api/useCache.md
+++ b/docs/core/api/useCache.md
@@ -34,12 +34,12 @@ function useCache<
 
 Excellent to use data in the normalized cache without fetching.
 
-| Expiry Status | Returns           | Conditions                                                                                            |
-| ------------- | --------------- | ----------------------------------------------------------------------------------------------------- |
-| Invalid       | `undefined` | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../getting-started/expiry-policy.md#endpointinvalidifstale) |
-| Stale         | denormalized | (first-render, arg change) & [expiry &lt; now](../getting-started/expiry-policy.md)                   |
-| Valid         | denormalized | fetch completion                                                                                      |
-| Ignore        | `undefined` | `null` used as second argument                                                                        |
+| Expiry Status | Returns      | Conditions                                                                                                                                                                          |
+| ------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Invalid       | `undefined`  | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../getting-started/expiry-policy.md#endpointinvalidifstale) |
+| Stale         | denormalized | (first-render, arg change) & [expiry &lt; now](../getting-started/expiry-policy.md)                                                                                                 |
+| Valid         | denormalized | fetch completion                                                                                                                                                                    |
+|               | `undefined`  | `null` used as second argument                                                                                                                                                      |
 
 ## Example
 
@@ -139,7 +139,7 @@ const sortedUsers = new Query(
     const sorted = [...entries].sort((a, b) => a.name.localeCompare(b.name));
     if (asc) return sorted;
     return sorted.reverse();
-  }
+  },
 );
 
 function UsersPage() {

--- a/docs/core/api/useController.md
+++ b/docs/core/api/useController.md
@@ -13,7 +13,7 @@ function useController(): Controller;
 
 Provides access to [Controller](./Controller.md) which can be used for imperative control
 over the cache. For instance [fetch](./Controller.md#fetch), [invalidate](./Controller.md#invalidate),
-and [receive](./Controller.md#receive)
+and [setResponse](./Controller.md#setResponse)
 
 ```tsx
 import { useController } from '@rest-hooks/react';

--- a/docs/core/api/useDLE.md
+++ b/docs/core/api/useDLE.md
@@ -44,18 +44,18 @@ function useDLE<
 
 In case you cannot use [suspense](../getting-started/data-dependency.md#async-fallbacks), useDLE() is just like [useSuspense()](./useSuspense.md) but returns [D]ata [L]oading [E]rror values.
 
-| Expiry Status | Fetch           | Data | Loading           | Error             | Conditions                                                                                            |
-| ------------- | --------------- | ------- | ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
-| Invalid       | yes<sup>1</sup> | `undefined` | true               | false                | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../getting-started/expiry-policy.md#endpointinvalidifstale) |
-| Stale         | yes<sup>1</sup> | denormalized |  maybe<sup>2</sup> | false                | (first-render, arg change) & [expiry &lt; now](../getting-started/expiry-policy.md)                   |
-| Valid         | no              | denormalized | false                | maybe<sup>2</sup> | fetch completion                                                                                      |
-| Ignore        | no              | `undefined` | false                | false                | `null` used as second argument                                                                        |
+| Expiry Status | Fetch           | Data         | Loading | Error             | Conditions                                                                                                                                                                          |
+| ------------- | --------------- | ------------ | ------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Invalid       | yes<sup>1</sup> | `undefined`  | true    | false             | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../getting-started/expiry-policy.md#endpointinvalidifstale) |
+| Stale         | yes<sup>1</sup> | denormalized | false   | false             | (first-render, arg change) & [expiry &lt; now](../getting-started/expiry-policy.md)                                                                                                 |
+| Valid         | no              | denormalized | false   | maybe<sup>2</sup> | fetch completion                                                                                                                                                                    |
+|               | no              | `undefined`  | false   | false             | `null` used as second argument                                                                                                                                                      |
 
 :::note
 
 1. Identical fetches are automatically deduplicated
 2. [Hard errors](../getting-started/expiry-policy.md#error-policy) to be [caught](../getting-started/data-dependency#async-fallbacks) by [Error Boundaries](./AsyncBoundary.md)
-:::
+   :::
 
 <ConditionalDependencies hook="useDLE" />
 
@@ -113,4 +113,3 @@ render(<ProfileList />);
 ```
 
 </HooksPlayground>
-

--- a/docs/core/api/useFetch.md
+++ b/docs/core/api/useFetch.md
@@ -37,7 +37,7 @@ This can be useful for ensuring resources early in a render tree before they are
 | Invalid       | yes<sup>1</sup> | Promise     | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate) |
 | Stale         | yes<sup>1</sup> | Promise     | (first-render, arg change) & [expiry &lt; now](../getting-started/expiry-policy.md)                   |
 | Valid         | no              | `undefined` | fetch completion                                                                                      |
-| Ignore        | no              | `undefined` | `null` used as second argument                                                                        |
+|               | no              | `undefined` | `null` used as second argument                                                                        |
 
 :::note
 

--- a/docs/core/api/useSuspense.md
+++ b/docs/core/api/useSuspense.md
@@ -41,12 +41,12 @@ Excellent for guaranteed data rendering.
 
 Cache policy is [Stale-While-Revalidate](https://tools.ietf.org/html/rfc5861) by default but also [configurable](../getting-started/expiry-policy.md).
 
-| Expiry Status | Fetch           | Suspend           | Error             | Conditions                                                                                            |
-| ------------- | --------------- | ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
-| Invalid       | yes<sup>1</sup> | yes               | no                | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../getting-started/expiry-policy.md#endpointinvalidifstale) |
-| Stale         | yes<sup>1</sup> | no | no                | (first-render, arg change) & [expiry &lt; now](../getting-started/expiry-policy.md)                   |
-| Valid         | no              | no                | maybe<sup>2</sup> | fetch completion                                                                                      |
-| Ignore        | no              | no                | no                | `null` used as second argument                                                                        |
+| Expiry Status | Fetch           | Suspend | Error             | Conditions                                                                                                                                                                          |
+| ------------- | --------------- | ------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Invalid       | yes<sup>1</sup> | yes     | no                | not in store, [deletion](/rest/api/createResource#delete), [invalidation](./Controller.md#invalidate), [invalidIfStale](../getting-started/expiry-policy.md#endpointinvalidifstale) |
+| Stale         | yes<sup>1</sup> | no      | no                | (first-render, arg change) & [expiry &lt; now](../getting-started/expiry-policy.md)                                                                                                 |
+| Valid         | no              | no      | maybe<sup>2</sup> | fetch completion                                                                                                                                                                    |
+|               | no              | no      | no                | `null` used as second argument                                                                                                                                                      |
 
 :::note
 

--- a/docs/core/guides/debugging.md
+++ b/docs/core/guides/debugging.md
@@ -50,7 +50,7 @@ For example, when a useSuspense() hook is first mounted it might
 
 - Start by dispatching a fetch action
 - If no identical fetches are in-flight, the central store will then start the network call over HTTP
-- When the network call resolves, a receive action is sent to the store's reducer, updating the state.
+- When the network call resolves, a setResponse action is sent to the store's reducer, updating the state.
 - The component is re-rendered with the updated state, resolving the suspense.
 
 > [More about control flow](../api/Manager#control-flow)

--- a/examples/benchmark/reducer.js
+++ b/examples/benchmark/reducer.js
@@ -27,7 +27,7 @@ export default function addReducerSuite(suite) {
   controllerPop.dispatch = action => {
     populatedState = reducerPop(state, action);
   };
-  controllerPop.receive(getProject, data);
+  controllerPop.setResponse(getProject, data);
   controllerPop.dispatch = action => {
     reducerPop(populatedState, action);
   };
@@ -38,14 +38,14 @@ export default function addReducerSuite(suite) {
   return (
     suite
       .add('receiveLong', () => {
-        return controller.receive(getProject, data);
+        return controller.setResponse(getProject, data);
       })
       .add('receiveLongWithMerge', () => {
-        return controllerPop.receive(getProject, data);
+        return controllerPop.setResponse(getProject, data);
       })
       // biggest performance bump is not spreading in merge
       .add('receiveLongWithSimpleMerge', () => {
-        return controllerPop.receive(getProjectSimple, data);
+        return controllerPop.setResponse(getProjectSimple, data);
       })
   );
 }

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -138,9 +138,9 @@ export default class Controller<
 
   /**
    * Stores response in cache for given Endpoint and args.
-   * @see https://resthooks.io/docs/api/Controller#receive
+   * @see https://resthooks.io/docs/api/Controller#set
    */
-  receive = <
+  setResponse = <
     E extends EndpointInterface & {
       update?: EndpointUpdateFunction<E>;
     },
@@ -156,11 +156,28 @@ export default class Controller<
     return this.dispatch(action);
   };
 
+  // TODO: deprecate
+  /**
+   * Another name for setResponse
+   * @see https://resthooks.io/docs/api/Controller#setResponse
+   */
+  /* istanbul ignore next */ receive = <
+    E extends EndpointInterface & {
+      update?: EndpointUpdateFunction<E>;
+    },
+  >(
+    endpoint: E,
+    ...rest: readonly [...Parameters<E>, any]
+  ): Promise<void> => {
+    /* istanbul ignore next */
+    return this.setResponse(endpoint, ...rest);
+  };
+
   /**
    * Stores the result of Endpoint and args as the error provided.
-   * @see https://resthooks.io/docs/api/Controller#receiveError
+   * @see https://resthooks.io/docs/api/Controller#setError
    */
-  receiveError = <
+  setError = <
     E extends EndpointInterface & {
       update?: EndpointUpdateFunction<E>;
     },
@@ -175,6 +192,23 @@ export default class Controller<
       error: true,
     });
     return this.dispatch(action);
+  };
+
+  // TODO: deprecate
+  /**
+   * Another name for setError
+   * @see https://resthooks.io/docs/api/Controller#setError
+   */
+  /* istanbul ignore next */ receiveError = <
+    E extends EndpointInterface & {
+      update?: EndpointUpdateFunction<E>;
+    },
+  >(
+    endpoint: E,
+    ...rest: readonly [...Parameters<E>, Error]
+  ): Promise<void> => {
+    /* istanbul ignore next */
+    return this.setError(endpoint, ...rest);
   };
 
   /**

--- a/packages/react/src/components/__tests__/provider.tsx
+++ b/packages/react/src/components/__tests__/provider.tsx
@@ -204,7 +204,11 @@ describe('<CacheProvider />', () => {
     unmount();
     expect(debugspy).not.toHaveBeenCalled();
     await act(() =>
-      injector.controller.receive(endpoint, { id: 5 }, { id: 5, title: 'hi' }),
+      injector.controller.setResponse(
+        endpoint,
+        { id: 5 },
+        { id: 5, title: 'hi' },
+      ),
     );
     expect(debugspy).toHaveBeenCalled();
     expect(debugspy.mock.calls[0]).toMatchInlineSnapshot(`

--- a/packages/react/src/hooks/__tests__/useController/receive.tsx
+++ b/packages/react/src/hooks/__tests__/useController/receive.tsx
@@ -72,13 +72,13 @@ describe('receive', () => {
     const { result } = renderRestHook(() => {
       return {
         data: useCache(FutureArticleResource.get, payload.id),
-        receive: useController().receive,
+        setResponse: useController().setResponse,
       };
     });
     expect(result.current.data).toBeUndefined();
     const ep = FutureArticleResource.get;
     await act(async () => {
-      await result.current.receive(ep, 5, payload);
+      await result.current.setResponse(ep, 5, payload);
     });
     expect(result.current.data).toBeDefined();
     expect(result.current.data?.content).toEqual(payload.content);
@@ -88,8 +88,8 @@ describe('receive', () => {
     // TODO: move these to own unit tests if/when applicable
     () => {
       // @ts-expect-error
-      result.current.receive(ep, payload);
-      result.current.receive(
+      result.current.setResponse(ep, payload);
+      result.current.setResponse(
         ep,
         // @ts-expect-error
         {
@@ -99,12 +99,12 @@ describe('receive', () => {
       );
       const create = FutureArticleResource.create;
       const update = FutureArticleResource.update;
-      result.current.receive(create, payload, payload);
+      result.current.setResponse(create, payload, payload);
       // @ts-expect-error
-      result.current.receive(create, {}, payload, payload);
-      result.current.receive(update, payload.id, payload, payload);
+      result.current.setResponse(create, {}, payload, payload);
+      result.current.setResponse(update, payload.id, payload, payload);
       // @ts-expect-error
-      result.current.receive(update, payload, payload);
+      result.current.setResponse(update, payload, payload);
     };
   });
 
@@ -113,14 +113,14 @@ describe('receive', () => {
       return {
         data: useCache(FutureArticleResource.get, payload.id),
         err: useError(FutureArticleResource.get, payload.id),
-        receiveError: useController().receiveError,
+        setError: useController().setError,
       };
     });
     expect(result.current.data).toBeUndefined();
     const error = new Error('hi');
     const ep = FutureArticleResource.get;
     await act(async () => {
-      await result.current.receiveError(ep, 5, error);
+      await result.current.setError(ep, 5, error);
     });
     expect(result.current.data).toBeUndefined();
     expect(result.current.err).toBeDefined();
@@ -130,8 +130,8 @@ describe('receive', () => {
     // TODO: move these to own unit tests if/when applicable
     () => {
       // @ts-expect-error
-      result.current.receiveError(ep, error);
-      result.current.receiveError(
+      result.current.setError(ep, error);
+      result.current.setError(
         ep,
         // @ts-expect-error
         {
@@ -141,12 +141,12 @@ describe('receive', () => {
       );
       const create = FutureArticleResource.create;
       const update = FutureArticleResource.update;
-      result.current.receiveError(create, payload, error);
+      result.current.setError(create, payload, error);
       // @ts-expect-error
-      result.current.receiveError(create, {}, payload, error);
-      result.current.receiveError(update, payload.id, payload, error);
+      result.current.setError(create, {}, payload, error);
+      result.current.setError(update, payload.id, payload, error);
       // @ts-expect-error
-      result.current.receiveError(update, payload, error);
+      result.current.setError(update, payload, error);
     };
   });
 });

--- a/packages/test/src/mockState.ts
+++ b/packages/test/src/mockState.ts
@@ -77,9 +77,9 @@ export function dispatchFixture(
     });
   } else {
     if (error === true) {
-      controller.receiveError(endpoint, ...args, response);
+      controller.setError(endpoint, ...args, response);
     } else {
-      controller.receive(endpoint, ...args, response);
+      controller.setResponse(endpoint, ...args, response);
     }
   }
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2927,21 +2927,21 @@ __metadata:
 
 "@rest-hooks/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
   version: 4.1.2
-  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=077d24&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=1d885f&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^9.3.3
     flux-standard-action: ^2.1.1
-  checksum: 92f156943422f2d52f3d2e1bffdcf520e1c3d84ab6f1c90500da8e7f5f6ba8d6447d6a93b3847ba693c46703cb68a6e20531c8dd124329e4a6e4f85a7cd46e03
+  checksum: 1e1f0f3da6bb77d731e06273a62adcac545fdb68c143861140380305293da38476cce0e4b55d2dea10512d3927f13c580768351c40a9b86b0008ea35aea8d639
   languageName: node
   linkType: hard
 
 "@rest-hooks/endpoint@file:../packages/endpoint::locator=root-workspace-0b6124%40workspace%3A.":
   version: 3.2.5
-  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=a237ff&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/endpoint@file:../packages/endpoint#../packages/endpoint::hash=62104b&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-  checksum: 53f5f650874a02d30ca567b469e4ac08bb658396aa734be8b78543e773d8ce0a9b823e1034d561d444e11c2520a7da28361f496e0b41c0fe4ad8888881d6eb13
+  checksum: 654a9a85005702b63a9762fbeb68c4df40d9a69f7486fbcef7f09ed7e95124eca8bc6027ff30f5d892c1676af5430e5e0d9ce4af195877243899a3a4de26ea22
   languageName: node
   linkType: hard
 
@@ -2983,7 +2983,7 @@ __metadata:
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.1.2
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=34c13e&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=d312fb&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.1.2
@@ -2997,24 +2997,24 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 073b5c509ef3a60858d2ed2f68a9b070d28cd01caed0b346906ce020ece077cb849e62f0c215072709813bfe4928c680311da1b5652518f8175009cdc8dd9189
+  checksum: b468f4eb3228d0b9c514c60fadcd57be1eebbafbf4ef8563605483c6a98212d35a4fc50b9874c9c7e0c446e14a4ff539ecbba6a74506c9d02aab4b807bbcb871
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
   version: 6.2.3
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=cfb0c8&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=788205&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.5
     path-to-regexp: ^6.2.1
-  checksum: c770c5ad7c76816e6a970af056a451fbda881d2286752bb9c4ef1c31d67f889951047f3de0166a82ab1f41e9d49b75775f48f4716944335a17ab28d35ec13d22
+  checksum: 236d3693ada1830379c142903921b73e43195133ed4f8ec1a7ce272d7e6f1c82c5179bcf86ef48dd9fa8471d12123116aded9cd1acf91cbc08c0b675997334ad
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 9.1.2
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=03983d&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=256932&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react-hooks": ~8.0.0
@@ -3025,7 +3025,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: ffcf4c8e1e50225e833559ee3ab9d6d179a355892a855d8c31041e2e02ff5c081819dd394add536b42798be87d7f7614513530217c694c70ed58b75e984b087e
+  checksum: 74c35c63848b939a5e52f1618c5ebdc13bc1408c61c3b9cb89cdfa792531ece6c43babfa969018b81028b818f91019b8e1110cb839ff67d145ca0626c9f51cd2
   languageName: node
   linkType: hard
 
@@ -12972,7 +12972,7 @@ __metadata:
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.0.3
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=c0af37&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=2926cf&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.2.5
@@ -12984,7 +12984,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 8daafe8764ee80045d6eeda126a7e6c22e3ebbf5d20ffb80ead5d2dc0b7c3b7601814d03416a40261c54444e8ef4613c2e6f33bc8b28171853fcfb459edaef7d
+  checksum: 5a302bccbf546b6b66d9da9d7c46d199920510552158be5c990d3952bd5f273756f9a17b55d3648ab0cd0c96376eea524f8f42cd448b64c684a7a04d64ac90c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Way better names. Following naming convention of 'getResponse' and 'getError'

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
receive -> setResponse
receiveError -> setError

Mark TODO to deprecate previous names in next sem major. Otherwise, both will continue to exist.