### PR TITLE
fix(rest): Collection extender body types match HTTP method semantics

### DIFF
--- a/.changeset/fix-extender-body-types.md
+++ b/.changeset/fix-extender-body-types.md
@@ -1,0 +1,27 @@
+---
+'@data-client/rest': patch
+---
+
+Fix [Collection](https://dataclient.io/rest/api/Collection) extender body types to match their HTTP method semantics
+
+PATCH extenders (`.move`, `.remove`) now type their body as `Partial`, matching
+[`partialUpdate`](https://dataclient.io/rest/api/resource#partialupdate). Previously they
+required the full body type even though they are PATCH endpoints.
+
+Standalone `RestEndpoint` without an explicit `body` option now derives a typed
+body from the Collection's entity schema instead of falling back to `any`.
+
+```ts
+const MyResource = resource({
+  path: '/articles/:id',
+  schema: Article,
+  body: {} as { title: string; content: string },
+});
+
+// move (PATCH) now accepts partial body
+MyResource.getList.move({ id: '1' }, { title: 'new title' });
+
+// push (POST) still requires full body
+MyResource.getList.push({ title: 'hi', content: 'there' });
+```
+

--- a/packages/endpoint/src/schemaTypes.ts
+++ b/packages/endpoint/src/schemaTypes.ts
@@ -29,6 +29,19 @@ export type CollectionArrayAdder<S extends PolymorphicInterface> =
     T
   : never;
 
+/** Schema when assigning to a Values Collection
+ * Conceptually only returns a single item
+ */
+export type CollectionValuesAdder<S extends PolymorphicInterface> =
+  S extends (
+    {
+      denormalize(...args: any): Record<string, unknown>;
+      schema: infer T;
+    }
+  ) ?
+    T
+  : never;
+
 /** Schema to remove/move (by value) from a Collection(Array|Values)
  * Conceptually only returns a single item
  */
@@ -181,9 +194,7 @@ export interface CollectionInterface<
   /** Schema to merge with a Values Collection
    * @see https://dataclient.io/rest/api/Collection#assign
    */
-  assign: S extends { denormalize(...args: any): Record<string, unknown> } ?
-    Collection<S, Args, Parent>
-  : never;
+  assign: CollectionValuesAdder<S>;
 
   /** Schema to remove (by value) from a Collection(Array|Values)
    * @see https://dataclient.io/rest/api/Collection#remove

--- a/packages/rest/src/RestEndpointTypes.ts
+++ b/packages/rest/src/RestEndpointTypes.ts
@@ -1,4 +1,5 @@
 import type {
+  Denormalize,
   EndpointExtraOptions,
   EndpointInstanceInterface,
   Schema,
@@ -175,10 +176,10 @@ export interface RestInstance<
   push: AddEndpoint<
     F,
     ExtractCollection<S>['push'],
-    Exclude<O, 'body' | 'method'> & {
+    Omit<O, 'body' | 'method'> & {
       body:
-        | OptionsToAdderBodyArgument<O>
-        | OptionsToAdderBodyArgument<O>[]
+        | OptionsToAdderBodyArgument<O, ExtractCollection<S>['push']>
+        | OptionsToAdderBodyArgument<O, ExtractCollection<S>['push']>[]
         | FormData;
     }
   >;
@@ -188,10 +189,10 @@ export interface RestInstance<
   unshift: AddEndpoint<
     F,
     ExtractCollection<S>['unshift'],
-    Exclude<O, 'body' | 'method'> & {
+    Omit<O, 'body' | 'method'> & {
       body:
-        | OptionsToAdderBodyArgument<O>
-        | OptionsToAdderBodyArgument<O>[]
+        | OptionsToAdderBodyArgument<O, ExtractCollection<S>['unshift']>
+        | OptionsToAdderBodyArgument<O, ExtractCollection<S>['unshift']>[]
         | FormData;
     }
   >;
@@ -201,8 +202,13 @@ export interface RestInstance<
   assign: AddEndpoint<
     F,
     ExtractCollection<S>,
-    Exclude<O, 'body' | 'method'> & {
-      body: Record<string, OptionsToAdderBodyArgument<O>> | FormData;
+    Omit<O, 'body' | 'method'> & {
+      body:
+        | Record<
+            string,
+            OptionsToAdderBodyArgument<O, ExtractCollection<S>['push']>
+          >
+        | FormData;
     }
   >;
   /** Remove item(s) (PATCH) from collection
@@ -211,10 +217,12 @@ export interface RestInstance<
   remove: RemoveEndpoint<
     F,
     ExtractCollection<S>['remove'],
-    Exclude<O, 'body' | 'method'> & {
+    Omit<O, 'body' | 'method'> & {
       body:
-        | OptionsToAdderBodyArgument<O>
-        | OptionsToAdderBodyArgument<O>[]
+        | Partial<OptionsToAdderBodyArgument<O, ExtractCollection<S>['remove']>>
+        | Partial<
+            OptionsToAdderBodyArgument<O, ExtractCollection<S>['remove']>
+          >[]
         | FormData;
     }
   >;
@@ -226,7 +234,9 @@ export interface RestInstance<
     ExtractCollection<S>['move'],
     {
       path: 'movePath' extends keyof O ? O['movePath'] & string : O['path'];
-      body: OptionsToAdderBodyArgument<O> | FormData;
+      body:
+        | Partial<OptionsToAdderBodyArgument<O, ExtractCollection<S>['move']>>
+        | FormData;
     }
   >;
 }
@@ -564,8 +574,8 @@ type InferRestMethodWhenOmitted<O extends RestGenerics> =
 type MethodArgForBodyInference<O extends RestGenerics> =
   'method' extends keyof O ? O['method'] : InferRestMethodWhenOmitted<O>;
 
-type OptionsToAdderBodyArgument<O extends { body?: any }> =
-  'body' extends keyof O ? O['body'] : any;
+type OptionsToAdderBodyArgument<O extends { body?: any }, EntitySchema = any> =
+  'body' extends keyof O ? O['body'] : Partial<Denormalize<EntitySchema>>;
 
 export interface RestEndpointOptions<
   F extends FetchFunction = FetchFunction,

--- a/packages/rest/src/RestEndpointTypes.ts
+++ b/packages/rest/src/RestEndpointTypes.ts
@@ -206,7 +206,7 @@ export interface RestInstance<
       body:
         | Record<
             string,
-            OptionsToAdderBodyArgument<O, ExtractCollection<S>['push']>
+            OptionsToAdderBodyArgument<O, ExtractCollection<S>['remove']>
           >
         | FormData;
     }

--- a/packages/rest/src/RestEndpointTypes.ts
+++ b/packages/rest/src/RestEndpointTypes.ts
@@ -206,7 +206,7 @@ export interface RestInstance<
       body:
         | Record<
             string,
-            OptionsToAdderBodyArgument<O, ExtractCollection<S>['remove']>
+            OptionsToAdderBodyArgument<O, ExtractCollection<S>['assign']>
           >
         | FormData;
     }

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -1,4 +1,4 @@
-import { Entity, schema, Collection } from '@data-client/endpoint';
+import { Entity, schema, Collection, Values } from '@data-client/endpoint';
 import { useController, useCache } from '@data-client/react';
 import { useSuspense } from '@data-client/react';
 import { CacheProvider } from '@data-client/react';
@@ -210,6 +210,21 @@ const getNextPage3 = getArticleList3.getPage;
   () => withBody.move({ id: 'a' }, { content: 'there' });
   // @ts-expect-error - move rejects invalid fields
   () => withBody.move({ id: 'a' }, { invalid: 'field' });
+
+  // Values Collection: assign body should accept Record<string, entity>
+  const valuesEndpoint = new RestEndpoint({
+    urlPrefix: 'http://test.com',
+    path: '/articles',
+    schema: new Collection(new Values(PaginatedArticle)),
+    method: 'GET',
+  });
+  // @ts-expect-error - assign body should not be any
+  valuesEndpoint.assign.body satisfies number;
+  valuesEndpoint.assign.body satisfies
+    | Record<string, Partial<PaginatedArticle>>
+    | FormData
+    | undefined;
+  () => valuesEndpoint.assign({ myKey: { id: 5, title: 'hi', content: 'ho' } });
 };
 
 describe('RestEndpoint', () => {

--- a/packages/rest/src/__tests__/RestEndpoint.ts
+++ b/packages/rest/src/__tests__/RestEndpoint.ts
@@ -145,6 +145,13 @@ const getNextPage3 = getArticleList3.getPage;
   flat.move.schema satisfies number;
   // @ts-expect-error - push schema should not be any
   flat.push.schema satisfies number;
+  // body should be derived from collection's entity schema, not any
+  // @ts-expect-error
+  flat.push.body satisfies number;
+  // @ts-expect-error
+  flat.move.body satisfies number;
+  // @ts-expect-error
+  flat.remove.body satisfies number;
 
   // nested Collection schema should also be typed
   const nested = new RestEndpoint({
@@ -161,6 +168,48 @@ const getNextPage3 = getArticleList3.getPage;
   nested.move.schema satisfies number;
   // @ts-expect-error - nested push schema should not be any
   nested.push.schema satisfies number;
+  // @ts-expect-error
+  nested.push.body satisfies number;
+  // @ts-expect-error
+  nested.move.body satisfies number;
+  // @ts-expect-error
+  nested.remove.body satisfies number;
+
+  // With explicit body: PATCH extenders should have Partial body
+  type Body = { title: string; content: string };
+  const withBody = new RestEndpoint({
+    urlPrefix: 'http://test.com',
+    path: '/articles/:id',
+    schema: new Collection([PaginatedArticle]),
+    method: 'GET',
+    body: {} as Body,
+  });
+  // POST extenders keep full body type
+  // @ts-expect-error - push body should not be any
+  withBody.push.body satisfies number;
+  withBody.push.body satisfies Body | Body[] | FormData | undefined;
+  // @ts-expect-error - unshift body should not be any
+  withBody.unshift.body satisfies number;
+  // PATCH extenders get Partial body (like partialUpdate)
+  // @ts-expect-error - move body should not be any
+  withBody.move.body satisfies number;
+  withBody.move.body satisfies Partial<Body> | FormData | undefined;
+  // @ts-expect-error - remove body should not be any
+  withBody.remove.body satisfies number;
+  withBody.remove.body satisfies
+    | Partial<Body>
+    | Partial<Body>[]
+    | FormData
+    | undefined;
+  // push body requires full Body (not partial)
+  () => withBody.push({ id: 'a' }, { title: 'hi', content: 'there' });
+  // @ts-expect-error - push rejects partial body
+  () => withBody.push({ id: 'a' }, { title: 'hi' });
+  // move body accepts partial Body (PATCH semantics)
+  () => withBody.move({ id: 'a' }, { title: 'hi' });
+  () => withBody.move({ id: 'a' }, { content: 'there' });
+  // @ts-expect-error - move rejects invalid fields
+  () => withBody.move({ id: 'a' }, { invalid: 'field' });
 };
 
 describe('RestEndpoint', () => {

--- a/packages/rest/src/__tests__/resource-construction.test.ts
+++ b/packages/rest/src/__tests__/resource-construction.test.ts
@@ -1361,6 +1361,53 @@ describe('resource()', () => {
     expect(result.current.task3?.status).toEqual('in-progress');
   });
 
+  it('extender body types should match mutation endpoint semantics', () => {
+    // resource without explicit body: extenders derive from Partial<Denormalize<schema>>
+    type PushBody = (typeof UserResource)['getList']['push']['body'];
+    type MoveBody = (typeof UserResource)['getList']['move']['body'];
+    type RemoveBody = (typeof UserResource)['getList']['remove']['body'];
+
+    // push (POST) body should not be any
+    // @ts-expect-error
+    ({}) as PushBody satisfies number;
+    // move (PATCH) body should not be any
+    // @ts-expect-error
+    ({}) as MoveBody satisfies number;
+    // remove (PATCH) body should not be any
+    // @ts-expect-error
+    ({}) as RemoveBody satisfies number;
+
+    // resource with explicit body: PATCH extenders should accept partial body
+    interface MyBody {
+      title: string;
+      content: string;
+    }
+    const TypedResource = resource({
+      path: 'http\\://test.com/articles/:id',
+      schema: User,
+      body: {} as MyBody,
+    });
+
+    // POST extenders: push requires full body
+    () => TypedResource.getList.push({ title: 'hi', content: 'there' });
+    // @ts-expect-error - push requires full body, not partial
+    () => TypedResource.getList.push({ title: 'hi' });
+
+    // PATCH extenders: move accepts partial body (like partialUpdate)
+    () => TypedResource.getList.move({ id: '1' }, { title: 'hi' });
+    () => TypedResource.getList.move({ id: '1' }, { content: 'there' });
+    // @ts-expect-error - move rejects invalid fields
+    () => TypedResource.getList.move({ id: '1' }, { invalid: 'field' });
+
+    // PATCH extenders: remove accepts partial body
+    () => TypedResource.getList.remove({ group: 'a' }, { title: 'hi' });
+    // @ts-expect-error - remove rejects invalid fields
+    () => TypedResource.getList.remove({ group: 'a' }, { invalid: 'field' });
+
+    // partialUpdate also accepts partial body
+    () => TypedResource.partialUpdate({ id: '1' }, { title: 'hi' });
+  });
+
   it.each([
     {
       response: {

--- a/packages/rest/typescript-tests/types.test.ts
+++ b/packages/rest/typescript-tests/types.test.ts
@@ -862,13 +862,14 @@ it('should handle more open ended type definitions', () => {
 
     const explicit: GetEndpoint<{
       path: `${string}:${string}`;
-      schema: schema.Collection<[typeof User]>;
+      schema: schema.Collection<(typeof User)[]>;
     }> = new RestEndpoint({
       path: '' as `${string}:${string}`,
       schema: new Collection([User]),
     });
     explicit({ hi: 5 });
-    explicit.push.process({} as any, { hi: 5 });
+    explicit.push.process({} as any, { username: 'test' });
+    // @ts-expect-error - push requires a body argument
     explicit.push();
   };
 });


### PR DESCRIPTION
### Motivation

Collection extender body types (`getList.push`, `.move`, `.remove`, etc.) didn't match the semantics of their HTTP method:

- **PATCH extenders** (`move`, `remove`) required the full body type instead of `Partial<Body>` like `partialUpdate`
- **Standalone `RestEndpoint`** without an explicit `body` option fell back to `any` for all extender bodies instead of deriving from the entity schema
- `Exclude<O, 'body' | 'method'>` (a union utility) was used where `Omit` was needed, causing the parent body type to leak through intersections

### Solution

**`OptionsToAdderBodyArgument`** gains an `EntitySchema` type parameter. When no explicit `body` is set, it derives `Partial<Denormalize<EntitySchema>>` from the Collection's inner schema instead of falling back to `any`.

**PATCH extenders** (`move`, `remove`) wrap their body in `Partial<>`, matching `partialUpdate` semantics. POST extenders (`push`, `unshift`, `assign`) keep the full body type, matching `create`.

**`Exclude` → `Omit`** for all extenders that replace `body`/`method` on the parent options, so the new body type isn't intersected back with the parent's original body.

Type tests verify both `resource()` (with/without explicit body) and standalone `RestEndpoint` scenarios.

### Open questions

N/A

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public TypeScript types for `RestEndpoint`/`resource()` extenders change (notably `move`/`remove` bodies becoming `Partial<>` and default body inference no longer `any`), which may cause downstream compile-time breakages even though runtime behavior is unchanged.
> 
> **Overview**
> Aligns `Collection` extender typings with HTTP semantics.
> 
> `RestEndpoint` extenders now infer a typed default body from the collection’s entity schema (instead of `any`) when no explicit `body` is provided, and PATCH-based extenders (`move`, `remove`) accept `Partial<Body>` to match `partialUpdate` behavior while POST extenders (`push`, `unshift`, `assign`) keep requiring full bodies. The extender option intersections were tightened by switching `Exclude<...>` to `Omit<...>` to prevent parent `body`/`method` types leaking back in.
> 
> Adds/updates type-level tests for standalone `RestEndpoint`, `resource()` usage, and Values-collection `assign` typing, plus a changeset for a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdbac431bae461d8afaf9805d26ee3cc7dbbe6d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->