### PR TITLE
feat: Add Interceptors

### DIFF
--- a/docs/core/api/mockInitialState.md
+++ b/docs/core/api/mockInitialState.md
@@ -11,23 +11,35 @@ used in [<MockResolver /\>](./MockResolver) to process the results prop. However
 can also be useful to send into a normal provider when testing more complete flows
 that need to handle `dispatches` (and thus fetch).
 
-## Arguments
+### Arguments
 
-### results
+#### results
 
 ```typescript
-export interface SuccessFixture {
-  request: ReadShape<Schema, object>;
-  params: object;
-  result: object | string | number;
-  error?: false;
+export interface SuccessFixture<
+  E extends EndpointInterface = EndpointInterface,
+> {
+  readonly endpoint: E;
+  readonly args: Parameters<E>;
+  readonly response:
+    | ResolveType<E>
+    | ((...args: Parameters<E>) => ResolveType<E>);
+  readonly error?: false;
+  /** Number of miliseconds to wait before resolving */
+  readonly delay?: number;
+  /** Waits to run `response()` after `delay` time */
+  readonly delayCollapse?: boolean;
 }
 
-export interface ErrorFixture {
-  request: ReadShape<Schema, object>;
-  params: object;
-  result: Error;
-  error: true;
+export interface ErrorFixture<E extends EndpointInterface = EndpointInterface> {
+  readonly endpoint: E;
+  readonly args: Parameters<E>;
+  readonly response: any;
+  readonly error: true;
+  /** Number of miliseconds to wait before resolving */
+  readonly delay?: number;
+  /** Waits to run `response()` after `delay` time */
+  readonly delayCollapse?: boolean;
 }
 
 export type Fixture = SuccessFixture | ErrorFixture;
@@ -36,11 +48,6 @@ export type Fixture = SuccessFixture | ErrorFixture;
 This prop specifies the fixtures to use data from. Each item represents a fetch defined by the
 [Endpoint](/rest/api/Endpoint) and params. `Result` contains the JSON response expected from said fetch.
 
-## Returns
-
-```typescript
-State
-```
 
 This can be used as the initialState prop for [<CacheProvider /\>](./CacheProvider)
 
@@ -76,5 +83,5 @@ const results = [
 
 <CacheProvider initialState={mockInitialState(results)}>
   <MyComponentToTest />
-</CacheProvider>
+</CacheProvider>;
 ```

