### PR TITLE
bench: Add degenerate-case spread benchmarks and memory pressure measurement

### DIFF
--- a/.cursor/rules/benchmarking.mdc
+++ b/.cursor/rules/benchmarking.mdc
@@ -142,12 +142,14 @@ This builds all packages and generates size comparison data. Document the bundle
   - `@examples/benchmark/entity.js`
   - `@examples/benchmark/normalizr.js`
   - `@examples/benchmark/core.js`
+  - `@examples/benchmark/spread.js` (degenerate-case store-size-scaling writes; scenarios in `@examples/benchmark/spread-scenarios.js`)
   - `@examples/benchmark/old-normalizr/normalizr.js`
+- **Memory pressure script**: `@examples/benchmark/memory.js` (allocation rate, GC churn, retained heap for the spread scenarios)
 - **Schemas/data used by multiple suites**:
   - `@examples/benchmark/schemas.js`
   - `@examples/benchmark/data.json`
   - `@examples/benchmark/user.json`
-- **CI benchmark runner**: `@.github/workflows/benchmark.yml`
+- **CI benchmark runners**: `@.github/workflows/benchmark.yml` (default suites), `@.github/workflows/benchmark-spread.yml` (single spread case, store-write triggers only)
 
 ## How to run
 
@@ -228,6 +230,17 @@ Use this mapping when deciding which suite(s) to run for a change:
     - Changes to `setResponse()` or reducer updates: `^set`
     - Changes to `getResponse()` or cache retrieval: `^get`
 
+- **`spread`** (`@examples/benchmark/spread.js`, scenarios shared with `memory.js` via `@examples/benchmark/spread-scenarios.js`)
+  - **Primary focus**: degenerate cases where spread-operation cost scales with **store size** rather than payload size — single-entity `setResponse` into 1k/10k/100k entity stores (per-type entity map clone in `NormalizeDelegate`), writes with 10k cached endpoint keys (`endpoints`/`meta` spreads in `setResponseReducer`), collection push onto 10k items (`pushMerge`), and `invalidateAll`/`expireAll` over 10k endpoints.
+  - **Packages exercised**:
+    - **`@data-client/core`**: `Controller`, `createReducer` write paths
+    - **`@data-client/normalizr`**: `normalize` store-copy behavior
+    - **`@data-client/endpoint`**: `Entity.merge`, `Collection` push
+  - **Recommended filters**: `setOneEntity` (store-size sweep + control), `collection push`, `invalidateAll`
+  - **CI**: only `setOneEntity in 10k entity store` is tracked over time, via its own workflow `@.github/workflows/benchmark-spread.yml` (separate `spread-bench` history dir on `gh-pages-bench`). It triggers on **store-write paths only**: `packages/core/src/state/**`, `packages/normalizr/src/normalize/**`, `packages/endpoint/src/schemas/EntityMixin.ts`, and the spread suite files. All other spread benchmarks are manual-only. The `setOneEntity` sweep should scale near-linearly with store size while the `control` benchmark stays flat.
+  - Scenario fixtures are built lazily per matching filter (`buildScenarios(filter)` in `spread-scenarios.js`), so filtered runs skip the expensive 100k-store construction.
+  - **Memory pressure**: run `yarn workspace example-benchmark start:memory [filter]` to measure allocation/op, GC counts and pause time, and retained heap for the same scenarios. Copies are transient, so expect high allocation + GC churn with ~0 retained.
+
 - **`old-normalizr`** (`@examples/benchmark/old-normalizr/normalizr.js`)
   - **Primary focus**: baseline comparison against the legacy `normalizr` npm package.
   - **Packages exercised**:
