### PR TITLE
bench-react: align data-client renderLimit with windowed denormalize

### DIFF
--- a/examples/benchmark-react/src/data-client/index.tsx
+++ b/examples/benchmark-react/src/data-client/index.tsx
@@ -27,6 +27,7 @@ import { setCurrentIssues } from '@shared/refStability';
 import {
   UserResource,
   IssueResource,
+  benchWindowedIssueListEndpoint,
   sortedIssuesEndpoint,
 } from '@shared/resources';
 import { patchIssue } from '@shared/server';
@@ -58,7 +59,10 @@ const benchGC = new BenchGCPolicy();
 
 /** Renders issues from the list endpoint (models rendering a list fetch response). */
 function ListView({ count, limit }: { count: number; limit?: number }) {
-  const { data: issues } = useDLE(IssueResource.getList, { count });
+  const listEndpoint =
+    limit != null ? benchWindowedIssueListEndpoint : IssueResource.getList;
+  const listParams = limit != null ? { count, renderLimit: limit } : { count };
+  const { data: issues } = useDLE(listEndpoint, listParams);
   if (!issues) return null;
   const list = issues as Issue[];
   setCurrentIssues(list);
@@ -85,7 +89,11 @@ function StateListView({
   count: number;
   limit?: number;
 }) {
-  const { data: issues } = useDLE(IssueResource.getList, { state, count });
+  const listEndpoint =
+    limit != null ? benchWindowedIssueListEndpoint : IssueResource.getList;
+  const listParams =
+    limit != null ? { state, count, renderLimit: limit } : { state, count };
+  const { data: issues } = useDLE(listEndpoint, listParams);
   if (!issues) return null;
   const list = issues as Issue[];
   return (

--- a/examples/benchmark-react/src/shared/resources.ts
+++ b/examples/benchmark-react/src/shared/resources.ts
@@ -164,3 +164,37 @@ export const sortedIssuesQuery = new Query(
 export const sortedIssuesEndpoint = IssueResource.getList.extend({
   schema: sortedIssuesQuery,
 });
+
+/**
+ * Same cache key and normalization as `IssueResource.getList`, but when
+ * `renderLimit` is passed in params, `queryKey` slices the collection ids before
+ * denormalization so hooks only materialize the first N issues. The full
+ * collection stays normalized; GC paths and entity subscriptions still cover
+ * all members, so nested entity updates (e.g. shared user) propagate correctly.
+ *
+ * Benchmark-only: matches the harness `renderLimit` pattern without shifting
+ * work to competitors (they already slice the array they hold).
+ */
+class BenchWindowedIssueListQuery extends Query<any, any> {
+  constructor() {
+    super(IssueResource.getList.schema, (entries: unknown) => entries);
+  }
+
+  queryKey(args: any, unvisit: (schema: any, input: any) => any) {
+    const full = unvisit(this.schema, args);
+    const limit = args?.renderLimit;
+    if (typeof limit === 'number' && limit > 0 && Array.isArray(full)) {
+      return full.slice(0, limit);
+    }
+    return full;
+  }
+}
+
+export const benchWindowedIssueListEndpoint = IssueResource.getList.extend({
+  schema: new BenchWindowedIssueListQuery(),
+  /** Omit client-only window hint so cache key matches `IssueResource.getList`. */
+  key(params: { count?: number; state?: string; renderLimit?: number }) {
+    const { renderLimit: _rl, ...rest } = params;
+    return IssueResource.getList.key(rest as any);
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `renderLimit` harness was only capping **DOM** rows while `useDLE(IssueResource.getList)` still **denormalized the full collection** (e.g. 10k issues) on every `updateUser`, which inflates work and timing spread.

## Change

- Add `benchWindowedIssueListEndpoint`: a `Query` whose `queryKey` slices the collection’s normalized ids to `renderLimit` **before** denormalization, so hooks only build objects for visible rows.
- Override `key()` to strip `renderLimit` from params so the endpoint cache key stays identical to `IssueResource.getList` (invalidation and shared cache behavior unchanged).
- Use this endpoint from `ListView` / `StateListView` in the data-client app **only when** `limit` is set.

## Results (local)

`npx tsx bench/runner.ts --lib data-client --scenario update-user-10000 --network-sim false`:

- Scenario **converged after 11** measurements (previously often hit **max 50**).
- `data-client.js` minified bundle: **~+0.4 KB** vs prior build.

`bench/validate.ts`: all scenarios pass for data-client.

## Notes

This is **benchmark-example only**; no published package API changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c289a7fd-5f8f-463f-9891-a7de24650ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c289a7fd-5f8f-463f-9891-a7de24650ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

