### PR TITLE
fix(normalizr): do not mutate cached journey on result-cache hit

### DIFF
--- a/.changeset/fix-journey-mutation.md
+++ b/.changeset/fix-journey-mutation.md
@@ -1,0 +1,19 @@
+---
+'@data-client/normalizr': patch
+'@data-client/core': patch
+'@data-client/endpoint': patch
+'@data-client/rest': patch
+'@data-client/graphql': patch
+'@data-client/react': patch
+---
+
+Fix cached journey being mutated on repeated result-cache hits.
+
+`GlobalCache.getResults` called `paths.shift()` on a cache hit, mutating
+the `journey` array stored by reference on the `WeakDependencyMap` `Link`
+node. After the first hit stripped the placeholder input slot, every
+subsequent hit on the same cached entry would shift off a real
+`EntityPath`, progressively losing subscription entries. This could cause
+missed `countRef` tracking (premature GC of still-referenced entities)
+and incorrect `entityExpiresAt` calculations. The hit path now returns a
+non-mutating copy.

--- a/packages/core/src/controller/__tests__/getResponseMeta-countRef.ts
+++ b/packages/core/src/controller/__tests__/getResponseMeta-countRef.ts
@@ -1,0 +1,93 @@
+import { Endpoint, Entity } from '@data-client/endpoint';
+
+import { GCPolicy } from '../../state/GCPolicy';
+import { initialState } from '../../state/reducer/createReducer';
+import Controller from '../Controller';
+
+/** Integration test for the `paths` → `countRef` pipeline.
+ *
+ * React hooks (`useSuspense`, `useCache`, `useLive`, `useDLE`, `useQuery`)
+ * all call `controller.getResponseMeta(...)` during `useMemo` and then
+ * pass the returned `countRef` to `useEffect`. `useEffect` executes
+ * `countRef` once per hook instance — iterating the **captured** `paths`
+ * array to increment `GCPolicy.entityCount` per referenced entity. When
+ * the component unmounts (or `data` changes) the returned `decrement`
+ * closure iterates that same captured `paths` array to decrement.
+ *
+ * Before the fix, `globalCache.getResults` called `paths.shift()` on a
+ * result-cache hit, mutating the journey array stored by reference on
+ * `WeakDependencyMap.Link.journey`. Because `paths` aliases that stored
+ * journey, every successive hit dropped one more real `EntityPath` from
+ * the subscription list. The Nth component mount (for N ≥ 3, same
+ * endpoint + args, entities unchanged) would have its `countRef`
+ * iterate a progressively shorter list — skipping the first real
+ * entity, then the second, etc. — leaving `entityCount` under-counted
+ * for those entities and allowing GC to reap entities that mounted
+ * components still subscribe to.
+ */
+describe('Controller.getResponseMeta + GCPolicy.countRef integration', () => {
+  it('entityCount tracks all entities for each subscriber across repeated result-cache hits', () => {
+    class Foo extends Entity {
+      id = '';
+      pk() {
+        return this.id;
+      }
+    }
+    const ep = new Endpoint(() => Promise.resolve(), {
+      key: () => 'listFoo',
+      schema: [Foo],
+    });
+
+    const gcPolicy = new GCPolicy();
+    const controller = new Controller({ gcPolicy });
+    gcPolicy.init(controller);
+
+    const state = {
+      ...initialState,
+      entities: {
+        Foo: {
+          '1': { id: '1' },
+          '2': { id: '2' },
+        },
+      },
+      endpoints: {
+        [ep.key()]: ['1', '2'],
+      },
+    };
+
+    // Three successive `getResponseMeta` calls simulate three React
+    // components mounting with the same endpoint + args, where the store
+    // has not changed between renders. Call 1 is a result-cache miss;
+    // calls 2 and 3 are hits — each hit mutates the shared journey.
+    const m1 = controller.getResponseMeta(ep, state);
+    const m2 = controller.getResponseMeta(ep, state);
+    const m3 = controller.getResponseMeta(ep, state);
+
+    // Simulate `useEffect(countRef, [data])` firing for each mount.
+    // Pre-fix: m2.paths and m3.paths both aliased the shared journey,
+    // and by the time the countRefs run the journey has been shifted
+    // twice — so both iterate `[Foo|'2']` only, silently skipping
+    // Foo|'1'. Only m1 (miss path, fresh `paths`) counted Foo|'1'.
+    const dec1 = m1.countRef();
+    const dec2 = m2.countRef();
+    const dec3 = m3.countRef();
+
+    // Each mount must have incremented *both* entities.
+    // Pre-fix: Foo|'1' = 1 (only m1 counted it); Foo|'2' = 3.
+    expect(gcPolicy['entityCount'].get('Foo')?.get('1')).toBe(3);
+    expect(gcPolicy['entityCount'].get('Foo')?.get('2')).toBe(3);
+
+    // Simulate all three components unmounting (or `data` changing).
+    // Pre-fix: only dec1 would decrement Foo|'1' (taking it from 1 to
+    // 0) — observable as premature GC-eligibility of Foo|'1' while
+    // the other two subscribers still depended on it.
+    dec1();
+    dec2();
+    dec3();
+
+    expect(gcPolicy['entityCount'].get('Foo')?.get('1')).toBeUndefined();
+    expect(gcPolicy['entityCount'].get('Foo')?.get('2')).toBeUndefined();
+
+    gcPolicy.cleanup();
+  });
+});

