### PR TITLE
enhance: Remove @rest-hooks/endpoint peerDep for /hooks

### DIFF
--- a/docs/core/api/useCancelling.md
+++ b/docs/core/api/useCancelling.md
@@ -1,6 +1,7 @@
 ---
 title: useCancelling()
 ---
+
 import HooksPlayground from '@site/src/components/HooksPlayground';
 
 <head>
@@ -8,17 +9,16 @@ import HooksPlayground from '@site/src/components/HooksPlayground';
 </head>
 
 ```typescript
-function useCancelling<E extends EndpointInterface & {
-    extend: (o: {
-        signal?: AbortSignal | undefined;
-    }) => any;
-}>(endpoint: E, params: EndpointParam<E> | null): E
+function useCancelling<
+  E extends EndpointInterface & {
+    extend: (o: { signal?: AbortSignal }) => any;
+  },
+>(endpoint: E, ...args: readonly [...Parameters<E>] | readonly [null]): E {
 ```
 
 Builds an Endpoint that cancels fetch everytime params change
 
 [Aborts](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) inflight request if the parameters change.
-
 
 <HooksPlayground>
 

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -72,10 +72,10 @@
     "url": "https://github.com/coinbase/rest-hooks/issues"
   },
   "dependencies": {
-    "@babel/runtime": "^7.17.0"
+    "@babel/runtime": "^7.17.0",
+    "@rest-hooks/normalizr": "^9.3.5"
   },
   "peerDependencies": {
-    "@rest-hooks/endpoint": "^0.6.1 || ^1.0.0-0 || ^2.0.0-0 || ^3.0.0",
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",
     "react": "^16.8.4 || ^17.0.0 || ^18.0.0-0"
   },

--- a/packages/hooks/src/useDebounce.ts
+++ b/packages/hooks/src/useDebounce.ts
@@ -10,7 +10,7 @@ import { useEffect, useState } from 'react';
  * @example
  ```
  const debouncedFilter = useDebounced(filter, 200);
- const list = useResource(ListShape, { filter });
+ const list = useSuspense(ListShape, { filter });
  ```
  */
 export default function useDebounce<T>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4232,6 +4232,7 @@ __metadata:
     "@babel/cli": 7.20.7
     "@babel/core": 7.20.12
     "@babel/runtime": ^7.17.0
+    "@rest-hooks/normalizr": ^9.3.5
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     rollup: 2.79.1
@@ -4243,7 +4244,6 @@ __metadata:
     rollup-plugin-replace: ^2.2.0
     rollup-plugin-terser: ^7.0.2
   peerDependencies:
-    "@rest-hooks/endpoint": ^0.6.1 || ^1.0.0-0 || ^2.0.0-0 || ^3.0.0
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
@rest-hooks/endpoint is no longer installed as standard top level library since splitting normalizr implementations and consumption.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
We have a dep of @rest-hooks/normalizr instead, which is used for consumers like @rest-hooks/react hooks. Since we only use its types it won't increase bundle size.