### PR TITLE
internal: Cut CI wall-clock latency on the validation critical path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,11 +56,12 @@ jobs:
                 CHANGED_FILES=".circleci/config.yml"
               fi
             else
-              if git rev-parse --verify "origin/${BASE_BRANCH}" >/dev/null 2>&1; then
-                git fetch origin "${BASE_BRANCH}" --depth=1 || true
-                CHANGED_FILES="$(git diff --name-only "origin/${BASE_BRANCH}...HEAD" || true)"
-              else
-                echo "origin/${BASE_BRANCH} not found; treating as relevant."
+              # NOTE: never fetch with --depth here: a shallow fetch severs the
+              # merge base, making the three-dot diff fail (and thus previously
+              # silently skipping these checks on every PR branch).
+              git fetch --force origin "${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}" || true
+              if ! CHANGED_FILES="$(git diff --name-only "origin/${BASE_BRANCH}...HEAD")"; then
+                echo "Could not diff against origin/${BASE_BRANCH}; treating as relevant."
                 CHANGED_FILES=".circleci/config.yml"
               fi
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,12 @@ executors:
 
 commands:
   halt-unless-esmodule-relevant-change:
-    # Reads the flag computed once in the `setup` job (attach_workspace must run first).
+    # Reads the flag computed once in the `setup` job. Transported via cache
+    # (not the workspace) so jobs can halt before paying attach_workspace.
     steps:
+      - restore_cache:
+          keys:
+            - esmodule-relevant-v1-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Skip job if only non-esmodule paths changed
           command: |
@@ -79,6 +83,10 @@ jobs:
             fi
 
             echo "${ESMODULE_RELEVANT}" > ~/project/.ci-esmodule-relevant