--- a/packages/normalizr/src/memo/globalCache.ts
+++ b/packages/normalizr/src/memo/globalCache.ts
@@ -145,7 +145,11 @@ export default class GlobalCache implements Cache {
       this.dependencies[0] = { path: { key: '', pk: '' }, entity: input };
       this._resultCache.set(this.dependencies, data);
     } else {
-      paths.shift();
+      // `paths` aliases the stored Link.journey — return a copy that skips
+      // the input placeholder slot. `paths.shift()` would mutate the shared
+      // journey, progressively dropping real entity paths on successive
+      // hits and corrupting subscriptions / GC ref-counting.
+      paths = paths.slice(1);
     }
     return { data, paths };
   }


### PR DESCRIPTION
## Summary

`GlobalCache.getResults` called `paths.shift()` on a result-cache hit, mutating the `journey` array stored by reference on the `WeakDependencyMap` `Link` node. After the first hit stripped the placeholder input slot, every subsequent hit on the same cached entry would shift off a real `EntityPath`, progressively losing subscription entries.

The hit path now returns a non-mutating copy (`paths.slice(1)`).

```diff
   } else {
-    paths.shift();
+    paths = paths.slice(1);
   }
```

## Why it matters

Downstream consumers capture `paths` by reference:

- **`Controller.getResponseMeta`** passes `paths` into `GCPolicy.createCountRef`, whose increment/decrement closures iterate the captured array at effect time. After three React subscribers to the same endpoint + args with entities unchanged (1 miss + 2 hits), the journey has been shifted twice — subscribers 2 and 3 silently skip the first entity. `entityCount` is under-counted and GC can reap entities still referenced by mounted components.
- **`entityExpiresAt(paths, ...)`** returns an incorrect (too-late) expiry when paths drop entries, suppressing auto-refetch.
- **React hooks** (`useSuspense`, `useCache`, `useLive`, `useDLE`, `useQuery`) all funnel through `getResponseMeta`, so any app rendering the same endpoint from multiple places can hit this.

### Empirical confirmation

On master, a tight loop of result-cache hits against the same primed `MemoCache` drains the journey to zero:

| iterations | paths.length (master) | paths.length (fix) |
|---|---|---|
| 1 | 2826 | 2826 |
| 100 | 2727 | 2826 |
| 1,000 | 1827 | 2826 |
| 10,000 | **0** | 2826 |

## Test plan

- [x] New integration test `packages/core/src/controller/__tests__/getResponseMeta-countRef.ts` simulates three React subscribers to the same endpoint + args, asserts all three `countRef` closures correctly increment `GCPolicy.entityCount` for every entity, and that decrement restores counts to zero. Fails on master (under-counts first entity); passes with fix.
- [x] `yarn jest --selectProjects ReactDOM --testPathPatterns "packages/(core|normalizr)"` — 259 tests pass.

## Performance analysis

Run on Linux 6.6.87.2 (WSL2), AMD Ryzen 9 7950X, Node v20.18.2, `example-benchmark` with `NODE_ENV=production` and `--expose_gc`.

### Methodological caveat

Master's `withCache` benchmark numbers are **not directly comparable** to the fix's numbers. The bug makes each `paths.shift()` mutate the shared journey on every hit, so after `benchmark.js`'s ~100k-iteration warmup the journey is fully drained and master enters a steady state where each hit returns an empty paths array (doing nearly no work). The fix does honest work on every hit (slice of a full-length journey).

The numbers below are reported as-measured. Interpret `withCache` rows with that bias in mind — a small slowdown vs. a journey-corrupting baseline is expected.

### `normalizr` suite