@@ -256,6 +269,14 @@ yarn workspace example-benchmark start | tee output.txt
 ```
 
 The output is parsed as **benchmark.js** format and reported by `rhysd/github-action-benchmark` (see `@.github/workflows/benchmark.yml`).
+
+A second workflow, `@.github/workflows/benchmark-spread.yml`, runs only:
+
+```bash
+yarn workspace example-benchmark start spread "setOneEntity in 10k entity store"
+```
+
+with narrower path triggers (store-write code: `packages/core/src/state/**`, `packages/normalizr/src/normalize/**`, `packages/endpoint/src/schemas/EntityMixin.ts`, spread suite files) and reports to a separate `spread-bench` history dir on the same `gh-pages-bench` branch.
 
 ## Expected variance
 

--- a/.github/workflows/benchmark-spread.yml
+++ b/.github/workflows/benchmark-spread.yml
@@ -1,0 +1,97 @@
+name: Benchmark Spread
+
+# Tracks one fast degenerate-case store-write benchmark over time.
+# Triggers are narrower than benchmark.yml: only store-write code paths
+# (reducers, normalize store copies, default Entity merge) affect this case.
+# The rest of the `spread` suite and the memory script are manual-only.
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'packages/core/src/state/**'
+      - 'packages/normalizr/src/normalize/**'
+      - 'packages/endpoint/src/schemas/EntityMixin.ts'
+      - 'examples/benchmark/spread.js'
+      - 'examples/benchmark/spread-scenarios.js'
+      - 'examples/benchmark/schemas.js'
+      - '.github/workflows/benchmark-spread.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'packages/core/src/state/**'
+      - 'packages/normalizr/src/normalize/**'
+      - 'packages/endpoint/src/schemas/EntityMixin.ts'
+      - 'examples/benchmark/spread.js'
+      - 'examples/benchmark/spread-scenarios.js'
+      - 'examples/benchmark/schemas.js'
+      - '.github/workflows/benchmark-spread.yml'
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.event_name == 'push' && 'gh-pages-bench-spread-push' || format('benchmark-spread-{0}', github.head_ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  benchmark-spread:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+        cache: 'yarn'
+    - name: Install packages
+      run: ./scripts/ci-install.sh examples/benchmark
+    - name: Build packages
+      run: yarn build:benchmark
+    - name: Tune system for benchmarking
+      run: |
+        # Pin CPU governor to performance mode (reduces frequency scaling jitter)
+        for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+          echo performance | sudo tee "$gov" 2>/dev/null || true
+        done
+        # Disable swap to prevent memory pressure variance
+        sudo swapoff -a || true
+    - name: Run benchmark
+      run: taskset -c 0,1 yarn workspace example-benchmark start spread "setOneEntity in 10k entity store" | tee output.txt
+
+    # PR comments on changes
+    - name: Store benchmark result (PR)
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: rhysd/github-action-benchmark@v1
+      with:
+        name: 'Benchmark Spread'
+        tool: 'benchmarkjs'
+        output-file-path: output.txt
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        gh-pages-branch: 'gh-pages-bench'
+        benchmark-data-dir-path: spread-bench
+        alert-threshold: '150%'
+        comment-always: true
+        fail-on-alert: false
+        alert-comment-cc-users: '@ntucker'
+        save-data-file: false
+        auto-push: false
+
+    # master reports to history
+    - name: Store benchmark result (main)
+      if: ${{ github.event_name == 'push' }}
+      uses: rhysd/github-action-benchmark@v1
+      with:
+        name: 'Benchmark Spread'
+        tool: 'benchmarkjs'
+        output-file-path: output.txt
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        gh-pages-branch: 'gh-pages-bench'
+        benchmark-data-dir-path: spread-bench
+        auto-push: true
+        fail-on-alert: false

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -35,6 +35,7 @@ Both arguments are optional:
 - `entity` - benchmarks various entity-specific operations
 - `core` - benchmarks entire operations using [Controller](https://dataclient.io/docs/api/Controller)
 - `normalizr` - benchmarks just normalize/denormalize
+- `spread` - degenerate-case writes where spread cost scales with store size (single-entity `setResponse` into 1k/10k/100k entity stores, 10k cached endpoint keys, collection push onto 10k items, invalidateAll/expireAll). One case (`setOneEntity in 10k entity store`) is tracked over time in CI via `.github/workflows/benchmark-spread.yml`; the rest are manual-only.
 - `micro` - isolated microbenchmarks for testing specific operations
 - `old-normalizr` - runs equivalent benchmarks using the normalizr package
 
@@ -60,6 +61,22 @@ Performance compared to normalizr package (higher is better):
 [Comparison done on a Ryzen 7950x; Ubuntu; Node 22.14.0]
 
 Not only is denormalize faster, but it is more feature-rich as well.
+
+### Memory pressure
+
+The `spread` scenarios allocate transient copies proportional to store size, so
+the memory symptom is allocation rate and GC churn rather than retained heap.
+Measure it with:
+
+```bash
+yarn start:memory [filter]
+```
+
+This runs the same scenarios as the `spread` suite (see `spread-scenarios.js`)
+and reports per scenario: approximate bytes allocated per operation, GC event
+counts (minor/major/other) and total GC pause during the loop, and retained
+heap after a full GC (should be ~0; nonzero indicates actual retention).
+Local-only — not tracked in CI.
 
 ### Profiling
 

--- a/examples/benchmark/filter.js
+++ b/examples/benchmark/filter.js
@@ -22,7 +22,7 @@ export function createAdd(suite, filter) {
  * @param {string} [filter]
  * @returns {(name: string) => boolean}
  */
