### PR TITLE
fix: paginated() should replace all results to ensure updated cursor

### DIFF
--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -230,12 +230,14 @@ describe('RestEndpoint', () => {
     () => result.current.fetch(getNextPage);
     // @ts-expect-error
     () => result.current.fetch(getNextPage, { fake: 5 });
+    expect(result.current.nextPage).toEqual(paginatedFirstPage.nextPage);
     await act(async () => {
       await result.current.fetch(getNextPage, {
-        cursor: 2,
+        cursor: result.current.nextPage,
       });
     });
     expect(result.current.articles.map(({ id }) => id)).toEqual([5, 3, 7, 8]);
+    expect(result.current.nextPage).toBeUndefined();
   });
 
   it('should update on get for a paginated resource with parameter in path', async () => {

--- a/packages/rest/src/paginationUpdate.ts
+++ b/packages/rest/src/paginationUpdate.ts
@@ -22,7 +22,7 @@ export default function paginationUpdate<
         (pk: string) => !existingSet.has(pk),
       );
       const mergedResults: string[] = [...existingList, ...addedList];
-      return setIn(existing, path, mergedResults);
+      return setIn(newPage, path, mergedResults);
     },
   });
 }

--- a/packages/rest/src/test-fixtures.ts
+++ b/packages/rest/src/test-fixtures.ts
@@ -124,6 +124,5 @@ export const paginatedFirstPage = {
 };
 
 export const paginatedSecondPage = {
-  nextPage: null,
   data: { results: moreNested },
 };


### PR DESCRIPTION
Fixes #2353 .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Paginated requires getting the updated cursor, not the first page cursor

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Based on the [previous docs ](https://resthooks.io/docs/6.3/guides/infinite-scrolling-pagination) we need to be simply using the new results to completely replace other values like the cursor

