### PR TITLE
Fix XHR abort handling in axios migration snippet

### DIFF
--- a/.cursor/skills/data-client-rest-setup/references/axios-migration.md
+++ b/.cursor/skills/data-client-rest-setup/references/axios-migration.md
@@ -282,14 +282,6 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
       if (init.headers) {
         Object.entries(init.headers).forEach(([k, v]) => xhr.setRequestHeader(k, v as string));
       }
-      const abortXhr = () => xhr.abort();
-      if (init.signal?.aborted) {
-        reject(new DOMException('The operation was aborted.', 'AbortError'));
-        return;
-      }
-      if (init.signal) {
-        init.signal.addEventListener('abort', abortXhr, { once: true });
-      }
       if (this.onProgress) {
         xhr.upload.onprogress = e => {
           if (e.lengthComputable) this.onProgress!(e.loaded / e.total);
@@ -312,6 +304,14 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
         init.signal?.removeEventListener('abort', abortXhr);
         reject(new DOMException('The operation was aborted.', 'AbortError'));
       };
+      const abortXhr = () => xhr.abort();
+      if (init.signal?.aborted) {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+        return;
+      }
+      if (init.signal) {
+        init.signal.addEventListener('abort', abortXhr, { once: true });
+      }
       xhr.send(init.body);
     });
   }

--- a/.cursor/skills/data-client-rest-setup/references/axios-migration.md
+++ b/.cursor/skills/data-client-rest-setup/references/axios-migration.md
@@ -282,8 +282,13 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
       if (init.headers) {
         Object.entries(init.headers).forEach(([k, v]) => xhr.setRequestHeader(k, v as string));
       }
+      const abortXhr = () => xhr.abort();
+      if (init.signal?.aborted) {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+        return;
+      }
       if (init.signal) {
-        init.signal.addEventListener('abort', () => xhr.abort());
+        init.signal.addEventListener('abort', abortXhr, { once: true });
       }
       if (this.onProgress) {
         xhr.upload.onprogress = e => {
@@ -296,9 +301,17 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
           const [key, ...rest] = line.split(': ');
           if (key) headers.append(key, rest.join(': '));
         });
+        init.signal?.removeEventListener('abort', abortXhr);
         resolve(new Response(xhr.response, { status: xhr.status, statusText: xhr.statusText, headers }));
       };
-      xhr.onerror = () => reject(new TypeError('Network request failed'));
+      xhr.onerror = () => {
+        init.signal?.removeEventListener('abort', abortXhr);
+        reject(new TypeError('Network request failed'));
+      };
+      xhr.onabort = () => {
+        init.signal?.removeEventListener('abort', abortXhr);
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      };
       xhr.send(init.body);
     });
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes # .

### Motivation
The migration example wired `AbortSignal` to call `xhr.abort()`, but it only handled `onload` and `onerror`. Since `XMLHttpRequest` fires `abort` on cancellation (not `load`/`error`), aborted requests could leave the promise pending indefinitely.

### Solution
- Add an `xhr.onabort` handler that rejects with `new DOMException('The operation was aborted.', 'AbortError')`
- Handle already-aborted signals before attaching listeners to avoid sending a request that should already be cancelled
- Use a stable abort listener (`abortXhr`) and remove it in `onload`, `onerror`, and `onabort` to avoid lingering listeners

### Open questions
None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82a1e13c-c8fe-4637-8006-23a308067378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82a1e13c-c8fe-4637-8006-23a308067378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

