### PR TITLE
feat: Add controller.invalidateAll()

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -564,6 +564,9 @@ export const GetPhoto = new Endpoint(
     key({ userId }: { userId: string }) {
       return `/users/${userId}/photo`;
     },
+    testKey(key: string) {
+      return /\/users\/([\w\W]+)\/photo/.test(key);
+    },
   },
 );
 

--- a/docs/core/api/Controller.md
+++ b/docs/core/api/Controller.md
@@ -14,17 +14,18 @@ import TabItem from '@theme/TabItem';
 ```ts
 class Controller {
   /*************** Action Dispatchers ***************/
-  fetch(endpoint, ...args) => ReturnType<E>;
-  invalidate(endpoint, ...args) => Promise<void>;
-  resetEntireStore: () => Promise<void>;
-  setResponse(endpoint, ...args, response) => Promise<void>;
-  setError(endpoint, ...args, error) => Promise<void>;
-  resolve(endpoint, { args, response, fetchedAt, error }) => Promise<void>;
-  subscribe(endpoint, ...args) => Promise<void>;
-  unsubscribe(endpoint, ...args) => Promise<void>;
+  fetch(endpoint, ...args): ReturnType<E>;
+  invalidate(endpoint, ...args): Promise<void>;
+  invalidateAll({ testKey }): Promise<void>;
+  resetEntireStore(): Promise<void>;
+  setResponse(endpoint, ...args, response): Promise<void>;
+  setError(endpoint, ...args, error): Promise<void>;
+  resolve(endpoint, { args, response, fetchedAt, error }): Promise<void>;
+  subscribe(endpoint, ...args): Promise<void>;
+  unsubscribe(endpoint, ...args): Promise<void>;
   /*************** Data Access ***************/
-  getResponse(endpoint, ...args, state)​ => { data, expiryStatus, expiresAt };
-  getError(endpoint, ...args, state)​ => ErrorTypes | undefined;
+  getResponse(endpoint, ...args, state): { data, expiryStatus, expiresAt };
+  getError(endpoint, ...args, state): ErrorTypes | undefined;
   snapshot(state: State<unknown>, fetchedAt?: number): SnapshotInterface;
   getState(): State<unknown>;
 }
@@ -171,6 +172,36 @@ To refresh while continuing to display stale data - [Controller.fetch](#fetch) i
 Use [schema.Delete](/rest/api/Delete) to invalidate every endpoint that contains a given entity.
 
 :::
+
+## invalidateAll({ testKey }) {#invalidateAll}
+
+[Invalidates](../concepts/expiry-policy#invalid) all endpoint configurations matching `testKey`.
+
+```tsx
+function ArticleName({ id }: { id: string }) {
+  const article = useSuspense(ArticleResource.get, { id });
+  const ctrl = useController();
+
+  return (
+    <div>
+      <h1>{article.title}<h1>
+      <button onClick={() => ctrl.invalidateAll(ArticleResource.get)}>Fetch &amp; suspend</button>
+    </div>
+  );
+}
+```
+
+Here we clear only GET endpoints using the test.com domain. This means other domains remain in cache.
+
+```tsx
+const myDomain = 'http://test.com';
+
+function useLogout() {
+  const ctrl = useController();
+  const testKey = (key: string) => key.startsWith(`GET ${myDomain}`);
+  return () => ctrl.invalidateAll({ testKey });
+}
+```
 
 ## resetEntireStore() {#resetEntireStore}
 

--- a/docs/core/api/LogoutManager.md
+++ b/docs/core/api/LogoutManager.md
@@ -125,6 +125,32 @@ const managers = [
 ];
 ```
 
