### PR TITLE
docs(website): publish v0.18 blog post dated May 1

### DIFF
--- a/.cursor/skills/data-client-v0.18-migration/SKILL.md
+++ b/.cursor/skills/data-client-v0.18-migration/SKILL.md
@@ -216,7 +216,7 @@ Existing schemas that use it should keep it after the delegate parameter.
 
 ### Optional Collection cleanup
 
-Unrelated to delegate signatures: v0.18 allows one `Collection` to carry both `argsKey` and `nestKey` so the same instance can back a top-level endpoint schema and a nested entity field. Consolidation is optional—see [Optional: consolidate Collection definitions](/blog/2026/04/24/v0.18-scalar-typed-downloads#collection-consolidation) in the v0.18 blog.
+Unrelated to delegate signatures: v0.18 allows one `Collection` to carry both `argsKey` and `nestKey` so the same instance can back a top-level endpoint schema and a nested entity field. Consolidation is optional—see [Optional: consolidate Collection definitions](/blog/2026/05/01/v0.18-scalar-typed-downloads#collection-consolidation) in the v0.18 blog.
 
 ## Where to find affected code
 

--- a/docs/rest/shared/_ScalarDemo.mdx
+++ b/docs/rest/shared/_ScalarDemo.mdx
@@ -1,9 +1,9 @@
 import HooksPlayground from '@site/src/components/HooksPlayground';
 import { companyFixtures } from '@site/src/fixtures/companies';
 
-<HooksPlayground fixtures={companyFixtures} row groupId="schema" defaultOpen={props.defaultOpen ?? "y"} defaultTab={props.defaultTab}>
+<HooksPlayground fixtures={companyFixtures} row={props.row ?? false} groupId="schema" defaultOpen={props.defaultOpen ?? "y"} defaultTab={props.defaultTab}>
 
-```ts title="api/Company" {11-20,26-28,34-36} collapsed
+```ts title="api/Company" {11-20,26-28,34-36}
 import { Collection, Entity, RestEndpoint, Scalar } from '@data-client/rest';
 
 export class Company extends Entity {
@@ -80,7 +80,7 @@ function formatShares(value: number | undefined) {
 }
 ```
 
-```tsx title="PortfolioGrid"
+```tsx title="PortfolioGrid" collapsed
 import { useSuspense, useFetch } from '@data-client/react';
 import { getCompanies, getPortfolioColumns } from './api/Company';
 import CompanyGrid from './CompanyGrid';

--- a/website/blog/2026-05-01-v0.18-scalar-typed-downloads.md
+++ b/website/blog/2026-05-01-v0.18-scalar-typed-downloads.md
@@ -11,24 +11,24 @@ v0.18 focuses on richer data modeling for values that vary by request context, s
 
 **New Features:**
 
-- [Scalar schema](/blog/2026/04/24/v0.18-scalar-typed-downloads#scalar) - Lens-dependent entity fields (e.g. portfolio-specific values) without ever mutating the underlying entity
-- [RestEndpoint `content` property](/blog/2026/04/24/v0.18-scalar-typed-downloads#content-property) - Typed file downloads, text responses, and streaming with a single property
-- [resource() `nonFilterArgumentKeys`](/blog/2026/04/24/v0.18-scalar-typed-downloads#non-filter-argument-keys) - Sort/pagination args don't fragment your [Collections](/rest/api/Collection)
+- [Scalar schema](/blog/2026/05/01/v0.18-scalar-typed-downloads#scalar) - Lens-dependent entity fields (e.g. portfolio-specific values) without ever mutating the underlying entity
+- [RestEndpoint `content` property](/blog/2026/05/01/v0.18-scalar-typed-downloads#content-property) - Typed file downloads, text responses, and streaming with a single property
+- [resource() `nonFilterArgumentKeys`](/blog/2026/05/01/v0.18-scalar-typed-downloads#non-filter-argument-keys) - Sort/pagination args don't fragment your [Collections](/rest/api/Collection)
 
 **Other Improvements:**
 
-- [Binary Content-Type auto-detection](/blog/2026/04/24/v0.18-scalar-typed-downloads#binary-auto-detection) - Images, PDFs, and other binary responses are handled automatically with no configuration ([#3868](https://github.com/reactive/data-client/pull/3868))
+- [Binary Content-Type auto-detection](/blog/2026/05/01/v0.18-scalar-typed-downloads#binary-auto-detection) - Images, PDFs, and other binary responses are handled automatically with no configuration ([#3868](https://github.com/reactive/data-client/pull/3868))
 - [Collection extender body types match HTTP method semantics](/rest/api/Collection) - PATCH extenders (`.move`, `.remove`) accept partial bodies; standalone [RestEndpoint](/rest/api/RestEndpoint) derives a typed body from the [Collection](/rest/api/Collection)'s entity schema ([#3910](https://github.com/reactive/data-client/pull/3910))
 - Export [`CollectionOptions`](/rest/api/Collection) from `@data-client/endpoint` and `@data-client/rest` for typed [Collection](/rest/api/Collection) construction ([#3904](https://github.com/reactive/data-client/pull/3904))
 
-<ScalarDemo />
+<ScalarDemo row={false} />
 
 The example shows the same `Company` entities rendered through different portfolio lenses. Stable [Entity](/rest/api/Entity) fields are reused, while lens-dependent values are selected from separate [`Scalar`](/rest/api/Scalar) cells.
 
-**[Breaking Changes:](/blog/2026/04/24/v0.18-scalar-typed-downloads#migration-guide)**
+**[Breaking Changes:](/blog/2026/05/01/v0.18-scalar-typed-downloads#migration-guide)**
 
-- [Schema.denormalize() takes a delegate](/blog/2026/04/24/v0.18-scalar-typed-downloads#denormalize-delegate) - `denormalize(input, args, unvisit)` → `denormalize(input, delegate)`. Affects custom [Schema](/rest/api/CustomSchema) implementations only.
-- [Schema.normalize() takes a delegate](/blog/2026/04/24/v0.18-scalar-typed-downloads#normalize-delegate) - `normalize(input, parent, key, args, visit, delegate)` → `normalize(input, parent, key, delegate)`. Affects custom [Schema](/rest/api/CustomSchema) implementations only.
+- [Schema.denormalize() takes a delegate](/blog/2026/05/01/v0.18-scalar-typed-downloads#denormalize-delegate) - `denormalize(input, args, unvisit)` → `denormalize(input, delegate)`. Affects custom [Schema](/rest/api/CustomSchema) implementations only.
+- [Schema.normalize() takes a delegate](/blog/2026/05/01/v0.18-scalar-typed-downloads#normalize-delegate) - `normalize(input, parent, key, args, visit, delegate)` → `normalize(input, parent, key, delegate)`. Affects custom [Schema](/rest/api/CustomSchema) implementations only.
 
 Upgrade with the automated [codemod](/codemods/v0.18.js):
 


### PR DESCRIPTION
### Motivation

The v0.18 announcement post should reflect a May 1 publication date rather than April 24, matching the intended ship schedule.

### Solution

Rename the blog file to use the `2026-05-01` date prefix so Docusaurus emits `/blog/2026/05/01/v0.18-scalar-typed-downloads`, update intra-post anchor links accordingly, and point the v0.18 migration skill at the same path.

### Open questions

N/A

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; main risk is broken internal links/embeds if any remaining references to the old blog date/path were missed.
> 
> **Overview**
> Updates the v0.18 release blog post to publish under the May 1, 2026 URL, including updating all intra-post links/anchors and the migration skill doc link to point at the new `/blog/2026/05/01/...` path.
> 
> Tweaks the shared `ScalarDemo` embed to make `row` configurable (defaulting to `false`) and adjusts code-block collapse behavior, then updates the blog to render the demo with `row={false}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 464ee0868e9b22a988ae55e3b34e07c5ee379871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->