### PR TITLE
docs: refresh skill descriptions and guidance

### DIFF
--- a/.cursor/skills/data-client-manager/SKILL.md
+++ b/.cursor/skills/data-client-manager/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: data-client-manager
-description: Implement @data-client Managers for global side effects - websocket, SSE, polling, subscriptions, logging, middleware, Controller actions, redux pattern
+description: Implement @data-client Managers for global/background side effects - websocket, SSE, polling, real-time updates, subscriptions, logging, analytics, middleware, intercepting Controller actions, DataProvider managers prop, redux-style action handling. Use when adding cross-cutting store behavior, reacting to dispatched actions, or handling external event streams.
 license: Apache 2.0
 ---
 # Guide: Using `@data-client` Managers for global side effects
 
 [Managers](references/managers.md) are singletons that handle global side-effects. Kind of like useEffect() for the central data store.
 They interface with the store using [Controller](references/Controller.md), and [redux middleware](https://redux.js.org/tutorials/fundamentals/part-4-store#middleware) is run in response to [actions](references/Actions.md).
+
+## Single Responsibility
+
+One concern per Manager; compose many small managers (e.g. transport, subscriptions, logging, auth) rather than one large one.
 
 ## References
 

--- a/.cursor/skills/data-client-react-testing/SKILL.md
+++ b/.cursor/skills/data-client-react-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-client-react-testing
-description: Test @data-client/react with renderDataHook - jest unit tests, fixtures, interceptors, mock responses, nock HTTP mocking, hook testing, component testing
+description: Test @data-client/react with renderDataHook and mountDataClient - jest unit tests, fixtures, interceptors, MockResolver, mock responses, nock HTTP mocking, fake timers for polling/subscription tests, DataProvider test setup, hook and component testing. Use when writing or debugging tests for hooks, components, or resources built on @data-client/react.
 license: Apache 2.0
 ---
 

--- a/.cursor/skills/data-client-react/SKILL.md
+++ b/.cursor/skills/data-client-react/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-client-react
-description: Use @data-client/react hooks - useSuspense, useFetch, useQuery, useCache, useLive, useDLE, useSubscription, useController for fetch/mutations, DataProvider, AsyncBoundary, useLoading, useDebounce
+description: Use @data-client/react hooks for data fetching, mutations, and rendering - useSuspense, useFetch, useQuery, useCache, useLive, useDLE, useSubscription, useController, DataProvider, AsyncBoundary, useLoading, useDebounce. Use when reading/rendering remote data, triggering mutations, doing optimistic updates, real-time subscriptions, or wiring Suspense/error boundaries in React.
 license: Apache 2.0
 ---
 ## Rendering

--- a/.cursor/skills/data-client-rest/SKILL.md
+++ b/.cursor/skills/data-client-rest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-client-rest
-description: Define REST APIs with @data-client/rest - resource(), RestEndpoint, CRUD, GET/POST/PUT/DELETE, HTTP fetch, normalize, cache, urlPrefix, path parameters, file download, blob, parseResponse
+description: Define REST APIs with @data-client/rest - resource(), RestEndpoint, CRUD (GET/POST/PUT/PATCH/DELETE), HTTP fetch, normalize, cache, urlPrefix, path-to-regexp parameters, searchParams, pagination, extend(), auth/headers, optimistic updates, polling, file download, blob, parseResponse. Use when defining or modifying network endpoints, REST resources, or the HTTP layer.
 license: Apache 2.0
 ---
 # Guide: Using `@data-client/rest` for Resource Modeling

--- a/.cursor/skills/data-client-schema/SKILL.md
+++ b/.cursor/skills/data-client-schema/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-client-schema
-description: Define data schemas - Entity, Collection, Union, Query, pk/primary key, normalize/denormalize, relational/nested data, polymorphic types, Invalidate, Values
+description: Model data with @data-client schemas (Entity, EntityMixin, Collection, Union, Query, Values, All, Invalidate, Lazy, Scalar) for atomic, consistent, referentially-equal async data via normalization, identity-based caching, and a single source of truth. Use when defining or editing pk, static schema, resource()/RestEndpoint schema, mutable lists/maps (push/unshift/assign/remove/move), polymorphic/discriminated types, memoized selectors / derived data, partial/supplementary entities, relational/nested/joined data, optimistic updates, or cache invalidation across @data-client/rest, /endpoint, /graphql, or /normalizr. Apply proactively when discussing data models, remote data shape, caching, normalization, identity, joins, polymorphism, mutable collections, or store consistency.
 license: Apache 2.0
 ---
 

--- a/.cursor/skills/data-client-vue-testing/SKILL.md
+++ b/.cursor/skills/data-client-vue-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-client-vue-testing
-description: Test @data-client/vue composables and components - renderDataCompose, mountDataClient, fixtures, jest, nock HTTP mocking, polling/subscription tests with fake timers, useSuspense, useLive, useSubscription, Vue 3 reactive props
+description: Test @data-client/vue composables and components - renderDataCompose, mountDataClient, fixtures, jest, nock HTTP mocking, polling/subscription tests with fake timers, useSuspense, useLive, useSubscription, Vue 3 reactive props. Use when writing or debugging tests for composables or components built on @data-client/vue.
 license: Apache 2.0
 ---
 

--- a/.cursor/skills/packages-documentation/SKILL.md
+++ b/.cursor/skills/packages-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: packages-documentation
-description: Write, update, and format docs for public APIs - API reference, README, docstrings, usage examples, migration guides, deprecation notices
+description: Write, update, and format documentation for @data-client public APIs - API reference (Docusaurus/MDX), README files, JSDoc/TSDoc docstrings, usage examples, migration guides, deprecation notices, changelog entries. Use when changing exported APIs (docs must update in the same PR), writing new package docs, or updating the dataclient.io site.
 license: Apache 2.0
 ---
 # Package Documentation Writing Guidelines


### PR DESCRIPTION
Clarify when each skill should be used and broaden the guidance to better match current data-client workflows.

<!--
Make sure to run yarn test:coverage to ensure coverage doesn't decrease
-->

Fixes # .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that expand and clarify when to apply each Cursor skill; no runtime code paths are affected.
> 
> **Overview**
> Refreshes several `.cursor/skills/*/SKILL.md` descriptions to better spell out *when to use* each @data-client skill (React hooks, REST modeling, schema modeling, Managers, and testing for React/Vue).
> 
> Adds small guidance details like a **single-responsibility** note for Managers and expands mention of current workflows (e.g., `mountDataClient`, fake timers for polling/subscriptions, PATCH in CRUD, path-to-regexp/searchParams/pagination, and docs expectations when exported APIs change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fabfb0ebab64c350505a41d167da70b1585fc1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->