### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,12 @@ Update docs **in the same commit/PR** when changing public APIs (anything export
 - **Jest**: Maps `@data-client/*` imports to local `packages/*/src` during tests
 - **TypeScript**: Uses TS 6.0 project references; ambient `.d.ts` files copied during build
 - **Native compilation**: When `COMPILE_TARGET=native`, prefers `.native.*` files
+
+## Cursor Cloud specific instructions
+
+- **Node version**: `.nvmrc` specifies Node 24. Use `nvm install` / `nvm use` to match.
+- **Package manager**: Yarn 4 (Berry) via Corepack — run `corepack enable` before `yarn install`.
+- **Build before test**: `yarn build` (or `yarn prepare` for types-only) must complete before running tests or the website. The build populates `lib/` directories and ambient `.d.ts` files that Jest and Docusaurus depend on.
+- **Lint scope**: CI runs `yarn lint --quiet packages/*/src`. Running bare `yarn lint` hits website/examples/config files with pre-existing warnings; scope to `packages/*/src` for a clean pass.
+- **Website dev server**: `cd website && yarn start:vscode` starts Docusaurus on port 3000 (no-open mode). Requires a prior `yarn build` so workspace-linked packages resolve.
+- **No external services**: No databases, Docker, or API keys are required. All examples hit public APIs client-side.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation

Adds development environment setup notes for Cursor Cloud agents so future agents can start services and run tests without re-discovering environment caveats.

### Solution

Appended a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering:
- Node version requirement (24 via `.nvmrc`)
- Corepack/Yarn 4 setup
- Build-before-test dependency
- Lint scope (CI uses `packages/*/src`)
- Website dev server startup
- No external services needed

### Verification

- `yarn lint --quiet packages/*/src` — clean
- `yarn test --ci` — 109 suites, 1530 tests passed
- `yarn build` — all packages built
- Website dev server (`yarn start:vscode`) — Docusaurus running on port 3000

[website_demo_walkthrough.mp4](https://cursor.com/agents/bc-dd90e333-fafe-41ed-a9ef-34bee242ff21/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebsite_demo_walkthrough.mp4)
[Documentation homepage](https://cursor.com/agents/bc-dd90e333-fafe-41ed-a9ef-34bee242ff21/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd90e333-fafe-41ed-a9ef-34bee242ff21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd90e333-fafe-41ed-a9ef-34bee242ff21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

