### PR TITLE
feat: Export initialState and createReducer

### DIFF
--- a/.changeset/smart-hotels-happen.md
+++ b/.changeset/smart-hotels-happen.md
@@ -1,0 +1,5 @@
+---
+'@rest-hooks/redux': patch
+---
+
+Export initialState and createReducer even with newer rest-hooks/react

--- a/packages/redux/src/index.ts
+++ b/packages/redux/src/index.ts
@@ -1,7 +1,7 @@
+export { applyManager, initialState, createReducer } from '@rest-hooks/core';
 export * from '@rest-hooks/react';
 export { prepareStore } from './prepareStore.js';
 export { default as CacheProvider } from './CacheProvider.js';
 export { default as ExternalCacheProvider } from './ExternalCacheProvider.js';
 export { default as mapMiddleware } from './mapMiddleware.js';
 export { default as PromiseifyMiddleware } from './PromiseifyMiddleware.js';
-export { applyManager } from '@rest-hooks/core';


### PR DESCRIPTION

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
These are needed from core and no longer provided by recent @rest-hooks/react versions

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Add initialState, createReducer export from core