### PR TITLE
fix(core): treat only undefined as missing for passthrough endpoint cache

### DIFF
--- a/.changeset/giant-dingos-wink.md
+++ b/.changeset/giant-dingos-wink.md
@@ -1,5 +1,8 @@
 ---
 '@data-client/core': patch
+'@data-client/normalizr': patch
+'@data-client/react': patch
+'@data-client/vue': patch
 ---
 
 Fix `Controller.getResponse()` treating cached falsy endpoint responses (`''`, `0`, `false`, and `null`) as missing data, which could cause `useSuspense()` and `useFetch()` to repeatedly refetch schema-less endpoints.

--- a/.changeset/giant-dingos-wink.md
+++ b/.changeset/giant-dingos-wink.md
@@ -5,4 +5,4 @@
 '@data-client/vue': patch
 ---
 
-Fix `Controller.getResponse()` treating cached falsy endpoint responses (`''`, `0`, `false`, and `null`) as missing data, which could cause `useSuspense()` and `useFetch()` to repeatedly refetch schema-less endpoints.
+Endpoints that resolve to falsy values (`''`, `0`, `false`, or `null`) no longer trigger infinite refetches.

--- a/.changeset/giant-dingos-wink.md
+++ b/.changeset/giant-dingos-wink.md
@@ -1,0 +1,5 @@
+---
+'@data-client/core': patch
+---
+
+Fix `Controller.getResponse()` treating cached falsy endpoint responses (`''`, `0`, `false`, and `null`) as missing data, which could cause `useSuspense()` and `useFetch()` to repeatedly refetch schema-less endpoints.

--- a/packages/core/src/controller/Controller.ts
+++ b/packages/core/src/controller/Controller.ts
@@ -529,7 +529,7 @@ export default class Controller<
       return {
         data: cacheEndpoints,
         expiryStatus: this.getExpiryStatus(
-          !cacheEndpoints,
+          cacheEndpoints === undefined,
           !!endpoint.invalidIfStale,
           meta,
         ),

--- a/packages/core/src/controller/__tests__/getResponse.ts
+++ b/packages/core/src/controller/__tests__/getResponse.ts
@@ -318,6 +318,53 @@ describe('Controller.getResponse() with Scalar', () => {
   );
 });
 
+describe('Controller.getResponse() with schema-less endpoints', () => {
+  it.each([
+    ['empty string', ''],
+    ['zero', 0],
+    ['false', false],
+    ['null', null],
+  ])('treats cached %s as valid data', (_name, cachedValue) => {
+    const controller = new Contoller();
+    const endpoint = new Endpoint(() => Promise.resolve(), {
+      key: () => 'falsy-endpoint',
+    });
+    const key = endpoint.key();
+    const fetchedAt = Date.now();
+    const state = {
+      ...initialState,
+      endpoints: {
+        [key]: cachedValue,
+      },
+      meta: {
+        [key]: {
+          date: fetchedAt,
+          fetchedAt,
+          expiresAt: fetchedAt + 1000,
+        },
+      },
+    };
+
+    const { data, expiryStatus } = controller.getResponse(endpoint, state);
+    expect(data).toBe(cachedValue);
+    expect(expiryStatus).toBe(ExpiryStatus.Valid);
+  });
+
+  it('treats undefined cache entries as invalid', () => {
+    const controller = new Contoller();
+    const endpoint = new Endpoint(() => Promise.resolve(), {
+      key: () => 'missing-endpoint',
+    });
+
+    const { data, expiryStatus } = controller.getResponse(
+      endpoint,
+      initialState,
+    );
+    expect(data).toBeUndefined();
+    expect(expiryStatus).toBe(ExpiryStatus.Invalid);
+  });
+});
+
 describe('Snapshot.getResponseMeta()', () => {
   it('denormalizes schema with extra members but not set', () => {
     const controller = new Contoller();


### PR DESCRIPTION
### Motivation

Schema-less endpoints that resolve to a falsy value (`''`, `0`, `false`, `null`) were stored correctly in `state.endpoints`, but `Controller.getResponseMeta()` used `!cacheEndpoints` on the passthrough branch. That treated any falsy cached value as missing, set `ExpiryStatus.Invalid`, and caused `useSuspense` / `useFetch` (and Vue equivalents) to refetch on every render.

### Solution

- In `getResponseMeta`, use `cacheEndpoints === undefined` instead of `!cacheEndpoints` when computing expiry for endpoints without a denormalizing schema, aligning with the existing `shouldQuery` check.
- Add regression tests in `packages/core/src/controller/__tests__/getResponse.ts` for cached falsy values and for missing cache entries.
- Add a changeset patch for `@data-client/core`.

### Open questions

N/A

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `Controller.getResponseMeta()` cache validity logic in `@data-client/core`, which can change when data is considered missing vs valid and therefore affect refetch behavior across clients.
> 
> **Overview**
> Fixes schema-less (passthrough) endpoint caching so only `undefined` is treated as a missing cache entry; cached falsy values like `''`, `0`, `false`, and `null` now remain **Valid** and won’t trigger repeated refetches.
> 
> Adds regression tests covering falsy cached values vs truly missing entries, and ships a patch changeset for `@data-client/core` (and related packages) documenting the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdba67b60c5b19783f2fbb87988868192c371371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->