+      - save_cache:
+          key: esmodule-relevant-v1-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - .ci-esmodule-relevant
       - run:
           name: Add examples/* to yarn workspace
           command: |
@@ -114,7 +122,6 @@ jobs:
           root: ~/
           paths:
             # explicitly list so we can ignore some directories that are not needed
-            - project/.ci-esmodule-relevant
             - project/.yarn
             - project/__tests__
             - project/examples/todo-app
@@ -227,9 +234,9 @@ jobs:
     executor: node
     resource_class: large
     steps:
+      - halt-unless-esmodule-relevant-change
       - attach_workspace:
           at: ~/
-      - halt-unless-esmodule-relevant-change
       - run:
           name: Build Legacy Types
           command: yarn run ci:build:legacy-types
@@ -245,9 +252,9 @@ jobs:
         type: string
     executor: node
     steps:
+      - halt-unless-esmodule-relevant-change
       - attach_workspace:
           at: ~/
-      - halt-unless-esmodule-relevant-change
       - run:
           name: Install TypeScript Version
           command: |
@@ -281,9 +288,9 @@ jobs:
   esmodule-types-latest:
     executor: node
     steps:
+      - halt-unless-esmodule-relevant-change
       - attach_workspace:
           at: ~/
-      - halt-unless-esmodule-relevant-change
       - run:
           name: Run Typecheck
           command: |
@@ -304,9 +311,9 @@ jobs:
   validate-esmodule-browser-build:
     executor: node
     steps:
+      - halt-unless-esmodule-relevant-change
       - attach_workspace:
           at: ~/
-      - halt-unless-esmodule-relevant-change
       - run: yarn run ci:build:esmodule
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,15 @@ commands:
       - run:
           name: Skip job if only non-esmodule paths changed
           command: |
-            # Fail open: only halt when setup explicitly determined irrelevance.
-            if [ "$(cat ~/project/.ci-esmodule-relevant 2>/dev/null)" = "false" ]; then
+            FLAG="$(cat ~/project/.ci-esmodule-relevant 2>/dev/null)" || FLAG=''
+            if [ "${FLAG}" = "false" ]; then
               echo "No relevant esmodule-related changes; halting this job."
               circleci-agent step halt
+            elif [ "${FLAG}" = "true" ]; then
+              echo "Relevant changes detected; continuing job."
+            else
+              echo "No relevance flag found; failing open (continuing job)."
             fi
-            echo "Relevant changes detected; continuing job."
 
 jobs:
   setup:
@@ -43,40 +46,39 @@ jobs:
       - run:
           name: Detect esmodule-relevant changes
           command: |
-            # Determine changed files relative to the default branch when available.
+            # Compare against the default branch (or its previous commit).
             # Use CIRCLE_DEFAULT_BRANCH so this stays correct if the default branch changes.
             BASE_BRANCH="${CIRCLE_DEFAULT_BRANCH:-master}"
+            # Fail open: run the esmodule jobs unless we can prove irrelevance.
+            ESMODULE_RELEVANT=true
 
-            # If we can't find origin/${BASE_BRANCH} (or previous commit), consider this run relevant.
             if [ "${CIRCLE_BRANCH}" = "${BASE_BRANCH}" ]; then
-              if git rev-parse HEAD~1 >/dev/null 2>&1; then
-                CHANGED_FILES="$(git diff --name-only HEAD~1...HEAD || true)"
-              else
-                echo "No previous commit on ${BASE_BRANCH}; treating as relevant."
-                CHANGED_FILES=".circleci/config.yml"
-              fi
+              DIFF_RANGE="HEAD~1...HEAD"
             else
               # NOTE: never fetch with --depth here: a shallow fetch severs the
               # merge base, making the three-dot diff fail (and thus previously
               # silently skipping these checks on every PR branch).
-              git fetch --force origin "${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}" || true
-              if ! CHANGED_FILES="$(git diff --name-only "origin/${BASE_BRANCH}...HEAD")"; then
-                echo "Could not diff against origin/${BASE_BRANCH}; treating as relevant."
-                CHANGED_FILES=".circleci/config.yml"
+              # blob:none keeps the commit/tree graph (enough for merge-base and
+              # --name-only diffs) without transferring file contents.
+              git fetch --force --filter=blob:none origin "${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}" || true
+              DIFF_RANGE="origin/${BASE_BRANCH}...HEAD"
+            fi
+
+            if CHANGED_FILES="$(git diff --name-only "${DIFF_RANGE}")"; then
+              echo "Changed files:"
+              echo "${CHANGED_FILES}"
+              if echo "${CHANGED_FILES}" | grep -Eq \
+                '^(\.circleci/config\.yml|yarn\.lock|examples/todo-app/|examples/github-app/|examples/normalizr-relationships/|packages/)'; then
+                echo "Relevant changes detected."
+              else
+                echo "No relevant esmodule-related changes; downstream esmodule jobs will halt."
+                ESMODULE_RELEVANT=false
               fi
-            fi
-
-            echo "Changed files:"
-            echo "${CHANGED_FILES}"
-
-            if echo "${CHANGED_FILES}" | grep -Eq \
-              '^(\.circleci/config\.yml|yarn\.lock|examples/todo-app/|examples/github-app/|packages/)'; then
-              echo "Relevant changes detected."
-              echo "true" > ~/project/.ci-esmodule-relevant
             else
-              echo "No relevant esmodule-related changes; downstream esmodule jobs will halt."
-              echo "false" > ~/project/.ci-esmodule-relevant
+              echo "Could not diff ${DIFF_RANGE}; treating as relevant."
             fi
+
+            echo "${ESMODULE_RELEVANT}" > ~/project/.ci-esmodule-relevant
       - run:
           name: Add examples/* to yarn workspace
           command: |
@@ -107,13 +109,7 @@ jobs:
           # These are independent (babel/rollup compile from src, not tsc output),
           # so run them concurrently to shorten the critical path.
           name: Build types and test lib (parallel)
-          command: |
-            yarn run ci:build:types &
-            TYPES_PID=$!
-            yarn run ci:build-test-lib &
-            TESTLIB_PID=$!
-            wait $TYPES_PID
-            wait $TESTLIB_PID
+          command: yarn run ci:build:setup
       - persist_to_workspace:
           root: ~/
           paths:
@@ -184,9 +180,7 @@ jobs:
           # --maxWorkers matches resource_class (large = 4 vCPU); Jest's
           # os.cpus() sees the host's CPUs in docker and would oversubscribe.
           command: |
-            if [ "<< parameters.react-version >>" == "^17" ]; then
-              yarn test:ci --maxWorkers=4 --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
-            elif [ "<< parameters.react-version >>" == "^18" ]; then
+            if [ "<< parameters.react-version >>" == "^17" ] || [ "<< parameters.react-version >>" == "^18" ]; then
               yarn test:ci --maxWorkers=4 --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
             elif [ "<< parameters.react-version >>" == "native" ]; then
               # No --maxWorkers here: the ReactNative suites are dominated by
@@ -225,8 +219,7 @@ jobs:
             yarn up react@^18 react-dom@^18 react-test-renderer@^18
       - run:
           # we must use npm because yarn 4 isn't compatible with legacy node versions
-          # --maxWorkers matches resource_class (default medium = 2 vCPU); Jest's
-          # os.cpus() sees the host's CPUs in docker and would oversubscribe.
+          # --maxWorkers matches resource_class (default medium = 2 vCPU); see unit_tests
           command: |
             ANANSI_JEST_TYPECHECK=false yarn test --ci --maxWorkers=2 --selectProjects Node
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,10 @@ jobs:
             elif [ "<< parameters.react-version >>" == "^18" ]; then
               yarn test:ci --maxWorkers=4 --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
             elif [ "<< parameters.react-version >>" == "native" ]; then
-              yarn test:ci --maxWorkers=4 --selectProjects ReactNative
+              # No --maxWorkers here: the ReactNative suites are dominated by
+              # fake-timer waits, and capping workers makes the heavy hook
+              # suites contend enough to flake 5s test timeouts.
+              yarn test:ci --selectProjects ReactNative
             else
               curl -Os https://uploader.codecov.io/latest/linux/codecov;
               chmod +x codecov;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,26 @@ executors:
 
 commands:
   halt-unless-esmodule-relevant-change:
+    # Reads the flag computed once in the `setup` job (attach_workspace must run first).
     steps:
-      # Ensure we have a git checkout with history to diff against
-      - checkout
       - run:
           name: Skip job if only non-esmodule paths changed
+          command: |
+            # Fail open: only halt when setup explicitly determined irrelevance.
+            if [ "$(cat ~/project/.ci-esmodule-relevant 2>/dev/null)" = "false" ]; then
+              echo "No relevant esmodule-related changes; halting this job."
+              circleci-agent step halt
+            fi
+            echo "Relevant changes detected; continuing job."
+
+jobs:
+  setup:
+    executor: node
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Detect esmodule-relevant changes
           command: |
             # Determine changed files relative to the default branch when available.
             # Use CIRCLE_DEFAULT_BRANCH so this stays correct if the default branch changes.
@@ -55,19 +70,12 @@ commands:
 
             if echo "${CHANGED_FILES}" | grep -Eq \
               '^(\.circleci/config\.yml|yarn\.lock|examples/todo-app/|examples/github-app/|packages/)'; then
-              echo "Relevant changes detected; continuing job."
+              echo "Relevant changes detected."
+              echo "true" > ~/project/.ci-esmodule-relevant
             else
-              echo "No relevant esmodule-related changes; halting this job."
-              circleci-agent step halt
+              echo "No relevant esmodule-related changes; downstream esmodule jobs will halt."
+              echo "false" > ~/project/.ci-esmodule-relevant
             fi
-
-jobs:
-  setup:
-    executor: node
-    resource_class: large
-    steps:
-      - checkout:
-          depth: 1
       - run:
           name: Add examples/* to yarn workspace
           command: |
@@ -94,12 +102,22 @@ jobs:
             - .yarn/cache
             - .yarn/install-state.gz
           key: v14-dependencies-{{ checksum "yarn.lock" }}-{{ checksum "examples/github-app/package.json" }}-{{ checksum "examples/todo-app/package.json" }}
-      - run: yarn run ci:build:types
-      - run: yarn run ci:build-test-lib
+      - run:
+          # These are independent (babel/rollup compile from src, not tsc output),
+          # so run them concurrently to shorten the critical path.
+          name: Build types and test lib (parallel)
+          command: |
+            yarn run ci:build:types &
+            TYPES_PID=$!
+            yarn run ci:build-test-lib &
+            TESTLIB_PID=$!
+            wait $TYPES_PID
+            wait $TESTLIB_PID
       - persist_to_workspace:
           root: ~/
           paths:
             # explicitly list so we can ignore some directories that are not needed
+            - project/.ci-esmodule-relevant
             - project/.yarn
             - project/__tests__
             - project/examples/todo-app
@@ -162,17 +180,19 @@ jobs:
             fi
       - run:
           name: Running Jest
+          # --maxWorkers matches resource_class (large = 4 vCPU); Jest's
+          # os.cpus() sees the host's CPUs in docker and would oversubscribe.
           command: |
             if [ "<< parameters.react-version >>" == "^17" ]; then
-              yarn test:ci --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
+              yarn test:ci --maxWorkers=4 --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
             elif [ "<< parameters.react-version >>" == "^18" ]; then
-              yarn test:ci --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
+              yarn test:ci --maxWorkers=4 --selectProjects ReactDOM --testPathPatterns packages/react packages/use-enhanced-reducer packages/img
             elif [ "<< parameters.react-version >>" == "native" ]; then
-              yarn test:ci --selectProjects ReactNative
+              yarn test:ci --maxWorkers=4 --selectProjects ReactNative
             else
               curl -Os https://uploader.codecov.io/latest/linux/codecov;
               chmod +x codecov;
-              yarn run test:coverage --ci --selectProjects ReactDOM Node --coverageReporters=text-lcov > ./lcov.info;
+              yarn run test:coverage --ci --maxWorkers=4 --selectProjects ReactDOM Node --coverageReporters=text-lcov > ./lcov.info;
               if [ "$CODECOV_TOKEN" != "" ]; then
                 ./codecov -t ${CODECOV_TOKEN} < ./lcov.info || true;
               else
@@ -201,16 +221,18 @@ jobs:
             yarn up react@^18 react-dom@^18 react-test-renderer@^18
       - run:
           # we must use npm because yarn 4 isn't compatible with legacy node versions
+          # --maxWorkers matches resource_class (default medium = 2 vCPU); Jest's
+          # os.cpus() sees the host's CPUs in docker and would oversubscribe.
           command: |
-            ANANSI_JEST_TYPECHECK=false yarn test --ci --selectProjects Node
+            ANANSI_JEST_TYPECHECK=false yarn test --ci --maxWorkers=2 --selectProjects Node
 
   setup-esmodule-types:
     executor: node
     resource_class: large
     steps:
-      - halt-unless-esmodule-relevant-change
       - attach_workspace:
           at: ~/
+      - halt-unless-esmodule-relevant-change
       - run:
           name: Build Legacy Types
           command: yarn run ci:build:legacy-types
@@ -226,9 +248,9 @@ jobs:
         type: string
     executor: node
     steps:
-      - halt-unless-esmodule-relevant-change
       - attach_workspace:
           at: ~/
+      - halt-unless-esmodule-relevant-change
       - run:
           name: Install TypeScript Version
           command: |
@@ -262,9 +284,9 @@ jobs:
   esmodule-types-latest:
     executor: node
     steps:
-      - halt-unless-esmodule-relevant-change
       - attach_workspace:
           at: ~/
+      - halt-unless-esmodule-relevant-change
       - run:
           name: Run Typecheck
           command: |
@@ -285,9 +307,9 @@ jobs:
   validate-esmodule-browser-build:
     executor: node
     steps:
-      - halt-unless-esmodule-relevant-change
       - attach_workspace:
           at: ~/
+      - halt-unless-esmodule-relevant-change
       - run: yarn run ci:build:esmodule
       - run:
           command: |

--- a/.cursor/rules/ci-config.mdc
+++ b/.cursor/rules/ci-config.mdc
@@ -1,0 +1,20 @@
+---
+description: CircleCI and GitHub Actions conventions - Jest worker pinning, esmodule relevance flag, workspace trimming
+globs: .circleci/**, .github/workflows/*.yml
+alwaysApply: false
+---
+
+# CI configuration
+
+## CircleCI (`.circleci/config.yml`)
+
+- Jest `--maxWorkers` is pinned per job to the `resource_class` vCPU count (large = 4, medium = 2) because docker containers report the host's CPUs via `os.cpus()`. Exception: the ReactNative `unit_tests` run is deliberately uncapped — its suites are fake-timer-wait dominated and capping workers flakes 5s test timeouts.
+- The esmodule jobs halt based on a `.ci-esmodule-relevant` flag computed once in `setup` and transported via `save_cache`/`restore_cache` (keyed on `CIRCLE_SHA1`) so jobs can halt before paying `attach_workspace`. The flag's path regex in `setup` must cover every path the esmodule jobs build (currently `examples/todo-app`, `examples/github-app`, `examples/normalizr-relationships`, `packages/`, `yarn.lock`, the config itself). Missing/unreadable flag fails open (jobs run).
+- Never `git fetch --depth` the base branch in the relevance check: a shallow fetch severs the merge base and the three-dot diff fails.
+- Changing root `package.json` `workspaces` requires updating the `setup` job's workspace trimming step.
+
+## GitHub Actions (`.github/workflows/`)
+
+- Workflows install only needed workspaces via `./scripts/ci-install.sh [extra-workspace ...]`.
+- `benchmark-react.yml` caches Playwright browsers keyed on the resolved `playwright` version from `examples/benchmark-react`; bumping playwright invalidates the cache automatically.
+- Benchmark workflows (`benchmark.yml`, `benchmark-react.yml`) tune the host (CPU governor, swapoff) and pin CPUs with `taskset` — they must run directly on the runner, not in a `container:`.

--- a/.github/workflows/benchmark-react.yml
+++ b/.github/workflows/benchmark-react.yml
@@ -46,7 +46,8 @@ jobs:
         run: ./scripts/ci-install.sh examples/benchmark-react
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "version=$(node -p "require(require.resolve('playwright/package.json', { paths: ['examples/benchmark-react'] })).version")" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v6
@@ -54,11 +55,13 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright (Chromium + system deps)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium --with-deps
-      - name: Install Playwright system deps (cached browsers)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        # System deps can't live in the cache, so install them either way.
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install chromium --with-deps
+          fi
       - name: Build packages
         run: yarn build:benchmark-react
       - name: Tune system for benchmarking

--- a/.github/workflows/benchmark-react.yml
+++ b/.github/workflows/benchmark-react.yml
@@ -44,8 +44,21 @@ jobs:
           cache: 'yarn'
       - name: Install packages
         run: ./scripts/ci-install.sh examples/benchmark-react
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright (Chromium + system deps)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium --with-deps
+      - name: Install Playwright system deps (cached browsers)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
       - name: Build packages
         run: yarn build:benchmark-react
       - name: Tune system for benchmarking

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,6 @@ Monorepo for `@data-client` high performance npm packages.
 
 Changing root `package.json` `workspaces` requires updating `.circleci/config.yml` (`setup` job) and `.github/workflows/` install steps.
 
-CircleCI pins Jest `--maxWorkers` to each job's `resource_class` vCPUs (docker reports host CPUs) — except ReactNative, which flakes when capped. ESM jobs halt via a `.ci-esmodule-relevant` flag computed once in `setup`; its path regex must cover the examples those jobs build.
-
 ## Changesets
 
 Any user-facing change in `packages/*` requires a changeset. Core packages are version-linked (bumping one bumps all). See skill "changeset" for full workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ Monorepo for `@data-client` high performance npm packages.
 
 Changing root `package.json` `workspaces` requires updating `.circleci/config.yml` (`setup` job) and `.github/workflows/` install steps.
 
+CircleCI pins Jest `--maxWorkers` to each job's `resource_class` vCPUs (docker reports host CPUs) — except ReactNative, which flakes when capped. ESM jobs halt via a `.ci-esmodule-relevant` flag computed once in `setup`; its path regex must cover the examples those jobs build.
+
 ## Changesets
 
 Any user-facing change in `packages/*` requires a changeset. Core packages are version-linked (bumping one bumps all). See skill "changeset" for full workflow.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build:clean": "yarn workspaces foreach -Wpti --no-private run build:clean",
     "build:types": "yarn build:copy:ambient && tsc --build && yarn workspaces foreach -Wpti --no-private run build:legacy-types",
     "ci:build": "yarn ci:build:types && yarn workspaces foreach -Wptiv --no-private run build:lib",
+    "ci:build:setup": "run-p ci:build:types ci:build-test-lib",
     "ci:build:types": "yarn build:copy:ambient && tsc --build",
     "ci:build:legacy-types": "yarn workspaces foreach -WptivR -j 10 --from @data-client/react --from @data-client/rest --from @data-client/graphql run build:legacy-types",
     "ci:build-test-lib": "yarn workspace @data-client/core run build:lib && yarn workspace @data-client/test run build:lib && yarn workspace @data-client/test run build:bundle",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation

The CircleCI `validation` workflow runs at ~3.5–4 min p50. Per-job Insights data shows the critical path is the 3-deep chain `setup` (101s) → `setup-esmodule-types` (61s) → `esmodule-types` matrix (~45s), with `unit_tests-latest` (60s) the second-longest branch. Several sources of dead time sit directly on that path:

- All 8 esmodule jobs do a full `checkout` + git diff against master just to decide whether to halt.
- `setup` runs `ci:build:types` and `ci:build-test-lib` sequentially even though they are independent.
- Jest sees the docker *host's* CPU count via `os.cpus()` and oversubscribes workers.
- The Benchmark React workflow re-downloads Chromium on every run.

### Solution

**CircleCI (`.circleci/config.yml`)**

- Compute the esmodule-relevance decision once in `setup` and transport a `.ci-esmodule-relevant` flag to the 8 downstream jobs via `save_cache`/`restore_cache` keyed on `CIRCLE_SHA1` (~0s restore, verified). Jobs halt **before** `attach_workspace`, so irrelevant (docs-only) pipelines stop each esmodule job in ~2s instead of paying a ~13–16s workspace attach or the old full checkout. Missing/unreadable flag fails open (jobs run); detection is deterministic per commit so the immutable cache key is safe across reruns.
- **Bug found and fixed along the way**: the old per-job check fetched the base branch with `--depth=1`, which severs the merge base, so `git diff origin/master...HEAD` failed on *every PR branch* and the empty-output fallback silently halted all esmodule jobs. The esmodule type checks and browser-build validation have effectively only been running on master pushes (post-merge), not on PRs. Detection now fetches the base ref with `--filter=blob:none` (commit graph only — enough for `--name-only` diffs) and treats an un-computable diff as relevant. The relevance regex also gains `examples/normalizr-relationships/`, which `validate-esmodule-browser-build` builds.
- Run `ci:build:types` and `ci:build-test-lib` concurrently in `setup` via a new root `ci:build:setup` script (`run-p`; 19s sequential → 14s measured).
- Pin `--maxWorkers=4` on the ReactDOM/coverage unit test runs (`large` = 4 vCPU) and `--maxWorkers=2` on `node_matrix` (`medium` = 2 vCPU). Verified effect: `unit_tests-latest` Jest step 49s → 33s. The ReactNative run deliberately keeps Jest defaults — its suites are fake-timer-wait dominated, and capping workers serialized the heavy hook suites (16s → 26s) and flaked `integration-garbage-collection`'s 5s timeout in two consecutive runs.
- Remove the no-op `depth: 1` parameter on `checkout` (the built-in step ignores it).

**GitHub Actions (`.github/workflows/benchmark-react.yml`)**

- Cache `~/.cache/ms-playwright` keyed on the `playwright` version resolved explicitly from `examples/benchmark-react`, so Renovate bumps invalidate automatically and hoisting changes can't break the key. On cache hit only system deps are installed.

**Docs**

- CI conventions (worker pinning, relevance-flag protocol, container caveats for benchmark workflows) live in a new glob-scoped rule `.cursor/rules/ci-config.mdc` that attaches only when editing `.circleci/**` or `.github/workflows/*.yml`, instead of costing context in root `AGENTS.md` on every conversation.

### Measured results (this PR's runs)

- Workflow wall clock 3:30 with the full esmodule chain actually running on a PR for the first time (historical master runs with the chain: ~3:40–4:10; pre-fix PR runs looked faster only because those jobs were silently skipping).
- `setup-esmodule-types` 61s → ~50s; `esmodule-types` jobs ~45s → ~40s (checkout removed from both hops).
- Docs-only changes: each halted esmodule job now costs ~2s (spin-up + cache restore) instead of a full checkout/attach.

### Open questions

- `Persisting to workspace` (~55s) now dominates `setup`; persisting `.yarn/cache` instead of `node_modules` and re-installing per job could net more, at the cost of more moving parts.
- tsbuildinfo caching is the other remaining `setup` lever (excluded here due to stale-cache risk).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f36a8597-8f2d-4ec4-9baf-2daa9b8b7aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f36a8597-8f2d-4ec4-9baf-2daa9b8b7aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

