### PR TITLE
chore(rollup-plugins): upgrade @rollup/plugin-terser to ^1.0.0

### DIFF
--- a/scripts/rollup-plugins/package.json
+++ b/scripts/rollup-plugins/package.json
@@ -16,7 +16,7 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-replace": "^6.0.2",
-    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-terser": "^1.0.0",
     "rollup-plugin-banner2": "^1.3.1",
     "rollup-plugin-dts": "6.1.1",
     "rollup-plugin-filesize": "^10.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6707,11 +6707,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-terser@npm:^0.4.4":
-  version: 0.4.4
-  resolution: "@rollup/plugin-terser@npm:0.4.4"
+"@rollup/plugin-terser@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@rollup/plugin-terser@npm:1.0.0"
   dependencies:
-    serialize-javascript: "npm:^6.0.1"
+    serialize-javascript: "npm:^7.0.3"
     smob: "npm:^1.0.0"
     terser: "npm:^5.17.4"
   peerDependencies:
@@ -6719,7 +6719,7 @@ __metadata:
   peerDependenciesMeta:
     rollup:
       optional: true
-  checksum: 10c0/b9cb6c8f02ac1c1344019e9fb854321b74f880efebc41b6bdd84f18331fce0f4a2aadcdb481042245cd3f409b429ac363af71f9efec4a2024731d67d32af36ee
+  checksum: 10c0/08be445cc2e0677132ee06cdebbcd1b6cd3ab22e220fcd89d8a22eaf9ee501a940f425931ac65c65ab113803ad31a895f2575716248609c882c8e562fd6cc2d4
   languageName: node
   linkType: hard
 
@@ -25871,7 +25871,7 @@ __metadata:
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-node-resolve": "npm:^16.0.0"
     "@rollup/plugin-replace": "npm:^6.0.2"
-    "@rollup/plugin-terser": "npm:^0.4.4"
+    "@rollup/plugin-terser": "npm:^1.0.0"
     rollup-plugin-banner2: "npm:^1.3.1"
     rollup-plugin-dts: "npm:6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
@@ -26425,6 +26425,13 @@ __metadata:
   dependencies:
     randombytes: "npm:^2.1.0"
   checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^7.0.3":
+  version: 7.0.5
+  resolution: "serialize-javascript@npm:7.0.5"
+  checksum: 10c0/7b7818e5267f6d474ec7a56d36ba69dd712726a13eab37706ec94615fb7ca8945471f2b7fb0dc9dbe8c79c1930c1079d97f66f91315c8c8c2ca6c38898cec96f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump `@rollup/plugin-terser` from `^0.4.4` to `^1.0.0` in the `rollup-plugins` workspace.
- Lockfile picks up `serialize-javascript@7.0.5`, addressing the high-severity audit findings associated with the old transitive `serialize-javascript@6.x` chain.

## Notes

- `@rollup/plugin-terser@1.0.0` declares `engines.node: ">=20"`. Rollup bundle jobs use the default CircleCI executor (`cimg/node:24.14`), not the Node 18/20 matrix (which only runs the Jest Node project).
- No changeset: this is an internal dev/build dependency, not a published `@data-client/*` package API change.

## Verification

- `yarn install` succeeded.
- Spot check: `import('@rollup/plugin-terser')` loads; `yarn npm audit` no longer reports `serialize-javascript` / `@rollup/plugin-terser` for this path.
- Full `rollup` on `packages/core` was not run to completion here (missing prior `normalizr` build artifacts); CI `build` workflow should exercise Rollup end-to-end.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a89164d-124d-4a40-a5a9-221bfe3a726d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a89164d-124d-4a40-a5a9-221bfe3a726d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

