### PR TITLE
internal(website): Simplify Playground editor components

### DIFF
--- a/website/src/components/HTTP/EndpointPlayground.tsx
+++ b/website/src/components/HTTP/EndpointPlayground.tsx
@@ -35,7 +35,6 @@ export default function EndpointPlayground({
           codeTabs={codeTabs}
           handleCodeChange={handleCodeChange}
           codes={codes}
-          large={false}
           isPlayground={false}
         />
       </LiveProvider>

--- a/website/src/components/Playground/DesignSystem/CurrentTime.tsx
+++ b/website/src/components/Playground/DesignSystem/CurrentTime.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useState } from 'react';
 
+const timeFormat = Intl.DateTimeFormat('en-US', { timeStyle: 'long' });
+
 export function CurrentTime() {
   const [time, setTime] = useState(() => new Date());
   useEffect(() => {
-    const intervalID = setInterval(() => setTime(new Date()));
+    // display only shows seconds, so update once per second
+    const intervalID = setInterval(() => setTime(new Date()), 1000);
     return () => clearInterval(intervalID);
   }, []);
-  return (
-    <time>
-      {Intl.DateTimeFormat('en-US', { timeStyle: 'long' }).format(time)}
-    </time>
-  );
+  return <time>{timeFormat.format(time)}</time>;
 }

--- a/website/src/components/Playground/FixturePreview.tsx
+++ b/website/src/components/Playground/FixturePreview.tsx
@@ -21,26 +21,23 @@ function FixtureResponse({
 }: {
   fixture: FixtureOrInterceptor;
 }): ReactElement {
+  if ('fetchResponse' in fixture || typeof fixture.response === 'function') {
+    const fn =
+      'fetchResponse' in fixture ? fixture.fetchResponse : fixture.response;
+    return (
+      <BrowserOnly>
+        {() => (
+          <CodeBlock language="javascript" className={styles.fixtureJson}>
+            {`${fn}`}
+          </CodeBlock>
+        )}
+      </BrowserOnly>
+    );
+  }
   return (
-    'fetchResponse' in fixture ?
-      <BrowserOnly>
-        {() => (
-          <CodeBlock language="javascript" className={styles.fixtureJson}>
-            {`${fixture.fetchResponse}`}
-          </CodeBlock>
-        )}
-      </BrowserOnly>
-    : typeof fixture.response === 'function' ?
-      <BrowserOnly>
-        {() => (
-          <CodeBlock language="javascript" className={styles.fixtureJson}>
-            {`${fixture.response}`}
-          </CodeBlock>
-        )}
-      </BrowserOnly>
-    : <CodeBlock language="json" className={styles.fixtureJson}>
-        {JSON.stringify(fixture.response)}
-      </CodeBlock>
+    <CodeBlock language="json" className={styles.fixtureJson}>
+      {JSON.stringify(fixture.response)}
+    </CodeBlock>
   );
 }
 
@@ -62,10 +59,12 @@ function FixtureOrInterceptor({
       </div>
     );
   }
+  // Interceptor endpoints don't declare these, but RestEndpoints provide them
+  const endpoint = fixture.endpoint as { method?: string; path?: string };
   return (
     <div className={styles.fixtureItem}>
       <div className={styles.fixtureHeader}>
-        {(fixture.endpoint as any).method} {(fixture.endpoint as any).path}
+        {endpoint.method} {endpoint.path}
       </div>
       <FixtureResponse fixture={fixture} />
     </div>

--- a/website/src/components/Playground/MonacoPreloads.tsx
+++ b/website/src/components/Playground/MonacoPreloads.tsx
@@ -1,39 +1,38 @@
 import pkg from 'monaco-editor/package.json';
 import React, { memo } from 'react';
 
+import { MOBILE_OR_BOT_UA_REGEX } from './isMobileOrBot';
+
 function MonacoPreloads() {
   return (
-    <>
-      <script
-        dangerouslySetInnerHTML={{ __html: preloadScript }}
-        type="application/javascript"
-      />
-    </>
+    <script
+      dangerouslySetInnerHTML={{ __html: preloadScript }}
+      type="application/javascript"
+    />
   );
 }
 export default memo(MonacoPreloads);
 
-export const MONACO_VERSION = pkg.version ?? '0.46.0';
+export const MONACO_CDN_VS = `https://cdn.jsdelivr.net/npm/monaco-editor@${pkg.version}/min/vs`;
 
 const monacoPreloads = [
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/editor/editor.main.js`,
-  //`https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/editor/editor.main.css`, if we load this early the css doesn't work right
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/loader.js`,
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/nls.messages-loader.js`,
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/basic-languages/monaco.contribution.js`,
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/editor.api-CalNCsUg.js`,
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/workers-DcJshg-q.js`,
+  `${MONACO_CDN_VS}/editor/editor.main.js`,
+  //`${MONACO_CDN_VS}/editor/editor.main.css`, if we load this early the css doesn't work right
+  `${MONACO_CDN_VS}/loader.js`,
+  `${MONACO_CDN_VS}/nls.messages-loader.js`,
+  `${MONACO_CDN_VS}/basic-languages/monaco.contribution.js`,
+  `${MONACO_CDN_VS}/editor.api-CalNCsUg.js`,
+  `${MONACO_CDN_VS}/workers-DcJshg-q.js`,
 ];
 const workerPreloads = [
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/typescript-DfOrAzoV.js`,
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/tsMode-CZz1Umrk.js`,
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/assets/ts.worker-CMbG-7ft.js`,
-  `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs/assets/editor.worker-Be8ye1pW.js`,
+  `${MONACO_CDN_VS}/typescript-DfOrAzoV.js`,
+  `${MONACO_CDN_VS}/tsMode-CZz1Umrk.js`,
+  `${MONACO_CDN_VS}/assets/ts.worker-CMbG-7ft.js`,
+  `${MONACO_CDN_VS}/assets/editor.worker-Be8ye1pW.js`,
 ];
 
-// Regex must match isMobileOrBot in isMobileOrBot.ts (cannot import into script string)
 const preloadScript = `
-if (!/bot|googlebot|crawler|spider|robot|crawling|Mobile|Android|BlackBerry/i.test(
+if (!/${MOBILE_OR_BOT_UA_REGEX.source}/i.test(
   navigator.userAgent,
 ) && !window.monacoPreloaded) {
 window.monacoPreloaded = true;

--- a/website/src/components/Playground/PlaygroundLiveEditor.tsx
+++ b/website/src/components/Playground/PlaygroundLiveEditor.tsx
@@ -10,6 +10,5 @@ export default function PlaygroundLiveEditor({
   onChange: (value: string) => void;
   code: string;
 }) {
-  //const isBrowser = useIsBrowser(); we used to key Editor on this; but I'm not sure why
   return <MemoEditor onChange={onChange} code={code} />;
 }

--- a/website/src/components/Playground/PlaygroundMonacoEditor.tsx
+++ b/website/src/components/Playground/PlaygroundMonacoEditor.tsx
@@ -2,25 +2,26 @@ import Editor from '@monaco-editor/react';
 import type { ISelection } from 'monaco-editor';
 import type * as Monaco from 'monaco-editor';
 import rangeParser from 'parse-numeric-range';
-import { useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { LiveEditor } from 'react-live';
 import './monaco-init';
 
 import { extensionToMonacoLanguage } from './extensionToMonacoLanguage';
 import { isMobileOrBot } from './isMobileOrBot';
-import { largeOptions, options } from './monacoOptions';
+import { options } from './monacoOptions';
 import PlaygroundLiveEditor from './PlaygroundLiveEditor';
 import useAutoHeight from './useAutoHeight';
 
-export default function PlaygroundMonacoEditor({
+// TODO: consider using the ts worker's getEmitOutput to compile rather than babel
+
+function PlaygroundMonacoEditor({
   onChange,
   code,
   path = '',
   onFocus,
   tabIndex,
-  highlights = undefined,
+  highlights,
   autoFocus = false,
-  large = false,
   isFocused = false,
   language = 'tsx',
   readOnly = false,
@@ -32,26 +33,11 @@ export default function PlaygroundMonacoEditor({
   tabIndex: number;
   highlights?: string;
   autoFocus?: boolean;
-  large?: boolean;
   isFocused?: boolean;
   language?: string;
   readOnly?: boolean;
 }) {
-  const editorOptions = useMemo(
-    () => ({ ...(large ? largeOptions : options), readOnly }),
-    [large, readOnly],
-  );
-  //const isBrowser = useIsBrowser(); we used to key Editor on this; but I'm not sure why
-
-  /* TODO: using ts to compile rather than babel
-  const handleChange = useWorkerCB(
-    tsWorker => {
-      tsWorker.getEmitOutput(`file:///${path}`).then(source => {
-        onChange(source.outputFiles[0].text);
-      });
-    },
-    [onChange, path],
-  );*/
+  const editorOptions = useMemo(() => ({ ...options, readOnly }), [readOnly]);
   const { height, handleMount: handleAutoMount } = useAutoHeight({
     isFocused,
     lineHeight: editorOptions.lineHeight,
@@ -102,6 +88,13 @@ export default function PlaygroundMonacoEditor({
     [],
   );
 
+  // loading only shows the initial snapshot, so it need not track code changes
+  const loading = useMemo(
+    () => <LiveEditor language={language} code={code} disabled />,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [language],
+  );
+
   // Use lightweight editor for mobile/bots
   // This runs inside BrowserOnly, so navigator is always defined
   // Check must be after hooks to satisfy React's rules of hooks
@@ -115,12 +108,12 @@ export default function PlaygroundMonacoEditor({
       defaultLanguage={extensionToMonacoLanguage(language)}
       onChange={onChange}
       defaultValue={code}
-      //value={code}
       options={editorOptions}
       theme="prism"
       onMount={handleMount}
       height={height}
-      loading={<LiveEditor language={language} code={code} disabled />}
+      loading={loading}
     />
   );
 }
+export default memo(PlaygroundMonacoEditor);

--- a/website/src/components/Playground/PlaygroundTextEdit.tsx
+++ b/website/src/components/Playground/PlaygroundTextEdit.tsx
@@ -26,7 +26,6 @@ export function PlaygroundTextEdit({
   codeTabs,
   handleCodeChange,
   codes,
-  large = false,
   isPlayground = true,
 }: PlaygroundProps) {
   const id = useId();
@@ -81,13 +80,11 @@ export function PlaygroundTextEdit({
                 onClick={() => handleTabToggle(i)}
                 closed={closedList[i]}
                 title={title}
-                collapsible={codeTabs.length > 1 || fixtures?.length}
-                lastChild={i === codeTabs.length - 1 && large}
+                collapsible={codeTabs.length > 1 || !!fixtures?.length}
               />
             : null}
             <TextEditTab
               hidden={closedList[i]}
-              key={i}
               tabIndex={i}
               onFocus={
                 row && !col && codeTabs.length > 1 ?
@@ -100,7 +97,6 @@ export function PlaygroundTextEdit({
               isFocused={!closedList[i]}
               language={language}
               {...rest}
-              large={large}
             />
           </React.Fragment>
         ),
@@ -114,7 +110,6 @@ interface PlaygroundProps {
   codeTabs: CodeTab[];
   handleCodeChange: UseCodeReturn['handleCodeChange'];
   codes: UseCodeReturn['codes'];
-  large?: boolean;
   isPlayground?: boolean;
 }
 
@@ -135,28 +130,24 @@ function TextEditTab({
         {code}
       </pre>
       // monaco editor doesn't work with SSR - so use LiveEditor which still shows readable code while the js loads
-    : <LiveEditor key={tabIndex} language={language} code={code} disabled />;
+    : <LiveEditor language={language} code={code} disabled />;
   return (
-    <>
-      <div
-        key={tabIndex}
-        className={clsx(styles.playgroundEditor, {
-          [styles.hidden]: hidden,
-        })}
-      >
-        <BrowserOnly fallback={fallback}>
-          {() => (
-            <PlaygroundEditor
-              key={tabIndex}
-              tabIndex={tabIndex}
-              code={code}
-              language={language}
-              {...rest}
-            />
-          )}
-        </BrowserOnly>
-      </div>
-    </>
+    <div
+      className={clsx(styles.playgroundEditor, {
+        [styles.hidden]: hidden,
+      })}
+    >
+      <BrowserOnly fallback={fallback}>
+        {() => (
+          <PlaygroundEditor
+            tabIndex={tabIndex}
+            code={code}
+            language={language}
+            {...rest}
+          />
+        )}
+      </BrowserOnly>
+    </div>
   );
 }
 
@@ -165,23 +156,15 @@ function CodeTabHeader({
   closed,
   title,
   collapsible = false,
-  lastChild = false,
 }: {
   onClick: () => void;
   closed: boolean;
   title: React.ReactNode;
-  collapsible?: boolean | number;
-  lastChild?: boolean;
+  collapsible?: boolean;
 }) {
   if (collapsible)
     return (
-      <Header
-        className={clsx({
-          [styles.lastChild]: lastChild && closed,
-        })}
-        small={true}
-        onClick={onClick}
-      >
+      <Header small={true} onClick={onClick}>
         <span
           className={clsx(styles.arrow, closed ? styles.right : styles.down)}
         >
@@ -232,6 +215,8 @@ function EditorTabs({
     </Header>
   );
 }
+// Not React's useId: ids are embedded in Monaco model URIs and extracted with
+// /\/\d+\// in monaco-init.ts, so they must be purely numeric (no ':').
 function useId() {
   return useMemo(() => (Math.random() * 10000).toPrecision(4).toString(), []);
 }

--- a/website/src/components/Playground/Preview.tsx
+++ b/website/src/components/Playground/Preview.tsx
@@ -30,9 +30,7 @@ function Preview<T>({
     useScrollPositionBlocker();
 
   const toggle = useCallback(
-    (
-      event: React.FocusEvent<HTMLLIElement> | React.MouseEvent<HTMLLIElement>,
-    ) => {
+    (event: React.MouseEvent<HTMLDivElement>) => {
       blockElementScrollPositionUntilNextRender(event.currentTarget);
       const next = selectedValue === 'y' ? 'n' : 'y';
       setTabGroupChoice(next);

--- a/website/src/components/Playground/Preview.tsx
+++ b/website/src/components/Playground/Preview.tsx
@@ -49,7 +49,7 @@ function Preview<T>({
     [],
   );
 
-  const hiddenResult = !(selectedValue === 'n' || !row);
+  const hiddenResult = row && selectedValue === 'y';
   return (
     <DataProvider managers={managers}>
       <MockResolver

--- a/website/src/components/Playground/PreviewBlock.tsx
+++ b/website/src/components/Playground/PreviewBlock.tsx
@@ -1,4 +1,3 @@
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import React from 'react';
 import { LiveError, LivePreview } from 'react-live';
 

--- a/website/src/components/Playground/StoreInspector.tsx
+++ b/website/src/components/Playground/StoreInspector.tsx
@@ -15,15 +15,9 @@ function StoreInspector({
   ) => void;
 }) {
   const isSelected = selectedValue === 'y';
-  const rotation = isSelected ? styles.right : styles.left;
   return (
     <>
-      <div className={styles.debugToggle} onClick={toggle}>
-        Store
-        <span className={clsx(styles.arrow, rotation, styles.vertical)}>
-          ▶
-        </span>
-      </div>
+      <StoreToggle onClick={toggle} open={isSelected} />
       {isSelected ?
         <StoreTreeM />
       : null}
@@ -32,13 +26,34 @@ function StoreInspector({
 }
 export default memo(StoreInspector);
 
+/** Toggle row shared with the preview loading fallback in ./index.tsx */
+export function StoreToggle({
+  onClick,
+  open = true,
+}: {
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  open?: boolean;
+}) {
+  return (
+    <div className={styles.debugToggle} onClick={onClick}>
+      Store
+      <span
+        className={clsx(
+          styles.arrow,
+          open ? styles.right : styles.left,
+          styles.vertical,
+        )}
+      >
+        ▶
+      </span>
+    </div>
+  );
+}
+
 function StoreTree() {
   const state = useContext(StateContext);
   const simplifiedState = useMemo(() => {
-    const ret = {
-      ...state,
-    };
-    delete ret.optimistic;
+    const { optimistic, ...ret } = state;
     return ret;
   }, [state]);
   return <Tree value={simplifiedState} />;

--- a/website/src/components/Playground/StoreInspector.tsx
+++ b/website/src/components/Playground/StoreInspector.tsx
@@ -10,9 +10,7 @@ function StoreInspector({
   selectedValue,
 }: {
   selectedValue: 'y' | 'n';
-  toggle: (
-    event: React.FocusEvent<HTMLLIElement> | React.MouseEvent<HTMLLIElement>,
-  ) => void;
+  toggle: React.MouseEventHandler<HTMLDivElement>;
 }) {
   const isSelected = selectedValue === 'y';
   return (
@@ -31,7 +29,7 @@ export function StoreToggle({
   onClick,
   open = true,
 }: {
-  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
   open?: boolean;
 }) {
   return (

--- a/website/src/components/Playground/Tree.tsx
+++ b/website/src/components/Playground/Tree.tsx
@@ -1,22 +1,20 @@
-import { useColorMode, usePrismTheme } from '@docusaurus/theme-common';
+import { useColorMode } from '@docusaurus/theme-common';
 import React, { useMemo } from 'react';
 import { JSONTree } from 'react-json-tree';
 
+const valueColorMap = {
+  String: 'rgb(195, 232, 141)',
+  Date: 'rgb(247, 140, 108)',
+  Number: 'rgb(247, 140, 108)',
+  Boolean: 'rgb(247, 140, 108)',
+  Null: 'rgb(255, 88, 116)',
+  Undefined: 'rgb(255, 88, 116)',
+  Function: 'rgb(247, 140, 108)',
+  Symbol: 'rgb(247, 140, 108)',
+};
+
 export default function Output({ value }: { value: any }) {
   const isDarkTheme = useColorMode().colorMode === 'dark';
-  const valueColorMap = useMemo(
-    () => ({
-      String: 'rgb(195, 232, 141)',
-      Date: 'rgb(247, 140, 108)',
-      Number: 'rgb(247, 140, 108)',
-      Boolean: 'rgb(247, 140, 108)',
-      Null: 'rgb(255, 88, 116)',
-      Undefined: 'rgb(255, 88, 116)',
-      Function: 'rgb(247, 140, 108)',
-      Symbol: 'rgb(247, 140, 108)',
-    }),
-    [],
-  );
   const theme = useMemo(
     () => ({
       tree: {
@@ -29,7 +27,7 @@ export default function Output({ value }: { value: any }) {
         font: 'var(--ifm-code-font-size) / var(--ifm-pre-line-height) var(--ifm-font-family-monospace) !important',
         color: 'rgb(227, 227, 227)',
       },
-      arrowContainer: ({ style }, arrowStyle) => ({
+      arrowContainer: ({ style }) => ({
         style: {
           ...style,
           fontFamily: 'arial',
@@ -54,7 +52,7 @@ export default function Output({ value }: { value: any }) {
       }),
       base0B: 'rgb(191, 199, 213)',
     }),
-    [isDarkTheme, valueColorMap],
+    [isDarkTheme],
   );
   const shouldExpandNodeInitially = useMemo(shouldExpandNode, []);
   return (
@@ -86,7 +84,15 @@ const shouldExpandNode = () => {
   };
 };
 
-const HASINTL = typeof Intl !== 'undefined';
+const timeFormatter =
+  typeof Intl !== 'undefined' ?
+    Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      fractionalSecondDigits: 3,
+    })
+  : undefined;
 
 function valueRenderer(
   valueAsString: string,
@@ -95,18 +101,13 @@ function valueRenderer(
 ) {
   const key = keyPath[0];
   if (
-    HASINTL &&
+    timeFormatter &&
     typeof value === 'number' &&
     typeof key === 'string' &&
     isFinite(value) &&
     (key === 'date' || key.endsWith('At'))
   ) {
-    return Intl.DateTimeFormat('en-US', {
-      hour: 'numeric',
-      minute: 'numeric',
-      second: 'numeric',
-      fractionalSecondDigits: 3,
-    }).format(value);
+    return timeFormatter.format(value);
   }
   return valueAsString;
 }

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -1,6 +1,5 @@
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import clsx from 'clsx';
-import type { Language, PrismTheme } from 'prism-react-renderer';
 import React, { lazy } from 'react';
 import { LiveProvider } from 'react-live';
 
@@ -9,27 +8,16 @@ import { isGoogleBot } from './isMobileOrBot';
 import MonacoPreloads from './MonacoPreloads';
 import { PlaygroundTextEdit } from './PlaygroundTextEdit';
 import PreviewWrapper from './PreviewWrapper';
+import { StoreToggle } from './StoreInspector';
 import styles from './styles.module.css';
 import type { PreviewProps } from './types';
 import { useCode } from './useCode';
 import { useReactLiveTheme } from './useReactLiveTheme';
 
-// previously exported by react-live
-type LiveProviderProps = {
-  code?: string;
-  disabled?: boolean;
-  enableTypeScript?: boolean;
-  language?: Language;
-  noInline?: boolean;
-  scope?: Record<string, unknown>;
-  theme?: PrismTheme;
-  hidden?: boolean;
-  transformCode?(code: string): void;
-};
+type LiveProviderProps = React.ComponentProps<typeof LiveProvider>;
 
 export default function Playground<T>({
   children,
-  transformCode,
   groupId,
   defaultOpen,
   row = false,
@@ -38,10 +26,11 @@ export default function Playground<T>({
   getInitialInterceptorData,
   defaultTab,
   ...props
-}: Omit<LiveProviderProps, 'ref'> &
+}: LiveProviderProps &
   Omit<PreviewProps<T>, 'row'> & {
     row?: boolean;
-    children: string | any[];
+    hidden?: boolean;
+    children: string | React.ReactElement[];
     defaultTab?: string;
   }) {
   const {
@@ -87,10 +76,8 @@ function PlaygroundContent<T>({
   getInitialInterceptorData,
 }: ContentProps<T>) {
   const { handleCodeChange, codes, codeTabs } = useCode(children, defaultTab);
-  /*const code = ready.every(v => v)
-    ? codes.join('\n')
-    : 'render(<div>Loading...</div>);';*/
-  const code = codes.join('\n');
+  // defer so typing in the editor isn't blocked by preview re-transpilation
+  const code = React.useDeferredValue(codes.join('\n'));
 
   return (
     <Reversible reverse={reverse}>
@@ -125,18 +112,13 @@ interface ContentProps<T = any> extends PreviewProps<T> {
 const previewLoading = (
   <PreviewWrapper key="preview">
     <div className={styles.playgroundPreview}></div>
-    <div className={styles.debugToggle}>
-      Store
-      <span className={clsx(styles.arrow, styles.right, styles.vertical)}>
-        ▶
-      </span>
-    </div>
+    <StoreToggle />
   </PreviewWrapper>
 );
 
 const PreviewWithScopeLazy = lazy(() =>
   isGoogleBot ?
-    Promise.resolve({ default: (props: any): JSX.Element => previewLoading })
+    Promise.resolve({ default: (): JSX.Element => previewLoading })
   : import(
       /* webpackChunkName: 'PreviewWithScope', webpackPrefetch: true */ './PreviewWithScope'
     ),

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -7,6 +7,7 @@ import Boundary from './Boundary';
 import { isGoogleBot } from './isMobileOrBot';
 import MonacoPreloads from './MonacoPreloads';
 import { PlaygroundTextEdit } from './PlaygroundTextEdit';
+import type PreviewWithScopeType from './PreviewWithScope';
 import PreviewWrapper from './PreviewWrapper';
 import { StoreToggle } from './StoreInspector';
 import styles from './styles.module.css';
@@ -116,9 +117,9 @@ const previewLoading = (
   </PreviewWrapper>
 );
 
-const PreviewWithScopeLazy = lazy(() =>
+const PreviewWithScopeLazy = lazy<typeof PreviewWithScopeType>(() =>
   isGoogleBot ?
-    Promise.resolve({ default: (): JSX.Element => previewLoading })
+    Promise.resolve({ default: () => previewLoading })
   : import(
       /* webpackChunkName: 'PreviewWithScope', webpackPrefetch: true */ './PreviewWithScope'
     ),

--- a/website/src/components/Playground/isMobileOrBot.ts
+++ b/website/src/components/Playground/isMobileOrBot.ts
@@ -1,6 +1,6 @@
-/** Shared user-agent patterns for bot/mobile detection. Inline copy in MonacoPreloads.tsx script string. */
-const BOT_UA_REGEX = /bot|googlebot|crawler|spider|robot|crawling/i;
-const MOBILE_OR_BOT_UA_REGEX =
+/** Shared user-agent patterns for bot/mobile detection. */
+export const BOT_UA_REGEX = /bot|googlebot|crawler|spider|robot|crawling/i;
+export const MOBILE_OR_BOT_UA_REGEX =
   /bot|googlebot|crawler|spider|robot|crawling|Mobile|Android|BlackBerry/i;
 
 /** True if crawler/bot (SSR-safe). Used for skipping Monaco/Preview load. */

--- a/website/src/components/Playground/monaco-init.ts
+++ b/website/src/components/Playground/monaco-init.ts
@@ -1,12 +1,13 @@
 import { loader } from '@monaco-editor/react';
 
-import { MONACO_VERSION } from './MonacoPreloads';
+import { MOBILE_OR_BOT_UA_REGEX } from './isMobileOrBot';
+import { MONACO_CDN_VS } from './MonacoPreloads';
 
-export let monacoMaster;
-
+// Mobile and bots render PlaygroundLiveEditor instead, so skip downloading
+// Monaco and the type bundles entirely. This module runs once per page load.
 if (
   typeof window !== 'undefined' &&
-  !/bot|googlebot|crawler|spider|robot|crawling/i.test(navigator.userAgent)
+  !MOBILE_OR_BOT_UA_REGEX.test(navigator.userAgent)
 ) {
   const rhDeps = [
     'rest',
@@ -28,238 +29,209 @@ if (
     'bignumber.js',
   ];
 
-  if (!monacoMaster) {
-    loader.config({
-      paths: {
-        vs: `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_VERSION}/min/vs`,
+  loader.config({
+    paths: {
+      vs: MONACO_CDN_VS,
+    },
+  });
+  const monacoPromise = loader.init();
+  monacoPromise.then(monaco => {
+    // or make sure that it exists by other ways
+    if (!monaco) return;
+    monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+      allowNonTsExtensions: true,
+      target: monaco.languages.typescript.ScriptTarget.ES2017,
+      jsx: monaco.languages.typescript.JsxEmit.ReactJSX,
+      strict: true,
+      strictNullChecks: true,
+      exactOptionalPropertyTypes: true,
+      lib: ['dom', 'esnext'],
+      module: monaco.languages.typescript.ModuleKind.ESNext,
+      moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+      allowSyntheticDefaultImports: true,
+      skipLibCheck: true,
+      skipDefaultLibCheck: true,
+      noImplicitAny: false,
+    });
+    // TODO: load theme from docusaurus config so we eliminate DRY violation
+    // see https://microsoft.github.io/monaco-editor/playground.html for full options
+    monaco.editor.defineTheme('prism', {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [
+        { token: 'number', foreground: 'f78c6c' },
+        { token: 'string', foreground: 'b6d986' },
+        {
+          token: 'keyword',
+          fontStyle: 'italic',
+          foreground: '7da4f6',
+        },
+        // type definitions variables like const X or class X
+        { token: 'type', foreground: 'ffcb6b' },
+        { token: 'delimiter', foreground: 'C792EA' },
+
+        { token: 'tag', foreground: 'FF5590' },
+      ],
+      colors: {
+        //'editor.background': '#292d3e',
+        'editor.foreground': '#bfc7d5',
+        //'editor.lineHighlightBorder': '#33384d',
+        'editor.inactiveSelectionBackground': '#484d5b',
       },
     });
-    const monacoPromise = loader.init();
-    monacoPromise.then(monaco => {
-      // or make sure that it exists by other ways
-      if (!monaco) return;
-      monacoMaster = monaco;
-      monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-        allowNonTsExtensions: true,
-        target: monaco.languages.typescript.ScriptTarget.ES2017,
-        jsx: monaco.languages.typescript.JsxEmit.ReactJSX,
-        strict: true,
-        strictNullChecks: true,
-        exactOptionalPropertyTypes: true,
-        lib: ['dom', 'esnext'],
-        module: monaco.languages.typescript.ModuleKind.ESNext,
-        moduleResolution:
-          monaco.languages.typescript.ModuleResolutionKind.NodeJs,
-        allowSyntheticDefaultImports: true,
-        skipLibCheck: true,
-        skipDefaultLibCheck: true,
-        noImplicitAny: false,
-      });
-      // TODO: load theme from docusaurus config so we eliminate DRY violation
-      // see https://microsoft.github.io/monaco-editor/playground.html for full options
-      monaco.editor.defineTheme('prism', {
-        base: 'vs-dark',
-        inherit: true,
-        rules: [
-          { token: 'number', foreground: 'f78c6c' },
-          { token: 'string', foreground: 'b6d986' },
-          {
-            token: 'keyword',
-            fontStyle: 'italic',
-            foreground: '7da4f6',
-          },
-          // type definitions variables like const X or class X
-          { token: 'type', foreground: 'ffcb6b' },
-          { token: 'delimiter', foreground: 'C792EA' },
-
-          { token: 'tag', foreground: 'FF5590' },
-        ],
-        colors: {
-          //'editor.background': '#292d3e',
-          'editor.foreground': '#bfc7d5',
-          //'editor.lineHighlightBorder': '#33384d',
-          'editor.inactiveSelectionBackground': '#484d5b',
-        },
-      });
-      //monaco.languages.typescript.getTypeScriptWorker().then(worker => worker)
-      // go to definition
-      monaco.editor.registerEditorOpener({
-        openCodeEditor(sourceEditor, resource, selectionOrPosition) {
-          if (resource.path.startsWith('/')) {
-            // alternatively set model directly in the editor if you have your own tab/navigation implementation\
-            const model = monaco.editor.getModel(resource);
-            const destinationEditor = monaco.editor
-              .getEditors()
-              .find(editor => editor.getModel() === model);
-            if (!destinationEditor) return false;
-            // focus event is handled by editor to show that tab
-            destinationEditor.focus();
-            requestIdleCallback(() => {
-              if (monaco.Range.isIRange(selectionOrPosition)) {
-                destinationEditor.revealRangeInCenterIfOutsideViewport(
+    // go to definition
+    monaco.editor.registerEditorOpener({
+      openCodeEditor(sourceEditor, resource, selectionOrPosition) {
+        if (resource.path.startsWith('/')) {
+          // alternatively set model directly in the editor if you have your own tab/navigation implementation\
+          const model = monaco.editor.getModel(resource);
+          const destinationEditor = monaco.editor
+            .getEditors()
+            .find(editor => editor.getModel() === model);
+          if (!destinationEditor) return false;
+          // focus event is handled by editor to show that tab
+          destinationEditor.focus();
+          requestIdleCallback(() => {
+            if (monaco.Range.isIRange(selectionOrPosition)) {
+              destinationEditor.revealRangeInCenterIfOutsideViewport(
+                selectionOrPosition,
+              );
+              destinationEditor.setSelection(selectionOrPosition);
+            } else {
+              if (selectionOrPosition) {
+                destinationEditor.revealPositionInCenterIfOutsideViewport(
                   selectionOrPosition,
                 );
-                destinationEditor.setSelection(selectionOrPosition);
-              } else {
-                if (selectionOrPosition) {
-                  destinationEditor.revealPositionInCenterIfOutsideViewport(
-                    selectionOrPosition,
-                  );
-                  destinationEditor.setPosition(selectionOrPosition);
-                }
+                destinationEditor.setPosition(selectionOrPosition);
               }
-              destinationEditor.focus();
-            });
-
-            return true;
-          }
-          return false;
-        },
-      });
-      // autocomplete imports
-      monaco.languages.registerCompletionItemProvider('typescript', {
-        // These characters should trigger our `provideCompletionItems` function
-        triggerCharacters: ["'", '"', '.', '/'],
-        // Function which returns a list of autocompletion ietems. If we return an empty array, there won't be any autocompletion.
-        provideCompletionItems: (model, position) => {
-          // Get all the text content before the cursor
-          const textUntilPosition = model.getValueInRange({
-            startLineNumber: 1,
-            startColumn: 1,
-            endLineNumber: position.lineNumber,
-            endColumn: position.column,
-          });
-          // Get the current word
-          const word = model.getWordUntilPosition(position);
-          const range = {
-            startLineNumber: position.lineNumber,
-            endLineNumber: position.lineNumber,
-            startColumn: word.startColumn,
-            endColumn: word.endColumn,
-          };
-          // Match things like `from "` and `require("`
-          if (
-            /(([\s|\n]+from\s+)|(\brequire\b\s*\())["|'][^'^"]*$/.test(
-              textUntilPosition,
-            )
-          ) {
-            // It's probably a `import` statement or `require` call
-            if (
-              textUntilPosition.endsWith('.') ||
-              textUntilPosition.endsWith('/')
-            ) {
-              //const thisId = /\/\d+\//g.exec(model.uri.path)?.[0];
-              //if (!thisId) return;
-              const completions = monaco.editor
-                .getModels()
-                .map(model => model.uri.path)
-                /*.filter(
-                  path => path.startsWith(thisId) && path !== model.uri.path,
-                )*/
-                .map(path => {
-                  const candidateId = /\/\d+\//g.exec(path)?.[0] ?? '';
-                  const file = path.substring(candidateId.length - 1);
-                  return {
-                    // Show the full file path for label
-                    label: file,
-                    // Don't keep extension for JS files
-                    insertText: file.replace(/\.tsx?$/, ''),
-                    kind: monaco.languages.CompletionItemKind.Module,
-                    range,
-                  };
-                });
-              if (!completions.length) return;
-              return { suggestions: completions };
-              // User is trying to import a file
-              /*return Object.keys(this.props.files)
-              .filter(path => path !== this.props.path)
-              .map(path => {
-                let file = getRelativePath(this.props.path, path);
-                // Only show files that match the prefix typed by user
-                if (file.startsWith(prefix)) {
-                  // Remove typed text from the path so that don't insert it twice
-                  file = file.slice(typed.length);
-                  return {
-                    // Show the full file path for label
-                    label: file,
-                    // Don't keep extension for JS files
-                    insertText: file.replace(/\.js$/, ''),
-                    kind: monaco.languages.CompletionItemKind.File,
-                  };
-                }
-                return null;
-              })
-              .filter(Boolean);*/
-            } else {
-              // User is trying to import a dependency
-              return {
-                suggestions: suggestionDependencies.map(name => ({
-                  label: name,
-                  //detail: suggestionDependencies[name],
-                  kind: monaco.languages.CompletionItemKind.Module,
-                  insertText: name,
-                  range,
-                })),
-              };
             }
-          }
-        },
-      });
+            destinationEditor.focus();
+          });
+
+          return true;
+        }
+        return false;
+      },
     });
+    // autocomplete imports
+    monaco.languages.registerCompletionItemProvider('typescript', {
+      // These characters should trigger our `provideCompletionItems` function
+      triggerCharacters: ["'", '"', '.', '/'],
+      // Function which returns a list of autocompletion ietems. If we return an empty array, there won't be any autocompletion.
+      provideCompletionItems: (model, position) => {
+        // Get all the text content before the cursor
+        const textUntilPosition = model.getValueInRange({
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: position.lineNumber,
+          endColumn: position.column,
+        });
+        // Get the current word
+        const word = model.getWordUntilPosition(position);
+        const range = {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: word.startColumn,
+          endColumn: word.endColumn,
+        };
+        // Match things like `from "` and `require("`
+        if (
+          /(([\s|\n]+from\s+)|(\brequire\b\s*\())["|'][^'^"]*$/.test(
+            textUntilPosition,
+          )
+        ) {
+          // It's probably a `import` statement or `require` call
+          if (
+            textUntilPosition.endsWith('.') ||
+            textUntilPosition.endsWith('/')
+          ) {
+            const completions = monaco.editor
+              .getModels()
+              .map(model => model.uri.path)
+              .map(path => {
+                const candidateId = /\/\d+\//g.exec(path)?.[0] ?? '';
+                const file = path.substring(candidateId.length - 1);
+                return {
+                  // Show the full file path for label
+                  label: file,
+                  // Don't keep extension for JS files
+                  insertText: file.replace(/\.tsx?$/, ''),
+                  kind: monaco.languages.CompletionItemKind.Module,
+                  range,
+                };
+              });
+            if (!completions.length) return;
+            return { suggestions: completions };
+          } else {
+            // User is trying to import a dependency
+            return {
+              suggestions: suggestionDependencies.map(name => ({
+                label: name,
+                //detail: suggestionDependencies[name],
+                kind: monaco.languages.CompletionItemKind.Module,
+                insertText: name,
+                range,
+              })),
+            };
+          }
+        }
+      },
+    });
+  });
 
-    Promise.allSettled([
-      monacoPromise,
-      import(
-        /* webpackChunkName: 'reactDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/react.d.ts'
-      ),
-      import(
-        /* webpackChunkName: 'bignumberDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/bignumber.d.ts'
-      ),
-      import(
-        /* webpackChunkName: 'numberflowDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/@number-flow/react.d.ts'
-      ),
-      import(
-        /* webpackChunkName: 'temporalDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/temporal.d.ts'
-      ),
-      import(
-        /* webpackChunkName: 'uuidDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/uuid.d.ts'
-      ),
-      import(
-        /* webpackChunkName: 'qsDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/qs.d.ts'
-      ),
-      import(
-        /* webpackChunkName: 'globalsDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/globals.d.ts'
-      ),
-      ...rhDeps.map(
-        dep =>
-          import(
-            /* webpackChunkName: '[request]', webpackPreload: true, webpackMode: "lazy-once" */ `!!raw-loader?esModule=false!./editor-types/@data-client/${dep}.d.ts`
-          ),
-      ),
-    ]).then(([mPromise, ...settles]) => {
-      if (mPromise.status !== 'fulfilled' || !mPromise.value) return;
-      const monaco = mPromise.value;
-      const [
-        react,
-        bignumber,
-        numberFlow,
-        temporal,
-        uuid,
-        qs,
-        globals,
-        ...rhLibs
-      ] = settles.map(result =>
-        result.status === 'fulfilled' ? result.value.default : '',
-      );
+  Promise.allSettled([
+    monacoPromise,
+    import(
+      /* webpackChunkName: 'reactDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/react.d.ts'
+    ),
+    import(
+      /* webpackChunkName: 'bignumberDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/bignumber.d.ts'
+    ),
+    import(
+      /* webpackChunkName: 'numberflowDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/@number-flow/react.d.ts'
+    ),
+    import(
+      /* webpackChunkName: 'temporalDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/temporal.d.ts'
+    ),
+    import(
+      /* webpackChunkName: 'uuidDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/uuid.d.ts'
+    ),
+    import(
+      /* webpackChunkName: 'qsDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/qs.d.ts'
+    ),
+    import(
+      /* webpackChunkName: 'globalsDTS', webpackPreload: true */ '!!raw-loader?esModule=false!./editor-types/globals.d.ts'
+    ),
+    ...rhDeps.map(
+      dep =>
+        import(
+          /* webpackChunkName: '[request]', webpackPreload: true, webpackMode: "lazy-once" */ `!!raw-loader?esModule=false!./editor-types/@data-client/${dep}.d.ts`
+        ),
+    ),
+  ]).then(([mPromise, ...settles]) => {
+    if (mPromise.status !== 'fulfilled' || !mPromise.value) return;
+    const monaco = mPromise.value;
+    const [
+      react,
+      bignumber,
+      numberFlow,
+      temporal,
+      uuid,
+      qs,
+      globals,
+      ...rhLibs
+    ] = settles.map(result =>
+      result.status === 'fulfilled' ? result.value.default : '',
+    );
 
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare module "react/jsx-runtime" {
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare module "react/jsx-runtime" {
         import './';
       }`,
-        'file:///node_modules/@types/react/jsx-runtime.d.ts',
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `import * as React from 'react'
+      'file:///node_modules/@types/react/jsx-runtime.d.ts',
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `import * as React from 'react'
 
     declare global {
       namespace JSX {
@@ -268,10 +240,10 @@ if (
         }
       }
     }`,
-        'file:///node_modules/@types/react/more.d.ts',
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare function render(component:JSX.Element):void;
+      'file:///node_modules/@types/react/more.d.ts',
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare function render(component:JSX.Element):void;
         declare function uuid(): string;
         declare function CurrentTime(props: {}):JSX.Element;
         declare function CancelButton(props: { onClick?: () => void }):JSX.Element;
@@ -321,55 +293,54 @@ if (
            */
           value: number;
         }`,
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare module "react" { ${react} }`,
-        'file:///node_modules/@types/react/index.d.ts',
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare module "bignumber.js" { ${bignumber} }`,
-        'file:///node_modules/bignumber.js/index.d.ts',
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare module "@number-flow/react" { ${numberFlow} };`,
-        'file:///node_modules/@number-flow/react/index.d.ts',
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare module "temporal-polyfill" { ${temporal} }`,
-        'file:///node_modules/temporal-polyfill/index.d.ts',
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare module "uuid" { ${uuid} }`,
-        'file:///node_modules/@types/uuid/index.d.ts',
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare module "qs" { ${qs} }`,
-        'file:///node_modules/@types/qs/index.d.ts',
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare globals { ${react} }`,
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare globals { export { default as NumberFlow } from '@number-flow/react'; }`,
-      );
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare globals { export { Temporal, DateTimeFormat } from 'temporal-polyfill'; }`,
-      );
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare module "react" { ${react} }`,
+      'file:///node_modules/@types/react/index.d.ts',
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare module "bignumber.js" { ${bignumber} }`,
+      'file:///node_modules/bignumber.js/index.d.ts',
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare module "@number-flow/react" { ${numberFlow} };`,
+      'file:///node_modules/@number-flow/react/index.d.ts',
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare module "temporal-polyfill" { ${temporal} }`,
+      'file:///node_modules/temporal-polyfill/index.d.ts',
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare module "uuid" { ${uuid} }`,
+      'file:///node_modules/@types/uuid/index.d.ts',
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare module "qs" { ${qs} }`,
+      'file:///node_modules/@types/qs/index.d.ts',
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare globals { ${react} }`,
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare globals { export { default as NumberFlow } from '@number-flow/react'; }`,
+    );
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare globals { export { Temporal, DateTimeFormat } from 'temporal-polyfill'; }`,
+    );
 
-      rhLibs.forEach((lib, i) => {
-        const dep = rhDeps[i];
-        monaco.languages.typescript.typescriptDefaults.addExtraLib(
-          `declare module "@data-client/${dep}" { ${lib} }`,
-          `file:///node_modules/@data-client/${dep}/index.d.ts`,
-        );
-      });
-
+    rhLibs.forEach((lib, i) => {
+      const dep = rhDeps[i];
       monaco.languages.typescript.typescriptDefaults.addExtraLib(
-        `declare globals { ${globals} }`,
+        `declare module "@data-client/${dep}" { ${lib} }`,
+        `file:///node_modules/@data-client/${dep}/index.d.ts`,
       );
-
-      monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
-      return monaco;
     });
-  }
+
+    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      `declare globals { ${globals} }`,
+    );
+
+    monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
+    return monaco;
+  });
 }

--- a/website/src/components/Playground/monacoOptions.tsx
+++ b/website/src/components/Playground/monacoOptions.tsx
@@ -16,9 +16,3 @@ export const options = {
   fontSize: 13,
   lineHeight: 19,
 } as const;
-
-export const largeOptions = {
-  ...options,
-  fontSize: 14,
-  lineHeight: 20,
-};

--- a/website/src/components/Playground/styles.module.css
+++ b/website/src/components/Playground/styles.module.css
@@ -76,10 +76,6 @@
 .playgroundHeader.noupper {
   text-transform: none;
 }
-.playgroundHeader.lastChild {
-  border-bottom-left-radius: var(--ifm-global-radius);
-  border-bottom-right-radius: var(--ifm-global-radius);
-}
 
 .codeHeader {
   color: rgb(191, 199, 213);

--- a/website/src/components/Playground/useAutoHeight.tsx
+++ b/website/src/components/Playground/useAutoHeight.tsx
@@ -27,8 +27,6 @@ export default function useAutoHeight({
       const el = editor.getContainerDomNode();
       const codeContainers = el.getElementsByClassName('view-lines');
 
-      let prevLineCount = 0;
-
       const model = editor.getModel();
       let lineCount = 10;
       if (model) {
@@ -42,6 +40,7 @@ export default function useAutoHeight({
 
       editor.layout();
 
+      let prevHeight = contentHeight;
       updateHeightRef.current = () => {
         // For diff editors, take max of both sides' line counts
         const codeContainerCount = Math.max(
@@ -54,7 +53,10 @@ export default function useAutoHeight({
         const lineCount =
           viewlinecount < modellinecount * 3 ? viewlinecount : modellinecount;
         const height = lineCount * LINE_HEIGHT + CONTAINER_GUTTER; // fold
-        prevLineCount = codeContainerCount;
+        // decorations change often without affecting height; skip the forced
+        // layout and state update when nothing changed
+        if (height === prevHeight) return;
+        prevHeight = height;
 
         el.style.height = height + 'px';
         setHeight(height);

--- a/website/src/components/Playground/useCode.tsx
+++ b/website/src/components/Playground/useCode.tsx
@@ -1,4 +1,7 @@
-import { parseCodeBlockTitle } from '@docusaurus/theme-common/internal';
+import {
+  parseCodeBlockTitle,
+  parseLanguage,
+} from '@docusaurus/theme-common/internal';
 import React, { useMemo, useReducer } from 'react';
 
 export interface CodeTab {
@@ -37,10 +40,10 @@ export function useCode(
         const collapsed =
           defaultTab ?
             title !== defaultTab
-          : (parseCodeBlockCollapsed(metastring) ?? false);
-        const col = parseCodeBlockCol(metastring) ?? false;
+          : parseCodeBlockCollapsed(metastring);
+        const col = parseCodeBlockCol(metastring);
         const highlights = /\{([\d\-,.]+)\}/.exec(metastring)?.[1];
-        const language = /language-(\w+)/.exec(rest.className)?.[1] ?? 'tsx';
+        const language = parseLanguage(rest.className) ?? 'tsx';
         const extension = langToExtension(language);
         const fileBase = title || 'default';
         const path =
@@ -62,15 +65,9 @@ export function useCode(
   const [codes, dispatch] = useReducer(reduceCodes, undefined, () =>
     codeTabs.map(({ code }) => code),
   );
-  //const [ready, setReady] = useState(() => codeTabs.map(() => false));
   const handleCodeChange = useMemo(
     () =>
       codeTabs.map((_, i) => v => {
-        /*setReady(readies => {
-      const ret = [...readies];
-      ret[i] = true;
-      return ret;
-    });*/
         dispatch({ i, code: v });
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -87,17 +84,17 @@ function reduceCodes(state: string[], action: { i: number; code: string }) {
 const codeBlockCollapsedRegex = /\bcollapsed\b/;
 const codeBlockColRegex = /\bcolumn\b/;
 const codeBlockPathRegex = /path=(?<quote>["'])(?<path>.*?)\1/;
-export function parseCodeBlockCollapsed(metastring?: string): boolean {
+function parseCodeBlockCollapsed(metastring?: string): boolean {
   return codeBlockCollapsedRegex.test(metastring ?? '');
 }
-export function parseCodeBlockCol(metastring?: string): boolean {
+function parseCodeBlockCol(metastring?: string): boolean {
   return codeBlockColRegex.test(metastring ?? '');
 }
-export function parseCodeBlockPath(metastring?: string): string {
-  return metastring?.match(codeBlockPathRegex)?.groups!.path ?? '';
+function parseCodeBlockPath(metastring?: string): string {
+  return metastring?.match(codeBlockPathRegex)?.groups?.path ?? '';
 }
 
-export function langToExtension(lang: string) {
+function langToExtension(lang: string) {
   if (lang === 'typescript') return 'ts';
   return lang;
 }

--- a/website/src/components/Playground/usingMonaco.ts
+++ b/website/src/components/Playground/usingMonaco.ts
@@ -1,9 +1,0 @@
-const usingMonaco =
-  // React 18: perhaps this causes hydration problems.
-  typeof navigator !== 'undefined' &&
-  // crawler or mobile browser
-  !/bot|googlebot|crawler|spider|robot|crawling|Mobile|Android|BlackBerry/i.test(
-    navigator.userAgent,
-  );
-
-export default usingMonaco;

--- a/website/src/components/TypeScriptEditor.tsx
+++ b/website/src/components/TypeScriptEditor.tsx
@@ -27,7 +27,6 @@ export default function TypeScriptEditor({ children, row }) {
           codeTabs={codeTabs}
           handleCodeChange={handleCodeChange}
           codes={codes}
-          large={false}
           isPlayground={false}
         />
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation

The website Playground/editor components accumulated dead code, duplicated logic, and a few real performance bugs. This cleanup came out of parallel code-quality, performance, and reuse reviews of `website/src/components/Playground/`.

### Solution

All changes are website-only (no changeset needed) and behavior-preserving, with the intended exception that mobile devices no longer download Monaco.

**Dead code removed**

- Delete `usingMonaco.ts` (imported nowhere; superseded by `isMobileOrBot.ts`). `PlaygroundEditor.tsx` is intentionally kept as the editor-selection alias.
- Drop unused `transformCode` prop destructure, `export let monacoMaster` + always-true guard, `prevLineCount` write-only variable (repurposed as an early-exit guard), unused `usePrismTheme`/`useBaseUrl` imports, no-op `?? false`, and ~60 lines of stale commented-out code.
- Remove the dead `large` prop pathway end to end (`largeOptions`, `large` branches, `lastChild` plumbing and its CSS) — every call site passed `large={false}` or omitted it.

**Consolidation**

- UA regexes now have one source of truth in `isMobileOrBot.ts`; the `MonacoPreloads` inline script interpolates `MOBILE_OR_BOT_UA_REGEX.source` so it can't drift.
- `monaco-init.ts` now skips Monaco core + all `.d.ts` chunk downloads on **mobile** (previously bots only) since mobile renders the lightweight `LiveEditor` — saves megabytes on phones.
- Monaco CDN base URL shared via `MONACO_CDN_VS`.
- Hand-rolled `LiveProviderProps` replaced with `React.ComponentProps<typeof LiveProvider>`; hand-rolled language regex replaced with docusaurus `parseLanguage`.
- Shared `StoreToggle` row extracted from `StoreInspector` and reused by the preview loading fallback (was copy-pasted markup).
- Identical function-response branches in `FixturePreview` merged.

**Performance fixes**

- `CurrentTime` ran `setInterval` with **no delay** (~250 re-renders/sec, constructing `Intl.DateTimeFormat` each render) — now 1s interval with a hoisted formatter.
- `Tree` hoists its `Intl.DateTimeFormat` and color map to module scope (ran per node per store update).
- Preview code wrapped in `useDeferredValue` so each keystroke isn't blocked by react-live re-transpilation/evaluation.
- `PlaygroundMonacoEditor` wrapped in `React.memo` with a memoized `loading` element, so a keystroke in one tab no longer re-renders all Monaco wrappers.
- `useAutoHeight` early-returns when the computed height is unchanged, skipping forced `editor.layout()` on every decoration change.

**Verification**

- `docusaurus build` succeeds; built HTML contains the consolidated preload regex.
- `tsc --noEmit` error diff vs `master` shows zero new errors (the website has pre-existing type errors; this PR removes five of them).
- ESLint clean on all touched files.

### Open questions

Deliberately skipped (flagged in review, need separate decisions): the double `docusaurus.tab.` storage-key prefix (fixing resets visitors' saved tab choices), per-page (vs per-Playground) preload script injection, the suspicious `declare globals` extra libs in `monaco-init.ts`, and merging the two tab-list renderers in `PlaygroundTextEdit.tsx`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e897ce8a-fa0b-47f5-a09d-13a549139f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e897ce8a-fa0b-47f5-a09d-13a549139f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

