### PR TITLE
fix: Compatibility with React 18 StrictMode

### DIFF
--- a/examples/todo-app/src/index.tsx
+++ b/examples/todo-app/src/index.tsx
@@ -1,12 +1,15 @@
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 
 import App from './App';
 import RootProvider from './RootProvider';
 
 const content = (
-  <RootProvider>
-    <App />
-  </RootProvider>
+  <StrictMode>
+    <RootProvider>
+      <App />
+    </RootProvider>
+  </StrictMode>
 );
 
 ReactDOM.createRoot(document.getElementById('react') || document.body).render(

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [4.1.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@4.1.4...@rest-hooks/core@4.1.5) (2023-01-14)
+
+### 📦 Package
+
+* Update linting packages ([#2351](https://github.com/coinbase/rest-hooks/issues/2351)) ([d3498ea](https://github.com/coinbase/rest-hooks/commit/d3498ea396dfbfdc745ec6e68920a714d8870fe8))
+
 ### [4.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/core@4.1.3...@rest-hooks/core@4.1.4) (2023-01-12)
 
 ### 📦 Package

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/core",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "Normalized Asynchronous data framework. Protocol and View agnostic.",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/normalizr": "^9.3.5",
+    "@rest-hooks/normalizr": "^9.3.6",
     "flux-standard-action": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/endpoint/CHANGELOG.md
+++ b/packages/endpoint/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.2.8](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@3.2.7...@rest-hooks/endpoint@3.2.8) (2023-01-14)
+
+### 📦 Package
+
+* Update linting packages ([#2351](https://github.com/coinbase/rest-hooks/issues/2351)) ([d3498ea](https://github.com/coinbase/rest-hooks/commit/d3498ea396dfbfdc745ec6e68920a714d8870fe8))
+
 ### [3.2.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/endpoint@3.2.6...@rest-hooks/endpoint@3.2.7) (2023-01-12)
 
 ### 📦 Package

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/endpoint",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "Declarative Network Interface Definitions",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [0.3.11](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.3.10...@rest-hooks/graphql@0.3.11) (2023-01-14)
+
+**Note:** Version bump only for package @rest-hooks/graphql
+
 ### [0.3.10](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/graphql@0.3.9...@rest-hooks/graphql@0.3.10) (2023-01-12)
 
 ### 📦 Package

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/graphql",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Endpoints for GraphQL APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/endpoint": "^3.2.7"
+    "@rest-hooks/endpoint": "^3.2.8"
   },
   "devDependencies": {
     "@babel/cli": "7.20.7",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [3.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.1.3...@rest-hooks/hooks@3.1.4) (2023-01-14)
+
+### 💅 Enhancement
+
+* Remove @rest-hooks/endpoint peerDep for /hooks ([#2360](https://github.com/coinbase/rest-hooks/issues/2360)) ([db57ea5](https://github.com/coinbase/rest-hooks/commit/db57ea5a4fe1276501b81934bdb284157b9f04f1))
+
 ### [3.1.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/hooks@3.1.2...@rest-hooks/hooks@3.1.3) (2023-01-12)
 
 ### 📦 Package

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/hooks",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Collection of composable data hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/normalizr": "^9.3.5"
+    "@rest-hooks/normalizr": "^9.3.6"
   },
   "peerDependencies": {
     "@types/react": "^16.8.4 || ^17.0.0 || ^18.0.0-0",

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [5.2.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@5.2.4...@rest-hooks/legacy@5.2.5) (2023-01-14)
+
+### 📦 Package
+
+* Update linting packages ([#2351](https://github.com/coinbase/rest-hooks/issues/2351)) ([d3498ea](https://github.com/coinbase/rest-hooks/commit/d3498ea396dfbfdc745ec6e68920a714d8870fe8))
+
 ### [5.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/legacy@5.2.3...@rest-hooks/legacy@5.2.4) (2023-01-12)
 
 ### 📦 Package

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/legacy",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "description": "Legacy features for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/normalizr/CHANGELOG.md
+++ b/packages/normalizr/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [9.3.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@9.3.5...@rest-hooks/normalizr@9.3.6) (2023-01-14)
+
+### 📦 Package
+
+* Update linting packages ([#2351](https://github.com/coinbase/rest-hooks/issues/2351)) ([d3498ea](https://github.com/coinbase/rest-hooks/commit/d3498ea396dfbfdc745ec6e68920a714d8870fe8))
+
 ### [9.3.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/normalizr@9.3.4...@rest-hooks/normalizr@9.3.5) (2023-01-12)
 
 ### 📦 Package

--- a/packages/normalizr/package.json
+++ b/packages/normalizr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/normalizr",
-  "version": "9.3.5",
+  "version": "9.3.6",
   "description": "Normalizes and denormalizes JSON according to schema for Redux and Flux applications",
   "homepage": "https://resthooks.io/docs/concepts/normalization",
   "bugs": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.1.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/react@7.1.4...@rest-hooks/react@7.1.5) (2023-01-14)
+
+### 🐛 Bug Fix
+
+* Compatibility with React 18 StrictMode ([e7174a3](https://github.com/coinbase/rest-hooks/commit/e7174a3c2aac3fd611d2e1305a4fe4927ef50e38))
+
+### 📦 Package
+
+* Update linting packages ([#2351](https://github.com/coinbase/rest-hooks/issues/2351)) ([d3498ea](https://github.com/coinbase/rest-hooks/commit/d3498ea396dfbfdc745ec6e68920a714d8870fe8))
+
 ### [7.1.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/react@7.1.3...@rest-hooks/react@7.1.4) (2023-01-12)
 
 ### 📦 Package

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -92,7 +92,7 @@ const articlesDescending = useCache(sortedArticles, { asc: false });
 
 ### ...all typed ...fast ...and consistent
 
-For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://resthooks.io/docs/getting-started/installation)
+For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://resthooks.io/docs/getting-started/installation) | [🥊Comparison](https://resthooks.io/docs/getting-started/comparison)
 
 ## Features
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/react",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "description": "Synchronous state management for async data. Safe. Fast. Resuable.",
   "sideEffects": [
     "./lib/hooks/useFocusEffect.native.js"
@@ -124,8 +124,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/core": "^4.1.4",
-    "@rest-hooks/use-enhanced-reducer": "^1.2.3"
+    "@rest-hooks/core": "^4.1.5",
+    "@rest-hooks/use-enhanced-reducer": "^1.2.4"
   },
   "peerDependencies": {
     "@react-navigation/native": "^6.0.0",

--- a/packages/react/src/components/CacheStore.tsx
+++ b/packages/react/src/components/CacheStore.tsx
@@ -47,19 +47,6 @@ function CacheStore({
       managers[i].init?.(state);
     }
     return () => {
-      // dispatching after unmount should be ignored
-      /* istanbul ignore else */
-      if (process.env.NODE_ENV !== 'production') {
-        (controller as any).dispatch = (action: any) => {
-          console.debug(
-            'Action dispatched after CacheProvider unmounted. This will be ignored.',
-          );
-          console.debug(JSON.stringify(action, undefined, 2));
-          return Promise.resolve();
-        };
-      } else {
-        (controller as any).dispatch = () => Promise.resolve();
-      }
       for (let i = 0; i < managers.length; ++i) {
         managers[i].cleanup();
       }

--- a/packages/react/src/components/__tests__/provider.tsx
+++ b/packages/react/src/components/__tests__/provider.tsx
@@ -24,7 +24,7 @@ describe('<CacheProvider />', () => {
   let debugspy: jest.SpyInstance;
   beforeEach(() => {
     warnspy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
-    debugspy = jest.spyOn(global.console, 'debug').mockImplementation(() => {});
+    debugspy = jest.spyOn(global.console, 'info').mockImplementation(() => {});
   });
   afterEach(() => {
     warnspy.mockRestore();
@@ -203,17 +203,15 @@ describe('<CacheProvider />', () => {
     expect(msg).toBeDefined();
     unmount();
     expect(debugspy).not.toHaveBeenCalled();
-    await act(() =>
-      injector.controller.setResponse(
-        endpoint,
-        { id: 5 },
-        { id: 5, title: 'hi' },
-      ),
+    await injector.controller.setResponse(
+      endpoint,
+      { id: 5 },
+      { id: 5, title: 'hi' },
     );
     expect(debugspy).toHaveBeenCalled();
     expect(debugspy.mock.calls[0]).toMatchInlineSnapshot(`
       [
-        "Action dispatched after CacheProvider unmounted. This will be ignored.",
+        "Action dispatched after unmount. This will be ignored.",
       ]
     `);
   });

--- a/packages/rest-hooks/CHANGELOG.md
+++ b/packages/rest-hooks/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.0.6](https://github.com/coinbase/rest-hooks/compare/rest-hooks@7.0.5...rest-hooks@7.0.6) (2023-01-14)
+
+### 🐛 Bug Fix
+
+* Compatibility with React 18 StrictMode ([e7174a3](https://github.com/coinbase/rest-hooks/commit/e7174a3c2aac3fd611d2e1305a4fe4927ef50e38))
+
+### 📦 Package
+
+* Update linting packages ([#2351](https://github.com/coinbase/rest-hooks/issues/2351)) ([d3498ea](https://github.com/coinbase/rest-hooks/commit/d3498ea396dfbfdc745ec6e68920a714d8870fe8))
+
 ### [7.0.5](https://github.com/coinbase/rest-hooks/compare/rest-hooks@7.0.4...rest-hooks@7.0.5) (2023-01-12)
 
 ### 📦 Package

--- a/packages/rest-hooks/README.md
+++ b/packages/rest-hooks/README.md
@@ -22,6 +22,9 @@ For [REST](https://resthooks.io/rest), [GraphQL](https://resthooks.io/graphql), 
 
 ## Installation
 
+It's now [recommended for new projects](https://resthooks.io/blog/2022/12/19/rest-hooks-7-react-native-web-nextjs) to use
+[@rest-hooks/react](https://www.npmjs.com/package/@rest-hooks/react) directly.
+
 ```bash
 npm install --save @rest-hooks/react @rest-hooks/test @rest-hooks/hooks @rest-hooks/rest
 ```
@@ -72,11 +75,10 @@ return (
 );
 ```
 
-### And [subscriptions](https://resthooks.io/docs/api/useSubscription)
+### And [subscriptions](https://resthooks.io/docs/api/useLive)
 
 ```tsx
-const price = useSuspense(PriceResource.get, { symbol });
-useSubscription(PriceResource.get, { symbol });
+const price = useLive(PriceResource.get, { symbol });
 return price.value;
 ```
 

--- a/packages/rest-hooks/package.json
+++ b/packages/rest-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-hooks",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Asynchronous data framework for React",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -109,7 +109,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/endpoint": "^3.2.7",
+    "@rest-hooks/endpoint": "^3.2.8",
     "redux": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [6.2.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@6.2.5...@rest-hooks/rest@6.2.6) (2023-01-14)
+
+**Note:** Version bump only for package @rest-hooks/rest
+
 ### [6.2.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@6.2.4...@rest-hooks/rest@6.2.5) (2023-01-12)
 
 ### 🐛 Bug Fix

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "6.2.5",
+  "version": "6.2.6",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.0",
-    "@rest-hooks/endpoint": "^3.2.7",
+    "@rest-hooks/endpoint": "^3.2.8",
     "path-to-regexp": "^6.2.1"
   },
   "devDependencies": {

--- a/packages/use-enhanced-reducer/CHANGELOG.md
+++ b/packages/use-enhanced-reducer/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [1.2.4](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.2.3...@rest-hooks/use-enhanced-reducer@1.2.4) (2023-01-14)
+
+### 🐛 Bug Fix
+
+* Compatibility with React 18 StrictMode ([e7174a3](https://github.com/coinbase/rest-hooks/commit/e7174a3c2aac3fd611d2e1305a4fe4927ef50e38))
+
 ### [1.2.3](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/use-enhanced-reducer@1.2.2...@rest-hooks/use-enhanced-reducer@1.2.3) (2023-01-12)
 
 ### 📦 Package

--- a/packages/use-enhanced-reducer/package.json
+++ b/packages/use-enhanced-reducer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/use-enhanced-reducer",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Add powerful orchestration to hooks-based Flux stores",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4126,14 +4126,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/core@^4.1.4, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
+"@rest-hooks/core@^4.1.5, @rest-hooks/core@workspace:^, @rest-hooks/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/core@workspace:packages/core"
   dependencies:
     "@babel/cli": 7.20.7
     "@babel/core": 7.20.12
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/normalizr": ^9.3.5
+    "@rest-hooks/normalizr": ^9.3.6
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     flux-standard-action: ^2.1.1
@@ -4150,7 +4150,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/endpoint@^3.2.6, @rest-hooks/endpoint@^3.2.7, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
+"@rest-hooks/endpoint@^3.2.6, @rest-hooks/endpoint@^3.2.8, @rest-hooks/endpoint@workspace:^, @rest-hooks/endpoint@workspace:packages/endpoint":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/endpoint@workspace:packages/endpoint"
   dependencies:
@@ -4210,7 +4210,7 @@ __metadata:
     "@babel/cli": 7.20.7
     "@babel/core": 7.20.12
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/endpoint": ^3.2.7
+    "@rest-hooks/endpoint": ^3.2.8
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -4232,7 +4232,7 @@ __metadata:
     "@babel/cli": 7.20.7
     "@babel/core": 7.20.12
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/normalizr": ^9.3.5
+    "@rest-hooks/normalizr": ^9.3.6
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     rollup: 2.79.1
@@ -4307,7 +4307,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rest-hooks/normalizr@^9.3.4, @rest-hooks/normalizr@^9.3.5, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
+"@rest-hooks/normalizr@^9.3.4, @rest-hooks/normalizr@^9.3.6, @rest-hooks/normalizr@workspace:^, @rest-hooks/normalizr@workspace:packages/normalizr":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/normalizr@workspace:packages/normalizr"
   dependencies:
@@ -4336,8 +4336,8 @@ __metadata:
     "@babel/cli": 7.20.7
     "@babel/core": 7.20.12
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/core": ^4.1.4
-    "@rest-hooks/use-enhanced-reducer": ^1.2.3
+    "@rest-hooks/core": ^4.1.5
+    "@rest-hooks/use-enhanced-reducer": ^1.2.4
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5
@@ -4400,7 +4400,7 @@ __metadata:
     "@babel/cli": 7.20.7
     "@babel/core": 7.20.12
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/endpoint": ^3.2.7
+    "@rest-hooks/endpoint": ^3.2.8
     "@types/babel__core": ^7
     "@types/copyfiles": ^2
     "@types/path-to-regexp": ^1.7.0
@@ -4502,7 +4502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rest-hooks/use-enhanced-reducer@^1.2.3, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
+"@rest-hooks/use-enhanced-reducer@^1.2.4, @rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer":
   version: 0.0.0-use.local
   resolution: "@rest-hooks/use-enhanced-reducer@workspace:packages/use-enhanced-reducer"
   dependencies:
@@ -19948,7 +19948,7 @@ __metadata:
     "@babel/cli": 7.20.7
     "@babel/core": 7.20.12
     "@babel/runtime": ^7.17.0
-    "@rest-hooks/endpoint": ^3.2.7
+    "@rest-hooks/endpoint": ^3.2.8
     "@types/babel__core": ^7
     downlevel-dts: ^0.10.0
     npm-run-all: ^4.1.5


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state

React 18 StrictMode calls useEffect callback twice; making it look like the component unmounted before it did.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
All sideeffects done in unmount must be reapplied on useEffect mount. Currently our dispatch is asymetric.