-function createMatcher(filter) {
+export function createMatcher(filter) {
   if (!filter) return () => true;
   if (filter.startsWith('^')) {
     const prefix = filter.slice(1);

--- a/examples/benchmark/index.js
+++ b/examples/benchmark/index.js
@@ -7,6 +7,7 @@ import addEntitySuite from './entity.js';
 import addMicroSuite from './micro.js';
 import addNormlizrSuite from './normalizr.js';
 import addOldNormlizrSuite from './old-normalizr/normalizr.js';
+import addSpreadSuite from './spread.js';
 
 v8.setFlagsFromString('--expose_gc');
 const gc = vm.runInNewContext('gc');
@@ -42,6 +43,15 @@ if (process.argv[2] === 'entity') {
     .run();
 } else if (process.argv[2] === 'old-normalizr') {
   addOldNormlizrSuite(new Benchmark.Suite(), filter)
+    .on('cycle', event => {
+      // Output benchmark result by converting benchmark result to string
+      console.log(String(event.target));
+      // collect garbage between runs to make results more consistent
+      gc();
+    })
+    .run();
+} else if (process.argv[2] === 'spread') {
+  addSpreadSuite(new Benchmark.Suite(), filter)
     .on('cycle', event => {
       // Output benchmark result by converting benchmark result to string
       console.log(String(event.target));

--- a/examples/benchmark/memory.js
+++ b/examples/benchmark/memory.js
@@ -7,8 +7,8 @@
  *
  * - allocated/op: approximate bytes allocated per operation, from summing
  *   positive used-heap deltas between samples (every SAMPLE_INTERVAL ops, to
- *   keep the sampler's own allocations out of the numbers). Undercounts when
- *   a scavenge lands mid-window, so treat as a lower bound.
+ *   reduce the sampler's own contribution). Undercounts when a scavenge lands
+ *   mid-window, so treat as a lower bound.
  * - GC minor/major/other + pause: count and total pause time of GC events
  *   during the measured loop (PerformanceObserver 'gc' entries).
  * - retained: used-heap delta vs. baseline after full GC — should be ~0;
@@ -29,8 +29,8 @@ const gc = vm.runInNewContext('gc');
 // v8.getHeapStatistics() avoids the /proc rss read that process.memoryUsage() does
 const heapUsed = () => v8.getHeapStatistics().used_heap_size;
 
-// heapUsed() itself allocates; sampling every op would inflate allocated/op
-// and GC counts for cheap scenarios
+// heapUsed() itself allocates; sample less often to reduce its effect on
+// allocated/op and GC counts for cheap scenarios.
 const SAMPLE_INTERVAL = 10;
 
 function fullGC() {

--- a/examples/benchmark/memory.js
+++ b/examples/benchmark/memory.js
@@ -1,0 +1,122 @@
+/**
+ * Memory-pressure measurement for the degenerate-case spread scenarios.
+ *
+ * The spread copies in the write path are transient (they die young), so the
+ * symptom is allocation rate and GC churn rather than retained heap. For each
+ * scenario this reports:
+ *
+ * - allocated/op: approximate bytes allocated per operation, from summing
+ *   positive used-heap deltas between ops. Undercounts when a scavenge lands
+ *   mid-op, so treat as a lower bound.
+ * - GC minor/major/other + pause: count and total pause time of GC events
+ *   during the measured loop (PerformanceObserver 'gc' entries).
+ * - retained: used-heap delta vs. baseline after full GC — should be ~0;
+ *   nonzero flags actual retention.
+ *
+ * Local-only; not part of CI benchmark tracking. Run with:
+ *   yarn workspace example-benchmark start:memory [filter]
+ */
+import { PerformanceObserver, constants } from 'node:perf_hooks';
+import vm from 'node:vm';
+import v8 from 'v8';
+
+import { buildScenarios } from './spread-scenarios.js';
+
+v8.setFlagsFromString('--expose_gc');
+const gc = vm.runInNewContext('gc');
+
+// v8.getHeapStatistics() avoids the /proc rss read that process.memoryUsage() does
+const heapUsed = () => v8.getHeapStatistics().used_heap_size;
+
+function fullGC() {
+  gc();
+  gc();
+}
+
+async function measure(name, fn, iterations, warmup = 25) {
+  for (let i = 0; i < warmup; i++) fn();
+  fullGC();
+  const baseline = heapUsed();
+
+  let gcMinor = 0;
+  let gcMajor = 0;
+  let gcOther = 0;
+  let gcPauseMs = 0;
+  const observer = new PerformanceObserver(list => {
+    for (const entry of list.getEntries()) {
+      gcPauseMs += entry.duration;
+      switch (entry.detail?.kind) {
+        case constants.NODE_PERFORMANCE_GC_MINOR:
+          gcMinor++;
+          break;
+        case constants.NODE_PERFORMANCE_GC_MAJOR:
+          gcMajor++;
+          break;
+        default:
+          gcOther++;
+      }
+    }
+  });
+  observer.observe({ entryTypes: ['gc'] });
+
+  let allocated = 0;
+  let prev = baseline;
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    fn();
+    const used = heapUsed();
+    if (used > prev) allocated += used - prev;
+    prev = used;
+  }
+  const elapsedMs = performance.now() - start;
+
+  // GC performance entries are delivered asynchronously
+  await new Promise(resolve => setTimeout(resolve, 100));
+  observer.disconnect();
+
+  fullGC();
+  const retained = heapUsed() - baseline;
+
+  return {
+    name,
+    iterations,
+    elapsedMs,
+    allocated,
+    gcMinor,
+    gcMajor,
+    gcOther,
+    gcPauseMs,
+    retained,
+  };
+}
+
+function formatBytes(bytes) {
+  const abs = Math.abs(bytes);
+  if (abs >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+  if (abs >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${Math.round(bytes)} B`;
+}
+
+const scenarios = buildScenarios(process.argv[2]);
+
+console.log(
+  `Measuring ${scenarios.length} scenario(s); heap sampling adds overhead so time/op is indicative only\n`,
+);
+
+const rows = [];
+for (const { name, fn, iterations } of scenarios) {
+  const result = await measure(name, fn, iterations);
+  rows.push({
+    scenario: result.name,
+    ops: result.iterations,
+    'time/op': `${((result.elapsedMs / result.iterations) * 1000).toFixed(1)} µs`,
+    'allocated/op': formatBytes(result.allocated / result.iterations),
+    'GC minor': result.gcMinor,
+    'GC major': result.gcMajor,
+    'GC other': result.gcOther,
+    'GC pause': `${result.gcPauseMs.toFixed(1)} ms`,
+    retained: formatBytes(result.retained),
+  });
+}
+
+console.table(rows);

--- a/examples/benchmark/memory.js
+++ b/examples/benchmark/memory.js
@@ -6,8 +6,9 @@
  * scenario this reports:
  *
  * - allocated/op: approximate bytes allocated per operation, from summing
- *   positive used-heap deltas between ops. Undercounts when a scavenge lands
- *   mid-op, so treat as a lower bound.
+ *   positive used-heap deltas between samples (every SAMPLE_INTERVAL ops, to
+ *   keep the sampler's own allocations out of the numbers). Undercounts when
+ *   a scavenge lands mid-window, so treat as a lower bound.
  * - GC minor/major/other + pause: count and total pause time of GC events
  *   during the measured loop (PerformanceObserver 'gc' entries).
  * - retained: used-heap delta vs. baseline after full GC — should be ~0;
@@ -27,6 +28,10 @@ const gc = vm.runInNewContext('gc');
 
 // v8.getHeapStatistics() avoids the /proc rss read that process.memoryUsage() does
 const heapUsed = () => v8.getHeapStatistics().used_heap_size;
+
+// heapUsed() itself allocates; sampling every op would inflate allocated/op
+// and GC counts for cheap scenarios
+const SAMPLE_INTERVAL = 10;
 
 function fullGC() {
   gc();
@@ -64,9 +69,11 @@ async function measure(name, fn, iterations, warmup = 25) {
   const start = performance.now();
   for (let i = 0; i < iterations; i++) {
     fn();
-    const used = heapUsed();
-    if (used > prev) allocated += used - prev;
-    prev = used;
+    if (i % SAMPLE_INTERVAL === SAMPLE_INTERVAL - 1 || i === iterations - 1) {
+      const used = heapUsed();
+      if (used > prev) allocated += used - prev;
+      prev = used;
+    }
   }
   const elapsedMs = performance.now() - start;
 

--- a/examples/benchmark/package.json
+++ b/examples/benchmark/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "webpack --mode=production --target=node --env readable",
     "start": "NODE_ENV=production node --allow-natives-syntax ./index.js",
+    "start:memory": "NODE_ENV=production node ./memory.js",
     "start:trace": "yarn run start --trace_opt --trace_deopt",
     "start:deopt": "NODE_ENV=production npx dexnode --out v8.log --redirect-code-traces-to=/tmp/codetrace --allow-natives-syntax ./index.js"
   },

--- a/examples/benchmark/schemas.js
+++ b/examples/benchmark/schemas.js
@@ -259,7 +259,7 @@ export const ProjectSchemaSimpleMerge = {
  * store-copy costs (per-type entity map clone in NormalizeDelegate,
  * endpoints/meta spreads in setResponseReducer) from schema traversal.
  */
-export class FlatItem extends Entity {
+class FlatItem extends Entity {
   id = '';
   name = '';
   value = 0;
@@ -275,7 +275,7 @@ export class FlatItem extends Entity {
 
 /** Second, small entity type used as a control: writes to it should not
  * scale with the number of FlatItem entities in the store. */
-export class ControlItem extends Entity {
+class ControlItem extends Entity {
   id = '';
   name = '';
 
@@ -285,7 +285,7 @@ export class ControlItem extends Entity {
   }
 }
 
-export const getFlatItems = new Endpoint(() => Promise.resolve([]), {
+const getFlatItems = new Endpoint(() => Promise.resolve([]), {
   schema: [FlatItem],
   key() {
     return '/flatItems';
@@ -297,7 +297,7 @@ export const getFlatItem = new Endpoint(({ id }) => Promise.resolve({ id }), {
     return `/flatItems/${id}`;
   },
 });
-export const getControlItems = new Endpoint(() => Promise.resolve([]), {
+const getControlItems = new Endpoint(() => Promise.resolve([]), {
   schema: [ControlItem],
   key() {
     return '/controlItems';
@@ -313,8 +313,8 @@ export const getControlItem = new Endpoint(
   },
 );
 
-export const FlatItemCollection = new Collection([FlatItem]);
-export const getFlatItemCollection = new Endpoint(() => Promise.resolve([]), {
+const FlatItemCollection = new Collection([FlatItem]);
+const getFlatItemCollection = new Endpoint(() => Promise.resolve([]), {
   schema: FlatItemCollection,
   key() {
     return '/flatItemsCollection';
@@ -343,7 +343,7 @@ export function buildFlatItemData(count, offset = 0) {
   return items;
 }
 
-export function buildControlItemData(count) {
+function buildControlItemData(count) {
   const items = [];
   for (let i = 0; i < count; i++) {
     items.push({ id: `c-${i}`, name: `Control ${i}` });
@@ -375,10 +375,17 @@ export function buildLargeEntityState(n) {
   return state;
 }
 
-/** buildLargeEntityState(n) plus `n` distinct cached endpoint keys,
- * simulating `n` previously-fetched detail requests. */
+/** State with `n` distinct cached endpoint keys, simulating `n`
+ * previously-fetched detail requests. Entity count stays minimal (10
+ * ControlItems) since the endpoints/meta spreads being measured don't
+ * depend on it; the keys reference pks that were since garbage collected. */
 export function buildManyEndpointsState(n) {
-  const state = buildLargeEntityState(n);
+  const state = applyResponse(
+    initialState,
+    getControlItems,
+    [],
+    buildControlItemData(10),
+  );
   const endpoints = { ...state.endpoints };
   const meta = { ...state.meta };
   const date = Date.now();

--- a/examples/benchmark/schemas.js
+++ b/examples/benchmark/schemas.js
@@ -6,6 +6,10 @@ import {
   All,
   Query,
   Scalar,
+  Controller,
+  createReducer,
+  initialState,
+  Endpoint,
 } from './dist/index.js';
 
 export class BuildTypeDescription extends Entity {
@@ -248,6 +252,153 @@ export class ProjectWithBuildTypesDescriptionSimpleMerge extends Entity {
 export const ProjectSchemaSimpleMerge = {
   project: [ProjectWithBuildTypesDescriptionSimpleMerge],
 };
+
+/* Degenerate-case fixtures for the `spread` suite and memory script.
+ *
+ * FlatItem has no nested schema, so single-entity writes isolate the
+ * store-copy costs (per-type entity map clone in NormalizeDelegate,
+ * endpoints/meta spreads in setResponseReducer) from schema traversal.
+ */
+export class FlatItem extends Entity {
+  id = '';
+  name = '';
+  value = 0;
+  category = '';
+  status = '';
+  updatedAt = 0;
+
+  static key = 'FlatItem';
+  pk() {
+    return this.id;
+  }
+}
+
+/** Second, small entity type used as a control: writes to it should not
+ * scale with the number of FlatItem entities in the store. */
+export class ControlItem extends Entity {
+  id = '';
+  name = '';
+
+  static key = 'ControlItem';
+  pk() {
+    return this.id;
+  }
+}
+
+export const getFlatItems = new Endpoint(() => Promise.resolve([]), {
+  schema: [FlatItem],
+  key() {
+    return '/flatItems';
+  },
+});
+export const getFlatItem = new Endpoint(({ id }) => Promise.resolve({ id }), {
+  schema: FlatItem,
+  key({ id }) {
+    return `/flatItems/${id}`;
+  },
+});
+export const getControlItems = new Endpoint(() => Promise.resolve([]), {
+  schema: [ControlItem],
+  key() {
+    return '/controlItems';
+  },
+});
+export const getControlItem = new Endpoint(
+  ({ id }) => Promise.resolve({ id }),
+  {
+    schema: ControlItem,
+    key({ id }) {
+      return `/controlItems/${id}`;
+    },
+  },
+);
+
+export const FlatItemCollection = new Collection([FlatItem]);
+export const getFlatItemCollection = new Endpoint(() => Promise.resolve([]), {
+  schema: FlatItemCollection,
+  key() {
+    return '/flatItemsCollection';
+  },
+});
+export const pushFlatItems = new Endpoint(() => Promise.resolve([]), {
+  schema: FlatItemCollection.push,
+  key() {
+    return '/flatItemsCollection/push';
+  },
+});
+
+export function buildFlatItemData(count, offset = 0) {
+  const items = [];
+  for (let i = 0; i < count; i++) {
+    const n = offset + i;
+    items.push({
+      id: `f-${n}`,
+      name: `Item ${n}`,
+      value: n * 3,
+      category: `cat-${n % 17}`,
+      status: n % 2 ? 'active' : 'inactive',
+      updatedAt: 1700000000000 + n,
+    });
+  }
+  return items;
+}
+
+export function buildControlItemData(count) {
+  const items = [];
+  for (let i = 0; i < count; i++) {
+    items.push({ id: `c-${i}`, name: `Control ${i}` });
+  }
+  return items;
+}
+
+/** Runs a real setResponse through the reducer and returns the next state. */
+function applyResponse(state, endpoint, args, response) {
+  const controller = new Controller({});
+  const reducer = createReducer(controller);
+  let nextState = state;
+  controller.dispatch = action => {
+    nextState = reducer(nextState, action);
+  };
+  controller.setResponse(endpoint, ...args, response);
+  return nextState;
+}
+
+/** State with `n` FlatItem entities plus 10 ControlItem entities. */
+export function buildLargeEntityState(n) {
+  let state = applyResponse(
+    initialState,
+    getFlatItems,
+    [],
+    buildFlatItemData(n),
+  );
+  state = applyResponse(state, getControlItems, [], buildControlItemData(10));
+  return state;
+}
+
+/** buildLargeEntityState(n) plus `n` distinct cached endpoint keys,
+ * simulating `n` previously-fetched detail requests. */
+export function buildManyEndpointsState(n) {
+  const state = buildLargeEntityState(n);
+  const endpoints = { ...state.endpoints };
+  const meta = { ...state.meta };
+  const date = Date.now();
+  for (let i = 0; i < n; i++) {
+    const key = getFlatItem.key({ id: `f-${i}` });
+    endpoints[key] = `f-${i}`;
+    meta[key] = { date, fetchedAt: date, expiresAt: date + 3600_000 };
+  }
+  return { ...state, endpoints, meta };
+}
+
+/** State with a Collection containing `n` FlatItems. */
+export function buildCollectionState(n) {
+  return applyResponse(
+    initialState,
+    getFlatItemCollection,
+    [],
+    buildFlatItemData(n),
+  );
+}
 
 export class User extends Entity {
   nodeId = '';

--- a/examples/benchmark/schemas.js
+++ b/examples/benchmark/schemas.js
@@ -375,10 +375,9 @@ export function buildLargeEntityState(n) {
   return state;
 }
 
-/** State with `n` distinct cached endpoint keys, simulating `n`
- * previously-fetched detail requests. Entity count stays minimal (10
- * ControlItems) since the endpoints/meta spreads being measured don't
- * depend on it; the keys reference pks that were since garbage collected. */
+/** State with `n` distinct cached endpoint keys. Entity count stays minimal
+ * since the endpoints/meta spreads being measured don't depend on it; the
+ * synthetic endpoint keys deliberately reference absent FlatItem entities. */
 export function buildManyEndpointsState(n) {
   const state = applyResponse(
     initialState,

--- a/examples/benchmark/spread-scenarios.js
+++ b/examples/benchmark/spread-scenarios.js
@@ -48,6 +48,8 @@ const tickArgs = { id: 'f-500' };
 const controlTick = { id: 'c-5', name: 'Control tick' };
 const controlArgs = { id: 'c-5' };
 const invalidateAllOptions = { testKey: () => true };
+// ids past any store fixture so pushed items never collide with existing pks
+const PUSH_ID_OFFSET = 1_000_000;
 
 /**
  * Degenerate-case write scenarios exercising the spread operations whose cost
@@ -63,31 +65,21 @@ const invalidateAllOptions = { testKey: () => true };
  *
  * `create()` builds the scenario's fixtures and returns the op to measure.
  */
+const storeSweep = [
+  ['1k', 5000, ctrl1k],
+  ['10k', 1000, ctrl10k],
+  ['100k', 200, ctrl100k],
+];
+
 const scenarios = [
-  {
-    name: 'setOneEntity in 1k entity store',
-    iterations: 5000,
+  ...storeSweep.map(([size, iterations, getCtrl]) => ({
+    name: `setOneEntity in ${size} entity store`,
+    iterations,
     create() {
-      const ctrl = ctrl1k();
+      const ctrl = getCtrl();
       return () => ctrl.setResponse(getFlatItem, tickArgs, tick);
     },
-  },
-  {
-    name: 'setOneEntity in 10k entity store',
-    iterations: 1000,
-    create() {
-      const ctrl = ctrl10k();
-      return () => ctrl.setResponse(getFlatItem, tickArgs, tick);
-    },
-  },
-  {
-    name: 'setOneEntity in 100k entity store',
-    iterations: 200,
-    create() {
-      const ctrl = ctrl100k();
-      return () => ctrl.setResponse(getFlatItem, tickArgs, tick);
-    },
-  },
+  })),
   {
     name: 'setOneEntity control in 100k entity store',
     iterations: 5000,
@@ -109,7 +101,7 @@ const scenarios = [
     iterations: 1000,
     create() {
       const ctrl = ctrlCollection();
-      const pushedItems = buildFlatItemData(10, 1_000_000);
+      const pushedItems = buildFlatItemData(10, PUSH_ID_OFFSET);
       return () => ctrl.setResponse(pushFlatItems, pushedItems);
     },
   },

--- a/examples/benchmark/spread-scenarios.js
+++ b/examples/benchmark/spread-scenarios.js
@@ -1,0 +1,153 @@
+import { Controller, createReducer } from './dist/index.js';
+import { createMatcher } from './filter.js';
+import {
+  buildLargeEntityState,
+  buildManyEndpointsState,
+  buildCollectionState,
+  buildFlatItemData,
+  getFlatItem,
+  getControlItem,
+  pushFlatItems,
+} from './schemas.js';
+
+/** Controller whose dispatches run the reducer against a fixed baseline state
+ * without persisting, so every op measures the same degenerate write. */
+function createStaticController(state) {
+  const controller = new Controller({});
+  const reducer = createReducer(controller);
+  controller.dispatch = action => {
+    reducer(state, action);
+  };
+  return controller;
+}
+
+/** Memoizes fixture construction so scenarios sharing a fixture (and repeat
+ * buildScenarios() calls) only build it once. */
+function lazy(build) {
+  let value;
+  return () => (value ??= build());
+}
+
+const ctrl1k = lazy(() => createStaticController(buildLargeEntityState(1_000)));
+const ctrl10k = lazy(() =>
+  createStaticController(buildLargeEntityState(10_000)),
+);
+const ctrl100k = lazy(() =>
+  createStaticController(buildLargeEntityState(100_000)),
+);
+const ctrlEndpoints = lazy(() =>
+  createStaticController(buildManyEndpointsState(10_000)),
+);
+const ctrlCollection = lazy(() =>
+  createStaticController(buildCollectionState(10_000)),
+);
+
+// websocket-tick style partial update to an existing entity
+const tick = { id: 'f-500', value: 42, updatedAt: 1700000000001 };
+const tickArgs = { id: 'f-500' };
+const controlTick = { id: 'c-5', name: 'Control tick' };
+const controlArgs = { id: 'c-5' };
+const invalidateAllOptions = { testKey: () => true };
+
+/**
+ * Degenerate-case write scenarios exercising the spread operations whose cost
+ * scales with store size rather than payload size:
+ *
+ * - setOneEntity sweep: per-entity-type map clone in NormalizeDelegate
+ *   (entities[key] + entitiesMeta[key] copied on first write to a type)
+ * - control write: same store, small entity type — confirms cost is per-type
+ * - cached endpoints: { ...state.endpoints } / { ...state.meta } in
+ *   setResponseReducer, O(distinct cached endpoint keys) per fetch
+ * - collection push: pushMerge [...existing, ...incoming], O(collection size)
+ * - invalidateAll/expireAll: full endpoints/meta copies
+ *
+ * `create()` builds the scenario's fixtures and returns the op to measure.
+ */
+const scenarios = [
+  {
+    name: 'setOneEntity in 1k entity store',
+    iterations: 5000,
+    create() {
+      const ctrl = ctrl1k();
+      return () => ctrl.setResponse(getFlatItem, tickArgs, tick);
+    },
+  },
+  {
+    name: 'setOneEntity in 10k entity store',
+    iterations: 1000,
+    create() {
+      const ctrl = ctrl10k();
+      return () => ctrl.setResponse(getFlatItem, tickArgs, tick);
+    },
+  },
+  {
+    name: 'setOneEntity in 100k entity store',
+    iterations: 200,
+    create() {
+      const ctrl = ctrl100k();
+      return () => ctrl.setResponse(getFlatItem, tickArgs, tick);
+    },
+  },
+  {
+    name: 'setOneEntity control in 100k entity store',
+    iterations: 5000,
+    create() {
+      const ctrl = ctrl100k();
+      return () => ctrl.setResponse(getControlItem, controlArgs, controlTick);
+    },
+  },
+  {
+    name: 'setOneEntity with 10k cached endpoints',
+    iterations: 1000,
+    create() {
+      const ctrl = ctrlEndpoints();
+      return () => ctrl.setResponse(getControlItem, controlArgs, controlTick);
+    },
+  },
+  {
+    name: 'collection push 10 onto 10k',
+    iterations: 1000,
+    create() {
+      const ctrl = ctrlCollection();
+      const pushedItems = buildFlatItemData(10, 1_000_000);
+      return () => ctrl.setResponse(pushFlatItems, pushedItems);
+    },
+  },
+  {
+    name: 'invalidateAll 10k endpoints',
+    iterations: 500,
+    create() {
+      const ctrl = ctrlEndpoints();
+      return () => ctrl.invalidateAll(invalidateAllOptions);
+    },
+  },
+  {
+    name: 'expireAll 10k endpoints',
+    iterations: 500,
+    create() {
+      const ctrl = ctrlEndpoints();
+      return () => ctrl.expireAll(invalidateAllOptions);
+    },
+  },
+];
+
+/**
+ * Builds only the scenarios matching `filter` (same syntax as suite filters:
+ * substring, or `^prefix`), so unmatched fixtures are never constructed.
+ *
+ * Shared by the `spread` Benchmark.js suite (throughput) and memory.js
+ * (allocation/GC pressure). `iterations` is only used by memory.js.
+ *
+ * @param {string} [filter]
+ * @returns {Array<{name: string, fn: () => void, iterations: number}>}
+ */
+export function buildScenarios(filter) {
+  const match = createMatcher(filter);
+  return scenarios
+    .filter(({ name }) => match(name))
+    .map(({ name, iterations, create }) => ({
+      name,
+      iterations,
+      fn: create(),
+    }));
+}

--- a/examples/benchmark/spread-scenarios.js
+++ b/examples/benchmark/spread-scenarios.js
@@ -61,18 +61,19 @@ const PUSH_ID_OFFSET = 1_000_000;
  * - cached endpoints: { ...state.endpoints } / { ...state.meta } in
  *   setResponseReducer, O(distinct cached endpoint keys) per fetch
  * - collection push: pushMerge [...existing, ...incoming], O(collection size)
- * - invalidateAll/expireAll: full endpoints/meta copies
+ * - invalidateAll: full endpoints + meta copies
+ * - expireAll: full meta copy
  *
  * `create()` builds the scenario's fixtures and returns the op to measure.
  */
 const storeSweep = [
-  ['1k', 5000, ctrl1k],
-  ['10k', 1000, ctrl10k],
-  ['100k', 200, ctrl100k],
+  { size: '1k', iterations: 5000, getCtrl: ctrl1k },
+  { size: '10k', iterations: 1000, getCtrl: ctrl10k },
+  { size: '100k', iterations: 200, getCtrl: ctrl100k },
 ];
 
 const scenarios = [
-  ...storeSweep.map(([size, iterations, getCtrl]) => ({
+  ...storeSweep.map(({ size, iterations, getCtrl }) => ({
     name: `setOneEntity in ${size} entity store`,
     iterations,
     create() {
@@ -114,7 +115,7 @@ const scenarios = [
     },
   },
   {
-    name: 'expireAll 10k endpoints',
+    name: 'expireAll 10k meta entries',
     iterations: 500,
     create() {
       const ctrl = ctrlEndpoints();

--- a/examples/benchmark/spread.js
+++ b/examples/benchmark/spread.js
@@ -1,4 +1,3 @@
-import { createAdd } from './filter.js';
 import { buildScenarios } from './spread-scenarios.js';
 
 /**
@@ -10,11 +9,9 @@ import { buildScenarios } from './spread-scenarios.js';
  * size of the written entity's type map, not the whole store.
  */
 export default function addSpreadSuite(suite, filter) {
-  const add = createAdd(suite, filter);
-
-  // buildScenarios pre-filters so unmatched fixtures are never constructed
+  // buildScenarios filters, so unmatched fixtures are never constructed
   for (const { name, fn } of buildScenarios(filter)) {
-    add(name, fn);
+    suite.add(name, fn);
   }
 
   return suite;

--- a/examples/benchmark/spread.js
+++ b/examples/benchmark/spread.js
@@ -1,0 +1,21 @@
+import { createAdd } from './filter.js';
+import { buildScenarios } from './spread-scenarios.js';
+
+/**
+ * Degenerate-case throughput benchmarks for spread operations in the core
+ * write path (see spread-scenarios.js for what each scenario isolates).
+ *
+ * The setOneEntity 1k/10k/100k sweep should show near-linear per-op cost,
+ * while the control write stays flat — confirming write cost scales with the
+ * size of the written entity's type map, not the whole store.
+ */
+export default function addSpreadSuite(suite, filter) {
+  const add = createAdd(suite, filter);
+
+  // buildScenarios pre-filters so unmatched fixtures are never constructed
+  for (const { name, fn } of buildScenarios(filter)) {
+    add(name, fn);
+  }
+
+  return suite;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes # .

### Motivation

Several spread operations in the core write path have cost that scales with **store size** rather than payload size:

- Per-entity-type map clone in `NormalizeDelegate` (`entities[key]` + `entitiesMeta[key]` copied on first write to a type) — a single-entity update into a type with 100k cached entities copies all 100k references.
- `{ ...state.endpoints }` / `{ ...state.meta }` in `setResponseReducer` — every successful fetch copies all cached endpoint keys.
- Collection `pushMerge` `[...existing, ...incoming]` — each pagination push is O(collection length).

The most degenerate case (large warm store receiving small frequent updates, e.g. websocket ticks) had no benchmark coverage, and the Node benchmark had no memory instrumentation. These copies are transient, so the memory symptom is allocation rate and GC churn rather than retained heap.

### Solution

**New `spread` throughput suite** (`examples/benchmark/spread.js`, scenarios in `spread-scenarios.js`):

| Benchmark | ops/sec |
|---|---|
| setOneEntity in 1k entity store | 2,752 |
| setOneEntity in 10k entity store | 231 |
| setOneEntity in 100k entity store | 15.4 |
| setOneEntity control in 100k entity store | 886,519 |
| setOneEntity with 10k cached endpoints | 230 |
| collection push 10 onto 10k | 231 |
| invalidateAll 10k endpoints | 167 |
| expireAll 10k endpoints | 317 |

The 1k/10k/100k sweep scales near-linearly (confirming the O(N) per-type clone), while the control write to a small entity type in the same 100k store stays flat — the cost is per-type, not whole-store. A single-entity write into a 100k store takes ~66ms.

**Memory pressure script** (`yarn start:memory [filter]`): reports approximate allocated bytes/op (used-heap deltas via `v8.getHeapStatistics`), GC minor/major counts and total pause time (`PerformanceObserver` `gc` entries), and retained heap after full GC. The 100k-store write allocates ~14MB/op with heavy GC churn but ~0 retained, versus 3.8KB/op and zero GC events for the control.

**CI tracking**: one fast, stable case (`setOneEntity in 10k entity store`, ±0.5%, ~6s end-to-end) is tracked over time via a new `benchmark-spread.yml` workflow. It triggers only on store-write code paths (`packages/core/src/state/**`, `packages/normalizr/src/normalize/**`, `packages/endpoint/src/schemas/EntityMixin.ts`, spread suite files) and reports to a separate `spread-bench` history dir on `gh-pages-bench`. All other spread benchmarks and the memory script are manual-only; the main benchmark workflow's default suites are unchanged.

Scenario fixtures build lazily per filter (`buildScenarios(filter)`), so the CI run only constructs the 10k fixture and filtered local runs skip the expensive 100k-store construction.

Key technical decisions:
- Fixture states are built through the real reducer (`setResponse` dispatches) so their shape is authentic, then each benchmark dispatches against a fixed baseline without persisting, so every op measures the same degenerate write.
- One shared scenarios module keeps the throughput suite and memory script measuring identical operations.
- No changeset: `examples/*` and CI/docs only, no `packages/*` source changes.

### Open questions

Whether to also track `setOneEntity with 10k cached endpoints` in CI — it isolates the `setResponseReducer` endpoints/meta spreads and is equally fast/stable, but starts the tracked set at two cases instead of one.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01ca6558-4c29-4c78-b9e5-a27ebf3e5cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01ca6558-4c29-4c78-b9e5-a27ebf3e5cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

