### PR TITLE
feat: Add schema.Invalidate

### DIFF
--- a/.changeset/nine-spies-repair.md
+++ b/.changeset/nine-spies-repair.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/normalizr': minor
+---
+
+Support schemas without denormalizeOnly and no denormalize method

--- a/.changeset/thirty-singers-type.md
+++ b/.changeset/thirty-singers-type.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/endpoint': minor
+'@rest-hooks/graphql': minor
+'@rest-hooks/rest': minor
+---
+
+Add INVALID symbol

--- a/.changeset/wise-files-confess.md
+++ b/.changeset/wise-files-confess.md
@@ -1,0 +1,7 @@
+---
+'@rest-hooks/endpoint': minor
+'@rest-hooks/graphql': minor
+'@rest-hooks/rest': minor
+---
+
+Add schema.Invalidate (new name for Delete)

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -26,3 +26,8 @@ Performance compared to normalizr package (higher is better):
 | normalize (long)    | 72%      | 72%        |
 | denormalize (long)  | 100%     | 830%       |
 | denormalize (short) | 600%     | 1120%      |
+
+[Comparison done on a Ryzen 7950x; Ubuntu; Node 18.15.0]
+
+Our normalize is slower due to handling much more features like metadata. Denormalize
+is even more feature rich, but significantly faster.

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -18,7 +18,7 @@ export type {
 export * as schema from './schema.js';
 export { default as Entity } from './schemas/Entity.js';
 export { default as validateRequired } from './validateRequired.js';
-export { DELETED } from './special.js';
+export { DELETED, INVALID } from './special.js';
 export type {
   Schema,
   SnapshotInterface,

--- a/packages/endpoint/src/normal.ts
+++ b/packages/endpoint/src/normal.ts
@@ -68,6 +68,8 @@ export type Denormalize<S> = S extends EntityInterface<infer U>
   ? U
   : S extends RecordClass
   ? AbstractInstanceType<S>
+  : S extends { denormalizeOnly: (...args: any) => any }
+  ? ReturnType<S['denormalizeOnly']>
   : S extends SchemaClass
   ? DenormalizeReturnType<S['denormalize']>
   : S extends Serializable<infer T>

--- a/packages/endpoint/src/schema.d.ts
+++ b/packages/endpoint/src/schema.d.ts
@@ -28,8 +28,9 @@ import {
   Constructor,
   PKClass,
 } from './schemas/EntitySchema.js';
+import { default as Invalidate } from './schemas/Invalidate.js';
 
-export { Delete, EntityMap };
+export { Delete, EntityMap, Invalidate };
 
 export { EntityInterface } from './interface.js';
 
@@ -352,6 +353,24 @@ export interface SchemaClass<T = any, N = T | undefined>
   _normalizeNullable(): any;
   // this is not an actual member, but is needed for the recursive DenormalizeNullable<> type algo
   _denormalizeNullable(): [N, boolean, boolean];
+}
+
+export interface SchemaSimpleNew<T = any> {
+  normalize(
+    input: any,
+    parent: any,
+    key: any,
+    visit: (...args: any) => any,
+    addEntity: (...args: any) => any,
+    visitedEntities: Record<string, any>,
+  ): any;
+  denormalizeOnly(input: {}, unvisit: (input: any, schema: any) => any): T;
+  infer(
+    args: readonly any[],
+    indexes: NormalizedIndex,
+    recurse: (...args: any) => any,
+    entities: EntityTable,
+  ): any;
 }
 
 // id is in Instance, so we default to that as pk

--- a/packages/endpoint/src/schema.js
+++ b/packages/endpoint/src/schema.js
@@ -5,4 +5,5 @@ export { default as Array } from './schemas/Array.js';
 export { default as All } from './schemas/All.js';
 export { default as Object } from './schemas/Object.js';
 export { default as Delete } from './schemas/Delete.js';
+export { default as Invalidate } from './schemas/Invalidate.js';
 export { default as Entity } from './schemas/EntitySchema.js';

--- a/packages/endpoint/src/schemas/Delete.ts
+++ b/packages/endpoint/src/schemas/Delete.ts
@@ -1,107 +1,22 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import Invalidate from './Invalidate.js';
 import type { EntityInterface } from '../interface.js';
 import type { AbstractInstanceType } from '../normal.js';
 import { SchemaClass, UnvisitFunction } from '../schema.js';
-import { DELETED } from '../special.js';
 
+// TODO(breaking): mark deprecated
 /**
  * Marks entity as deleted.
  * @see https://resthooks.io/rest/api/Delete
  */
 export default class Delete<E extends EntityInterface & { process: any }>
+  extends Invalidate<E>
   implements SchemaClass
 {
-  private declare _entity: E;
-
-  constructor(entity: E) {
-    if (process.env.NODE_ENV !== 'production' && !entity) {
-      throw new Error('Expected option "entity" not found on DeleteSchema.');
-    }
-    this._entity = entity;
-  }
-
-  get key() {
-    return this._entity.key;
-  }
-
-  normalize(
-    input: any,
-    parent: any,
-    key: string | undefined,
-    visit: (...args: any) => any,
-    addEntity: (...args: any) => any,
-    visitedEntities: Record<string, any>,
-  ): string | undefined {
-    // TODO: what's store needs to be a differing type from fromJS
-    const processedEntity = this._entity.process(input, parent, key);
-    const id = this._entity.pk(processedEntity, parent, key);
-
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      (id === undefined || id === '')
-    ) {
-      const error = new Error(
-        `Missing usable primary key when normalizing response.
-
-  This is likely due to a malformed response.
-  Try inspecting the network response or fetch() return value.
-  Or use debugging tools: https://resthooks.io/docs/guides/debugging
-  Learn more about schemas: https://resthooks.io/docs/api/schema
-
-  Delete(Entity): Delete(${(this._entity as any).name ?? this._entity})
-  Value: ${input && JSON.stringify(input, null, 2)}
-  `,
-      );
-      (error as any).status = 400;
-      throw error;
-    }
-    addEntity(this, DELETED, id);
-    return id;
-  }
-
-  infer(args: any, indexes: any, recurse: any): any {
-    return undefined;
-  }
-
   denormalize(
     id: string,
     unvisit: UnvisitFunction,
   ): [denormalized: AbstractInstanceType<E>, found: boolean, suspend: boolean] {
     return unvisit(id, this._entity) as any;
-  }
-
-  denormalizeOnly(
-    id: string,
-    unvisit: (input: any, schema: any) => any,
-  ): AbstractInstanceType<E> {
-    return unvisit(id, this._entity) as any;
-  }
-
-  /* istanbul ignore next */
-  _denormalizeNullable(): [
-    AbstractInstanceType<E> | undefined,
-    boolean,
-    false,
-  ] {
-    return [] as any;
-  }
-
-  /* istanbul ignore next */
-  _normalizeNullable(): string | undefined {
-    return [] as any;
-  }
-
-  /* istanbul ignore next */
-  merge(existing: any, incoming: any) {
-    return incoming;
-  }
-
-  useIncoming(
-    existingMeta: { date: number; fetchedAt: number },
-    incomingMeta: { date: number; fetchedAt: number },
-    existing: any,
-    incoming: any,
-  ) {
-    return existingMeta.date <= incomingMeta.date;
   }
 }

