### PR TITLE
internal: Fix security issues in data-client-rest-setup skill

### DIFF
--- a/.cursor/skills/data-client-rest-setup/references/axios-migration.md
+++ b/.cursor/skills/data-client-rest-setup/references/axios-migration.md
@@ -5,8 +5,10 @@
 **Always run this first**, before any manual edits. It handles deterministic transforms that save significant manual work:
 
 ```bash
-npx jscodeshift -t https://dataclient.io/codemods/axios-to-rest.js --extensions=ts,tsx,js,jsx src/
+npx jscodeshift -t <skill-root>/scripts/axios-to-rest.js --extensions=ts,tsx,js,jsx src/
 ```
+
+Resolve `<skill-root>` to the absolute path of this skill's directory (the parent of `scripts/`).
 
 **What the codemod does:**
 - `import axios from 'axios'` → `import { RestEndpoint } from '@data-client/rest'`
@@ -212,7 +214,7 @@ class BasicAuthEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
   getHeaders(headers: HeadersInit) {
     return {
       ...headers,
-      Authorization: `Basic ${btoa('user:pass')}`,
+      Authorization: `Basic ${btoa(`${username}:${password}`)}`,
     };
   }
 }
@@ -280,12 +282,22 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
       if (init.headers) {
         Object.entries(init.headers).forEach(([k, v]) => xhr.setRequestHeader(k, v as string));
       }
+      if (init.signal) {
+        init.signal.addEventListener('abort', () => xhr.abort());
+      }
       if (this.onProgress) {
         xhr.upload.onprogress = e => {
           if (e.lengthComputable) this.onProgress!(e.loaded / e.total);
         };
       }
-      xhr.onload = () => resolve(new Response(xhr.response, { status: xhr.status, statusText: xhr.statusText }));
+      xhr.onload = () => {
+        const headers = new Headers();
+        xhr.getAllResponseHeaders().trim().split(/\r?\n/).forEach(line => {
+          const [key, ...rest] = line.split(': ');
+          if (key) headers.append(key, rest.join(': '));
+        });
+        resolve(new Response(xhr.response, { status: xhr.status, statusText: xhr.statusText, headers }));
+      };
       xhr.onerror = () => reject(new TypeError('Network request failed'));
       xhr.send(init.body);
     });

--- a/.cursor/skills/data-client-rest-setup/references/axios-migration.md
+++ b/.cursor/skills/data-client-rest-setup/references/axios-migration.md
@@ -282,9 +282,6 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
       if (init.headers) {
         Object.entries(init.headers).forEach(([k, v]) => xhr.setRequestHeader(k, v as string));
       }
-      if (init.signal) {
-        init.signal.addEventListener('abort', () => xhr.abort());
-      }
       if (this.onProgress) {
         xhr.upload.onprogress = e => {
           if (e.lengthComputable) this.onProgress!(e.loaded / e.total);
@@ -296,9 +293,25 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
           const [key, ...rest] = line.split(': ');
           if (key) headers.append(key, rest.join(': '));
         });
+        init.signal?.removeEventListener('abort', abortXhr);
         resolve(new Response(xhr.response, { status: xhr.status, statusText: xhr.statusText, headers }));
       };
-      xhr.onerror = () => reject(new TypeError('Network request failed'));
+      xhr.onerror = () => {
+        init.signal?.removeEventListener('abort', abortXhr);
+        reject(new TypeError('Network request failed'));
+      };
+      xhr.onabort = () => {
+        init.signal?.removeEventListener('abort', abortXhr);
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      };
+      const abortXhr = () => xhr.abort();
+      if (init.signal?.aborted) {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+        return;
+      }
+      if (init.signal) {
+        init.signal.addEventListener('abort', abortXhr, { once: true });
+      }
       xhr.send(init.body);
     });
   }

--- a/.cursor/skills/data-client-rest-setup/references/superagent-migration.md
+++ b/.cursor/skills/data-client-rest-setup/references/superagent-migration.md
@@ -133,7 +133,7 @@ await request
 const uploadFile = new RestEndpoint({
   path: '/upload',
   method: 'POST',
-  body: undefined as unknown as FormData,
+  body: {} as FormData,
   schema: undefined,
 });
 // Usage: ctrl.fetch(uploadFile, formData)

--- a/.cursor/skills/data-client-rest-setup/scripts/axios-to-rest.js
+++ b/.cursor/skills/data-client-rest-setup/scripts/axios-to-rest.js
@@ -1,0 +1,1 @@
+../../../../website/static/codemods/axios-to-rest.js


### PR DESCRIPTION
### Motivation

Security review of the `data-client-rest-setup` agent skill found several issues: a remote URL for code execution, hardcoded placeholder credentials, missing abort/header handling in an XHR example, and an inconsistency with the skill's own body-typing guidance.

### Solution

- **Supply chain**: Replace remote codemod URL (`https://dataclient.io/codemods/axios-to-rest.js`) with a local symlink to `website/static/codemods/axios-to-rest.js`, avoiding downloading and executing code from a remote URL
- **Credentials**: Parameterize the basic auth example (`btoa('user:pass')` → `btoa(\`\${username}:\${password}\`)`) so it can't be copy-pasted verbatim
- **XHR upload handler**: Wire `init.signal` to `xhr.abort()` for AbortSignal propagation, and forward response headers via `xhr.getAllResponseHeaders()`
- **Body typing**: Fix `superagent-migration.md` to use `body: {} as FormData` (truthy placeholder) consistent with the main skill's guidance

### Open questions

N/A

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to skill documentation/examples and a local codemod reference, with no runtime application code impact.
> 
> **Overview**
> Updates the `data-client-rest-setup` skill to avoid executing a remote codemod by pointing the Axios migration step at a local `scripts/axios-to-rest.js` shim.
> 
> Hardens migration examples by removing copy-pastable basic-auth credentials, improving the XHR upload example to propagate `AbortSignal` and forward response headers, and aligning the SuperAgent upload example to use a truthy `FormData` body placeholder (`body: {} as FormData`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e0c615048d6161ae72fb4d78fef954d30e13e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->