--- a/docs/core/guides/storybook.md
+++ b/docs/core/guides/storybook.md
@@ -94,13 +94,10 @@ if (process.env.NODE_ENV !== 'production') {
       },
       {
         endpoint: ArticleResource.update,
-        args: [{ id: 532 }] as const,
-        response: {
-          id: 532,
-          content: 'updated "never again"',
-          author: 23,
-          contributors: [5],
-        },
+        response: ({ id }, body) => ({
+          ...body,
+          id,
+        }),
       },
     ],
     empty: [

--- a/docs/rest/api/RestEndpoint.md
+++ b/docs/rest/api/RestEndpoint.md
@@ -674,6 +674,12 @@ export const TodoResource = {
 };
 ```
 
+## testKey(key): boolean
+
+Returns `true` if the provided (fetch) key matches this endpoint.
+
+This is used for mock interceptors with with [<MockResolver /&gt;](/docs/api/MockResolver)
+
 ## extend(options): Endpoint {#extend}
 
 Can be used to further customize the endpoint definition

--- a/docs/rest/guides/nested-response.md
+++ b/docs/rest/guides/nested-response.md
@@ -19,13 +19,12 @@ Next we'll provide a definition of nested members in the [schema][3] member.
 {
 endpoint: new RestEndpoint({ urlPrefix: 'http://fakeapi.com',
 path: '/article/:id',}),
-args: [{ id: '5' }],
-response: {
-id: '5',
+response: ({ id }) => ({
+id,
 author: { id: '123', name: 'Jim' },
 content: 'Happy day',
 contributors: [{ id: '100', name: 'Eliza' }],
-},
+}),
 delay: 150,
 },
 ]}>

--- a/docs/rest/guides/optimistic-updates.md
+++ b/docs/rest/guides/optimistic-updates.md
@@ -209,6 +209,17 @@ more complicated transforms. To make it more obvious we're using a simple counte
 endpoint: new RestEndpoint({path: '/api/count'}),
 args: [],
 response: { count: 0 }
+},
+{
+  endpoint: new RestEndpoint({
+    path: '/api/count/increment',
+    method: 'POST',
+    body: undefined,
+  }),
+  response: () => ({
+    "count": (globalThis.RH_count = (globalThis.RH_count ?? 0) + 1),
+  }),
+  delay: () => 500 + Math.random() * 4500,
 }
 ]}>
 
@@ -344,7 +355,7 @@ We use [snap.fetchedAt](/docs/api/Snapshot#fetchedat) in our [getOptimisticRespo
 endpoint: new RestEndpoint({path: '/api/count'}),
 args: [],
 response: { count: 0, updatedAt: Date.now() }
-}
+},
 ]}>
 
 ```ts title="api/Count.ts" {24-29,35}

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@9.2.4...@rest-hooks/experimental@9.3.0) (2023-01-23)
+
+### 🚀 Features
+
+* makeRenderRestHook(CacheProvider) and React 18 testing ([#2328](https://github.com/coinbase/rest-hooks/issues/2328)) ([0e9e51e](https://github.com/coinbase/rest-hooks/commit/0e9e51e3bce3c9c978888a734c43be8d1fe3ae55))
+
 ### [9.2.5](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/experimental@9.2.4...@rest-hooks/experimental@9.2.5) (2023-01-23)
 
 ### 🚀 Features

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/experimental",
-  "version": "9.2.5",
+  "version": "9.3.0",
   "description": "Experimental extensions for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.cjs.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+### [7.1.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/react@7.1.6...@rest-hooks/react@7.1.7) (2023-01-23)
+
+### 🐛 Bug Fix
+
+* Add back DenormalizeCacheContext for older versions of redux ([8e0acab](https://github.com/coinbase/rest-hooks/commit/8e0acabbd86ca8cd2cd45d07c8e815df8c7375d9))
+
 ### [7.1.6](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/react@7.1.5...@rest-hooks/react@7.1.6) (2023-01-23)
 
 ### 🚀 Features

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/react",
-  "version": "7.1.6",
+  "version": "7.1.7",
   "description": "Normalized state management for async data. Safe. Fast. Reusable.",
   "sideEffects": [
     "./lib/hooks/useFocusEffect.native.js"

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -21,8 +21,14 @@ const dispatch = (value: ActionTypes) => {
   return Promise.resolve();
 };
 
+// this is not needed anymore, but keeping around for backcompatibility
 /** @deprecated use Controller.dispatch */
 export const DispatchContext = createContext(dispatch);
+/** @deprecated */
+export const DenormalizeCacheContext = createContext<DenormalizeCache>({
+  entities: {},
+  results: {},
+});
 
 export const ControllerContext = createContext<Controller>(
   new Controller({

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -50,6 +50,7 @@ export {
   DispatchContext,
   ControllerContext,
   StoreContext,
+  DenormalizeCacheContext,
   type Store,
 } from './context.js';
 export * as __INTERNAL__ from './internal.js';

--- a/packages/react/src/makeCacheProvider.tsx
+++ b/packages/react/src/makeCacheProvider.tsx
@@ -1,76 +1,24 @@
-import { actionTypes, CombinedActionTypes } from '@rest-hooks/core';
 import React from 'react';
 
-import { State, CacheProvider, Manager, Controller } from './index.js';
+import { State, CacheProvider, Manager } from './index.js';
 
 export default function makeCacheProvider(
   managers: Manager[],
   initialState?: State<unknown>,
-  act?: Act,
 ): (props: { children: React.ReactNode }) => JSX.Element {
   return function ConfiguredCacheProvider({
     children,
   }: {
     children: React.ReactNode;
   }) {
-    class ActController<
-      D extends GenericDispatch = CompatibleDispatch,
-    > extends Controller<D> {
-      #dispatch: any;
-
-      constructor(...args: any) {
-        super(...args);
-        const set = (dispatch: any) => {
-          if (act) {
-            this.#dispatch = (v: any) => {
-              let promise: any;
-              if (
-                [actionTypes.FETCH_TYPE, actionTypes.RECEIVE_TYPE].includes(
-                  v.type,
-                )
-              ) {
-                act(() => {
-                  promise = dispatch(v);
-                });
-              } else {
-                return dispatch(v);
-              }
-              return promise;
-            };
-          } else {
-            this.#dispatch = dispatch;
-          }
-        };
-        set(this.dispatch);
-        Object.defineProperty(this, 'dispatch', {
-          get: () => this.#dispatch,
-          set,
-        });
-      }
-    }
     if (initialState) {
       return (
-        <CacheProvider
-          managers={managers}
-          initialState={initialState}
-          Controller={ActController}
-        >
+        <CacheProvider managers={managers} initialState={initialState}>
           {children}
         </CacheProvider>
       );
     } else {
-      return (
-        <CacheProvider managers={managers} Controller={ActController}>
-          {children}
-        </CacheProvider>
-      );
+      return <CacheProvider managers={managers}>{children}</CacheProvider>;
     }
   };
 }
-
-export type GenericDispatch = (value: any) => Promise<void>;
-export type CompatibleDispatch = (value: CombinedActionTypes) => Promise<void>;
-type Act = {
-  (callback: () => Promise<void | undefined>): Promise<undefined>;
-  (callback: () => void | undefined): void;
-};

--- a/packages/rest/CHANGELOG.md
+++ b/packages/rest/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.3.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@6.2.6...@rest-hooks/rest@6.3.0) (2023-01-23)
+
+### 🚀 Features
+
+* Add RestEndpoint.testKey() ([#2380](https://github.com/coinbase/rest-hooks/issues/2380)) ([c84c08f](https://github.com/coinbase/rest-hooks/commit/c84c08f4a135d87ed1aaedf36f7ab689154cba50))
+* makeRenderRestHook(CacheProvider) and React 18 testing ([#2328](https://github.com/coinbase/rest-hooks/issues/2328)) ([0e9e51e](https://github.com/coinbase/rest-hooks/commit/0e9e51e3bce3c9c978888a734c43be8d1fe3ae55))
+* More fleixble types for hookableResource ([6d388af](https://github.com/coinbase/rest-hooks/commit/6d388afcb178a3d139c807e8b3163bcea371f86c))
+
+### 💅 Enhancement
+
+* Remove deprecated string.substr() calls ([de3ed4f](https://github.com/coinbase/rest-hooks/commit/de3ed4f6db938aece3e3926e35de5a1c51a195c5))
+
 ### [6.2.7](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/rest@6.2.6...@rest-hooks/rest@6.2.7) (2023-01-23)
 
 ### 🚀 Features

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/rest",
-  "version": "6.2.7",
+  "version": "6.3.0",
   "description": "Endpoints for REST APIs",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/rest/src/RestEndpoint.d.ts
+++ b/packages/rest/src/RestEndpoint.d.ts
@@ -55,6 +55,9 @@ export interface RestInstance<
   /** @see https://resthooks.io/rest/api/RestEndpoint#process */
   process(value: any, ...args: Parameters<F>): ResolveType<F>;
 
+  /* utilities */
+  testKey(key: string): boolean;
+
   /* extenders */
   paginated<
     E extends RestInstance<FetchFunction, Schema | undefined, undefined>,

--- a/packages/rest/src/RestEndpoint.d.ts
+++ b/packages/rest/src/RestEndpoint.d.ts
@@ -56,6 +56,7 @@ export interface RestInstance<
   process(value: any, ...args: Parameters<F>): ResolveType<F>;
 
   /* utilities */
+  /** @see https://resthooks.io/rest/api/RestEndpoint#testKey */
   testKey(key: string): boolean;
 
   /* extenders */

--- a/packages/rest/src/RestEndpoint.js
+++ b/packages/rest/src/RestEndpoint.js
@@ -1,4 +1,5 @@
 import { Endpoint } from '@rest-hooks/endpoint';
+import { pathToRegexp } from 'path-to-regexp';
 
 import NetworkError from './NetworkError.js';
 import paginationUpdate from './paginationUpdate.js';
@@ -165,6 +166,18 @@ Response (first 300 characters): ${text.substring(0, 300)}`;
 
   errorPolicy(error) {
     return error.status >= 500 ? 'soft' : undefined;
+  }
+
+  get pathRegex() {
+    return pathToRegexp(this.path);
+  }
+
+  testKey(key) {
+    const prefix = this.method + ' ' + this.urlPrefix;
+    if (!key.startsWith(prefix)) return false;
+    let lastQuestion = key.lastIndexOf('?');
+    if (lastQuestion === -1) lastQuestion = undefined;
+    return this.pathRegex.test(key.substring(prefix.length, lastQuestion));
   }
 
   extend(options) {

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -37,6 +37,7 @@ const getUser = new RestEndpoint({
   name: 'User.get',
   schema: User,
   method: 'GET',
+  searchParams: {} as { extra?: string },
 });
 export class PaginatedArticle extends Entity {
   readonly id: number | undefined = undefined;
@@ -54,7 +55,8 @@ export class PaginatedArticle extends Entity {
   };
 }
 const getArticleList = new RestEndpoint({
-  path: 'http\\://test.com/article-paginated',
+  urlPrefix: 'http://test.com',
+  path: '/article-paginated',
   name: 'get',
   schema: {
     nextPage: '',
@@ -124,6 +126,14 @@ describe('RestEndpoint', () => {
 
   afterEach(() => {
     nock.cleanAll();
+  });
+
+  it('testKey should match keys', () => {
+    expect(getArticleList.testKey(getArticleList.key())).toBeTruthy();
+    expect(
+      getUser.testKey(getUser.key({ id: '100', extra: '345' })),
+    ).toBeTruthy();
+    expect(getUser.testKey(getUser.key({ id: 'xxx?*' }))).toBeTruthy();
   });
 
   it('should assign members', () => {

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [10.1.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@10.0.0...@rest-hooks/test@10.1.0) (2023-01-23)
+
+### 🚀 Features
+
+* Add Interceptors ([#2380](https://github.com/coinbase/rest-hooks/issues/2380)) ([53653ba](https://github.com/coinbase/rest-hooks/commit/53653ba9462510938f57cfe4ff907fda2efcc874))
+
+### 📝 Documentation
+
+* Update docs for @rest-hooks/test@10 ([86c630b](https://github.com/coinbase/rest-hooks/commit/86c630b4b313679c7a441cc7fa060dfb9005d1da))
+
 ### [10.0.0](https://github.com/coinbase/rest-hooks/compare/@rest-hooks/test@9.1.4...@rest-hooks/test@10.0.0) (2023-01-23)
 
 ### ⚠ 💥 BREAKING CHANGES

--- a/packages/test/README.md
+++ b/packages/test/README.md
@@ -101,7 +101,6 @@ export const FullArticleList = ({ result }) => (
     <ArticleList maxResults={10} />
   </MockResolver>
 );
-
 ```
 
 </details>
@@ -116,24 +115,30 @@ import options from './fixtures';
 const renderRestHook = makeRenderRestHook(CacheProvider);
 
 it('should resolve list', async () => {
-  const { result } = renderRestHook(() => {
-    return useSuspense(ArticleResource.list(), {
-      maxResults: 10,
-    });
-  }, { fixtures: options.full });
+  const { result } = renderRestHook(
+    () => {
+      return useSuspense(ArticleResource.list(), {
+        maxResults: 10,
+      });
+    },
+    { initialFixtures: options.full },
+  );
   expect(result.current).toBeDefined();
   expect(result.current.length).toBe(2);
   expect(result.current[0]).toBeInstanceOf(ArticleResource);
 });
 
 it('should throw errors on bad network', async () => {
-  const { result } = renderRestHook(() => {
-    return useSuspense(ArticleResource.list(), {
-      maxResults: 10,
-    });
-  }, { fixtures: options.error });
-    expect(result.error).toBeDefined();
-    expect((result.error as any).status).toBe(400);
+  const { result } = renderRestHook(
+    () => {
+      return useSuspense(ArticleResource.list(), {
+        maxResults: 10,
+      });
+    },
+    { initialFixtures: options.error },
+  );
+  expect(result.error).toBeDefined();
+  expect((result.error as any).status).toBe(400);
 });
 ```
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rest-hooks/test",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Testing utilities for Rest Hooks",
   "sideEffects": false,
   "main": "dist/index.js",

--- a/packages/test/src/MockResolver.tsx
+++ b/packages/test/src/MockResolver.tsx
@@ -1,17 +1,14 @@
-import {
-  actionTypes,
-  ActionTypes,
-  ControllerContext,
-  useController,
-} from '@rest-hooks/react';
+import { ControllerContext, useController } from '@rest-hooks/react';
 import { useCallback, useMemo } from 'react';
 import React from 'react';
 
-import { Fixture, dispatchFixture } from './mockState.js';
+import { createControllerInterceptor } from './createControllerInterceptor.js';
+import { createFixtureMap } from './createFixtureMap.js';
+import type { Fixture, Interceptor } from './fixtureTypes.js';
 
 type Props = {
   children: React.ReactNode;
-  fixtures: Fixture[];
+  readonly fixtures: (Fixture | Interceptor)[];
   silenceMissing: boolean;
 };
 
@@ -28,90 +25,21 @@ export default function MockResolver({
 }: Props) {
   const controller = useController();
 
-  const fixtureMap = useMemo(() => {
-    const map: Record<string, Fixture> = {};
-    for (const fixture of fixtures) {
-      const key = fixture.endpoint.key(...fixture.args);
-      map[key] = fixture;
-    }
-    return map;
-  }, [fixtures]);
-
-  const dispatchInterceptor = useCallback(
-    function (action: ActionTypes) {
-      if (action.type === actionTypes.FETCH_TYPE) {
-        const { key, resolve, reject } = action.meta;
-        // TODO(breaking): remove support for Date type in 'Receive' action
-        const createdAt =
-          typeof action.meta.createdAt !== 'number'
-            ? action.meta.createdAt.getTime()
-            : action.meta.createdAt;
-        if (Object.hasOwn(fixtureMap, key)) {
-          const fixture = fixtureMap[key];
-          // All updates must be async or React will complain about re-rendering in same pass
-          setTimeout(() => {
-            try {
-              dispatchFixture(
-                'endpoint' in action
-                  ? {
-                      ...fixture,
-                      endpoint: action.endpoint as typeof fixture.endpoint,
-                    }
-                  : fixture,
-                controller,
-                createdAt,
-              );
-
-              // dispatch goes through user-code that can sometimes fail.
-              // let's ensure we always complete the promise
-            } finally {
-              const complete = fixture.error ? reject : resolve;
-              complete(fixture.response);
-            }
-          }, fixture.delay ?? 0);
-          return Promise.resolve();
-        }
-        if (!silenceMissing) {
-          // This is only a warn because sometimes this is intentional
-          console.warn(
-            `<MockResolver/> received a dispatch:
-  ${JSON.stringify(action, undefined, 2)}
-  for which there is no matching fixture.
-
-  If you were expecting to see results, it is likely due to data not being found in fixtures.
-  Double check your params and Endpoint match. For example:
-
-  useResource(ArticleResource.list(), { maxResults: 10 });
-
-  and
-
-  {
-    endpoint: ArticleResource.list(),
-    args: [{ maxResults: 10 }],
-    response: [],
-  }`,
-          );
-        }
-      } else if (action.type === actionTypes.SUBSCRIBE_TYPE) {
-        const { key } = action.meta;
-        if (Object.hasOwn(fixtureMap, key)) {
-          return Promise.resolve();
-        }
-      }
-      return controller.dispatch(action);
-    },
-    [controller, fixtureMap, silenceMissing],
+  const [fixtureMap, interceptors] = useMemo(
+    () => createFixtureMap(fixtures),
+    [fixtures],
   );
-  const controllerInterceptor = useMemo(() => {
-    return new (controller.constructor as any)({
-      ...controller,
-      dispatch: dispatchInterceptor,
-    });
-    /*TODO: this is better but we need to disallow destructuring with controller
-    return Object.create(controller, {
-      dispatch: { value: dispatchInterceptor },
-    });*/
-  }, [controller, dispatchInterceptor]);
+
+  const controllerInterceptor = useMemo(
+    () =>
+      createControllerInterceptor(
+        controller,
+        fixtureMap,
+        interceptors,
+        silenceMissing,
+      ),
+    [interceptors, controller, fixtureMap, silenceMissing],
+  );
 
   return (
     <ControllerContext.Provider value={controllerInterceptor}>

--- a/packages/test/src/browser.ts
+++ b/packages/test/src/browser.ts
@@ -5,6 +5,6 @@ Object.hasOwn =
   };
 import mockInitialState from './mockState.js';
 export { default as MockResolver } from './MockResolver.js';
-export type { Fixture, SuccessFixture, ErrorFixture } from './mockState.js';
+export type { Fixture, SuccessFixture, ErrorFixture } from './fixtureTypes.js';
 
 export { mockInitialState };

--- a/packages/test/src/collapseFixture.ts
+++ b/packages/test/src/collapseFixture.ts
@@ -1,0 +1,17 @@
+import type { Fixture, Interceptor } from './fixtureTypes.js';
+
+export function collapseFixture(fixture: Fixture | Interceptor, args: any[]) {
+  let error = 'error' in fixture ? fixture.error : false;
+  let response = fixture.response;
+  if (typeof fixture.response === 'function') {
+    try {
+      response = fixture.response(...args);
+      // dispatch goes through user-code that can sometimes fail.
+      // let's ensure we always handle errors
+    } catch (e: any) {
+      response = e;
+      error = true;
+    }
+  }
+  return { response, error };
+}

--- a/packages/test/src/createControllerInterceptor.tsx
+++ b/packages/test/src/createControllerInterceptor.tsx
@@ -1,0 +1,100 @@
+import { actionTypes, ActionTypes, Controller } from '@rest-hooks/react';
+
+import { collapseFixture } from './collapseFixture.js';
+import type { Fixture, Interceptor } from './fixtureTypes.js';
+
+export function createControllerInterceptor(
+  controller: Controller,
+  fixtureMap: Record<string, Fixture>,
+  interceptors: Interceptor[],
+  silenceMissing = false,
+) {
+  const dispatchInterceptor = function (action: ActionTypes) {
+    if (action.type === actionTypes.FETCH_TYPE) {
+      // eslint-disable-next-line prefer-const
+      let { key, args } = action.meta;
+      let fixture: Fixture | Interceptor | undefined;
+      if (Object.hasOwn(fixtureMap, key)) {
+        fixture = fixtureMap[key];
+        if (!args) args = fixture.args;
+        // exact matches take priority; now test ComputedFixture
+      } else {
+        for (const cfix of interceptors) {
+          if (cfix.endpoint.testKey(key)) {
+            fixture = cfix;
+            break;
+          }
+        }
+      }
+      // we have a match
+      if (fixture !== undefined) {
+        const replacedAction: typeof action = {
+          ...action,
+        };
+        const delayMs =
+          typeof fixture.delay === 'function'
+            ? fixture.delay(...(args as any))
+            : fixture.delay ?? 0;
+
+        replacedAction.payload = () =>
+          new Promise((resolve, reject) => {
+            if (fixture !== undefined) {
+              // delayCollapse determines when the fixture function is 'collapsed' (aka 'run')
+              // collapsed: https://en.wikipedia.org/wiki/Copenhagen_interpretation
+              if (fixture.delayCollapse) {
+                setTimeout(() => {
+                  const result = collapseFixture(fixture as any, args as any);
+                  const complete = result.error ? reject : resolve;
+                  complete(result.response);
+                }, delayMs);
+              } else {
+                const result = collapseFixture(fixture, args as any);
+                const complete = result.error ? reject : resolve;
+                setTimeout(() => {
+                  complete(result.response);
+                }, delayMs);
+              }
+            }
+          });
+
+        return controller.dispatch(replacedAction);
+      }
+      if (!silenceMissing) {
+        // This is only a warn because sometimes this is intentional
+        console.warn(
+          `<MockResolver/> received a dispatch:
+  ${JSON.stringify(action, undefined, 2)}
+  for which there is no matching fixture.
+
+  If you were expecting to see results, it is likely due to data not being found in fixtures.
+  Double check your params and Endpoint match. For example:
+
+  useResource(ArticleResource.list(), { maxResults: 10 });
+
+  and
+
+  {
+    endpoint: ArticleResource.list(),
+    args: [{ maxResults: 10 }],
+    response: [],
+  }`,
+        );
+      }
+    } else if (action.type === actionTypes.SUBSCRIBE_TYPE) {
+      const { key } = action.meta;
+      if (Object.hasOwn(fixtureMap, key)) {
+        return Promise.resolve();
+      }
+    }
+    return controller.dispatch(action);
+  };
+  const controllerInterceptor = new (controller.constructor as any)({
+    ...controller,
+    dispatch: dispatchInterceptor,
+  });
+  /*TODO: this is better but we need to disallow destructuring with controller
+    return Object.create(controller, {
+      dispatch: { value: dispatchInterceptor },
+    });*/
+  return controllerInterceptor;
+}

--- a/packages/test/src/createFixtureMap.tsx
+++ b/packages/test/src/createFixtureMap.tsx
@@ -1,0 +1,15 @@
+import type { Fixture, Interceptor } from './fixtureTypes.js';
+
+export function createFixtureMap(fixtures: (Fixture | Interceptor)[] = []) {
+  const map: Record<string, Fixture> = {};
+  const computed: Interceptor[] = [];
+  for (const fixture of fixtures) {
+    if ('args' in fixture) {
+      const key = fixture.endpoint.key(...fixture.args);
+      map[key] = fixture;
+    } else {
+      computed.push(fixture);
+    }
+  }
+  return [map, computed] as const;
+}

--- a/packages/test/src/fixtureTypes.ts
+++ b/packages/test/src/fixtureTypes.ts
@@ -1,0 +1,61 @@
+import type { EndpointInterface, ResolveType } from '@rest-hooks/react';
+
+type Updater = (
+  result: any,
+  ...args: any
+) => Record<string, (...args: any) => any>;
+
+export interface SuccessFixtureEndpoint<
+  E extends EndpointInterface & { update?: Updater } = EndpointInterface,
+> {
+  readonly endpoint: E;
+  readonly args: Parameters<E>;
+  readonly response:
+    | ResolveType<E>
+    | ((...args: Parameters<E>) => ResolveType<E>);
+  readonly error?: false;
+  /** Number of miliseconds to wait before resolving */
+  readonly delay?: number;
+  /** Waits to run `response()` after `delay` time */
+  readonly delayCollapse?: boolean;
+}
+
+export interface Interceptor<
+  E extends EndpointInterface & {
+    update?: Updater;
+    testKey(key: string): boolean;
+  } = EndpointInterface & { testKey(key: string): boolean },
+> {
+  readonly endpoint: E;
+  readonly response: (...args: Parameters<E>) => ResolveType<E>;
+  /** Number of miliseconds (or function that returns) to wait before resolving */
+  readonly delay?: number | ((...args: Parameters<E>) => number);
+  /** Waits to run `response()` after `delay` time */
+  readonly delayCollapse?: boolean;
+}
+
+export interface ErrorFixtureEndpoint<
+  E extends EndpointInterface & { update?: Updater } = EndpointInterface,
+> {
+  readonly endpoint: E;
+  readonly args: Parameters<E>;
+  readonly response: any;
+  readonly error: true;
+  /** Number of miliseconds to wait before resolving */
+  readonly delay?: number;
+  /** Waits to run `response()` after `delay` time */
+  readonly delayCollapse?: boolean;
+}
+
+export type FixtureEndpoint<
+  E extends EndpointInterface & { update?: Updater } = EndpointInterface,
+> = SuccessFixtureEndpoint<E> | ErrorFixtureEndpoint<E>;
+export type SuccessFixture<
+  E extends EndpointInterface & { update?: Updater } = EndpointInterface,
+> = SuccessFixtureEndpoint<E>;
+export type ErrorFixture<
+  E extends EndpointInterface & { update?: Updater } = EndpointInterface,
+> = ErrorFixtureEndpoint<E>;
+export type Fixture<
+  E extends EndpointInterface & { update?: Updater } = EndpointInterface,
+> = FixtureEndpoint<E>;

--- a/packages/test/src/index.ts
+++ b/packages/test/src/index.ts
@@ -13,7 +13,8 @@ export type {
   Fixture,
   SuccessFixture,
   ErrorFixture,
-} from './mockState.js';
+  Interceptor,
+} from './fixtureTypes.js';
 export { act } from './makeRenderRestHook/renderHook.cjs';
 
 export { makeRenderRestHook, mockInitialState };

--- a/website/src/components/HooksPlayground.tsx
+++ b/website/src/components/HooksPlayground.tsx
@@ -1,4 +1,4 @@
-import type { FixtureEndpoint } from '@rest-hooks/test';
+import type { Fixture, Interceptor } from '@rest-hooks/test';
 import React, { memo } from 'react';
 
 import Playground from './Playground';
@@ -10,7 +10,7 @@ const HooksPlayground = ({
   defaultOpen,
   row = false,
   fixtures,
-}) => (
+}: PlaygroundProps) => (
   <Playground
     includeEndpoints={!Array.isArray(children)}
     noInline
@@ -29,8 +29,19 @@ const HooksPlayground = ({
 );
 HooksPlayground.defaultProps = {
   defaultOpen: 'n' as const,
-  fixtures: [] as FixtureEndpoint[],
+  fixtures: [] as Fixture[],
 };
 export default memo(HooksPlayground);
 
 //child.props.children.props.title
+
+interface PlaygroundProps {
+  groupId: string;
+  defaultOpen: 'y' | 'n';
+  row: boolean;
+  hidden: boolean;
+  fixtures: (Fixture | Interceptor)[];
+  children: React.ReactNode;
+  reverse?: boolean;
+  includeEndpoints: boolean;
+}

--- a/website/src/components/Playground/FixturePreview.tsx
+++ b/website/src/components/Playground/FixturePreview.tsx
@@ -1,10 +1,10 @@
-import type { FixtureEndpoint } from '@rest-hooks/test';
-import React, { memo, type ReactElement } from 'react';
+import type { Fixture } from '@rest-hooks/test';
 import CodeBlock from '@theme/CodeBlock';
+import React, { memo, type ReactElement } from 'react';
 
 import styles from './styles.module.css';
 
-function FixturePreview({ fixtures }: { fixtures: FixtureEndpoint[] }) {
+function FixturePreview({ fixtures }: { fixtures: Fixture[] }) {
   return (
     <div className={styles.fixtureBlock}>
       {fixtures.map(fixture => (
@@ -23,11 +23,7 @@ function FixturePreview({ fixtures }: { fixtures: FixtureEndpoint[] }) {
 }
 export default memo(FixturePreview);
 
-function FixtureResponse({
-  fixture,
-}: {
-  fixture: FixtureEndpoint;
-}): ReactElement {
+function FixtureResponse({ fixture }: { fixture: Fixture }): ReactElement {
   return typeof fixture.response === 'function' ? (
     ('function' as any)
   ) : (

--- a/website/src/components/Playground/PlaygroundTextEdit.tsx
+++ b/website/src/components/Playground/PlaygroundTextEdit.tsx
@@ -1,5 +1,5 @@
 import Translate from '@docusaurus/Translate';
-import type { FixtureEndpoint } from '@rest-hooks/test';
+import type { Fixture, FixtureEndpoint, Interceptor } from '@rest-hooks/test';
 import clsx from 'clsx';
 import { useContext, useMemo, useReducer, useState } from 'react';
 import React from 'react';
@@ -18,7 +18,7 @@ export function PlaygroundTextEdit({
   codes,
   large = false,
   isPlayground = true,
-}) {
+}: PlaygroundProps) {
   const id = useId();
 
   const [closedList, setClosed] = useState(() =>
@@ -28,7 +28,7 @@ export function PlaygroundTextEdit({
   return (
     <div>
       <EditorHeader
-        fixtures={!row && fixtures}
+        fixtures={!row ? fixtures : []}
         title={row && codeTabs.length === 1 ? codeTabs[0].title : undefined}
       />
       {row && codeTabs.length > 1 ? (
@@ -77,6 +77,15 @@ export function PlaygroundTextEdit({
       ))}
     </div>
   );
+}
+interface PlaygroundProps {
+  fixtures: (Fixture | Interceptor)[];
+  row: boolean;
+  codeTabs: any;
+  handleCodeChange: any;
+  codes: any;
+  large?: boolean;
+  isPlayground?: boolean;
 }
 
 export function useCode(children) {
@@ -225,10 +234,10 @@ function HeaderWithTabControls({ children }) {
 
 function EditorHeader({
   title,
-  fixtures,
+  fixtures = [],
 }: {
   title: string;
-  fixtures: FixtureEndpoint[];
+  fixtures: (Fixture | Interceptor)[];
 }) {
   const { values } = useContext(CodeTabContext);
   const hasTabs = values.length > 0;

--- a/website/src/components/Playground/Preview.tsx
+++ b/website/src/components/Playground/Preview.tsx
@@ -2,7 +2,11 @@ import {
   useScrollPositionBlocker,
   useTabGroupChoice,
 } from '@docusaurus/theme-common/internal';
-import { type FixtureEndpoint, MockResolver } from '@rest-hooks/test/browser';
+import {
+  type Fixture,
+  type Interceptor,
+  MockResolver,
+} from '@rest-hooks/test/browser';
 import clsx from 'clsx';
 import React, { memo, useCallback, useState, useMemo, lazy } from 'react';
 import {
@@ -25,7 +29,7 @@ function Preview({
   groupId: string;
   row: boolean;
   defaultOpen: 'y' | 'n';
-  fixtures: FixtureEndpoint[];
+  fixtures: (Fixture | Interceptor)[];
 }) {
   const { tabGroupChoices, setTabGroupChoices } = useTabGroupChoice();
   const [selectedValue, setSelectedValue] = useState(defaultOpen);

--- a/website/src/components/Playground/PreviewWithHeader.tsx
+++ b/website/src/components/Playground/PreviewWithHeader.tsx
@@ -1,11 +1,12 @@
-import React, { memo } from 'react';
 import Translate from '@docusaurus/Translate';
+import { Fixture, Interceptor } from '@rest-hooks/test';
+import React, { memo } from 'react';
 
+import Header from './Header';
 import Preview from './Preview';
 import styles from './styles.module.css';
-import Header from './Header';
 
-function PreviewWithHeader({ groupId, defaultOpen, row, fixtures }) {
+function PreviewWithHeader({ groupId, defaultOpen, row, fixtures }: Props) {
   return (
     <div
       style={{ overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
@@ -30,3 +31,10 @@ function PreviewWithHeader({ groupId, defaultOpen, row, fixtures }) {
   );
 }
 export default memo(PreviewWithHeader);
+
+interface Props {
+  groupId: string;
+  defaultOpen: 'y' | 'n';
+  row: boolean;
+  fixtures: (Fixture | Interceptor)[];
+}

--- a/website/src/components/Playground/PreviewWithScope.tsx
+++ b/website/src/components/Playground/PreviewWithScope.tsx
@@ -2,12 +2,11 @@ import * as graphql from '@rest-hooks/graphql';
 import * as hooks from '@rest-hooks/hooks';
 import * as rhReact from '@rest-hooks/react';
 import * as rest from '@rest-hooks/rest';
-import type { FixtureEndpoint } from '@rest-hooks/test';
+import type { Fixture, Interceptor } from '@rest-hooks/test';
 import BigNumber from 'bignumber.js';
 import React, { useEffect, useState, memo } from 'react';
 import { LiveProvider } from 'react-live';
 
-import ResetableErrorBoundary from '../ResettableErrorBoundary';
 import PreviewWithHeader from './PreviewWithHeader';
 import {
   TodoResource as BaseTodoResource,
@@ -15,6 +14,7 @@ import {
   TodoEndpoint,
 } from './resources/TodoResource';
 import transformCode from './transformCode';
+import ResetableErrorBoundary from '../ResettableErrorBoundary';
 
 function randomFloatInRange(min, max, decimals) {
   const str = (Math.random() * (max - min) + min).toFixed(decimals);
@@ -111,7 +111,7 @@ export default function PreviewWithScope({
   groupId: string;
   defaultOpen: 'y' | 'n';
   row: boolean;
-  fixtures: FixtureEndpoint[];
+  fixtures: (Fixture | Interceptor)[];
 }) {
   return (
     <LiveProvider

--- a/website/src/components/Playground/editor-types/@rest-hooks/react.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/react.d.ts
@@ -1,5 +1,5 @@
 import * as _rest_hooks_core from '@rest-hooks/core';
-import { Manager, State as State$1, Controller, NetworkError as NetworkError$1, ActionTypes, legacyActions, __INTERNAL__, createReducer, applyManager } from '@rest-hooks/core';
+import { Manager, State as State$1, Controller, NetworkError as NetworkError$1, ActionTypes, DenormalizeCache, legacyActions, __INTERNAL__, createReducer, applyManager } from '@rest-hooks/core';
 export { AbstractInstanceType, ActionTypes, Controller, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, ExpiryStatus, FetchAction, FetchFunction, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, PK, PollingSubscription, ReceiveAction, ReceiveTypes, ResetAction, ResolveType, Schema, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@rest-hooks/core';
 import React$1, { Context } from 'react';
 import * as packages_core_lib_controller_Controller from 'packages/core/lib/controller/Controller';
@@ -291,6 +291,8 @@ declare function useLive<E extends EndpointInterface<FetchFunction, Schema | und
 declare const StateContext: Context<State$1<unknown>>;
 /** @deprecated use Controller.dispatch */
 declare const DispatchContext: Context<(value: ActionTypes) => Promise<void>>;
+/** @deprecated */
+declare const DenormalizeCacheContext: Context<DenormalizeCache>;
 declare const ControllerContext: Context<Controller<packages_core_lib_controller_Controller.CompatibleDispatch>>;
 interface Store<S> {
     subscribe(listener: () => void): () => void;
@@ -339,4 +341,4 @@ declare namespace internal_d {
 /** Turns a dispatch function into one that resolves once its been commited */
 declare function usePromisifiedDispatch<R extends React$1.Reducer<any, any>>(dispatch: React$1.Dispatch<React$1.ReducerAction<R>>, state: React$1.ReducerState<R>): (action: React$1.ReducerAction<R>) => Promise<void>;
 
-export { _default as AsyncBoundary, _default$1 as BackupBoundary, CacheProvider, ControllerContext, DispatchContext, NetworkErrorBoundary, StateContext, Store, StoreContext, internal_d as __INTERNAL__, useCache, useController, useDLE, useError, useFetch, useLive, usePromisifiedDispatch, useSubscription, useSuspense };
+export { _default as AsyncBoundary, _default$1 as BackupBoundary, CacheProvider, ControllerContext, DenormalizeCacheContext, DispatchContext, NetworkErrorBoundary, StateContext, Store, StoreContext, internal_d as __INTERNAL__, useCache, useController, useDLE, useError, useFetch, useLive, usePromisifiedDispatch, useSubscription, useSuspense };

--- a/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
+++ b/website/src/components/Playground/editor-types/@rest-hooks/rest.d.ts
@@ -900,6 +900,9 @@ interface RestInstance<
   /** @see https://resthooks.io/rest/api/RestEndpoint#process */
   process(value: any, ...args: Parameters<F>): ResolveType<F>;
 
+  /* utilities */
+  testKey(key: string): boolean;
+
   /* extenders */
   paginated<
     E extends RestInstance<FetchFunction, Schema | undefined, undefined>,

--- a/website/src/components/Playground/editor-types/rest-hooks.d.ts
+++ b/website/src/components/Playground/editor-types/rest-hooks.d.ts
@@ -1,5 +1,5 @@
 import * as _rest_hooks_core from '@rest-hooks/core';
-import { Manager, State as State$1, Controller, NetworkError as NetworkError$2, ActionTypes, legacyActions, __INTERNAL__, Schema as Schema$2, EndpointExtraOptions as EndpointExtraOptions$2, createReducer as createReducer$1, applyManager as applyManager$1, DenormalizeNullable as DenormalizeNullable$3, ExpiryStatus, EndpointInterface as EndpointInterface$2, FetchFunction as FetchFunction$2, ResolveType as ResolveType$2, UnknownError as UnknownError$2, Denormalize as Denormalize$3 } from '@rest-hooks/core';
+import { Manager, State as State$1, Controller, NetworkError as NetworkError$2, ActionTypes, DenormalizeCache, legacyActions, __INTERNAL__, Schema as Schema$2, EndpointExtraOptions as EndpointExtraOptions$2, createReducer as createReducer$1, applyManager as applyManager$1, DenormalizeNullable as DenormalizeNullable$3, ExpiryStatus, EndpointInterface as EndpointInterface$2, FetchFunction as FetchFunction$2, ResolveType as ResolveType$2, UnknownError as UnknownError$2, Denormalize as Denormalize$3 } from '@rest-hooks/core';
 export { AbstractInstanceType, ActionTypes, Controller, DefaultConnectionListener, Denormalize, DenormalizeNullable, DevToolsManager, Dispatch, EndpointExtraOptions, EndpointInterface, ExpiryStatus, FetchAction, FetchFunction, InvalidateAction, LogoutManager, Manager, Middleware, MiddlewareAPI, NetworkError, NetworkManager, Normalize, NormalizeNullable, PK, PollingSubscription, ReceiveAction, ReceiveTypes, ResetAction, ResolveType, Schema, State, SubscribeAction, SubscriptionManager, UnknownError, UnsubscribeAction, UpdateFunction, actionTypes } from '@rest-hooks/core';
 import React$1, { Context } from 'react';
 import * as packages_core_lib_controller_Controller from 'packages/core/lib/controller/Controller';
@@ -602,6 +602,8 @@ declare function useLive<E extends EndpointInterface<FetchFunction, Schema | und
 declare const StateContext: Context<State$1<unknown>>;
 /** @deprecated use Controller.dispatch */
 declare const DispatchContext: Context<(value: ActionTypes) => Promise<void>>;
+/** @deprecated */
+declare const DenormalizeCacheContext: Context<DenormalizeCache>;
 declare const ControllerContext: Context<Controller<packages_core_lib_controller_Controller.CompatibleDispatch>>;
 interface Store<S> {
     subscribe(listener: () => void): () => void;
@@ -664,13 +666,9 @@ type ParamsFromShape<S> = S extends {
     getFetchKey: (first: infer A, ...rest: any) => any;
 } ? A : never;
 
-declare function makeCacheProvider(managers: Manager[], initialState?: State$1<unknown>, act?: Act): (props: {
+declare function makeCacheProvider(managers: Manager[], initialState?: State$1<unknown>): (props: {
     children: React$1.ReactNode;
 }) => JSX.Element;
-type Act = {
-    (callback: () => Promise<void | undefined>): Promise<undefined>;
-    (callback: () => void | undefined): void;
-};
 
 declare const createFetch: typeof createFetch$1;
 declare const createReceive: typeof createReceive$1;
@@ -944,4 +942,4 @@ declare function useRetrieve<Shape extends ReadShape<any, any>>(fetchShape: Shap
  */
 declare function useSubscription<E extends EndpointInterface$2<FetchFunction$2, Schema$2 | undefined, undefined> | ReadShape<any, any>, Args extends (E extends (...args: any) => any ? readonly [...Parameters<E>] : readonly [ParamsFromShape<E>]) | readonly [null]>(endpoint: E, ...args: Args): void;
 
-export { ArrayElement, _default as AsyncBoundary, _default$1 as BackupBoundary, CacheProvider, ControllerContext, DeleteShape, DispatchContext, Endpoint, EndpointParam, EndpointExtraOptions$1 as FetchOptions, FetchShape, Index, IndexParams, MutateEndpoint, MutateShape, NetworkErrorBoundary, ParamsFromShape, ReadEndpoint, ReadShape, SetShapeParams, StateContext, Store, StoreContext, internal_d as __INTERNAL__, makeCacheProvider, useCache, useController, useDLE, useDenormalized, useError, useFetch, useLive, useMeta, usePromisifiedDispatch, useResource, useRetrieve, useSubscription, useSuspense };
+export { ArrayElement, _default as AsyncBoundary, _default$1 as BackupBoundary, CacheProvider, ControllerContext, DeleteShape, DenormalizeCacheContext, DispatchContext, Endpoint, EndpointParam, EndpointExtraOptions$1 as FetchOptions, FetchShape, Index, IndexParams, MutateEndpoint, MutateShape, NetworkErrorBoundary, ParamsFromShape, ReadEndpoint, ReadShape, SetShapeParams, StateContext, Store, StoreContext, internal_d as __INTERNAL__, makeCacheProvider, useCache, useController, useDLE, useDenormalized, useError, useFetch, useLive, useMeta, usePromisifiedDispatch, useResource, useRetrieve, useSubscription, useSuspense };

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -1,6 +1,6 @@
 import { usePrismTheme } from '@docusaurus/theme-common';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import type { FixtureEndpoint } from '@rest-hooks/test';
+import type { Fixture, FixtureEndpoint, Interceptor } from '@rest-hooks/test';
 import clsx from 'clsx';
 import React, { lazy } from 'react';
 import { LiveProvider, LiveProviderProps } from 'react-live';
@@ -26,7 +26,7 @@ export default function Playground({
   defaultOpen: 'y' | 'n';
   row: boolean;
   children: string | any[];
-  fixtures: FixtureEndpoint[];
+  fixtures: (Fixture | Interceptor)[];
   includeEndpoints: boolean;
 }) {
   const {
@@ -72,7 +72,7 @@ function PlaygroundContent({
   includeEndpoints,
   groupId,
   defaultOpen,
-}) {
+}: ContentProps) {
   const { handleCodeChange, codes, codeTabs } = useCode(children);
   /*const code = ready.every(v => v)
     ? codes.join('\n')
@@ -115,6 +115,15 @@ function PlaygroundContent({
       </Boundary>
     </Reversible>
   );
+}
+interface ContentProps {
+  groupId: string;
+  defaultOpen: 'y' | 'n';
+  row: boolean;
+  fixtures: (Fixture | Interceptor)[];
+  children: React.ReactNode;
+  reverse?: boolean;
+  includeEndpoints: boolean;
 }
 
 const isGoogleBot =

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2982,7 +2982,7 @@ __metadata:
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.1.7
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=43ce35&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=f766ca&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.1.6
@@ -2996,7 +2996,7 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: df954d207a437e2eb1a5ea25c027ebc7664f934753a4694b0409374c9dcafe1ec3b3d30fb593beac0f32d37dbb6e1193b0aec7ec344798d504acfe98f5c50c7e
+  checksum: 711782f6e0f17463b5c76d4919e2e16cc8eaf14461d11566cc58ab3e789ab15bb69cfbce61e7f46af5cd97c0387646de6618520054815e6d7ddb7ebb880d9111
   languageName: node
   linkType: hard
 
@@ -3013,7 +3013,7 @@ __metadata:
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 10.0.0
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=15dffc&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=2c591c&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react": ^13.4.0
@@ -3039,7 +3039,7 @@ __metadata:
       optional: true
     react-test-renderer:
       optional: true
-  checksum: 5ab13f3cfd8098454499cb8119e0726f03e391f57b4937b94bf9b4e8536dca2d091a7da62db73b1c48364e8bba3044ed02a0c2044d2144e307680e0514ca4480
+  checksum: 02335902c0f6e8062ec04387773c38688924237fc199ead63a48b55470498a46df9b2dae9e1263d9077e60457832e00388d1b7d2eef818f891624e1eaa78a762
   languageName: node
   linkType: hard
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3001,19 +3001,19 @@ __metadata:
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 6.2.7
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=89a757&locator=root-workspace-0b6124%40workspace%3A."
+  version: 6.3.0
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=997c7d&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.3.0
     path-to-regexp: ^6.2.1
-  checksum: 0a67747e7b2944f1cc563a139a963c0295d1a229672c2ada47d566e64331519e532a86cb60b346095836e51049ca358a8ea99dc9a733dff5ae9cd6a06ced005c
+  checksum: 89a714bedb661fed779ea9f591fefaf198919eef5f421d1ce8bd92d7ecd7680e59e40a1204e6cd3b391257a72c8a47754d60d696497a0461929d78b24978dc39
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 10.0.0
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=2c591c&locator=root-workspace-0b6124%40workspace%3A."
+  version: 10.1.0
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=a78d7e&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react": ^13.4.0
@@ -3039,7 +3039,7 @@ __metadata:
       optional: true
     react-test-renderer:
       optional: true
-  checksum: 02335902c0f6e8062ec04387773c38688924237fc199ead63a48b55470498a46df9b2dae9e1263d9077e60457832e00388d1b7d2eef818f891624e1eaa78a762
+  checksum: 8bf238885b32411c574840c5a2ff5c597ac80a7d75ef7947b94412e46bbbc59d35621f45d68539ac0123ec9c21defc2f782dcbaf98866260d91008d4345850e3
   languageName: node
   linkType: hard
 

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2981,8 +2981,8 @@ __metadata:
   linkType: hard
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
-  version: 7.1.6
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=524139&locator=root-workspace-0b6124%40workspace%3A."
+  version: 7.1.7
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=43ce35&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.1.6
@@ -2996,24 +2996,24 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 6419f2f7510c66e6440db68c9a49abe2af620e07a231f1f50e9c1343840078d4a34c520d8d47dd7faa7ee21e29f238ea2520fab8f60370db6abf00a641adbb02
+  checksum: df954d207a437e2eb1a5ea25c027ebc7664f934753a4694b0409374c9dcafe1ec3b3d30fb593beac0f32d37dbb6e1193b0aec7ec344798d504acfe98f5c50c7e
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
   version: 6.2.7
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=5cb81b&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=89a757&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.3.0
     path-to-regexp: ^6.2.1
-  checksum: a0a263d31246088e495574f91e4881ff4b5f190d19f9a51f17f9b4d158c0ee70371adf4b4697828bc274cd2544b2a5fe633d827969af0d1cab2a10202705623d
+  checksum: 0a67747e7b2944f1cc563a139a963c0295d1a229672c2ada47d566e64331519e532a86cb60b346095836e51049ca358a8ea99dc9a733dff5ae9cd6a06ced005c
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 10.0.0
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=0599a4&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=15dffc&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react": ^13.4.0
@@ -3039,7 +3039,7 @@ __metadata:
       optional: true
     react-test-renderer:
       optional: true
-  checksum: efa74665fc925d5a748d8346de1cf405474fb28ba9a15b4619aa471e9eaf8a047237e3285c8165353db70e30b858ad9fc1d68a276fda14f8e248a749da1f3101
+  checksum: 5ab13f3cfd8098454499cb8119e0726f03e391f57b4937b94bf9b4e8536dca2d091a7da62db73b1c48364e8bba3044ed02a0c2044d2144e307680e0514ca4480
   languageName: node
   linkType: hard
 
@@ -13023,7 +13023,7 @@ __metadata:
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.0.7
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=6d242e&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=522428&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.3.0
@@ -13035,7 +13035,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 80be1a37d11a9d13ae4c6a7e11c201b934ee34452ba9477e518e56232dcd5d3af6048c2202de4fc6a0d79a5e0bc181251006a8c8c68076f863bf0a402f9dcc8d
+  checksum: 6a296fb760392b37ff35cde5f23608d891e470fe63101f798571b3ec4776f68c0aad7c878041f316c39f45027621a4aee675a68b408574c3082e5d98b22b4d0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- More flexible data mocking and testing
- Especially helpful for mutations
- Critical to filling all mock capabilities of dock site thus removing need for MSW

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Name taken from nock.

```ts
export interface Interceptor<
  E extends EndpointInterface & {
    update?: Updater;
    testKey(key: string): boolean;
  } = EndpointInterface & { testKey(key: string): boolean },
> {
  readonly endpoint: E;
  readonly response: (...args: Parameters<E>) => ResolveType<E>;
  readonly delay?: number | ((...args: Parameters<E>) => number);
  readonly delayCollapse?: boolean;
}
```

Interceptors can only be used with the resolver - not initial state (for obvious reasons they pattern match).

#### testKey

This was added to RestEndpoint, utilizing path-to-regex to ensure matching all potential endpoints. This can later be used to invalidate everything matching an endpoint as well.

#### Example

```tsx
it('should resolve useSuspense() with Interceptors', async () => {
  const { result, waitFor, controller } = renderRestHook(
    () => {
      return useSuspense(CoolerArticleResource.get, { id: 'abc123' });
    },
    {
      resolverFixtures: [
        {
          endpoint: CoolerArticleResource.get,
          response: ({ id }) => ({ ...payload, id }),
        },
        {
          endpoint: CoolerArticleResource.partialUpdate,
          response: ({ id }, body) => ({ ...body, id }),
        },
      ],
    },
  );
  expect(result.current).toBeUndefined();
  await waitFor(() => expect(result.current).toBeDefined());
  expect(result.current.title).toBe(payload.title);
  // @ts-expect-error
  expect(result.current.lafsjlfd).toBeUndefined();
  await controller.fetch(
    CoolerArticleResource.partialUpdate,
    { id: 'abc123' },
    { title: 'updated title' },
  );
  expect(result.current.title).toBe('updated title');
});
```

### Fix: renderRestHook().controller uses fixtures

`renderRestHook().controller` does not use Context, therefore was not getting overriden by MockProvider. Extract the logic and also wrap it

### Fix: mock resolutions with optimistic updates working

Rather than completely replacing all fetch actions, we simply replace the part that would call the networking event: action.payload.

### delayCollapse

If true, will run the response function after `delay` ms rather than immediately. Both will resolve the computed value after `delay` ms.

## Future work

Add lower level interceptor that overrides fetchResponse in an endpoint. This effectively replaces the core `fetch` implementation without actually monkey patching it. This is critical to run codepaths like `RestEndpoint.getRequestInit()`