| Benchmark | Master (buggy) | Fix | Δ |
|---|---:|---:|---:|
| normalizeLong | 756 | 785 | +3.8% |
| normalizeLong Values | 681 | 701 | +2.9% |
| denormalizeLong | 666 | 465 | -30.2% ‡ |
| denormalizeLong Values | 438 | 412 | -5.9% |
| denormalizeLong donotcache | 1,804 | 1,789 | -0.8% |
| denormalizeLong Values donotcache | 1,280 | 1,292 | +0.9% |
| denormalizeShort donotcache 500x | 2,603 | 2,658 | +2.1% |
| denormalizeShort 500x | 1,617 | 1,275 | -21.2% ‡ |
| denormalizeShort 500x withCache † | 12,956 | 13,373 | +3.2% |
| queryShort 500x withCache † | 4,648 | 4,848 | +4.3% |
| buildQueryKey All | 80,880 | 80,950 | +0.1% |
| query All withCache † | 11,540 | 10,683 | -7.4% |
| denormalizeLong with mixin Entity | 589 | 419 | -28.9% ‡ |
| denormalizeLong withCache † | 12,671 | 12,373 | -2.4% |
| denormalizeLong Values withCache † | 9,442 | 8,648 | -8.4% |
| denormalizeLong All withCache † | 11,999 | 10,200 | -15.0% |
| denormalizeLong Query-sorted withCache † | 11,665 | 10,772 | -7.7% |
| denormalizeLongAndShort withEntityCacheOnly | 2,965 | 3,071 | +3.6% |
| denormalize bidirectional 50 | 10,292 | 8,858 | -13.9% ‡ |
| denormalize bidirectional 50 donotcache | 77,675 | 76,023 | -2.1% |

† withCache scenarios — master is biased low-work by journey drain. See caveat.
‡ Scenarios not touching the hit path. Deltas here are run-to-run noise (these rows do not call `getResults` on a hit, so the fix cannot affect them). Re-running multiple times produced swings of similar magnitude, including >10% swings on the `Values withCache` row (9,190 → 11,078 on repeated master runs).

### `core` suite (does not exercise the hit path in the changed branch; all rows are noise-level)

| Benchmark | Master | Fix | Δ |
|---|---:|---:|---:|
| getResponse | 9,275 | 9,290 | +0.2% |
| getResponse (null) | 19.9M | 20.7M | +3.8% |
| getResponse (clear cache) | 644 | 458 | -28.9% ‡ |
| getSmallResponse | 7,274 | 7,392 | +1.6% |
| getSmallInferredResponse | 5,148 | 4,965 | -3.6% |
| getResponse Collection | 8,122 | 7,954 | -2.1% |
| get Collection | 6,457 | 6,960 | +7.8% |
| get Query-sorted | 7,215 | 8,128 | +12.7% |
| setLong | 777 | 778 | +0.1% |
| setLongWithMerge | 434 | 440 | +1.4% |
| setLongWithSimpleMerge | 477 | 476 | -0.2% |
| setSmallResponse 500x | 1,446 | 1,438 | -0.6% |

Core suite is mostly within run-to-run noise (±3–5%). `getResponse (clear cache)` has known wide variance; the -29% is noise, not a fix-related regression.

### Controlled microbenchmark (drain-free)

To isolate the per-hit cost without the benchmark.js journey-drain artifact, I ran three scenarios with fresh `MemoCache` per outer iteration (so the bug can't bias toward "shift on empty array"):

| Scenario | Master (buggy) | Fix | Δ |
|---|---:|---:|---:|
| single-hit (fresh memo, primed once, 1 hit measured) | 632 | 573 | -9.3% |
| 1000 hits back-to-back (shared memo, biased by drain) | 16.60 | 15.17 | -8.6% |
| **1000 hits with fresh memo per outer iteration** | **12.51** | **14.04** | **+12.2%** |

The last row — the only scenario where both branches do equal work — shows the fix is actually **faster**. `Array.prototype.shift` on a 2800-element array is O(n) reindex-in-place, which V8 routinely hits slow paths for; `Array.prototype.slice(1)` is O(n) allocate + memcpy which V8 optimizes well. Once we stop the bug from letting master do less work, the fix wins.

### Real-world impact

A React app does not iterate one endpoint 10,000 times in a tight loop — it does `O(hook instances × re-renders)` hits per second. At typical hook counts (tens to low hundreds), one extra `slice(1)` per hit on a ~50-element paths array is sub-microsecond per render. The correctness benefits (no silent under-subscription, no premature GC of live entities, correct `entityExpiresAt`) are unambiguously worth it.

## Changeset

Included as `.changeset/fix-journey-mutation.md`. Version-linked packages: `normalizr`, `core`, `endpoint`, `rest`, `graphql`, `react`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core caching/subscription metadata used by GC ref-counting; behavior change is small but impacts correctness across repeated cache hits and could affect dependency tracking if wrong.
> 
> **Overview**
> Fixes a bug where `GlobalCache.getResults` mutated cached dependency "journey" data on result-cache hits by replacing `paths.shift()` with a non-mutating `paths.slice(1)` copy, preventing progressive loss of entity subscription paths.
> 
> Adds an integration test covering repeated `Controller.getResponseMeta()` calls to ensure `countRef` increments/decrements entity ref-counts correctly across multiple subscribers, and includes a changeset bumping several `@data-client/*` packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e758f359b5364349984e155c763e37a1a1a1bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->