### PR TITLE
Fix XHR abort handling in axios migration example

### DIFF
--- a/.cursor/skills/data-client-rest-setup/references/axios-migration.md
+++ b/.cursor/skills/data-client-rest-setup/references/axios-migration.md
@@ -5,8 +5,10 @@
 **Always run this first**, before any manual edits. It handles deterministic transforms that save significant manual work:
 
 ```bash
-npx jscodeshift -t https://dataclient.io/codemods/axios-to-rest.js --extensions=ts,tsx,js,jsx src/
+npx jscodeshift -t <skill-root>/scripts/axios-to-rest.js --extensions=ts,tsx,js,jsx src/
 ```
+
+Resolve `<skill-root>` to the absolute path of this skill's directory (the parent of `scripts/`).
 
 **What the codemod does:**
 - `import axios from 'axios'` → `import { RestEndpoint } from '@data-client/rest'`
@@ -212,7 +214,7 @@ class BasicAuthEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
   getHeaders(headers: HeadersInit) {
     return {
       ...headers,
-      Authorization: `Basic ${btoa('user:pass')}`,
+      Authorization: `Basic ${btoa(`${username}:${password}`)}`,
     };
   }
 }
@@ -280,12 +282,22 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
       if (init.headers) {
         Object.entries(init.headers).forEach(([k, v]) => xhr.setRequestHeader(k, v as string));
       }
+      if (init.signal) {
+        init.signal.addEventListener('abort', () => xhr.abort());
+      }
       if (this.onProgress) {
         xhr.upload.onprogress = e => {
           if (e.lengthComputable) this.onProgress!(e.loaded / e.total);
         };
       }
-      xhr.onload = () => resolve(new Response(xhr.response, { status: xhr.status, statusText: xhr.statusText }));
+      xhr.onload = () => {
+        const headers = new Headers();
+        xhr.getAllResponseHeaders().trim().split(/\r?\n/).forEach(line => {
+          const [key, ...rest] = line.split(': ');
+          if (key) headers.append(key, rest.join(': '));
+        });
+        resolve(new Response(xhr.response, { status: xhr.status, statusText: xhr.statusText, headers }));
+      };
       xhr.onerror = () => reject(new TypeError('Network request failed'));
       xhr.send(init.body);
     });

--- a/.cursor/skills/data-client-rest-setup/references/axios-migration.md
+++ b/.cursor/skills/data-client-rest-setup/references/axios-migration.md
@@ -282,14 +282,6 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
       if (init.headers) {
         Object.entries(init.headers).forEach(([k, v]) => xhr.setRequestHeader(k, v as string));
       }
-      const abortXhr = () => xhr.abort();
-      if (init.signal?.aborted) {
-        reject(new DOMException('The operation was aborted.', 'AbortError'));
-        return;
-      }
-      if (init.signal) {
-        init.signal.addEventListener('abort', abortXhr, { once: true });
-      }
       if (this.onProgress) {
         xhr.upload.onprogress = e => {
           if (e.lengthComputable) this.onProgress!(e.loaded / e.total);
@@ -312,6 +304,14 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
         init.signal?.removeEventListener('abort', abortXhr);
         reject(new DOMException('The operation was aborted.', 'AbortError'));
       };
+      const abortXhr = () => xhr.abort();
+      if (init.signal?.aborted) {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+        return;
+      }
+      if (init.signal) {
+        init.signal.addEventListener('abort', abortXhr, { once: true });
+      }
       xhr.send(init.body);
     });
   }

--- a/.cursor/skills/data-client-rest-setup/references/axios-migration.md
+++ b/.cursor/skills/data-client-rest-setup/references/axios-migration.md
@@ -282,8 +282,13 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
       if (init.headers) {
         Object.entries(init.headers).forEach(([k, v]) => xhr.setRequestHeader(k, v as string));
       }
+      const abortXhr = () => xhr.abort();
+      if (init.signal?.aborted) {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+        return;
+      }
       if (init.signal) {
-        init.signal.addEventListener('abort', () => xhr.abort());
+        init.signal.addEventListener('abort', abortXhr, { once: true });
       }
       if (this.onProgress) {
         xhr.upload.onprogress = e => {
@@ -296,9 +301,17 @@ class UploadEndpoint<O extends RestGenerics = any> extends RestEndpoint<O> {
           const [key, ...rest] = line.split(': ');
           if (key) headers.append(key, rest.join(': '));
         });
+        init.signal?.removeEventListener('abort', abortXhr);
         resolve(new Response(xhr.response, { status: xhr.status, statusText: xhr.statusText, headers }));
       };
-      xhr.onerror = () => reject(new TypeError('Network request failed'));
+      xhr.onerror = () => {
+        init.signal?.removeEventListener('abort', abortXhr);
+        reject(new TypeError('Network request failed'));
+      };
+      xhr.onabort = () => {
+        init.signal?.removeEventListener('abort', abortXhr);
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      };
       xhr.send(init.body);
     });
   }

--- a/.cursor/skills/data-client-rest-setup/references/superagent-migration.md
+++ b/.cursor/skills/data-client-rest-setup/references/superagent-migration.md
@@ -133,7 +133,7 @@ await request
 const uploadFile = new RestEndpoint({
   path: '/upload',
   method: 'POST',
-  body: undefined as unknown as FormData,
+  body: {} as FormData,
   schema: undefined,
 });
 // Usage: ctrl.fetch(uploadFile, formData)

--- a/.cursor/skills/data-client-rest-setup/scripts/axios-to-rest.js
+++ b/.cursor/skills/data-client-rest-setup/scripts/axios-to-rest.js
@@ -1,0 +1,1 @@
+../../../../website/static/codemods/axios-to-rest.js


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the `onUploadProgress` XHR example in the axios migration skill reference.

### Motivation

The `XMLHttpRequest`-based `fetchResponse()` example had a missing `xhr.onabort` handler. When `xhr.abort()` was called (via the abort signal), `XMLHttpRequest` fires only the `abort` event — not `load` or `error`. Since the promise only had `onload` and `onerror` handlers, an abort would cause the promise to hang indefinitely.

Additionally, the abort signal listener was set up as an anonymous function with no cleanup, creating potential memory leaks and a race condition if the signal was already aborted before `xhr.send()`.

### Solution

- Added `xhr.onabort` handler that rejects with `new DOMException('The operation was aborted.', 'AbortError')` (matching fetch API behavior)
- Replaced the anonymous abort listener with a named `abortXhr` function using `{ once: true }`
- Added `removeEventListener('abort', abortXhr)` cleanup in all three handlers (`onload`, `onerror`, `onabort`)
- Added an early-abort check (`init.signal?.aborted`) before calling `xhr.send()` to handle already-aborted signals
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5730f835-acf3-493a-a836-8f1d37886df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5730f835-acf3-493a-a836-8f1d37886df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