+:::tip
+
+Use [controller.invalidateAll](./Controller.md#invalidateAll) to only clear part of the cache.
+
+```ts
+import { unAuth } from '../authentication';
+
+// highlight-next-line
+const testKey = (key: string) => key.startsWith(`GET ${myDomain}`);
+
+const managers = [
+  new LogoutManager({
+    handleLogout(controller) {
+      // call custom unAuth function we defined
+      unAuth();
+      // still reset the store
+      // highlight-next-line
+      controller.invalidateAll({ testKey })
+    },
+  }),
+  ...CacheProvider.defaultProps.managers,
+];
+```
+
+:::
+
 ## Members
 
 ### handleLogout(controller)

--- a/packages/core/src/actionTypes.ts
+++ b/packages/core/src/actionTypes.ts
@@ -7,4 +7,5 @@ export const RESET_TYPE = 'rest-hooks/reset' as const;
 export const SUBSCRIBE_TYPE = 'rest-hooks/subscribe' as const;
 export const UNSUBSCRIBE_TYPE = 'rest-hook/unsubscribe' as const;
 export const INVALIDATE_TYPE = 'rest-hooks/invalidate' as const;
+export const INVALIDATEALL_TYPE = 'rest-hooks/invalidateall' as const;
 export const GC_TYPE = 'rest-hooks/gc' as const;

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -19,6 +19,7 @@ import { inferResults } from '@rest-hooks/normalizr';
 
 import createFetch from './createFetch.js';
 import createInvalidate from './createInvalidate.js';
+import createInvalidateAll from './createInvalidateAll.js';
 import createReceive from './createReceive.js';
 import createReset from './createReset.js';
 import {
@@ -115,7 +116,7 @@ export default class Controller<
   };
 
   /**
-   * Forces refetching and suspense on useResource with the same Endpoint and parameters.
+   * Forces refetching and suspense on useSuspense with the same Endpoint and parameters.
    * @see https://resthooks.io/docs/api/Controller#invalidate
    */
   invalidate = <E extends EndpointInterface>(
@@ -129,6 +130,13 @@ export default class Controller<
           }),
         )
       : Promise.resolve();
+
+  /**
+   * Forces refetching and suspense on useSuspense on all matching endpoint result keys.
+   * @see https://resthooks.io/docs/api/Controller#invalidateAll
+   */
+  invalidateAll = (options: { testKey: (key: string) => boolean }) =>
+    this.dispatch(createInvalidateAll((key: string) => options.testKey(key)));
 
   /**
    * Resets the entire Rest Hooks cache. All inflight requests will not resolve.
@@ -156,7 +164,7 @@ export default class Controller<
     return this.dispatch(action);
   };
 
-  // TODO(breaking): deprecate
+  // TODO: deprecate
   /**
    * Another name for setResponse
    * @see https://resthooks.io/docs/api/Controller#setResponse

--- a/packages/core/src/controller/createInvalidateAll.ts
+++ b/packages/core/src/controller/createInvalidateAll.ts
@@ -1,0 +1,11 @@
+import { INVALIDATEALL_TYPE } from '../actionTypes.js';
+import type { InvalidateAllAction } from '../newActions.js';
+
+export default function createInvalidateAll(
+  testKey: (key: string) => boolean,
+): InvalidateAllAction {
+  return {
+    type: INVALIDATEALL_TYPE,
+    testKey,
+  };
+}

--- a/packages/core/src/newActions.ts
+++ b/packages/core/src/newActions.ts
@@ -13,6 +13,7 @@ import type {
   INVALIDATE_TYPE,
   GC_TYPE,
   OPTIMISTIC_TYPE,
+  INVALIDATEALL_TYPE,
 } from './actionTypes.js';
 import type { EndpointUpdateFunction } from './controller/types.js';
 
@@ -103,6 +104,11 @@ export interface UnsubscribeAction<
 }
 
 /* INVALIDATE */