--- a/packages/endpoint/src/schemas/EntitySchema.ts
+++ b/packages/endpoint/src/schemas/EntitySchema.ts
@@ -232,8 +232,8 @@ export default function EntitySchema<TBase extends Constructor>(
           (error as any).status = 400;
           throw error;
         } else {
-          // these make the keys get deleted
-          return undefined;
+          // these make the keys get deleted; return undefined
+          return;
         }
       }
       const entityType = this.key;

--- a/packages/endpoint/src/schemas/Invalidate.ts
+++ b/packages/endpoint/src/schemas/Invalidate.ts
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import type { EntityInterface } from '../interface.js';
+import type { AbstractInstanceType } from '../normal.js';
+import { SchemaSimpleNew, UnvisitFunction } from '../schema.js';
+import { INVALID } from '../special.js';
+
+/**
+ * Marks entity as Invalid.
+ *
+ * This triggers suspense for all endpoints requiring it.
+ * Optional (like variable sized Array and Values) will simply remove the item.
+ * @see https://resthooks.io/rest/api/Invalidate
+ */
+export default class Invalidate<E extends EntityInterface & { process: any }>
+  implements SchemaSimpleNew
+{
+  protected declare _entity: E;
+
+  constructor(entity: E) {
+    if (process.env.NODE_ENV !== 'production' && !entity) {
+      throw new Error('Expected option "entity" not found on DeleteSchema.');
+    }
+    this._entity = entity;
+  }
+
+  get key() {
+    return this._entity.key;
+  }
+
+  normalize(
+    input: any,
+    parent: any,
+    key: string | undefined,
+    visit: (...args: any) => any,
+    addEntity: (...args: any) => any,
+    visitedEntities: Record<string, any>,
+  ): string | undefined {
+    // TODO: what's store needs to be a differing type from fromJS
+    const processedEntity = this._entity.process(input, parent, key);
+    const id = this._entity.pk(processedEntity, parent, key);
+
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      (id === undefined || id === '')
+    ) {
+      const error = new Error(
+        `Missing usable primary key when normalizing response.
+
+  This is likely due to a malformed response.
+  Try inspecting the network response or fetch() return value.
+  Or use debugging tools: https://resthooks.io/docs/guides/debugging
+  Learn more about schemas: https://resthooks.io/docs/api/schema
+
+  Delete(Entity): Delete(${(this._entity as any).name ?? this._entity})
+  Value: ${input && JSON.stringify(input, null, 2)}
+  `,
+      );
+      (error as any).status = 400;
+      throw error;
+    }
+    addEntity(this, INVALID, id);
+    return id;
+  }
+
+  infer(args: any, indexes: any, recurse: any): any {
+    return undefined;
+  }
+
+  denormalizeOnly(
+    id: string,
+    unvisit: (input: any, schema: any) => any,
+  ): AbstractInstanceType<E> {
+    return unvisit(id, this._entity) as any;
+  }
+
+  /* istanbul ignore next */
+  _denormalizeNullable(): [
+    AbstractInstanceType<E> | undefined,
+    boolean,
+    false,
+  ] {
+    return [] as any;
+  }
+
+  /* istanbul ignore next */
+  _normalizeNullable(): string | undefined {
+    return [] as any;
+  }
+
+  /* istanbul ignore next */
+  merge(existing: any, incoming: any) {
+    return incoming;
+  }
+
+  useIncoming(
+    existingMeta: { date: number; fetchedAt: number },
+    incomingMeta: { date: number; fetchedAt: number },
+    existing: any,
+    incoming: any,
+  ) {
+    return existingMeta.date <= incomingMeta.date;
+  }
+}

