### PR TITLE
fix: update type tests for stricter Collection extender body types

### DIFF
--- a/packages/rest/typescript-tests/types.test.ts
+++ b/packages/rest/typescript-tests/types.test.ts
@@ -862,13 +862,14 @@ it('should handle more open ended type definitions', () => {
 
     const explicit: GetEndpoint<{
       path: `${string}:${string}`;
-      schema: schema.Collection<[typeof User]>;
+      schema: schema.Collection<(typeof User)[]>;
     }> = new RestEndpoint({
       path: '' as `${string}:${string}`,
       schema: new Collection([User]),
     });
     explicit({ hi: 5 });
-    explicit.push.process({} as any, { hi: 5 });
+    explicit.push.process({} as any, { username: 'test' });
+    // @ts-expect-error - push requires a body argument
     explicit.push();
   };
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3910 typecheck CI failure.

### Motivation

PR [#3910](https://github.com/reactive/data-client/pull/3910) changed Collection extender body types from `any` to properly derived types (using `Omit` instead of `Exclude`, and `OptionsToAdderBodyArgument` now falls back to `Partial<Denormalize<EntitySchema>>` instead of `any`). This caused three typecheck failures in `packages/rest/typescript-tests/types.test.ts`.

### Solution

Updated the existing type tests to match the new (correct) behavior:

1. **Fixed `Collection` type annotation**: Changed `schema.Collection<[typeof User]>` (tuple) to `schema.Collection<(typeof User)[]>` (array) to match what `new Collection([User])` actually produces. The stricter `assign` extender types surfaced this pre-existing mismatch.

2. **Updated `push.process` test body**: Changed `{ hi: 5 }` to `{ username: 'test' }` since the body type is now `Partial<User>` instead of `any`.

3. **Added `@ts-expect-error` for `push()` call**: `push()` now correctly requires a body argument since the body type is `Partial<User>` instead of `any`.

### Open questions

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a343ad60-ac8b-400c-a1fc-265d4f193dab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a343ad60-ac8b-400c-a1fc-265d4f193dab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

