### PR TITLE
enhance: Export CollectionOptions type from endpoint and rest packages

### DIFF
--- a/.changeset/export-collection-options.md
+++ b/.changeset/export-collection-options.md
@@ -1,0 +1,6 @@
+---
+'@data-client/endpoint': patch
+'@data-client/rest': patch
+---
+
+Export `CollectionOptions` from the public `@data-client/endpoint` and `@data-client/rest` entrypoints.

--- a/docs/rest/api/Collection.md
+++ b/docs/rest/api/Collection.md
@@ -618,10 +618,15 @@ Controls how the moved entity is added to its destination collection.
 The exported [`unshift`](#unshift-merge) merge function places items at the start:
 
 ```ts
-import { Collection, unshift } from '@data-client/rest';
+import { Collection, unshift, type CollectionOptions } from '@data-client/rest';
+import type { PolymorphicInterface } from '@data-client/endpoint';
 
-class MyCollection extends Collection {
-  constructor(schema, options) {
+class MyCollection<
+  S extends any[] | PolymorphicInterface = any,
+  Args extends any[] = any[],
+  Parent = any,
+> extends Collection<S, Args, Parent> {
+  constructor(schema: S, options?: CollectionOptions<Args, Parent>) {
     super(schema, options);
     // Prepend moved items instead of appending
     // highlight-next-line

--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -24,6 +24,7 @@ export {
 // Without this we get 'cannot be named without a reference to' for resource()....why is this?
 // Clue 1) It only happens with types mentioned in return types of other types
 export type { Array, DefaultArgs, Object } from './schema.js';
+export type { CollectionOptions } from './schemas/Collection.js';
 export { default as Entity } from './schemas/Entity.js';
 export { default as EntityMixin } from './schemas/EntityMixin.js';
 export type { IEntityClass, IEntityInstance } from './schemas/EntityTypes.js';

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -47,5 +47,6 @@ export type {
   PathArgsAndSearch,
 } from './pathTypes.js';
 
+export type { CollectionOptions } from '@data-client/endpoint';
 export * from '@data-client/endpoint';
 export * from './RestEndpoint.js';


### PR DESCRIPTION
### Motivation

`CollectionOptions` is the type for the second argument to the `Collection` constructor, but it was never exported from `@data-client/endpoint` or `@data-client/rest`. This made it impossible to properly type `Collection` subclass constructors without duplicating the type or using `any`.

### Solution

- Export `CollectionOptions` from `@data-client/endpoint` (source in `schemas/Collection.ts`)
- Re-export it from `@data-client/rest` so users of the higher-level package get it too
- Update the `Collection` docs `moveWith` example to show correct generics (`S`, `Args`, `Parent`) and typed constructor, replacing the previous untyped snippet
- Add a note in the Collection Options docs section showing the import path

### Open questions

N/A

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-only public API change plus docs update; main risk is minor TypeScript export/compatibility issues for consumers relying on existing type surfaces.
> 
> **Overview**
> Exports the `CollectionOptions` type from the public `@data-client/endpoint` entrypoint and re-exports it from `@data-client/rest`, enabling consumers to properly type `Collection` subclass constructors.
> 
> Updates the `Collection` docs `moveWith()` example to use explicit generics and a typed constructor that accepts `CollectionOptions`, and adds a changeset to publish patch releases for both packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e087fc797d883ad3103e02e73b40cc05332571e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->