--- a/packages/endpoint/src/schemas/__tests__/legacy-compat/denormalize.ts
+++ b/packages/endpoint/src/schemas/__tests__/legacy-compat/denormalize.ts
@@ -155,7 +155,8 @@ const getUnvisit = (
     if (isEntity(schema)) {
       return unvisitEntity(
         input,
-        schema,
+        // this casting is ok because the interface was never exposed to users
+        schema as any,
         unvisit,
         getEntity,
         localCache,

--- a/packages/endpoint/src/special.ts
+++ b/packages/endpoint/src/special.ts
@@ -1,1 +1,2 @@
 export const DELETED = Symbol('ENTITY WAS DELETED');
+export const INVALID = DELETED;

--- a/packages/normalizr/src/denormalize/unvisit.ts
+++ b/packages/normalizr/src/denormalize/unvisit.ts
@@ -89,7 +89,10 @@ function unvisitEntityObject(
     if (typeof schema.denormalizeOnly === 'function') {
       localCacheKey[pk] = schema.denormalizeOnly(entityCopy, unvisit);
     } else {
-      [localCacheKey[pk], _, deleted] = schema.denormalize(entityCopy, unvisit);
+      [localCacheKey[pk], _, deleted] = (schema as any).denormalize(
+        entityCopy,
+        unvisit,
+      );
       if (deleted) localCacheKey[pk] = INVALID;
     }
   }

--- a/packages/normalizr/src/interface.ts
+++ b/packages/normalizr/src/interface.ts
@@ -1,5 +1,3 @@
-import { AbstractInstanceType, Denormalize, EntityMap } from './types.js';
-
 export type Schema =
   | null
   | string
@@ -23,7 +21,7 @@ export interface SchemaSimple<T = any> {
     addEntity: (...args: any) => any,
     visitedEntities: Record<string, any>,
   ): any;
-  denormalize(
+  denormalize?(
     // eslint-disable-next-line @typescript-eslint/ban-types
     input: {},
     unvisit: UnvisitFunction,

--- a/packages/normalizr/src/types.ts
+++ b/packages/normalizr/src/types.ts
@@ -85,6 +85,8 @@ export type Denormalize<S> = S extends EntityInterface<infer U>
   ? U
   : S extends RecordClass
   ? AbstractInstanceType<S>
+  : S extends { denormalizeOnly: (...args: any) => any }
+  ? ReturnType<S['denormalizeOnly']>
   : S extends SchemaClass
   ? DenormalizeReturnType<S['denormalize']>
   : S extends Serializable<infer T>


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Less names = less to learn.

We are consolidating concepts around [expiry policy](https://resthooks.io/docs/concepts/expiry-policy). There are three possible states for both endpoints and entities:

- Invalid
- Stale
- Valid



### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Therefore, the schema that sets an entity invalid will be called Invalidate. A schema that sets an entity stale will be called Stale (or verb form?)