### PR TITLE
enhance: Improve strictNullChecks: false compatibility

### DIFF
--- a/__tests__/new.ts
+++ b/__tests__/new.ts
@@ -341,7 +341,7 @@ export const FutureArticleResource = {
       CoolerArticle
     >
   ).extend({
-    url(id: string) {
+    url(id: string, body) {
       return `http://test.com/article-cooler/${id}`;
     },
   }),

--- a/packages/core/src/controller/types.ts
+++ b/packages/core/src/controller/types.ts
@@ -4,8 +4,11 @@ import type {
   ResolveType,
 } from '@rest-hooks/normalizr';
 
-export type ResultEntry<E extends EndpointInterface> =
-  E['schema'] extends undefined ? ResolveType<E> : Normalize<E>;
+export type ResultEntry<E extends EndpointInterface> = E['schema'] extends
+  | undefined
+  | null
+  ? ResolveType<E>
+  : Normalize<E>;
 
 export type EndpointUpdateFunction<
   Source extends EndpointInterface,

--- a/packages/experimental/src/types.ts
+++ b/packages/experimental/src/types.ts
@@ -1,7 +1,9 @@
 import { Normalize } from '@rest-hooks/endpoint';
 import type { EndpointInterface, ResolveType } from '@rest-hooks/endpoint';
 
-type ResultEntry<E extends EndpointInterface> = E['schema'] extends undefined
+type ResultEntry<E extends EndpointInterface> = E['schema'] extends
+  | undefined
+  | null
   ? ResolveType<E>
   : Normalize<E>;
 

--- a/packages/react/src/hooks/__tests__/useDLE.tsx
+++ b/packages/react/src/hooks/__tests__/useDLE.tsx
@@ -111,6 +111,33 @@ describe('useDLE()', () => {
     expect(result.current.data).toEqual(CoolerArticle.fromJS(payload));
   });
 
+  it('should properly discriminate null args types', () => {
+    () => {
+      const result = useDLE(
+        TypedArticleResource.get,
+        (true as boolean)
+          ? {
+              id: payload.id,
+            }
+          : null,
+      );
+      if (!result.loading && !result.error) {
+        // @ts-expect-error
+        result.data.title;
+
+        result.data && result.data.title;
+      }
+    };
+    () => {
+      const result = useDLE(TypedArticleResource.get, {
+        id: payload.id,
+      });
+      if (!result.loading && !result.error) {
+        result.data.title;
+      }
+    };
+  });
+
   it('should return errors on bad network', async () => {
     const { result, waitForNextUpdate } = renderRestHook(() => {
       return useDLE(CoolerArticleResource.get, {

--- a/packages/react/src/hooks/__tests__/useLive.tsx
+++ b/packages/react/src/hooks/__tests__/useLive.tsx
@@ -121,6 +121,9 @@ describe.each([
       .get(`/article/${articlePayload.id}`)
       .reply(200, { ...articlePayload, title: 'sixer' });
     jest.advanceTimersByTime(frequency);
+    // @ts-expect-error
+    () => result.current.title;
+    () => result.current && result.current.title;
     expect(result.current).toBeUndefined();
 
     // errors should not fail when data already exists

--- a/packages/react/src/hooks/types.ts
+++ b/packages/react/src/hooks/types.ts
@@ -7,13 +7,18 @@ import {
   FetchFunction,
 } from '@rest-hooks/normalizr';
 
+/* Inlining this on unions does not work for some reason, so make it a generic type to call */
+export type CondNull<P, A, B> = P extends null ? A : B;
+
 export type SuspenseReturn<
   E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
   Args extends readonly [...Parameters<E>] | readonly [null],
-> = Args extends [null]
-  ? E['schema'] extends undefined | null
+> = CondNull<
+  Args[0],
+  E['schema'] extends undefined | null
     ? undefined
-    : DenormalizeNullable<E['schema']>
-  : E['schema'] extends undefined | null
-  ? ResolveType<E>
-  : Denormalize<E['schema']>;
+    : DenormalizeNullable<E['schema']>,
+  E['schema'] extends undefined | null
+    ? ResolveType<E>
+    : Denormalize<E['schema']>
+>;

--- a/packages/react/src/hooks/types.ts
+++ b/packages/react/src/hooks/types.ts
@@ -1,0 +1,19 @@
+import {
+  DenormalizeNullable,
+  ResolveType,
+  EndpointInterface,
+  Denormalize,
+  Schema,
+  FetchFunction,
+} from '@rest-hooks/normalizr';
+
+export type SuspenseReturn<
+  E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
+  Args extends readonly [...Parameters<E>] | readonly [null],
+> = Args extends [null]
+  ? E['schema'] extends undefined | null
+    ? undefined
+    : DenormalizeNullable<E['schema']>
+  : E['schema'] extends undefined | null
+  ? ResolveType<E>
+  : Denormalize<E['schema']>;

--- a/packages/react/src/hooks/useCache.ts
+++ b/packages/react/src/hooks/useCache.ts
@@ -27,7 +27,7 @@ export default function useCache<
 >(
   endpoint: E,
   ...args: Args
-): E['schema'] extends undefined
+): E['schema'] extends undefined | null
   ? E extends (...args: any) => any
     ? ResolveType<E> | undefined
     : any

--- a/packages/react/src/hooks/useDLE.ts
+++ b/packages/react/src/hooks/useDLE.ts
@@ -42,7 +42,7 @@ export default function useDLE<
 >(
   endpoint: E,
   ...args: Args
-): E['schema'] extends undefined
+): E['schema'] extends undefined | null
   ? {
       data: E extends (...args: any) => any ? ResolveType<E> | undefined : any;
       loading: boolean;

--- a/packages/react/src/hooks/useLive.ts
+++ b/packages/react/src/hooks/useLive.ts
@@ -7,6 +7,7 @@ import {
   FetchFunction,
 } from '@rest-hooks/normalizr';
 
+import { SuspenseReturn } from './types.js';
 import useSubscription from './useSubscription.js';
 import useSuspense from './useSuspense.js';
 
@@ -21,16 +22,7 @@ import useSuspense from './useSuspense.js';
 export default function useLive<
   E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
   Args extends readonly [...Parameters<E>] | readonly [null],
->(
-  endpoint: E,
-  ...args: Args
-): Args extends [null]
-  ? E['schema'] extends Exclude<Schema, null>
-    ? DenormalizeNullable<E['schema']>
-    : undefined
-  : E['schema'] extends Exclude<Schema, null>
-  ? Denormalize<E['schema']>
-  : ResolveType<E> {
+>(endpoint: E, ...args: Args): SuspenseReturn<E, Args> {
   useSubscription(endpoint, ...args);
   return useSuspense(endpoint, ...args);
 }

--- a/packages/react/src/hooks/useSuspense.native.ts
+++ b/packages/react/src/hooks/useSuspense.native.ts
@@ -13,6 +13,7 @@ import {
 import { useMemo } from 'react';
 import { InteractionManager } from 'react-native';
 
+import { SuspenseReturn } from './types.js';
 import useCacheState from './useCacheState.js';
 import useController from './useController.js';
 import useFocusEffect from './useFocusEffect.native.js';
@@ -29,16 +30,7 @@ import useFocusEffect from './useFocusEffect.native.js';
 export default function useSuspense<
   E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
   Args extends readonly [...Parameters<E>] | readonly [null],
->(
-  endpoint: E,
-  ...args: Args
-): Args extends [null]
-  ? E['schema'] extends Exclude<Schema, null>
-    ? DenormalizeNullable<E['schema']>
-    : undefined
-  : E['schema'] extends Exclude<Schema, null>
-  ? Denormalize<E['schema']>
-  : ResolveType<E> {
+>(endpoint: E, ...args: Args): SuspenseReturn<E, Args> {
   const state = useCacheState();
   const controller = useController();
 

--- a/packages/react/src/hooks/useSuspense.ts
+++ b/packages/react/src/hooks/useSuspense.ts
@@ -1,10 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
-  DenormalizeNullable,
   ExpiryStatus,
-  ResolveType,
-} from '@rest-hooks/normalizr';
-import {
   EndpointInterface,
   Denormalize,
   Schema,
@@ -12,6 +8,7 @@ import {
 } from '@rest-hooks/normalizr';
 import { useMemo } from 'react';
 
+import { SuspenseReturn } from './types.js';
 import useCacheState from './useCacheState.js';
 import useController from '../hooks/useController.js';
 
@@ -27,16 +24,7 @@ import useController from '../hooks/useController.js';
 export default function useSuspense<
   E extends EndpointInterface<FetchFunction, Schema | undefined, undefined>,
   Args extends readonly [...Parameters<E>] | readonly [null],
->(
-  endpoint: E,
-  ...args: Args
-): Args extends [null]
-  ? E['schema'] extends Exclude<Schema, null>
-    ? DenormalizeNullable<E['schema']>
-    : undefined
-  : E['schema'] extends Exclude<Schema, null>
-  ? Denormalize<E['schema']>
-  : ResolveType<E> {
+>(endpoint: E, ...args: Args): SuspenseReturn<E, Args> {
   const state = useCacheState();
   const controller = useController();
 

--- a/packages/rest/src/RestEndpoint.d.ts
+++ b/packages/rest/src/RestEndpoint.d.ts
@@ -375,3 +375,37 @@ export type Defaults<O, D> = {
     ? Exclude<O[K], undefined>
     : D[Extract<K, keyof D>];
 };
+
+export type NewGetEndpoint<
+  O extends {
+    path: string;
+    searchParams?: any;
+  } = { path: string },
+  S extends Schema | undefined = Schema | undefined,
+> = RestTypeNoBody<
+  'searchParams' extends keyof O
+    ? O['searchParams'] & PathArgs<O['path']>
+    : PathArgs<O['path']>,
+  S,
+  undefined,
+  any,
+  O & { body: undefined }
+>;
+
+export type NewMutateEndpoint<
+  O extends {
+    path: string;
+    body?: any;
+    searchParams?: any;
+  } = { path: string; body: any },
+  S extends Schema | undefined = Schema | undefined,
+> = RestTypeWithBody<
+  'searchParams' extends keyof O
+    ? O['searchParams'] & PathArgs<O['path']>
+    : PathArgs<O['path']>,
+  S,
+  true,
+  O['body'],
+  any,
+  O
+>;

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -3,7 +3,7 @@ import { useController } from '@rest-hooks/react';
 import { useSuspense } from '@rest-hooks/react';
 import { CacheProvider } from '@rest-hooks/react';
 import { act } from '@testing-library/react-hooks';
-import { CoolerArticle, CoolerArticleResource } from '__tests__/new';
+import { Article, CoolerArticle, CoolerArticleResource } from '__tests__/new';
 import nock from 'nock';
 
 import { makeRenderRestHook } from '../../../test';
@@ -799,6 +799,29 @@ describe('RestEndpoint', () => {
           bigger: true,
         }),
       ).toMatchInlineSnapshot(`"http://test.com/user/what?bigger=true"`);
+
+      const searchParams4 = getUserBase
+        .extend({
+          path: '/users',
+        })
+        .extend({ searchParams: {} as { bigger?: boolean } | undefined });
+      () => searchParams4({ bigger: true });
+      () => searchParams4();
+      () => searchParams4({});
+      // @ts-expect-error
+      () => searchParams4({ id: 'what', bigger: false });
+      // @ts-expect-error
+      () => searchParams4({ bigger: 5 });
+      // @ts-expect-error
+      () => searchParams4({ id: 'what' });
+      // @ts-expect-error
+      () => searchParams4.url({ id: 'what' });
+      expect(
+        searchParams4.url({
+          bigger: true,
+        }),
+      ).toMatchInlineSnapshot(`"/users?bigger=true"`);
+      expect(searchParams4.url()).toMatchInlineSnapshot(`"/users"`);
     });
   });
   it('extending with name should work', () => {

--- a/packages/rest/src/__tests__/types.test.ts
+++ b/packages/rest/src/__tests__/types.test.ts
@@ -5,7 +5,7 @@ import {
   PathKeys,
   ShortenPath,
 } from '../pathTypes';
-import { GetEndpoint } from '../RestEndpoint';
+import { GetEndpoint, NewGetEndpoint } from '../RestEndpoint';
 
 describe('PathArgs', () => {
   it('should infer types', () => {
@@ -108,6 +108,17 @@ describe('PathArgs', () => {
     () => a({ cursor: '5' }, { cursor: '5' });
   });
 
+  it('searchParams', () => {
+    const a: GetEndpoint<undefined | { cursor?: string | number }> = 0 as any;
+    () => a();
+    () => a({});
+    () => a({ cursor: 5 });
+    // @ts-expect-error
+    () => a({ id: '5' });
+    //@ts-expect-error
+    () => a({ cursor: '5' }, { cursor: '5' });
+  });
+
   describe('PathArgsAndSearch', () => {
     it('works with required path member', () => {
       const a: GetEndpoint<
@@ -125,8 +136,12 @@ describe('PathArgs', () => {
       () => a();
     });
     it('works with no path members', () => {
-      const a: GetEndpoint<PathArgsAndSearch<'http\\://test.com/groups/'>> =
-        0 as any;
+      const a: NewGetEndpoint<{
+        path: 'http\\://test.com/groups';
+        searchParams: Record<string, number | string | boolean> | undefined;
+      }> = 0 as any;
+      /*const a: GetEndpoint<PathArgsAndSearch<'http\\://test.com/groups/'>> =
+        0 as any;*/
       () => a({ group: '5' });
       () => a({ group: '5', sdf: '5' });
       () => a();
@@ -134,6 +149,16 @@ describe('PathArgs', () => {
       () => a({});
       //@ts-expect-error
       () => a({ page: '5' }, { hi: '5' });
+
+      () => {
+        const b = a.extend({
+          searchParams: {} as { userId?: number | string } | undefined,
+        });
+        b({ userId: '5' });
+        b();
+        // @ts-expect-error
+        b({ sdf: '5' });
+      };
     });
   });
 });

--- a/packages/rest/src/createResource.ts
+++ b/packages/rest/src/createResource.ts
@@ -5,10 +5,10 @@ import {
   type EndpointExtraOptions,
 } from '@rest-hooks/endpoint';
 
-import { PathArgs, PathArgsAndSearch, ShortenPath } from './pathTypes.js';
+import { PathArgs, ShortenPath } from './pathTypes.js';
 import RestEndpoint, {
-  GetEndpoint,
-  MutateEndpoint,
+  NewGetEndpoint,
+  NewMutateEndpoint,
   RestTypeNoBody,
 } from './RestEndpoint.js';
 import { shortenPath } from './RestHelpers.js';
@@ -80,27 +80,39 @@ export interface Resource<U extends string, S extends Schema> {
    *
    * @see https://resthooks.io/rest/api/createResource#get
    */
-  get: GetEndpoint<PathArgs<U>, S>;
+  get: NewGetEndpoint<{ path: U }, S>;
   /** Get a list of item
    *
    * @see https://resthooks.io/rest/api/createResource#getlist
    */
-  getList: GetEndpoint<PathArgsAndSearch<ShortenPath<U>>, S[]>;
+  getList: NewGetEndpoint<
+    {
+      path: ShortenPath<U>;
+      searchParams: Record<string, number | string | boolean> | undefined;
+    },
+    S[]
+  >;
   /** Create a new item (POST)
    *
    * @see https://resthooks.io/rest/api/createResource#create
    */
-  create: MutateEndpoint<PathArgs<ShortenPath<U>>, Partial<Denormalize<S>>, S>;
+  create: NewMutateEndpoint<
+    { path: ShortenPath<U>; body: Partial<Denormalize<S>> },
+    S
+  >;
   /** Update an item (PUT)
    *
    * @see https://resthooks.io/rest/api/createResource#update
    */
-  update: MutateEndpoint<PathArgs<U>, Partial<Denormalize<S>>, S>;
+  update: NewMutateEndpoint<{ path: U; body: Partial<Denormalize<S>> }, S>;
   /** Update an item (PATCH)
    *
    * @see https://resthooks.io/rest/api/createResource#partialupdate
    */
-  partialUpdate: MutateEndpoint<PathArgs<U>, Partial<Denormalize<S>>, S>;
+  partialUpdate: NewMutateEndpoint<
+    { path: U; body: Partial<Denormalize<S>> },
+    S
+  >;
   /** Delete an item (DELETE)
    *
    * @see https://resthooks.io/rest/api/createResource#delete
@@ -109,6 +121,9 @@ export interface Resource<U extends string, S extends Schema> {
     PathArgs<U>,
     S extends schema.EntityInterface & { process: any } ? schema.Delete<S> : S,
     undefined,
-    Partial<PathArgs<U>>
+    Partial<PathArgs<U>>,
+    {
+      path: U;
+    }
   >;
 }

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -7,6 +7,8 @@ export { default as RestEndpoint } from './RestEndpoint.js';
 export type {
   GetEndpoint,
   MutateEndpoint,
+  NewGetEndpoint,
+  NewMutateEndpoint,
   Defaults,
   RestGenerics,
   FetchGet,

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -22,7 +22,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    "strict": true,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -40,6 +40,7 @@
     /* Module Resolution Options */
     "resolveJsonModule": true,
     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleSuffixes": ["", ".native"],
     //"baseUrl": "packages/rest-hooks/src",                       /* Base directory to resolve non-absolute module names. */
     // "rootDirs": ["./src"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -177,7 +177,7 @@ module.exports = {
         lastVersion: 'current',
         includeCurrentVersion: true,
         versions: {
-          current: { label: '6.1', path: '', badge: false, banner: 'none' },
+          current: { label: '6.x', path: '', badge: false, banner: 'none' },
           5.2: { label: '5.2', path: '5.2', banner: 'none' },
         },
         /*onlyIncludeVersions: isDev

--- a/website/src/components/Demo/index.js
+++ b/website/src/components/Demo/index.js
@@ -364,7 +364,7 @@ export default function TodoItem({ todo }: { todo: Todo }) {
 import TodoItem from './TodoItem';
 
 function TodoList() {
-  const todos = useSuspense(TodoResource.getList);
+  const todos = useSuspense(TodoResource.getList, { userId: 1 });
   return (
     <div>
       {todos.map(todo => (


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

`strictNullChecks: false` should result in looser types, not broken types.

null unions as args to useSuspense don't properly unionize nullability.

GetEndpoint, MutateEndpoint did not previously set the path, searchParams, body values used by .extends() to keep extension types precise.


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

#### strictNullChecks

- hooks:
  - schema should be ignored with both `null` and `undefined`
  - schema extends `null` | `undefined` works even with strictNullChecks (schema extends Schema does not)
- REST
  - Use strictNullChecks detection when generating function parameters to make more flexible type

#### null arguments

For some reason for a union type to properly run through each case in a conditional, it must be a separated type instead of inline. So we add `CondNull`

```ts
export type CondNull<P, A, B> = P extends null ? A : B;
```

#### createResource().get.extend({ searchParams })

Add `NewGetEndpoint` and `NewMutateEndpoint`, which we use in createResource - these take the parameter options O