+export interface InvalidateAllAction {
+  type: typeof INVALIDATEALL_TYPE;
+  testKey: (key: string) => boolean;
+}
+
 export interface InvalidateAction {
   type: typeof INVALIDATE_TYPE;
   meta: {

--- a/packages/core/src/previousActions.ts
+++ b/packages/core/src/previousActions.ts
@@ -19,6 +19,7 @@ import {
 import { EndpointUpdateFunction } from './controller/types.js';
 import { FetchShape } from './endpoint/index.js';
 import { ErrorableFSAWithPayloadAndMeta } from './fsa.js';
+import type { InvalidateAction, InvalidateAllAction } from './newActions.js';
 
 export interface ReceiveMeta<S extends Schema | undefined> {
   schema?: S;
@@ -138,12 +139,7 @@ export interface UnsubscribeAction
   };
 }
 
-export interface InvalidateAction
-  extends FSAWithMeta<typeof INVALIDATE_TYPE, undefined, any> {
-  meta: {
-    key: string;
-  };
-}
+export type { InvalidateAction, InvalidateAllAction };
 
 export interface GCAction {
   type: typeof GC_TYPE;
@@ -158,5 +154,6 @@ export type ActionTypes =
   | SubscribeAction
   | UnsubscribeAction
   | InvalidateAction
+  | InvalidateAllAction
   | ResetAction
   | GCAction;

--- a/packages/react/src/hooks/__tests__/useController/invalidateAll.tsx
+++ b/packages/react/src/hooks/__tests__/useController/invalidateAll.tsx
@@ -1,13 +1,13 @@
 import { CacheProvider } from '@rest-hooks/react';
+import { makeRenderRestHook } from '@rest-hooks/test';
 import { FixtureEndpoint } from '@rest-hooks/test/mockState';
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from '@testing-library/react-hooks';
-import { FutureArticleResource, GetPhoto } from '__tests__/new';
+import { CoolerArticleResource, GetPhoto } from '__tests__/new';
 import nock from 'nock';
 import { useEffect } from 'react';
 
 import { useCache, useController } from '../..';
-import { makeRenderRestHook } from '../../../../../test';
 
 export const payload = {
   id: 5,
@@ -24,13 +24,13 @@ export const createPayload = {
 };
 
 export const detail: FixtureEndpoint = {
-  endpoint: FutureArticleResource.get,
-  args: [5],
+  endpoint: CoolerArticleResource.get,
+  args: [{ id: 5 }],
   response: payload,
 };
 
 export const nested: FixtureEndpoint = {
-  endpoint: FutureArticleResource.getList,
+  endpoint: CoolerArticleResource.getList,
   args: [],
   response: [
     {
@@ -69,12 +69,12 @@ afterEach(() => {
   nock.cleanAll();
 });
 
-describe('invalidate', () => {
-  it('should not invalidate anything if params is null', () => {
+describe('invalidateAll', () => {
+  it('should not invalidate anything not matching', () => {
     const { result } = renderRestHook(
       () => {
         return {
-          data: useCache(FutureArticleResource.get, 5),
+          data: useCache(CoolerArticleResource.get, { id: 5 }),
           controller: useController(),
         };
       },
@@ -82,7 +82,11 @@ describe('invalidate', () => {
     );
     expect(result.current.data).toBeDefined();
     act(() => {
-      result.current.controller.invalidate(FutureArticleResource.get, null);
+      result.current.controller.invalidateAll(CoolerArticleResource.update);
+    });
+    expect(result.current.data).toBeDefined();
+    act(() => {
+      result.current.controller.invalidateAll(CoolerArticleResource.getList);
     });
     expect(result.current.data).toBeDefined();
   });
@@ -91,7 +95,7 @@ describe('invalidate', () => {
     const { result } = renderRestHook(
       () => {
         return {
-          data: useCache(FutureArticleResource.get, 5),
+          data: useCache(CoolerArticleResource.get, { id: 5 }),
           controller: useController(),
         };
       },
@@ -99,7 +103,7 @@ describe('invalidate', () => {
     );
     expect(result.current.data).toBeDefined();
     act(() => {
-      result.current.controller.invalidate(FutureArticleResource.get, 5);
+      result.current.controller.invalidateAll(CoolerArticleResource.get);
     });
     expect(result.current.data).toBeUndefined();
   });
@@ -108,8 +112,8 @@ describe('invalidate', () => {
     const track = jest.fn();
 
     const { rerender } = renderHook(() => {
-      const invalidate = useController().invalidate;
-      useEffect(track, [invalidate]);
+      const invalidateAll = useController().invalidateAll;
+      useEffect(track, [invalidateAll]);
     });
     expect(track.mock.calls.length).toBe(1);
     for (let i = 0; i < 4; ++i) {
@@ -140,7 +144,7 @@ describe('invalidate', () => {
     );
     expect(result.current.data).toEqual(response);
     act(() => {
-      result.current.controller.invalidate(GetPhoto, { userId });
+      result.current.controller.invalidateAll(GetPhoto);
     });
     expect(result.current.data).toBeUndefined();
   });

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -132,7 +132,7 @@ module.exports = {
           lastVersion: 'current',
           includeCurrentVersion: true,
           versions: {
-            current: { label: '7.1', path: '', badge: false },
+            current: { label: '7.x', path: '', badge: false },
             6.6: { label: '6.6', path: '6.6', banner: 'none' },
           },
           onlyIncludeVersions: isDev

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -140,18 +140,12 @@
           "id": "api/types"
         },
         {
-          "type": "category",
-          "label": "Imperative",
-          "items": [
-            {
-              "type": "doc",
-              "id": "api/Controller"
-            },
-            {
-              "type": "doc",
-              "id": "api/Snapshot"
-            }
-          ]
+          "type": "doc",
+          "id": "api/Controller"
+        },
+        {
+          "type": "doc",
+          "id": "api/Snapshot"
         },
         {
           "type": "category",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2927,12 +2927,12 @@ __metadata:
 
 "@rest-hooks/core@file:../packages/core::locator=root-workspace-0b6124%40workspace%3A.":
   version: 4.1.6
-  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=747e15&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/core@file:../packages/core#../packages/core::hash=2cbfb7&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/normalizr": ^9.3.7
     flux-standard-action: ^2.1.1
-  checksum: 6cb975cf5466a9f247b92571f1e55b20b6b2ebcee151a1d3ceedcb25a593fc3f07334cd35f60fd0f8d6bb1173204f3d9765cf887835a872080e4a7e49bf5a647
+  checksum: 55494165d6ac5a59ed0a016cf45efd93c9750af571e7f9edaf091b8f7913315e1fa13376a26f0af4d3ecfed265cae486cb6967221239a2493e8e57870f94d0c7
   languageName: node
   linkType: hard
 
@@ -2973,16 +2973,16 @@ __metadata:
 
 "@rest-hooks/normalizr@file:../packages/normalizr::locator=root-workspace-0b6124%40workspace%3A.":
   version: 9.3.7
-  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=cfc327&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/normalizr@file:../packages/normalizr#../packages/normalizr::hash=f1613c&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
-  checksum: 4d5a583d75475edfbd2218d5b738ddfec8dcb3778b1f4ae24e6fa914cf2d4ad5c9bceff7e6d0107f1a45805be04d4060069d95473e946d39cd852d73a3b6fd1b
+  checksum: dcd5c91fd014d8e3ab0eae4c39f7c13cc56401021100c6cc10ae09604d194f99a97c016758ef3c1cc8b9ac12489dd02de56169816f94a81784fa4f26ce12ee93
   languageName: node
   linkType: hard
 
 "@rest-hooks/react@file:../packages/react::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.1.7
-  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=f766ca&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/react@file:../packages/react#../packages/react::hash=1b16c0&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/core": ^4.1.6
@@ -2996,24 +2996,24 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 711782f6e0f17463b5c76d4919e2e16cc8eaf14461d11566cc58ab3e789ab15bb69cfbce61e7f46af5cd97c0387646de6618520054815e6d7ddb7ebb880d9111
+  checksum: 02ea9310f6a635ae753b4941cf7bb7c4a9841087cce39b5071c4252eacd50186c335f39b8a1d77a480bc4a04ac5df7180f54009fce32613c446b913f059439b9
   languageName: node
   linkType: hard
 
 "@rest-hooks/rest@file:../packages/rest::locator=root-workspace-0b6124%40workspace%3A.":
   version: 6.3.0
-  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=997c7d&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/rest@file:../packages/rest#../packages/rest::hash=950540&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.3.0
     path-to-regexp: ^6.2.1
-  checksum: 89a714bedb661fed779ea9f591fefaf198919eef5f421d1ce8bd92d7ecd7680e59e40a1204e6cd3b391257a72c8a47754d60d696497a0461929d78b24978dc39
+  checksum: 58fec2d6a890880d500c3356c1eb9151591219516b5f52d9bfc58b23caf4cc0c0a3573bfa81bdc0473990b5e752b3bf26ad71c117b1932248c9817d7fe58e6c8
   languageName: node
   linkType: hard
 
 "@rest-hooks/test@file:../packages/test::locator=root-workspace-0b6124%40workspace%3A.":
   version: 10.1.0
-  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=a78d7e&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/test@file:../packages/test#../packages/test::hash=8ca2f3&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@testing-library/react": ^13.4.0
@@ -3039,20 +3039,20 @@ __metadata:
       optional: true
     react-test-renderer:
       optional: true
-  checksum: 8bf238885b32411c574840c5a2ff5c597ac80a7d75ef7947b94412e46bbbc59d35621f45d68539ac0123ec9c21defc2f782dcbaf98866260d91008d4345850e3
+  checksum: a1a05325e106860cbcb08dd22cbdfc06db466a782ff34e3a9b07a7f340a61c58375ca4bf15a7221a81f16c8a25cb12a124bb8b5c3945f12c0fb6766d244d82c5
   languageName: node
   linkType: hard
 
 "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer::locator=root-workspace-0b6124%40workspace%3A.":
   version: 1.2.4
-  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=f2b502&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "@rest-hooks/use-enhanced-reducer@file:../packages/use-enhanced-reducer#../packages/use-enhanced-reducer::hash=9f51c4&locator=root-workspace-0b6124%40workspace%3A."
   peerDependencies:
     "@types/react": ^16.8.4 || ^17.0.0 || ^18.0.0-0
     react: ^16.8.4 || ^17.0.0 || ^18.0.0-0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 32b8450656ba39564e31840d7cfd11848999bb82c6aa075092482540f80ca72e7e019d7d5a04b35160e6defe44827f7292fdfeffc03ddd8eb1d0685044b4ab5b
+  checksum: 95cb5cd95154abd7005bbef1bcfd0493f8d4e00a915024368355d3bdadd762ddb3fe8e8e1e44e17934cc6bf44260d917d4bdc5eefcb7f96ae74849fa47633ba4
   languageName: node
   linkType: hard
 
@@ -13023,7 +13023,7 @@ __metadata:
 
 "rest-hooks@file:../packages/rest-hooks::locator=root-workspace-0b6124%40workspace%3A.":
   version: 7.0.7
-  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=522428&locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "rest-hooks@file:../packages/rest-hooks#../packages/rest-hooks::hash=2be301&locator=root-workspace-0b6124%40workspace%3A."
   dependencies:
     "@babel/runtime": ^7.17.0
     "@rest-hooks/endpoint": ^3.3.0
@@ -13035,7 +13035,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 6a296fb760392b37ff35cde5f23608d891e470fe63101f798571b3ec4776f68c0aad7c878041f316c39f45027621a4aee675a68b408574c3082e5d98b22b4d0b
+  checksum: 67424236209c03e45915dbd7294490303dd4ea9817fb22127703cac6f7c1b472f7f8706c32b6e1f332a6848ed15f184c8795c15bde5c9c4954b00a6bf5c6096b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1548 (the @stufisher part).

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
- Easily reset part of cache (when logout but only some endpoints use that auth)
- Easily invalidate all results matching an endpoint (every possible arg)

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### With @rest-hooks/rest

```ts
controller.invalidateAll(CoolerArticleResource.get)
```


#### Any endpoint

```ts
controller.invalidateAll({
    testKey(key: string) {
      return /\/users\/([\w\W]+)\/photo/.test(key);
    }
});
```

### Future work

We still plan on adding an atomic mutation solution for #1548 - enabling a more performant and automatic answer to this use case of not knowing all parameters that are relevant