### PR TITLE
docs: add agent-skills entry to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Schema driven. Zero updater functions.
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-cc785c?style=flat-square&logo=claude&logoColor=white)](https://skills.sh/reactive/data-client)
 [![Chat](https://img.shields.io/discord/768254430381735967.svg?style=flat-square&colorB=758ED3)](https://discord.gg/35nb8Mz)
 
-**[📖Read The Docs](https://dataclient.io/docs)** &nbsp;|&nbsp; [🏁Getting Started](https://dataclient.io/docs/getting-started/installation) &nbsp;|&nbsp; [🤖Agent Skills](https://skills.sh/reactive/data-client)<br/>🎮 Demos: &nbsp;
+**[📖Read The Docs](https://dataclient.io/docs)** &nbsp;|&nbsp; [🏁Getting Started](https://dataclient.io/docs/getting-started/agent-skills) &nbsp;|&nbsp; [🤖Agent Skills](https://skills.sh/reactive/data-client)<br/>🎮 Demos: &nbsp;
 [Todo](https://stackblitz.com/github/reactive/data-client/tree/master/examples/todo-app?file=src%2Fpages%2FHome%2FTodoList.tsx) &nbsp;|&nbsp;
 [Github Social](https://stackblitz.com/github/reactive/data-client/tree/master/examples/github-app?file=src%2Fpages%2FIssueList.tsx) &nbsp;|&nbsp;
 [NextJS SSR](https://stackblitz.com/github/reactive/data-client/tree/master/examples/nextjs?file=components%2Ftodo%2FTodoList.tsx) &nbsp;|&nbsp;
@@ -36,7 +36,7 @@ Schema driven. Zero updater functions.
 npm install --save @data-client/react @data-client/rest @data-client/test
 ```
 
-For more details, see [the Installation docs page](https://dataclient.io/docs/getting-started/installation).
+For more details, see [the Getting Started docs page](https://dataclient.io/docs/getting-started/agent-skills).
 
 ### Skills
 
@@ -243,7 +243,7 @@ const Story = () => (
 
 ### ...all typed ...fast ...and consistent
 
-For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://dataclient.io/docs/getting-started/installation)
+For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://dataclient.io/docs/getting-started/agent-skills)
 
 ## Features
 

--- a/docs/core/getting-started/README.md
+++ b/docs/core/getting-started/README.md
@@ -4,6 +4,7 @@ draft: true
 ## Getting Started
 
 - [Introduction](../README.md)
+- [Agent Skills](./agent-skills.md)
 - [Installation](./installation.md)
 - [Define Data](./resource.md)
 - [Render Data](./data-dependency.md)

--- a/docs/core/getting-started/agent-skills.md
+++ b/docs/core/getting-started/agent-skills.md
@@ -7,37 +7,37 @@ sidebar_label: Agent Skills
 import SkillTabs from '@site/src/components/SkillTabs';
 import Link from '@docusaurus/Link';
 
-[Agent Skills](https://skills.sh/reactive/data-client) teach AI coding agents
-(Claude Code, Cursor, Codex, etc.) how to use Reactive Data Client correctly —
-covering installation, schema design, REST/GraphQL endpoints, hooks, and testing.
-
-Install the skills into your project so your agent can scaffold, migrate, and
-extend `@data-client` code without guessing.
+The quickest way to get started is to let an [AI Agent](https://agentskills.io) install using skill [/data-client-setup](https://skills.sh/reactive/data-client/data-client-setup).
 
 ## Install
 
 <SkillTabs repo="reactive/data-client" />
 
 Then run skill `/data-client-setup` to install and wire up the provider for your
-project. The setup skill detects your framework (NextJS, Expo, React Native, Vue,
-plain React) and protocol (REST, GraphQL, custom) and applies the right configuration.
+project. It will automatically detect your framework (NextJS, Expo, React Native, Vue,
+plain React), perform installation, as well as do migrations when existing
+endpoints are found.
 
 ## Available Skills
 
-- **`/data-client-setup`** — installs packages and adds the provider for your stack.
-- **`/data-client-rest-setup`** — generates `resource()` definitions and migrates
-  existing `fetch`/`axios` clients (see [REST Agent Skills](/rest#rest-agent-skills)).
-- **`/data-client-schema`** — designs `Entity`, `Collection`, `Union`, and `Query` schemas.
-- **`/data-client-react`** — uses `useSuspense`, `useQuery`, `useLive`, mutations.
-- **`/data-client-react-testing`** / **`/data-client-vue-testing`** — writes tests with
-  `renderDataHook` / `renderDataCompose`, fixtures, and `nock`.
-- **`/data-client-manager`** — implements custom `Manager`s for websockets, SSE,
-  polling, logging, and middleware.
+- [**`/data-client-setup`**](https://skills.sh/reactive/data-client/data-client-setup) — installs and configures Data Client for your framework and API style.
+- [**`/data-client-rest-setup`**](https://skills.sh/reactive/data-client/data-client-rest-setup) — sets up `@data-client/rest` and migrates existing
+  `fetch`/`axios` clients.
+- [**`/data-client-endpoint-setup`**](https://skills.sh/reactive/data-client/data-client-endpoint-setup) — wraps custom async functions with `Endpoint`
+  for non-REST and non-GraphQL workflows.
+- [**`/data-client-graphql-setup`**](https://skills.sh/reactive/data-client/data-client-graphql-setup) — configures `@data-client/graphql` and `GQLEndpoint`
+  for GraphQL APIs.
+- [**`/data-client-schema`**](https://skills.sh/reactive/data-client/data-client-schema) — designs `Entity`, `Collection`, `Union`, `Query`,
+  and related schemas.
+- [**`/data-client-rest`**](https://skills.sh/reactive/data-client/data-client-rest) — defines REST APIs with `resource()`, `RestEndpoint`,
+  CRUD methods, and response parsing.
+- [**`/data-client-react`**](https://skills.sh/reactive/data-client/data-client-react) — uses `useSuspense`, `useFetch`, `useQuery`, `useLive`,
+  and mutation hooks.
+- [**`/data-client-react-testing`**](https://skills.sh/reactive/data-client/data-client-react-testing) — writes React tests with `renderDataHook`,
+  fixtures, interceptors, and `nock`.
+- [**`/data-client-vue-testing`**](https://skills.sh/reactive/data-client/data-client-vue-testing) — writes Vue tests with `renderDataCompose`,
+  `mountDataClient`, fixtures, and `nock`.
+- [**`/data-client-manager`**](https://skills.sh/reactive/data-client/data-client-manager) — implements custom `Manager`s for websockets, SSE,
+  polling, subscriptions, logging, and middleware.
 
 Browse the full catalog at [skills.sh/reactive/data-client](https://skills.sh/reactive/data-client).
-
-<center>
-
-<Link className="button button--secondary" to="./installation">Next: Installation »</Link>
-
-</center>

--- a/docs/core/getting-started/agent-skills.md
+++ b/docs/core/getting-started/agent-skills.md
@@ -1,0 +1,43 @@
+---
+id: agent-skills
+title: Agent Skills
+sidebar_label: Agent Skills
+---
+
+import SkillTabs from '@site/src/components/SkillTabs';
+import Link from '@docusaurus/Link';
+
+[Agent Skills](https://skills.sh/reactive/data-client) teach AI coding agents
+(Claude Code, Cursor, Codex, etc.) how to use Reactive Data Client correctly —
+covering installation, schema design, REST/GraphQL endpoints, hooks, and testing.
+
+Install the skills into your project so your agent can scaffold, migrate, and
+extend `@data-client` code without guessing.
+
+## Install
+
+<SkillTabs repo="reactive/data-client" />
+
+Then run skill `/data-client-setup` to install and wire up the provider for your
+project. The setup skill detects your framework (NextJS, Expo, React Native, Vue,
+plain React) and protocol (REST, GraphQL, custom) and applies the right configuration.
+
+## Available Skills
+
+- **`/data-client-setup`** — installs packages and adds the provider for your stack.
+- **`/data-client-rest-setup`** — generates `resource()` definitions and migrates
+  existing `fetch`/`axios` clients (see [REST Agent Skills](/rest#rest-agent-skills)).
+- **`/data-client-schema`** — designs `Entity`, `Collection`, `Union`, and `Query` schemas.
+- **`/data-client-react`** — uses `useSuspense`, `useQuery`, `useLive`, mutations.
+- **`/data-client-react-testing`** / **`/data-client-vue-testing`** — writes tests with
+  `renderDataHook` / `renderDataCompose`, fixtures, and `nock`.
+- **`/data-client-manager`** — implements custom `Manager`s for websockets, SSE,
+  polling, logging, and middleware.
+
+Browse the full catalog at [skills.sh/reactive/data-client](https://skills.sh/reactive/data-client).
+
+<center>
+
+<Link className="button button--secondary" to="./installation">Next: Installation »</Link>
+
+</center>

--- a/docs/core/getting-started/installation.md
+++ b/docs/core/getting-started/installation.md
@@ -8,16 +8,17 @@ hide_title: true
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import PkgTabs from '@site/src/components/PkgTabs';
-import SkillTabs from '@site/src/components/SkillTabs';
 import Installation from '../shared/\_installation.mdx';
 import StackBlitz from '@site/src/components/StackBlitz';
 import Link from '@docusaurus/Link';
 
-<SkillTabs repo="reactive/data-client" />
-
-Then run skill `/data-client-setup` or:
-
 <PkgTabs pkgs="@data-client/react @data-client/test @data-client/rest" />
+
+:::tip[Use Agent Skills]
+
+Prefer to scaffold via your AI agent? See [Agent Skills](./agent-skills.md) and run `/data-client-setup`.
+
+:::
 
 ## Add provider at top-level component
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,7 @@ automatic expiry policies, data normalization. Consumes [TypeScript Standard End
 
 <div align="center">
 
-**[📖Read The Docs](https://dataclient.io/docs)** &nbsp;|&nbsp; [🏁Getting Started](https://dataclient.io/docs/getting-started/installation) &nbsp;|&nbsp;
+**[📖Read The Docs](https://dataclient.io/docs)** &nbsp;|&nbsp; [🏁Getting Started](https://dataclient.io/docs/getting-started/agent-skills) &nbsp;|&nbsp;
 [🎮Todo Demo](https://stackblitz.com/github/reactive/data-client/tree/master/examples/todo-app?file=src%2Fpages%2FHome%2FTodoList.tsx) &nbsp;|&nbsp;
 [🎮Github Demo](https://stackblitz.com/github/reactive/data-client/tree/master/examples/github-app?file=src%2Fpages%2FIssueList.tsx) &nbsp;|&nbsp;
 [🎮NextJS SSR Demo](https://stackblitz.com/github/reactive/data-client/tree/master/examples/nextjs?file=components%2Ftodo%2FTodoList.tsx)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -24,7 +24,7 @@ Schema driven. Zero updater functions.
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-cc785c?style=flat-square&logo=claude&logoColor=white)](https://skills.sh/reactive/data-client)
 [![Chat](https://img.shields.io/discord/768254430381735967.svg?style=flat-square&colorB=758ED3)](https://discord.gg/35nb8Mz)
 
-**[📖Read The Docs](https://dataclient.io/docs)** &nbsp;|&nbsp; [🏁Getting Started](https://dataclient.io/docs/getting-started/installation) &nbsp;|&nbsp; [🤖Agent Skills](https://skills.sh/reactive/data-client) <br/>🎮 **Demos:** &nbsp;
+**[📖Read The Docs](https://dataclient.io/docs)** &nbsp;|&nbsp; [🏁Getting Started](https://dataclient.io/docs/getting-started/agent-skills) &nbsp;|&nbsp; [🤖Agent Skills](https://skills.sh/reactive/data-client) <br/>🎮 **Demos:** &nbsp;
 [Todo](https://stackblitz.com/github/reactive/data-client/tree/master/examples/todo-app?file=src%2Fpages%2FHome%2FTodoList.tsx) &nbsp;|&nbsp;
 [Github](https://stackblitz.com/github/reactive/data-client/tree/master/examples/github-app?file=src%2Fpages%2FIssueList.tsx) &nbsp;|&nbsp;
 [NextJS SSR](https://stackblitz.com/github/reactive/data-client/tree/master/examples/nextjs?file=components%2Ftodo%2FTodoList.tsx) &nbsp;|&nbsp;
@@ -38,7 +38,7 @@ Schema driven. Zero updater functions.
 npm install --save @data-client/react @data-client/rest @data-client/test
 ```
 
-For more details, see [the Installation docs page](https://dataclient.io/docs/getting-started/installation).
+For more details, see [the Getting Started docs page](https://dataclient.io/docs/getting-started/agent-skills).
 
 ### Skills
 
@@ -245,7 +245,7 @@ const Story = () => (
 
 ### ...all typed ...fast ...and consistent
 
-For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://dataclient.io/docs/getting-started/installation)
+For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://dataclient.io/docs/getting-started/agent-skills)
 
 ## Features
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -24,7 +24,7 @@ Schema driven. Zero updater functions.
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-cc785c?style=flat-square&logo=claude&logoColor=white)](https://skills.sh/reactive/data-client)
 [![Chat](https://img.shields.io/discord/768254430381735967.svg?style=flat-square&colorB=758ED3)](https://discord.gg/35nb8Mz)
 
-**[📖Read The Docs](https://dataclient.io/docs)** &nbsp;|&nbsp; [🏁Getting Started](https://dataclient.io/docs/getting-started/installation) &nbsp;|&nbsp; [🤖Agent Skills](https://skills.sh/reactive/data-client) &nbsp;|&nbsp; [🎮Todo Demo](https://stackblitz.com/github/reactive/data-client/tree/master/examples/vue-todo-app?file=src%2Fcomponents%2FTodoListContent.vue)
+**[📖Read The Docs](https://dataclient.io/docs)** &nbsp;|&nbsp; [🏁Getting Started](https://dataclient.io/docs/getting-started/agent-skills) &nbsp;|&nbsp; [🤖Agent Skills](https://skills.sh/reactive/data-client) &nbsp;|&nbsp; [🎮Todo Demo](https://stackblitz.com/github/reactive/data-client/tree/master/examples/vue-todo-app?file=src%2Fcomponents%2FTodoListContent.vue)
 
 </div>
 
@@ -34,7 +34,7 @@ Schema driven. Zero updater functions.
 npm install --save @data-client/vue @data-client/rest
 ```
 
-For more details, see [the Installation docs page](https://dataclient.io/docs/getting-started/installation).
+For more details, see [the Getting Started docs page](https://dataclient.io/docs/getting-started/agent-skills).
 
 ### Skills
 
@@ -261,7 +261,7 @@ app.mount('#app');
 
 ### ...all typed ...fast ...and consistent
 
-For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://dataclient.io/docs/getting-started/installation)
+For the small price of 9kb gziped. &nbsp;&nbsp; [🏁Get started now](https://dataclient.io/docs/getting-started/agent-skills)
 
 ## Features
 

--- a/website/blog/2026-01-06-v0.15-vue-support-collection-remove.md
+++ b/website/blog/2026-01-06-v0.15-vue-support-collection-remove.md
@@ -111,7 +111,7 @@ app.use(MockPlugin, {
 ```
 
 <p style={{ textAlign: 'center' }}>
-  <Link className="button button--primary" to="/docs/getting-started/installation">Full Vue Guide</Link>
+  <Link className="button button--primary" to="/docs/getting-started/agent-skills">Getting Started Guide</Link>
 </p>
 
 ## Collection.remove

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -11,6 +11,10 @@
       "items": [
         {
           "type": "doc",
+          "id": "getting-started/agent-skills"
+        },
+        {
+          "type": "doc",
           "id": "getting-started/installation"
         },
         {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -54,7 +54,7 @@ function HomepageHeader() {
           <GithubStarsButton />
           <Link
             className="button button--primary"
-            to="/docs/getting-started/installation"
+            to="/docs/getting-started/agent-skills"
           >
             Get Started
           </Link>
@@ -86,7 +86,7 @@ function HomepageEnder() {
           </Link>
           <Link
             className="button button--primary"
-            to="/docs/getting-started/installation"
+            to="/docs/getting-started/agent-skills"
           >
             Get Started{' '}
             <svg


### PR DESCRIPTION
### Motivation

Agent Skills now provide the preferred AI-assisted onboarding flow for Reactive Data Client, but the Getting Started section and several top-level onboarding links still sent users directly to the installation page. That made the new skills entry point easy to miss and split setup guidance across multiple places.

### Solution

Add a dedicated `Agent Skills` page as the first entry in Getting Started, move the skills-based setup guidance there, and keep `installation.md` focused on manual package installation and provider setup. Retarget general onboarding links in the root README, package READMEs, homepage CTAs, and a Vue blog CTA to the new page while leaving installation-specific provider links unchanged.

### Open questions

N/A

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is broken/incorrect doc links or navigation ordering changes in the website sidebar/homepage.
> 
> **Overview**
> **Adds a new `Getting Started` entry point for AI-assisted onboarding.** Introduces `docs/core/getting-started/agent-skills.md`, links it from the Getting Started index, and adds it as the first item in `website/sidebars.json`.
> 
> **Retargets general “Get Started” CTAs to the new page.** Updates root/package READMEs, website homepage buttons, and a Vue release blog CTA to point to `/docs/getting-started/agent-skills` instead of `/installation`, and trims `installation.md` to focus on manual install while pointing to Agent Skills via a tip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25538e24997265ca57ee6b2c14e17bcab6f58ad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->