### PR TITLE
Add two-track plan for ImmutableJS support

### DIFF
--- a/plans/immutablejs-support.md
+++ b/plans/immutablejs-support.md
@@ -1,0 +1,150 @@
+# Full ImmutableJS Support — Staged Plan
+
+Status: draft
+Owner: TBD
+Related: [GOALS.md](../GOALS.md), `docs/ROADMAP.md` ("Immutable.js support as optional peerdep")
+
+## Constraints (from GOALS.md)
+
+1. **Zero bundle cost for POJO users** — all immutable code stays behind `/imm` subpath exports; nothing immutable-related in main entries.
+2. **Zero runtime cost for POJO users** — no per-call duck-type checks or branching on the hot path; behavior differences are resolved once via policy/delegate injection (the pattern established by `MemoCache(policy)` in 0.15).
+3. **SRP / drift protection** — one implementation per concern; immutable semantics live in dedicated modules, never inlined into shared schema code.
+
+## Current state (baseline)
+
+- `@data-client/normalizr/imm` exists: `MemoPolicy` (`ImmDelegate`), `normalize`, `denormalize`, `ImmNormalizeDelegate`. `MemoCache` and `Controller` accept injected policies.
+- **Supported contract**: outer state tables (`entities`/`indexes`/`entitiesMeta`) are Immutable Maps; entity *values* are POJOs. Tested for `Values`, `All`, `Invalidate`, `Query`, `MemoCache`.
+- **Known gaps** (details in each stage):
+  - Entity values as Immutable Records/Maps are broken (`fromJS`/`merge`/`denormalize`/`validate` in `EntityMixin` assume POJOs; see corrupt snapshot in `packages/normalizr/src/__tests__/__snapshots__/immutable.test.ts.snap`).
+  - `isImmutable`/`denormalizeImmutable` ship in **main** bundles of both normalizr and endpoint (`Object.ts`, `Polymorphic.ts`) and run a per-object check on the denormalize hot path for everyone.
+  - The two `ImmutableUtils.ts` copies (normalizr, endpoint) have already drifted (different signatures and INVALID handling).
+  - `normalize.imm.ts` ships a fake-immutable default store (`deepClone`, `createNestedImmutable`).
+  - `packages/endpoint/src/schemas/EntityRecord.ts` is an empty stub.
+  - Core (reducers, `GCPolicy`, `Controller` state reads) is POJO-only; no written decision on whether that is in scope.
+  - No user-facing docs for immutable usage.
+
+---
+
+## Stage 0 — Spikes and knowledge gathering
+
+No production code changes. Each spike de-risks a later stage; results get recorded in this document before the dependent stage starts.
+
+### S0.1 Measure the `isImmutable` hot-path cost (feeds Stage 1)
+
+- Add a microbenchmark to `examples/benchmark/micro.js` isolating object-schema denormalize with and without the `isImmutable(input)` check (hack it out locally; don't commit the removal).
+- Establishes the expected payoff for Stage 1 and the baseline for its regression gate.
+- **Question answered**: is the win measurable (the 0.15 entity-path removal claimed 10–20%), or is it noise on modern V8? Either result is useful — if noise, Stage 1 is justified by bundle size and SRP alone and we shouldn't oversell it in the changeset.
+
+### S0.2 Prototype the policy seam for object/polymorphic denormalize (feeds Stage 1)
+
+- The immutable branch in `Object.ts`/`Polymorphic.ts` must move behind the injected policy. Prototype where the strategy lives: on the unvisit `delegate` (one object per denormalize tree) vs. resolved at `getUnvisit` construction from `IMemoPolicy`.
+- **Constraints to verify** (per `packages/normalizr/AGENTS.md`): adding fields to hot-path objects changes hidden classes and has measured 5–10% costs; conditional call-site shapes deopt. The prototype must run `yarn workspace example-benchmark start normalizr` and hold ≤2% on cached benches.
+- **Question answered**: exact seam shape, and whether `Polymorphic`'s discrimination reads (`value.get('schema')`, `value.get('id')`) can share the same strategy or need their own hook.
+
+### S0.3 Enumerate immutable-input surfaces under the supported contract (feeds Stages 1–2)
+
+- Audit which schema `denormalize`/`queryKey` paths can ever receive immutable input when (a) only tables are immutable, (b) entity values are also immutable. Known suspects beyond Object/Polymorphic: `Values` (iterates `Object.keys(input)`), `Collection.createIfValid` (spread), `All` (table iteration — `ImmDelegate.getEntities` already returns the Immutable Map, which is iterable-compatible).
+- Deliverable: a table of schema × operation × input-kind, marking which need policy-routed handling and which are already safe. This becomes the Stage 2 test matrix.
+
+### S0.4 `EntityRecord` design spike (feeds Stage 2)
+
+Prototype an Entity mixin whose instances are Immutable Records. Questions that must be answered before committing to an API:
+
+- **Composition**: extend/wrap `EntityMixin` overriding statics (`fromJS`, `createIfValid`, `merge`, `mergeWithStore`, `denormalize`, `validate`, `defaults`), or a parallel mixin sharing helpers? Prefer the smallest override surface that avoids duplicating normalize logic.
+- **Storage shape**: do Record instances go *into* the entity table, or do we normalize to POJOs and only construct Records at denormalize time? Storage shape is public API (snapshot tests, SSR payloads, devtools) — POJO storage is the conservative default and keeps `mergeWithStore` trivial; Record storage would need Record-aware merge and meta handling. Decide with evidence.
+- **Memoization**: `WeakDependencyMap` chains are keyed by entity object identity. Verify referential-stability contracts hold (`toBe` across repeated `MemoCache.denormalize` calls) with Records, including after unrelated store writes.
+- **Immutable dependency**: `immutable` becomes an optional `peerDependency` (with `peerDependenciesMeta.optional`) imported **only** from the `/imm` entry — verify no accidental graph reachability from the main entry. Check whether we need actual imports at all or can stay duck-typed like `ImmutableUtils` does today (types-only import may suffice).
+- **Types**: confirm the `/imm` subpath types pattern (as done in normalizr's `package.json` `exports`) works across the supported TS matrix, and decide whether legacy `typesVersions` (3.4/4.0/4.1) get the export or it's TS ≥5.x-only.
+
+### S0.5 External immutable-store integration reality check (feeds Stage 4)
+
+- Build a minimal Redux + ImmutableJS example driving `MemoCache(ImmPolicy)` + `/imm` `normalize` in a user reducer. Identify exactly which `Controller` reads break when the *outer* state object is immutable (`state.endpoints[key]`, `state.meta[...]`, `GCPolicy` reads).
+- Search issues/discussions for actual demand signal for an immutable *internal* store vs. external-store interop.
+- **Question answered**: is a thin outer-state adapter (fixed keys: `entities`, `endpoints`, `indexes`, `meta`, `entitiesMeta`, `optimistic`, `lastReset`) sufficient for real integrations, making a `@data-client/core/imm` unnecessary?
+
+---
+
+## Stage 1 — Evict immutable code from main bundles; consolidate `ImmutableUtils`
+
+**Depends on**: S0.1, S0.2, S0.3.
+
+**Why**: constraints 1–3 are currently violated on the object/polymorphic path; this also creates the seam Stage 2 builds on.
+
+Work items:
+
+1. Move the immutable branch of `Object.ts` and `Polymorphic.ts` denormalize (both packages) behind the policy seam chosen in S0.2. POJO policy performs no check; imm policy supplies the immutable-aware implementations.
+2. Consolidate the two drifted `ImmutableUtils.ts` copies into a single implementation, living with the imm policy code (or delete entirely if the policy move subsumes them).
+3. Bundle verification: `yarn ci:build:bundlesize`; assert main entries of normalizr and endpoint contain no `isImmutable`/immutable branches (add a grep-based check to CI if cheap).
+4. Benchmarks: `normalizr` suite `^denormalize` filters, plus the S0.1 microbenchmark as the before/after evidence.
+5. Changeset (likely **breaking** for anyone denormalizing immutable input through the *main* entry — they must switch to `/imm`, same migration shape as the 0.15 `MemoCache` change).
+
+**Exit criteria**: no immutable code in main bundles; POJO benches within noise or improved; existing `/imm` tests green; drift eliminated (one implementation).
+
+## Stage 2 — `EntityRecord` and `@data-client/endpoint/imm`
+
+**Depends on**: Stage 1 (seam), S0.3 (test matrix), S0.4 (design decisions).
+
+**Why**: this is the actual "full support" feature gap — immutable entity *values* are currently corrupt (the committed snapshot proves it).
+
+Work items:
+
+1. Implement `EntityRecord` per the S0.4 design in `packages/endpoint`, exported from a new `/imm` subpath (`package.json` `exports`, build wiring, `yarn build:types`).
+2. `immutable` as optional peer dependency of `@data-client/endpoint` (or stay duck-typed if S0.4 shows imports are unnecessary).
+3. Fix or explicitly reject the mixed case: plain `Entity` classes with deep-immutable stored values. If rejected, `fromJS` should fail loudly in dev rather than silently producing `id: ""` garbage.
+4. Tests: convert the corrupt-Record snapshot into real assertions; re-enable the commented-out denormalize expectations in `immutable.test.ts`; cover the S0.3 matrix (Collection push/unshift, Union discrimination, Values, All) with Record entities; referential-stability `toBe` tests. All three Jest projects (Node, ReactDOM, ReactNative).
+5. Docs in the same PR (see Stage 5 for the guide; API reference for `EntityRecord` lands here per the docs-in-same-PR policy).
+6. Changeset (minor — new feature).
+
+**Exit criteria**: Record-based entities normalize, merge, and denormalize correctly with memoization intact; zero main-bundle growth; no new peer warnings for non-users.
+
+## Stage 3 — Remove the fake-immutable fallback from `normalize.imm.ts`
+
+**Depends on**: nothing (can run parallel to Stage 2). No spike needed — the design question is small.
+
+Work items:
+
+1. Delete `emptyImmutableLike`, `createNestedImmutable`, and `deepClone`; require explicit immutable state (anyone importing `/imm` has `immutable` available) or accept an injected empty-state factory.
+2. Changeset (**breaking** for `/imm` `normalize` callers relying on the implicit default).
+
+**Exit criteria**: `/imm` bundle shrinks; no POJO shim masquerading as immutable state.
+
+## Stage 4 — Core scope decision (ADR) + external-store adapter if warranted
+
+**Depends on**: S0.5.
+
+**Why**: "full support" needs a written boundary, or scope will creep into an immutable internal store that fights the performance goal.
+
+Work items:
+
+1. Write an ADR (this folder): immutable support targets **external stores**; core's internal store stays POJO. Cite GOALS.md performance priorities and S0.5 findings.
+2. If S0.5 showed real integrations need it: ship the thin outer-state adapter (or document the hand-rolled equivalent) so `Controller.getResponse`/`GCPolicy` work against immutable outer state. This should be a few lines per fixed key, not a core rewrite.
+3. Publish the S0.5 example as `examples/` entry or docs snippet.
+
+**Exit criteria**: the boundary is documented and discoverable; the supported integration path has a working, tested example.
+
+## Stage 5 — Verification infrastructure and docs
+
+**Depends on**: Stages 1–2 (content to document and guard).
+
+Work items:
+
+1. **Benchmarks**: add an imm-policy suite to `examples/benchmark` (normalize + memoized denormalize against Immutable tables, and Record entities once Stage 2 lands) plus a POJO-path guard so "zero cost to non-users" is CI-enforced, not asserted. Keep names stable for history.
+2. **Bundle guard**: CI assertion that main entries contain no immutable code (from Stage 1, item 3).
+3. **Version matrix**: decide the supported `immutable` peer range; if it spans v4 and v5, add a CI cell (devDep is pinned 5.1.8 today; `isImmutable` duck-typing (`__ownerID`, `_map`) must be verified against both).
+4. **Docs**: a guide covering the `/imm` entries, `EntityRecord`, the tables-immutable vs. values-immutable contracts, and the Redux+ImmutableJS integration; link from ROADMAP (and mark the roadmap item done). Follow the packages-documentation skill for placement/format.
+
+**Exit criteria**: a regression in bundle size, POJO perf, or immutable correctness fails CI; a new user can integrate from docs alone.
+
+---
+
+## Sequencing summary
+
+```
+S0.1 ─┐
+S0.2 ─┼─► Stage 1 ─► Stage 2 ─► Stage 5
+S0.3 ─┘              ▲
+S0.4 ────────────────┘
+S0.5 ─────► Stage 4          Stage 3 (independent, anytime)
+```
+
+Every stage that touches `packages/*` needs a changeset; Stages 1 and 3 are breaking for `/imm`-adjacent users and should ideally land in the same minor release to consolidate migration cost.

--- a/plans/immutablejs-support.md
+++ b/plans/immutablejs-support.md
@@ -18,10 +18,10 @@ Table representation and value representation are separate policy dimensions; co
 
 | | POJO values | Immutable values |
 |---|---|---|
-| **POJO tables** | default (main entries) | legacy main-entry behavior via inline `isImmutable` checks (to be policy-gated in F1) |
-| **Immutable tables** | Track A contract; already implemented by `/imm` | Track B contract (`EntityRecord`) |
+| **POJO tables** | ① default (main entries) | ③ legacy accident via inline `isImmutable` checks — **dropped in F1** (no known users; loud dev-mode error + migration note) |
+| **Immutable tables** | ② Track A contract *and* Track B's default recommendation; already implemented by `/imm` | ④ Track B candidate (`EntityRecord`) — **gated by spike B0.0** |
 
-Denormalize always converts entity values to plain classes (`createIfValid`/`fromJS`), so Track A only needs the immutable-tables/POJO-values cell. `EntityRecord` and immutable-value denormalization are Track B only.
+Denormalize always converts entity values to plain classes (`createIfValid`/`fromJS`), so Track A only needs cell ②. Cell ④ is **additive** on top of ② (a new mixin + value policy in `/imm` entries) — Track B can ship ② first and add ④ later without breaking anything, which is why ④ is spike-gated rather than assumed.
 
 ## Constraints (from GOALS.md — apply to both tracks)
 
@@ -59,7 +59,7 @@ Creates the *value-shape* policy seam. Prerequisite for B1 (and the F-track bund
   - `getUnvisit` currently receives only `getEntity`/cache/args — the policy is reduced to `getEntities()` in `MemoCache.denormalize` before `getUnvisit` is called. The seam must thread a denormalize strategy through construction.
   - A closure-resolved strategy only fixes the *shorthand* Object dispatch in `unvisit.ts`; endpoint `Object.denormalize` receives the delegate, and `Polymorphic` receives only `unvisit` through Array/Values — so the **delegate protocol** changes, which triggers constraint 5 (cross-package version compatibility).
   - Must hold ≤2% on cached `normalizr` benches; no optional delegate fields.
-- **F0.3 — Migration path for the legacy cell.** Main entries today support POJO tables + immutable *input* (endpoint Object/Union). `/imm`'s `MemoPolicy` requires `getIn` tables, so "switch to `/imm`" is **not** drop-in for those users. Decide: a hybrid policy (POJO tables + immutable-value handling), an explicit conversion recipe, or dropping the combination with a loud error.
+- **F0.3 — Kill path for cell ③ (decision recorded: drop it).** Main entries today accidentally support POJO tables + immutable *input* (endpoint Object/Union inline checks). Nobody wants this combination; F1 drops it rather than building a hybrid policy. Remaining spike work is only the exit ramp: a loud dev-mode error when immutable input reaches main-entry denormalize (cheap detection at the error site only, not the hot path), and a changelog migration note (convert values, or move fully to `/imm` cell ②).
 
 ### Work items
 
@@ -126,15 +126,26 @@ Changeset (minor — opt-in). Docs per docs-in-same-PR policy.
 
 Target user: owns their store (e.g. Redux + Immutable), calls `normalize`/`denormalize`/`MemoCache(ImmPolicy)` directly. Core's internal store is explicitly **not** this track's concern (that's Track A).
 
+**Contract question**: cell ② (immutable tables, POJO values) is the working hypothesis for what external users actually want — it already works, and denormalize output is plain classes either way. Cell ④ (Records/Maps as stored values) is only observable in the *store itself* (user middleware, devtools, persistence, hand-written selectors on raw state), so its entire justification must come from store-level capabilities. B0.0 decides whether ④ is worth building at all.
+
 ### Stage B0 — Spikes
 
-- **B0.1 — `EntityRecord` design.** Prototype an Entity mixin for Immutable Record instances. If Records are stored in entity tables, the override surface is the **full lifecycle**, not just denormalize statics: `process` (spreads input), `pk` (property-based prototype method), `normalize` (`Object.hasOwn`, bracket reads, mutation), index extraction, `merge`/`mergeWithStore` (spreads), `fromJS` (`Object.assign`), `createIfValid`, `denormalize` (bracket mutation), plus polymorphic discrimination and `queryKey`. Decide: storage shape (Records in the table vs. POJO storage + Record construction at denormalize — storage shape is public API; POJO storage is the conservative default and dramatically shrinks the override surface); memoization (`toBe` stability with Records across repeated calls and unrelated writes); dependency wiring (optional peer imported only from `/imm`, or duck-typed per F1's detection decision); `/imm` subpath types across the supported TS matrix incl. legacy `typesVersions`.
+- **B0.0 — Cell ② vs. cell ④ tradeoff spike (gate for the `EntityRecord` line: B0.1, B0.3, B1).** Since ④ is additive, default to shipping ② and defer ④ unless this spike finds concrete justification. Evaluate:
+  - **Performance**: ④ pays Record/Map `get()` field access through the whole normalize lifecycle (`process`/`pk`/`merge`/index extraction) and a double conversion on read (Record in store → plain class out of denormalize). ② runs the ordinary POJO path after table access. Measure normalize + denormalize throughput and memoization stability for both on the imm benchmark suite. Expected: ② wins or ties everywhere; ④ needs a surprise to win.
+  - **Bundle size**: ④ adds `EntityRecord` + value-aware Object/Polymorphic denormalize to `/imm` entries (imm users only — measure, but weight lightly).
+  - **Simplicity — the real question**: what does ④ enable that ② can't?
+    - Store-wide immutability invariants: apps whose middleware/lint rejects plain objects anywhere in state (e.g. strict `redux-immutable-state-invariant`-style enforcement).
+    - Deep-persistence rehydration: `fromJS(serialized)` naturally produces ④; supporting only ② means shipping a shallow table-level hydration helper *and* loud dev-mode detection of immutable values in tables (this helper is needed regardless — it's the same hydration footgun Track A's A0.3 identified).
+    - User-side structural equality (`Immutable.is`) and cursor patterns over raw store values.
+  - Against ④: the full lifecycle override surface from B0.1's findings, a second documented contract, and the double-conversion mental model (Records in store, classes in components).
+  - **Decision rule**: ship ② as the documented Track B contract; build ④ only if the spike identifies a named user capability (not aesthetics) that ② + the hydration helper cannot satisfy, and the perf cost is acceptable. Record the outcome as an ADR either way.
+- **B0.1 — `EntityRecord` design** *(only if B0.0 selects ④)*. Prototype an Entity mixin for Immutable Record instances. If Records are stored in entity tables, the override surface is the **full lifecycle**, not just denormalize statics: `process` (spreads input), `pk` (property-based prototype method), `normalize` (`Object.hasOwn`, bracket reads, mutation), index extraction, `merge`/`mergeWithStore` (spreads), `fromJS` (`Object.assign`), `createIfValid`, `denormalize` (bracket mutation), plus polymorphic discrimination and `queryKey`. Decide: storage shape (Records in the table vs. POJO storage + Record construction at denormalize — storage shape is public API; POJO storage is the conservative default and dramatically shrinks the override surface); memoization (`toBe` stability with Records across repeated calls and unrelated writes); dependency wiring (optional peer imported only from `/imm`, or duck-typed per F1's detection decision); `/imm` subpath types across the supported TS matrix incl. legacy `typesVersions`.
 - **B0.2 — Integration reality check.** Minimal Redux + Immutable example driving the `/imm` APIs. Known mismatch (not just a demand question): `normalize.imm` destructures a plain wrapper object and `MemoCache.query` reads `state.entities`/`state.indexes` as properties — a typical Immutable *root* state needs a thin adapter. Also gauge demand signal from issues/discussions to bound scope.
-- **B0.3 — Immutable-input surface matrix.** Broadened per review: every exported schema (Object, Array, Union, Values, All, Collection Array *and* Values, Query, Lazy, Scalar, Invalidate, Serializable) × operation (normalize, denormalize, queryKey) × input kind (Record by id, Record passed by reference, deep-immutable Map, POJO refs inside immutable tables). Include Record discriminator access, Record indexes, and merge ordering. Deliverable → Stage B1 test matrix.
+- **B0.3 — Immutable-input surface matrix** *(only if B0.0 selects ④)*. Broadened per review: every exported schema (Object, Array, Union, Values, All, Collection Array *and* Values, Query, Lazy, Scalar, Invalidate, Serializable) × operation (normalize, denormalize, queryKey) × input kind (Record by id, Record passed by reference, deep-immutable Map, POJO refs inside immutable tables). Include Record discriminator access, Record indexes, and merge ordering. Deliverable → Stage B1 test matrix.
 
-### Stage B1 — `EntityRecord` + `@data-client/endpoint/imm`
+### Stage B1 — `EntityRecord` + `@data-client/endpoint/imm` *(conditional on B0.0 selecting ④)*
 
-Depends on F1 (value-policy seam for nested denormalization) and B0.1/B0.3.
+Depends on B0.0 (gate), F1 (value-policy seam for nested denormalization), and B0.1/B0.3. If B0.0 selects ②, this stage is replaced by a much smaller one: the shallow table-level hydration helper, dev-mode detection of immutable values in tables (fail loudly instead of the current silent `id: ""` corruption), and converting the corrupt-Record snapshot into an assertion of the *rejection* behavior.
 
 1. Implement per B0.1; new `/imm` subpath in `packages/endpoint` (full packaging checklist: `exports`, `typesVersions`, CJS/native, `npm pack` verification, `yarn build:types`).
 2. Fix or explicitly reject the mixed case (plain `Entity` with deep-immutable stored values); if rejected, fail loudly in dev instead of silently producing `id: ""` garbage.
@@ -147,11 +158,11 @@ Delete `emptyImmutableLike`/`createNestedImmutable`/`deepClone` from `normalize.
 
 ### Stage B3 — Verification + docs
 
-Depends on F1, B1, B2, B0.2.
+Depends on F1, B1 (or its cell-② replacement), B2, B0.2.
 
-1. imm-policy benchmark suite in `examples/benchmark` (normalize + memoized denormalize on immutable tables; Record entities after B1).
+1. imm-policy benchmark suite in `examples/benchmark` (normalize + memoized denormalize on immutable tables; Record entities only if ④ shipped).
 2. CI matrix for the `immutable` version range decided in F1 (v4 + v5 cells if the range spans both).
-3. Docs: extend the existing normalizr README ImmutableJS section + site guide — `/imm` entries, `EntityRecord`, the tables-immutable vs. values-immutable contracts, POJO-leaf constraint, Redux root-state adapter (from B0.2), hydration. Mark the ROADMAP item done.
+3. Docs: extend the existing normalizr README ImmutableJS section + site guide — `/imm` entries, the cell-② contract (immutable tables, POJO values) as *the* documented contract, the POJO-leaf constraint and hydration helper, Redux root-state adapter (from B0.2); `EntityRecord` only if ④ shipped. Mark the ROADMAP item done.
 
 ---
 
@@ -166,13 +177,15 @@ Track A:  A0.3 ──► A1 (react/vue accessors) ──► A2 (core seam) ─�
           A0.1 (gate; needs throwaway A2-prototype adapter) ─┬─► A2/A3 decision
           A0.2 ──────────────────────────────────────────────┘
 
-Track B:  B0.1, B0.3 ──► B1 (EntityRecord + endpoint/imm; needs F1)
-          B0.2 ─────────► B3 (docs, CI matrix; needs F1 + B1 + B2)
+Track B:  B0.0 (② vs ④ gate) ─┬─ ④ ─► B0.1, B0.3 ──► B1 (EntityRecord + endpoint/imm; needs F1)
+                               └─ ② ─► B1-lite (hydration helper + loud rejection)
+          B0.2 ────────────────────► B3 (docs, CI matrix; needs F1 + B1 + B2)
           B2 (independent; any time)
 ```
 
 - A1 and B2 are independent and can land early; neither needs F1.
-- A0.1 is the gate: no shippable core immutable work until the benchmark verdict; A1/A2 seams are shape-agnostic and independently justified.
+- A0.1 is the Track A gate: no shippable core immutable work until the benchmark verdict; A1/A2 seams are shape-agnostic and independently justified.
 - A0.1 requires prototyping a disposable store-operation adapter (the harness is hard-wired to the default reducer) — this is expected cost, not scope creep.
-- Track B has no performance gate — correctness/completeness commitment; scope bounded by B0.2's demand findings.
+- B0.0 is the Track B gate for the `EntityRecord` line: cell ④ is additive on top of ②, so deferring it burns no bridges; default outcome is shipping ② with the hydration helper.
+- Track B has no performance gate — correctness/completeness commitment; scope bounded by B0.2's demand findings and B0.0's contract decision.
 - Breaking changes (F1, B2) should be batched into one planned breaking release with a single migration guide (note: release-type labels must follow the project's 0.x versioning policy).

--- a/plans/immutablejs-support.md
+++ b/plans/immutablejs-support.md
@@ -6,7 +6,7 @@ Related: [GOALS.md](../GOALS.md), `docs/ROADMAP.md` ("Immutable.js support as op
 
 ## Two distinct goals
 
-**Track A — Internal store performance (core + react).** Use immutable data structures *inside* the store as a potential performance optimization, targeting the spread-heavy `core` benchmarks (`^set` suite) and memory benchmarks (heap-delta scenarios in `examples/benchmark-react`). ImmutableJS is an implementation detail here and must **never leak** to the react layer or users: entities stay plain classes, hook outputs are unchanged, referential-stability contracts hold. This track is benchmark-gated — if immutable tables don't beat cheaper alternatives (native `Map` tables with lazy cloning), we ship the alternative instead and close the ImmutableJS half of this track with an ADR.
+**Track A — Internal store performance (core + react).** Use immutable data structures *inside* the store as a potential performance optimization, targeting the degenerate-case store-size-scaling writes measured by the `spread` benchmark suite (`examples/benchmark/spread.js` — single-entity `setResponse` into 1k/10k/100k stores plus flat control, 10k cached endpoint keys, collection push, `invalidateAll`/`expireAll`), the `core` `^set` benchmarks, and the memory-pressure script (`yarn workspace example-benchmark start:memory` — allocation/op, GC churn, retained heap). The spread scenarios' memory symptom is transient allocation + GC churn from store-size-proportional copies, which is precisely what structural sharing attacks. ImmutableJS is an implementation detail here and must **never leak** to the react layer or users: entities stay plain classes, hook outputs are unchanged, referential-stability contracts hold. This track is benchmark-gated — if immutable tables don't beat cheaper alternatives (native `Map` tables with lazy cloning), we ship the alternative instead and close the ImmutableJS half of this track with an ADR.
 
 **Track B — External ImmutableJS support for `@data-client/normalizr` users.** Users with their own ImmutableJS-based stores (e.g. Redux + Immutable) who drive `normalize`/`denormalize`/`MemoCache` directly. Here ImmutableJS *is* the user-facing contract, including entity values as Immutable Records (`EntityRecord`). Correctness- and docs-focused, not performance-focused.
 
@@ -56,12 +56,12 @@ Prerequisite for both tracks; creates the policy seam everything else uses.
 
 ### Stage A0 — Spikes (A0.1 is the go/no-go gate for the whole track)
 
-- **A0.1 — Three-arm store benchmark (gate).** Compare on `core` suite `^set` filters and memory scenarios, at realistic and adversarial sizes (10k+ entities of one type; thousands of `endpoints`/`meta` keys):
-  1. Current POJO tables (lazy per-key clone in `NormalizeDelegate` — already manual structural sharing),
+- **A0.1 — Three-arm store benchmark (gate).** The harness already exists: the `spread` suite (`examples/benchmark/spread.js`, scenarios in `spread-scenarios.js`) covers exactly the degenerate cases immutable tables target — `setOneEntity` 1k/10k/100k store sweep (per-type entity map clone in `NormalizeDelegate`), 10k cached endpoint keys (`endpoints`/`meta` spreads in `setResponseReducer`), collection push onto 10k items (`pushMerge`), `invalidateAll`/`expireAll` — and `start:memory` reports allocation/op, GC counts/pause time, and retained heap for the same scenarios. Run all three arms through it, plus `core` `^set`/`^get` for the non-degenerate baseline:
+  1. Current POJO tables (lazy per-key clone — already manual structural sharing; the `control` scenario shows the flat baseline),
   2. Immutable Map tables (existing `ImmNormalizeDelegate`),
   3. Native `Map` tables with the same lazy-clone strategy (no dependency, no leak risk).
 
-  Measure write throughput, read/denormalize-miss overhead (`getIn` vs. property access), allocation churn, and heap deltas (extend `examples/benchmark` with a memory harness or reuse `benchmark-react` heap-delta methodology). **Decision rule**: ImmutableJS proceeds only if it clearly beats arm 3; otherwise arm 3 (or status quo) becomes the deliverable and A3 pivots accordingly.
+  Expected signatures: arm 1 scales near-linearly with store size on the `setOneEntity` sweep with high allocation/GC churn; arms 2–3 should flatten the sweep and cut allocation/op. Watch read/denormalize-miss overhead (`getIn` vs. property access) on `core` `^get` as the counter-metric. **Decision rule**: ImmutableJS proceeds only if it clearly beats arm 3 across the spread sweep *and* memory metrics without regressing `^get`; otherwise arm 3 (or status quo) becomes the deliverable and A3 pivots accordingly.
 - **A0.2 — GC sweep vs. memoization.** The GC reducer mutates in place (`delete state.entities[key][pk]` in `createReducer.ts`) deliberately, preserving table identity so sweeps don't bust `WeakDependencyMap` chains. Immutable `deleteIn` creates a new per-key table map, invalidating memo chains for every entity of that type per sweep. Investigate mitigations (batched sweeps via `withMutations`, GC epochs, accepting and measuring the re-denormalize cost) — outcome feeds the A0.1 decision.
 - **A0.3 — State-read audit → accessor API design.** Enumerate every raw state read outside core reducers: react hooks (`state.endpoints[key]`, `state.meta[key]` bracket reads in `useCache`/`useSuspense`/`useFetch`/`useDLE`/`useQuery`; table refs used as `useMemo` deps are identity-only and already shape-agnostic), `ExternalDataProvider`'s optimistic replay, managers, `packages/ssr`, devtools serialization. Design the minimal `Controller` accessor surface (or state facade) that makes them shape-agnostic.
 
@@ -91,7 +91,7 @@ POJO policy is the default with **zero added indirection cost** (verify on `core
 
 Changeset (minor). Docs per docs-in-same-PR policy.
 
-**Exit criteria**: measured wins on the targeted `^set`/memory benchmarks landed in CI history; react benchmark suite shows no regression; zero user-visible data-shape change.
+**Exit criteria**: measured wins on the `spread` sweep and `start:memory` metrics, with the tracked CI case (`setOneEntity in 10k entity store` in `.github/workflows/benchmark-spread.yml`, which already triggers on the store-write paths this stage touches: `packages/core/src/state/**`, `packages/normalizr/src/normalize/**`) showing the improvement in its history; `core` `^set`/`^get` and react benchmark suites show no regression; zero user-visible data-shape change.
 
 ---
 

--- a/plans/immutablejs-support.md
+++ b/plans/immutablejs-support.md
@@ -1,54 +1,76 @@
 # ImmutableJS — Two-Track Plan
 
-Status: draft
+Status: draft (revised after adversarial review)
 Owner: TBD
 Related: [GOALS.md](../GOALS.md), `docs/ROADMAP.md` ("Immutable.js support as optional peerdep")
 
 ## Two distinct goals
 
-**Track A — Internal store performance (core + react).** Use immutable data structures *inside* the store as a potential performance optimization, targeting the degenerate-case store-size-scaling writes measured by the `spread` benchmark suite (`examples/benchmark/spread.js` — single-entity `setResponse` into 1k/10k/100k stores plus flat control, 10k cached endpoint keys, collection push, `invalidateAll`/`expireAll`), the `core` `^set` benchmarks, and the memory-pressure script (`yarn workspace example-benchmark start:memory` — allocation/op, GC churn, retained heap). The spread scenarios' memory symptom is transient allocation + GC churn from store-size-proportional copies, which is precisely what structural sharing attacks. ImmutableJS is an implementation detail here and must **never leak** to the react layer or users: entities stay plain classes, hook outputs are unchanged, referential-stability contracts hold. This track is benchmark-gated — if immutable tables don't beat cheaper alternatives (native `Map` tables with lazy cloning), we ship the alternative instead and close the ImmutableJS half of this track with an ADR.
+**Track A — Internal store performance (core + react).** Use immutable data structures *inside* the store as a potential performance optimization, targeting the degenerate-case store-size-scaling writes measured by the `spread` benchmark suite (`examples/benchmark/spread.js` — single-entity `setResponse` into 1k/10k/100k stores plus flat control, 10k cached endpoint keys, collection push, `invalidateAll`/`expireAll`), the `core` `^set` benchmarks, and the memory-pressure script (`yarn workspace example-benchmark start:memory` — allocation/op, GC churn, retained heap). The spread scenarios' memory symptom is transient allocation + GC churn from store-size-proportional copies, which is what persistent structural sharing attacks. ImmutableJS must **never leak** to user data: entities stay plain classes, hook outputs unchanged, referential-stability contracts hold. This track is benchmark-gated — if immutable tables don't clearly win, we ship the cheaper alternative (or status quo) and close the ImmutableJS half with an ADR.
+
+**Important scope caveat**: the store state shape is *not* a pure implementation detail. `State<unknown>` is a public exported type (`packages/core/src/types.ts`), observed via `controller.getState()`, `Manager.init`/middleware, the `initialState` prop, SSR payloads, and devtools — and normalizr's AGENTS.md states "storage shape is API". Consequence: an **opt-in** store policy is a minor feature; changing the **default** state representation (even to native `Map`) is a breaking change. Track A plans for opt-in.
 
 **Track B — External ImmutableJS support for `@data-client/normalizr` users.** Users with their own ImmutableJS-based stores (e.g. Redux + Immutable) who drive `normalize`/`denormalize`/`MemoCache` directly. Here ImmutableJS *is* the user-facing contract, including entity values as Immutable Records (`EntityRecord`). Correctness- and docs-focused, not performance-focused.
 
-Key insight separating them: denormalize always converts entity values to plain classes (`createIfValid`/`fromJS`), so Track A only needs **immutable tables with POJO values** — a contract the existing `@data-client/normalizr/imm` layer already implements. `EntityRecord` and the immutable branches of Object/Polymorphic denormalize are **Track B only**.
+### The two independent axes
+
+Table representation and value representation are separate policy dimensions; conflating them is how scope creeps:
+
+| | POJO values | Immutable values |
+|---|---|---|
+| **POJO tables** | default (main entries) | legacy main-entry behavior via inline `isImmutable` checks (to be policy-gated in F1) |
+| **Immutable tables** | Track A contract; already implemented by `/imm` | Track B contract (`EntityRecord`) |
+
+Denormalize always converts entity values to plain classes (`createIfValid`/`fromJS`), so Track A only needs the immutable-tables/POJO-values cell. `EntityRecord` and immutable-value denormalization are Track B only.
 
 ## Constraints (from GOALS.md — apply to both tracks)
 
 1. **Zero bundle cost for non-users** — all immutable code behind `/imm` subpath exports.
-2. **Zero runtime cost for the default path** — no per-call duck-type checks; behavior differences resolved once via policy injection (the `MemoCache(policy)` pattern from 0.15).
+2. **Zero runtime cost for the default path** — no per-call duck-type checks; behavior differences resolved once via policy injection (the `MemoCache(policy)` pattern from 0.15). Policy hooks must be monomorphic — no optional delegate fields (hidden-class constraints per `packages/normalizr/AGENTS.md`).
 3. **SRP / drift protection** — one implementation per concern; immutable semantics in dedicated modules, never inlined into shared schema code.
-4. **Track A only**: no ImmutableJS types, values, or APIs observable from `@data-client/react` hooks or user data. Acknowledged soft leak: `controller.getState()` raw state in managers/middleware (documented caveat when the opt-in policy is active).
+4. **Leaf reference identity is sacred** — store policies must never wrap or proxy entity leaves on read; `WeakDependencyMap` chains are keyed by leaf object identity (`packages/normalizr/AGENTS.md`).
+5. **Wide version ranges** — endpoint and normalizr declare `IDenormalizeDelegate` independently; any delegate-protocol change needs cross-version compatibility testing (or a capability check) so new endpoint works with older normalizr and vice versa.
+6. **Track A only**: no ImmutableJS observable from `@data-client/react` hooks or user data. Acknowledged soft leaks when the opt-in policy is active: `controller.getState()`, `Manager.init`, middleware, devtools — documented caveats.
 
 ## Current state (baseline)
 
-- `@data-client/normalizr/imm` exists: `MemoPolicy` (`ImmDelegate`), `normalize`, `denormalize`, `ImmNormalizeDelegate`. `MemoCache` and `Controller` accept injected policies.
-- **Supported contract**: outer tables (`entities`/`indexes`/`entitiesMeta`) immutable, entity values POJO. Tested for `Values`, `All`, `Invalidate`, `Query`, `MemoCache`.
+- `@data-client/normalizr/imm` exists: `MemoPolicy` (`ImmDelegate`), `normalize`, `denormalize`, `ImmNormalizeDelegate`. `MemoCache` takes a policy; `Controller` takes a preconstructed `memo` (policy injection is indirect, via `new MemoCache(policy)`).
+- **Supported contract**: outer tables (`entities`/`indexes`/`entitiesMeta`) immutable, entity values POJO. Tested for `Values`, `All`, `Invalidate`, `Query`, `MemoCache`. Note: some existing tests use deep `fromJS` (immutable values) — test helpers need to distinguish the two contracts deliberately.
+- **Known bugs (fix immediately, no stage gate)**:
+  - `denormalize.imm.ts` constructs `LocalCache()` **without `args`** while the main entry passes `new LocalCache(args)` — breaks args-dependent schemas (e.g. `Scalar`'s `argsKey` path) on direct `/imm` denormalize.
 - **Known gaps**:
-  - `isImmutable`/`denormalizeImmutable` ship in **main** bundles of both normalizr and endpoint (`Object.ts`, `Polymorphic.ts`); per-object hot-path check for everyone. The two `ImmutableUtils.ts` copies have already drifted.
-  - Entity values as Records/Maps are broken (`fromJS`/`merge`/`denormalize`/`validate` assume POJOs; corrupt snapshot committed in `packages/normalizr/src/__tests__/__snapshots__/immutable.test.ts.snap`). `EntityRecord.ts` is an empty stub. (Track B)
-  - Core reducers/`Controller`/`GCPolicy` and react hooks assume POJO state shape (bracket reads like `state.endpoints[key]`; spreads; in-place GC deletes). (Track A)
+  - `isImmutable`/`denormalizeImmutable` ship in **main** bundles: normalizr `schemas/Object.ts`, endpoint `schemas/Object.ts` + `schemas/Polymorphic.ts` (Polymorphic exists only in endpoint); per-object hot-path check for everyone. The two `ImmutableUtils.ts` copies have drifted (different signatures; normalizr collapses nested symbols to `INVALID`, endpoint propagates the symbol).
+  - Entity values as Records/Maps are broken (`fromJS`/`merge`/`denormalize` assume POJOs; corrupt snapshot committed in `packages/normalizr/src/__tests__/__snapshots__/immutable.test.ts.snap`). `EntityRecord.ts` is an empty stub. (Track B)
+  - Core reducers/`Controller`/`GCPolicy`/managers and react+vue hooks assume POJO state shape (details in A0.3). (Track A)
   - `normalize.imm.ts` ships a fake-immutable default store (`deepClone`, `createNestedImmutable`).
-  - No user-facing docs for immutable usage.
+  - `immutable` is a devDependency only; runtime detection is duck-typed against private internals (`__ownerID`, `_map`) — version-range/predicate decision needed.
+  - Docs: normalizr README has an ImmutableJS section (`/imm` normalize/denormalize examples) but doesn't cover the POJO-leaf contract, `MemoPolicy`, Records, Redux integration, or hydration.
 
 ---
 
 ## Shared Foundation — Stage F1: evict immutable code from main bundles
 
-Prerequisite for both tracks; creates the policy seam everything else uses.
+Creates the *value-shape* policy seam. Prerequisite for B1 (and the F-track bundle goals); **not** a prerequisite for Track A spikes or A1 (Track A uses the existing table policy).
 
 ### Spikes
 
 - **F0.1 — Measure the `isImmutable` hot-path cost.** Microbenchmark in `examples/benchmark/micro.js` isolating object-schema denormalize with/without the check. Sets the regression gate; tells us whether the payoff is perf (0.15 entity-path removal claimed 10–20%) or only bundle/SRP.
-- **F0.2 — Prototype the policy seam** for object/polymorphic denormalize: strategy on the unvisit `delegate` vs. resolved at `getUnvisit` construction from `IMemoPolicy`. Must respect the hidden-class/deopt constraints in `packages/normalizr/AGENTS.md`; hold ≤2% on cached `normalizr` benches. Decides whether `Polymorphic`'s discrimination reads (`value.get('schema')`/`value.get('id')`) share the strategy or need their own hook.
+- **F0.2 — Design the value-policy seam end to end.** Known constraints discovered in review:
+  - `getUnvisit` currently receives only `getEntity`/cache/args — the policy is reduced to `getEntities()` in `MemoCache.denormalize` before `getUnvisit` is called. The seam must thread a denormalize strategy through construction.
+  - A closure-resolved strategy only fixes the *shorthand* Object dispatch in `unvisit.ts`; endpoint `Object.denormalize` receives the delegate, and `Polymorphic` receives only `unvisit` through Array/Values — so the **delegate protocol** changes, which triggers constraint 5 (cross-package version compatibility).
+  - Must hold ≤2% on cached `normalizr` benches; no optional delegate fields.
+- **F0.3 — Migration path for the legacy cell.** Main entries today support POJO tables + immutable *input* (endpoint Object/Union). `/imm`'s `MemoPolicy` requires `getIn` tables, so "switch to `/imm`" is **not** drop-in for those users. Decide: a hybrid policy (POJO tables + immutable-value handling), an explicit conversion recipe, or dropping the combination with a loud error.
 
 ### Work items
 
-1. Move the immutable branches of `Object.ts`/`Polymorphic.ts` (both packages) behind the policy; POJO policy performs no check, imm policy supplies immutable-aware implementations.
-2. Consolidate the two drifted `ImmutableUtils.ts` copies (or delete if subsumed).
-3. Bundle verification (`yarn ci:build:bundlesize`) + a CI grep asserting main entries contain no immutable code.
-4. Changeset — **breaking** for anyone denormalizing immutable input via main entries (migrate to `/imm`, same shape as the 0.15 `MemoCache` migration).
+1. Move the immutable branches of normalizr `Object.ts`, endpoint `Object.ts`, and endpoint `Polymorphic.ts` behind the value policy; POJO policy performs no check.
+2. Consolidate the two drifted `ImmutableUtils.ts` copies (resolving the symbol-propagation difference deliberately, with a test).
+3. Decide the ImmutableJS detection approach (official predicates vs. duck-typing) and supported version range here — F1 owns it since consolidation bakes it in (B3 CI matrix verifies it).
+4. Cross-version compatibility tests (new endpoint ↔ old normalizr and inverse) or a delegate capability check.
+5. Bundle verification (`yarn ci:build:bundlesize`) + a CI grep asserting main entries contain no immutable code.
+6. Changeset — **breaking**, precisely scoped: immutable normalized *input* with main-entry (POJO-table) denormalization; migration per F0.3 outcome. (Immutable *tables* already required `/imm` since 0.15.)
 
-**Exit criteria**: no immutable code in main bundles; POJO benches within noise or improved; `/imm` tests green.
+**Exit criteria**: no immutable code in main bundles; POJO benches within noise or improved; `/imm` tests green; F0.3 migration documented.
 
 ---
 
@@ -56,42 +78,47 @@ Prerequisite for both tracks; creates the policy seam everything else uses.
 
 ### Stage A0 — Spikes (A0.1 is the go/no-go gate for the whole track)
 
-- **A0.1 — Three-arm store benchmark (gate).** The harness already exists: the `spread` suite (`examples/benchmark/spread.js`, scenarios in `spread-scenarios.js`) covers exactly the degenerate cases immutable tables target — `setOneEntity` 1k/10k/100k store sweep (per-type entity map clone in `NormalizeDelegate`), 10k cached endpoint keys (`endpoints`/`meta` spreads in `setResponseReducer`), collection push onto 10k items (`pushMerge`), `invalidateAll`/`expireAll` — and `start:memory` reports allocation/op, GC counts/pause time, and retained heap for the same scenarios. Run all three arms through it, plus `core` `^set`/`^get` for the non-degenerate baseline:
-  1. Current POJO tables (lazy per-key clone — already manual structural sharing; the `control` scenario shows the flat baseline),
-  2. Immutable Map tables (existing `ImmNormalizeDelegate`),
-  3. Native `Map` tables with the same lazy-clone strategy (no dependency, no leak risk).
+- **A0.1 — Three-arm store benchmark (gate).** The `spread` suite + `start:memory` measure the right scenarios, but the harness is hard-wired to the default `Controller`/`createReducer` (`spread-scenarios.js`) — arms 2–3 require a **throwaway store-operation adapter** (a disposable prototype of the A2 seam; budget for this). Arms:
+  1. Current POJO tables (lazy per-key clone; the `control` scenario shows the flat baseline),
+  2. Immutable Map tables (existing `ImmNormalizeDelegate` for entity tables; prototype immutable `endpoints`/`meta` reducer ops),
+  3. Native `Map` tables with clone-on-write.
 
-  Expected signatures: arm 1 scales near-linearly with store size on the `setOneEntity` sweep with high allocation/GC churn; arms 2–3 should flatten the sweep and cut allocation/op. Watch read/denormalize-miss overhead (`getIn` vs. property access) on `core` `^get` as the counter-metric. **Decision rule**: ImmutableJS proceeds only if it clearly beats arm 3 across the spread sweep *and* memory metrics without regressing `^get`; otherwise arm 3 (or status quo) becomes the deliverable and A3 pivots accordingly.
-- **A0.2 — GC sweep vs. memoization.** The GC reducer mutates in place (`delete state.entities[key][pk]` in `createReducer.ts`) deliberately, preserving table identity so sweeps don't bust `WeakDependencyMap` chains. Immutable `deleteIn` creates a new per-key table map, invalidating memo chains for every entity of that type per sweep. Investigate mitigations (batched sweeps via `withMutations`, GC epochs, accepting and measuring the re-denormalize cost) — outcome feeds the A0.1 decision.
-- **A0.3 — State-read audit → accessor API design.** Enumerate every raw state read outside core reducers: react hooks (`state.endpoints[key]`, `state.meta[key]` bracket reads in `useCache`/`useSuspense`/`useFetch`/`useDLE`/`useQuery`; table refs used as `useMemo` deps are identity-only and already shape-agnostic), `ExternalDataProvider`'s optimistic replay, managers, `packages/ssr`, devtools serialization. Design the minimal `Controller` accessor surface (or state facade) that makes them shape-agnostic.
+  **Honest expectations**: arm 3's `new Map(old)` is O(n) like the spread — it's a *constant-factor control*, not an asymptotic competitor; only arm 2 (HAMT) can flatten the `setOneEntity` sweep. A mutable-Map variant would be O(1) but keeps stable identity, breaking React `useMemo`/`useSyncExternalStore` invalidation — only viable with explicit version tokens (separate design, only if arm 2 fails). Also: collection push stays O(collection) (array copy in `pushMerge`) and `invalidateAll`/`expireAll` stay O(keys) under every arm — expect improved constants at best there. Counter-metrics: `core` `^get` and denormalize-miss overhead (`getIn` vs. property access), allocation/op and GC pause from `start:memory`. Follow the paired trimmed-mean methodology from `packages/normalizr/AGENTS.md`. **Decision rule**: ImmutableJS proceeds only if arm 2 clearly beats arm 3 on the sweep *and* memory metrics without regressing `^get`; otherwise ship arm 3 (as opt-in, given the public-shape caveat) or status quo, and write the closing ADR.
+- **A0.2 — GC sweep vs. memoization (corrected).** The GC reducer deletes in place (`createReducer.ts`) — safe because refcounts are zero. Per-entity denormalization chains are keyed by **leaf entity identity**, so an immutable `deleteIn` of one pk does *not* bust surviving entities' chains. What does change: the per-type table identity (`getEntitiesObject` deps), which invalidates **queryKey caches** (`All`, collection membership) for that type per sweep — arguably *correct* invalidation, but measure the re-query cost at GC frequency. `withMutations` batches a sweep but still yields one new table identity per type. Add a GC + `All`-query benchmark case for this.
+- **A0.3 — State-read/write audit → accessor + facade design.** Complete inventory (review-verified):
+  - **Reducers**: `setResponseReducer` *and* `setReducer` import POJO `normalize` directly; `endpoints`/`meta` spreads including the **error path** (`reduceError`); `endpoint.update()` updaters read/write `endpoints[key]`; `fetchReducer` optimistic-array writes; `RESET` reinstalls POJO `initialState`; GC branch.
+  - **Core reads**: `Controller` (`state.endpoints[key]`, `entityExpiresAt` over `state.entitiesMeta`), `selectMeta`, `GCPolicy` (both meta tables), `initManager` (raw state), `NetworkManager` and `PollingSubscription` (`state.meta[key]`).
+  - **React**: bracket reads in `useCache`/`useSuspense`/`useFetch`/`useDLE`/`useQuery`; `useCache`/`useDLE` also construct `{...state, entities: {}}` fallback states — accessors alone don't fix this; the policy must provide an empty-tables factory. Table refs as `useMemo` deps are identity-only and already shape-agnostic.
+  - **Vue**: same `entities: {}` pattern in `packages/vue` consumers; `createDataClient` builds `initialState` and does optimistic replay.
+  - **SSR**: lives at `packages/react/src/server` (published `@data-client/react/ssr`) — `ServerData` JSON-serializes state, `getInitialData` parses it; NextJS + Redux (`ExternalDataProvider`, `prepareStore`) variants. Native `Map` serializes to `{}` via JSON; Immutable needs conversion. Hydration must be **shallow/table-level** — a generic deep `fromJS` would corrupt POJO leaves (arrays, Union discriminators, endpoint Object results). Design schema-preserving table-level (de)serialization, not `toJS`/`fromJS`.
+  - **Test utilities**: `core/src/mock/mockState.ts` (`mockInitialState`) and react/vue test wrappers construct POJO state — need policy-aware fixtures.
+  - **Devtools**: display serialization for immutable state.
+
+  Deliverable: the accessor/facade API and the list of policy operations (initial state, empty-tables factory, table get/set/delete, serialize/hydrate).
 
 ### Stage A1 — React/Controller accessor refactor (independent, zero user-facing change)
 
-Route the hooks' bracket reads through `Controller` accessors per A0.3. Ships on its own — it's a correctness-neutral decoupling that also benefits any future store representation. No changeset-visible behavior change (internal, but verify no public API shifts; if accessors become public API, document them).
+Route hook bracket reads through `Controller` accessors and replace the `entities: {}` fallback construction with a policy/Controller-provided mechanism, per A0.3. Apply the same to `packages/vue`. Ships on its own — correctness-neutral decoupling that benefits any future store representation. Does **not** depend on F1.
 
-**Exit criteria**: `packages/react` contains no POJO-shape assumptions on state; all Jest projects green; react benchmarks within noise.
+**Exit criteria**: `packages/react` and `packages/vue` contain no POJO-shape assumptions on state; all Jest projects green; react benchmarks within noise.
 
 ### Stage A2 — Core store policy seam
 
-Make state-shape-dependent operations in core pluggable via one injected store policy (mirroring `MemoCache(policy)`):
+Make state-shape-dependent operations pluggable via one injected store policy (mirroring `MemoCache(policy)`), covering the full A0.3 inventory: both reducers' normalize wiring, all table ops including error paths and `endpoint.update()`, `RESET`/initial state, GC branch (per A0.2), Controller/manager reads, empty-tables factory, and the serialize/hydrate hooks. Depends on A0.3 (design) and benefits from A1 landing first (fewer raw-state consumers).
 
-1. `initialState` construction; `setResponseReducer`'s direct POJO `normalize` import → policy-provided normalize/delegate.
-2. Reducer table ops: `endpoints`/`meta` spreads in `setResponseReducer`, `invalidateReducer`, `expireReducer`; the GC branch (per A0.2 outcome).
-3. Reads in `Controller` (`state.endpoints[key]`, `entityExpiresAt` over `state.entitiesMeta`), `selectMeta`, `GCPolicy`.
-4. Serialization hooks for devtools display and `packages/ssr` hydration (toJS/fromJS boundary).
+POJO policy is the default with **zero added indirection cost** (verify on `core` `^set`/`^get` benches, ≤2%; the tracked `benchmark-spread.yml` case guards the write path automatically since it triggers on `packages/core/src/state/**`).
 
-POJO policy is the default with **zero added indirection cost** (verify on `core` `^set`/`^get` benches, ≤2%).
+**Exit criteria**: default path benchmark-neutral; policy is the single injection point; policy-aware `mockInitialState`/test fixtures.
 
-**Exit criteria**: default path benchmark-neutral; policy is the single injection point (no scattered conditionals).
+### Stage A3 — Ship the winning store (opt-in)
 
-### Stage A3 — Ship the winning store
+- If **ImmutableJS won A0.1**: `@data-client/core/imm` exporting the immutable store policy; opt-in wiring through `DataProvider`/`CacheProvider` — mind the RSC boundary (policy objects aren't serializable; likely a subpath provider so server and client select the same policy). `immutable` as optional peer of core. Document the `getState()`/`Manager.init`/middleware caveats. SSR round-trip tests (Object results, Union discriminators, Collections, symbols, POJO leaves).
+- If **native-Map or status quo won**: ship as opt-in policy (default change would be breaking per the scope caveat) or keep status quo; write the ADR closing the ImmutableJS internal-store question with benchmark evidence.
+- Either way: add a policy-specific named benchmark case + CI trigger paths (`benchmark-spread.yml` runs the default policy and won't show opt-in wins on its own); packaging checklist for any new subpath (`exports`, `typesVersions` — wildcard mappings would otherwise resolve subpaths to the main declarations — CJS/native variants, `npm pack` verification).
 
-- If **ImmutableJS won A0.1**: `@data-client/core/imm` exporting the immutable store policy; opt-in wiring through `DataProvider`/`CacheProvider`; `immutable` as optional peer of core. Document the `getState()` caveat for manager authors.
-- If **native-Map or status quo won**: land the winner in the main package (no subpath needed — no dependency), write the ADR closing the ImmutableJS internal-store question with benchmark evidence.
+Changeset (minor — opt-in). Docs per docs-in-same-PR policy.
 
-Changeset (minor). Docs per docs-in-same-PR policy.
-
-**Exit criteria**: measured wins on the `spread` sweep and `start:memory` metrics, with the tracked CI case (`setOneEntity in 10k entity store` in `.github/workflows/benchmark-spread.yml`, which already triggers on the store-write paths this stage touches: `packages/core/src/state/**`, `packages/normalizr/src/normalize/**`) showing the improvement in its history; `core` `^set`/`^get` and react benchmark suites show no regression; zero user-visible data-shape change.
+**Exit criteria**: measured wins on the `spread` sweep and `start:memory` metrics under the opt-in policy's named CI case; `core` `^set`/`^get` and react suites show no default-path regression; zero user-visible data-shape change on the default path.
 
 ---
 
@@ -101,44 +128,51 @@ Target user: owns their store (e.g. Redux + Immutable), calls `normalize`/`denor
 
 ### Stage B0 — Spikes
 
-- **B0.1 — `EntityRecord` design.** Prototype an Entity mixin for Immutable Record instances. Decide: composition (override surface on `EntityMixin` statics — `fromJS`, `createIfValid`, `merge`, `mergeWithStore`, `denormalize`, `validate`, `defaults` — vs. parallel mixin); storage shape (Records in the entity table vs. POJO storage + Record construction at denormalize — storage shape is public API per normalizr AGENTS.md; POJO storage is the conservative default); memoization (`toBe` stability with Records across repeated calls and unrelated writes); dependency wiring (`immutable` as optional peer imported only from `/imm`, or stay duck-typed); `/imm` subpath types across the supported TS matrix.
-- **B0.2 — Integration reality check.** Minimal Redux + ImmutableJS example driving the `/imm` APIs in a user reducer. Identify demand signal (issues/discussions) and whether a thin outer-state adapter (fixed keys) is needed for `Controller`-based reads in that context.
-- **B0.3 — Immutable-input surface matrix.** Audit schema `denormalize`/`queryKey` paths receiving immutable input when entity values are also immutable: `Values` (iterates `Object.keys(input)`), `Collection.createIfValid` (spread), Union/Polymorphic discrimination, `All` table iteration. Deliverable: schema × operation × input-kind table → Stage B1 test matrix.
+- **B0.1 — `EntityRecord` design.** Prototype an Entity mixin for Immutable Record instances. If Records are stored in entity tables, the override surface is the **full lifecycle**, not just denormalize statics: `process` (spreads input), `pk` (property-based prototype method), `normalize` (`Object.hasOwn`, bracket reads, mutation), index extraction, `merge`/`mergeWithStore` (spreads), `fromJS` (`Object.assign`), `createIfValid`, `denormalize` (bracket mutation), plus polymorphic discrimination and `queryKey`. Decide: storage shape (Records in the table vs. POJO storage + Record construction at denormalize — storage shape is public API; POJO storage is the conservative default and dramatically shrinks the override surface); memoization (`toBe` stability with Records across repeated calls and unrelated writes); dependency wiring (optional peer imported only from `/imm`, or duck-typed per F1's detection decision); `/imm` subpath types across the supported TS matrix incl. legacy `typesVersions`.
+- **B0.2 — Integration reality check.** Minimal Redux + Immutable example driving the `/imm` APIs. Known mismatch (not just a demand question): `normalize.imm` destructures a plain wrapper object and `MemoCache.query` reads `state.entities`/`state.indexes` as properties — a typical Immutable *root* state needs a thin adapter. Also gauge demand signal from issues/discussions to bound scope.
+- **B0.3 — Immutable-input surface matrix.** Broadened per review: every exported schema (Object, Array, Union, Values, All, Collection Array *and* Values, Query, Lazy, Scalar, Invalidate, Serializable) × operation (normalize, denormalize, queryKey) × input kind (Record by id, Record passed by reference, deep-immutable Map, POJO refs inside immutable tables). Include Record discriminator access, Record indexes, and merge ordering. Deliverable → Stage B1 test matrix.
 
 ### Stage B1 — `EntityRecord` + `@data-client/endpoint/imm`
 
-1. Implement per B0.1; new `/imm` subpath in `packages/endpoint` (`exports` wiring, `yarn build:types`).
+Depends on F1 (value-policy seam for nested denormalization) and B0.1/B0.3.
+
+1. Implement per B0.1; new `/imm` subpath in `packages/endpoint` (full packaging checklist: `exports`, `typesVersions`, CJS/native, `npm pack` verification, `yarn build:types`).
 2. Fix or explicitly reject the mixed case (plain `Entity` with deep-immutable stored values); if rejected, fail loudly in dev instead of silently producing `id: ""` garbage.
-3. Tests: convert the corrupt-Record snapshot into real assertions; re-enable the commented-out expectations in `immutable.test.ts`; cover the B0.3 matrix; referential-stability `toBe` tests; all three Jest projects.
+3. Tests: convert the corrupt-Record snapshot into real assertions; re-enable the commented-out expectations in `immutable.test.ts`; cover the B0.3 matrix; referential-stability `toBe` tests; separate test helpers for shallow-table vs. deep-immutable state (existing tests conflate them); all three Jest projects.
 4. Changeset (minor) + API reference docs in the same PR.
 
 ### Stage B2 — Remove the fake-immutable fallback
 
-Delete `emptyImmutableLike`/`createNestedImmutable`/`deepClone` from `normalize.imm.ts`; require explicit immutable state (anyone importing `/imm` has `immutable`). Changeset (**breaking** for `/imm` `normalize` callers relying on the implicit default). Independent — can land any time after F1.
+Delete `emptyImmutableLike`/`createNestedImmutable`/`deepClone` from `normalize.imm.ts`; require explicit immutable state. Changeset (**breaking** for `/imm` `normalize` callers relying on the implicit default — which existing tests exercise, so those migrate too). Independent of F1 — can land any time.
 
 ### Stage B3 — Verification + docs
 
+Depends on F1, B1, B2, B0.2.
+
 1. imm-policy benchmark suite in `examples/benchmark` (normalize + memoized denormalize on immutable tables; Record entities after B1).
-2. Supported `immutable` version range decision; CI cell for v4 + v5 if the range spans both (`isImmutable` duck-typing against `__ownerID`/`_map` verified on each; devDep pinned 5.1.8 today).
-3. Docs guide: `/imm` entries, `EntityRecord`, tables-immutable vs. values-immutable contracts, Redux+ImmutableJS integration (from B0.2). Mark the ROADMAP item done.
+2. CI matrix for the `immutable` version range decided in F1 (v4 + v5 cells if the range spans both).
+3. Docs: extend the existing normalizr README ImmutableJS section + site guide — `/imm` entries, `EntityRecord`, the tables-immutable vs. values-immutable contracts, POJO-leaf constraint, Redux root-state adapter (from B0.2), hydration. Mark the ROADMAP item done.
 
 ---
 
 ## Sequencing
 
 ```
-F0.1, F0.2 ──► F1 (shared foundation)
-                │
-   ┌────────────┴────────────┐
-   ▼ Track A                 ▼ Track B
-A0.3 ─► A1 (react accessors) B0.1 ─► B1 (EntityRecord + endpoint/imm)
-A0.1 ─┬► A2 (core seam)      B0.2 ─► B3 (docs, CI matrix)
-A0.2 ─┘   │                  B0.3 ─► B1
-          ▼                  B2 (independent after F1)
-        A3 (ship winner)
+Immediate: fix /imm denormalize LocalCache(args) bug
+
+F0.1, F0.2, F0.3 ──► F1 (value-policy seam; needed by B1, not by A-track)
+
+Track A:  A0.3 ──► A1 (react/vue accessors) ──► A2 (core seam) ──► A3 (ship opt-in winner)
+          A0.1 (gate; needs throwaway A2-prototype adapter) ─┬─► A2/A3 decision
+          A0.2 ──────────────────────────────────────────────┘
+
+Track B:  B0.1, B0.3 ──► B1 (EntityRecord + endpoint/imm; needs F1)
+          B0.2 ─────────► B3 (docs, CI matrix; needs F1 + B1 + B2)
+          B2 (independent; any time)
 ```
 
-- A1 and B2 are independent and can land early.
-- A0.1 is the gate: no core immutable work beyond the (shape-agnostic, independently justified) A1/A2 seams until the benchmark verdict is in.
-- Track B has no performance gate — it's a correctness/completeness commitment; scope is bounded by B0.2's demand findings.
-- Breaking changes (F1, B2) should land in the same minor release to consolidate migration cost.
+- A1 and B2 are independent and can land early; neither needs F1.
+- A0.1 is the gate: no shippable core immutable work until the benchmark verdict; A1/A2 seams are shape-agnostic and independently justified.
+- A0.1 requires prototyping a disposable store-operation adapter (the harness is hard-wired to the default reducer) — this is expected cost, not scope creep.
+- Track B has no performance gate — correctness/completeness commitment; scope bounded by B0.2's demand findings.
+- Breaking changes (F1, B2) should be batched into one planned breaking release with a single migration guide (note: release-type labels must follow the project's 0.x versioning policy).

--- a/plans/immutablejs-support.md
+++ b/plans/immutablejs-support.md
@@ -1,150 +1,144 @@
-# Full ImmutableJS Support — Staged Plan
+# ImmutableJS — Two-Track Plan
 
 Status: draft
 Owner: TBD
 Related: [GOALS.md](../GOALS.md), `docs/ROADMAP.md` ("Immutable.js support as optional peerdep")
 
-## Constraints (from GOALS.md)
+## Two distinct goals
 
-1. **Zero bundle cost for POJO users** — all immutable code stays behind `/imm` subpath exports; nothing immutable-related in main entries.
-2. **Zero runtime cost for POJO users** — no per-call duck-type checks or branching on the hot path; behavior differences are resolved once via policy/delegate injection (the pattern established by `MemoCache(policy)` in 0.15).
-3. **SRP / drift protection** — one implementation per concern; immutable semantics live in dedicated modules, never inlined into shared schema code.
+**Track A — Internal store performance (core + react).** Use immutable data structures *inside* the store as a potential performance optimization, targeting the spread-heavy `core` benchmarks (`^set` suite) and memory benchmarks (heap-delta scenarios in `examples/benchmark-react`). ImmutableJS is an implementation detail here and must **never leak** to the react layer or users: entities stay plain classes, hook outputs are unchanged, referential-stability contracts hold. This track is benchmark-gated — if immutable tables don't beat cheaper alternatives (native `Map` tables with lazy cloning), we ship the alternative instead and close the ImmutableJS half of this track with an ADR.
+
+**Track B — External ImmutableJS support for `@data-client/normalizr` users.** Users with their own ImmutableJS-based stores (e.g. Redux + Immutable) who drive `normalize`/`denormalize`/`MemoCache` directly. Here ImmutableJS *is* the user-facing contract, including entity values as Immutable Records (`EntityRecord`). Correctness- and docs-focused, not performance-focused.
+
+Key insight separating them: denormalize always converts entity values to plain classes (`createIfValid`/`fromJS`), so Track A only needs **immutable tables with POJO values** — a contract the existing `@data-client/normalizr/imm` layer already implements. `EntityRecord` and the immutable branches of Object/Polymorphic denormalize are **Track B only**.
+
+## Constraints (from GOALS.md — apply to both tracks)
+
+1. **Zero bundle cost for non-users** — all immutable code behind `/imm` subpath exports.
+2. **Zero runtime cost for the default path** — no per-call duck-type checks; behavior differences resolved once via policy injection (the `MemoCache(policy)` pattern from 0.15).
+3. **SRP / drift protection** — one implementation per concern; immutable semantics in dedicated modules, never inlined into shared schema code.
+4. **Track A only**: no ImmutableJS types, values, or APIs observable from `@data-client/react` hooks or user data. Acknowledged soft leak: `controller.getState()` raw state in managers/middleware (documented caveat when the opt-in policy is active).
 
 ## Current state (baseline)
 
 - `@data-client/normalizr/imm` exists: `MemoPolicy` (`ImmDelegate`), `normalize`, `denormalize`, `ImmNormalizeDelegate`. `MemoCache` and `Controller` accept injected policies.
-- **Supported contract**: outer state tables (`entities`/`indexes`/`entitiesMeta`) are Immutable Maps; entity *values* are POJOs. Tested for `Values`, `All`, `Invalidate`, `Query`, `MemoCache`.
-- **Known gaps** (details in each stage):
-  - Entity values as Immutable Records/Maps are broken (`fromJS`/`merge`/`denormalize`/`validate` in `EntityMixin` assume POJOs; see corrupt snapshot in `packages/normalizr/src/__tests__/__snapshots__/immutable.test.ts.snap`).
-  - `isImmutable`/`denormalizeImmutable` ship in **main** bundles of both normalizr and endpoint (`Object.ts`, `Polymorphic.ts`) and run a per-object check on the denormalize hot path for everyone.
-  - The two `ImmutableUtils.ts` copies (normalizr, endpoint) have already drifted (different signatures and INVALID handling).
+- **Supported contract**: outer tables (`entities`/`indexes`/`entitiesMeta`) immutable, entity values POJO. Tested for `Values`, `All`, `Invalidate`, `Query`, `MemoCache`.
+- **Known gaps**:
+  - `isImmutable`/`denormalizeImmutable` ship in **main** bundles of both normalizr and endpoint (`Object.ts`, `Polymorphic.ts`); per-object hot-path check for everyone. The two `ImmutableUtils.ts` copies have already drifted.
+  - Entity values as Records/Maps are broken (`fromJS`/`merge`/`denormalize`/`validate` assume POJOs; corrupt snapshot committed in `packages/normalizr/src/__tests__/__snapshots__/immutable.test.ts.snap`). `EntityRecord.ts` is an empty stub. (Track B)
+  - Core reducers/`Controller`/`GCPolicy` and react hooks assume POJO state shape (bracket reads like `state.endpoints[key]`; spreads; in-place GC deletes). (Track A)
   - `normalize.imm.ts` ships a fake-immutable default store (`deepClone`, `createNestedImmutable`).
-  - `packages/endpoint/src/schemas/EntityRecord.ts` is an empty stub.
-  - Core (reducers, `GCPolicy`, `Controller` state reads) is POJO-only; no written decision on whether that is in scope.
   - No user-facing docs for immutable usage.
 
 ---
 
-## Stage 0 — Spikes and knowledge gathering
+## Shared Foundation — Stage F1: evict immutable code from main bundles
 
-No production code changes. Each spike de-risks a later stage; results get recorded in this document before the dependent stage starts.
+Prerequisite for both tracks; creates the policy seam everything else uses.
 
-### S0.1 Measure the `isImmutable` hot-path cost (feeds Stage 1)
+### Spikes
 
-- Add a microbenchmark to `examples/benchmark/micro.js` isolating object-schema denormalize with and without the `isImmutable(input)` check (hack it out locally; don't commit the removal).
-- Establishes the expected payoff for Stage 1 and the baseline for its regression gate.
-- **Question answered**: is the win measurable (the 0.15 entity-path removal claimed 10–20%), or is it noise on modern V8? Either result is useful — if noise, Stage 1 is justified by bundle size and SRP alone and we shouldn't oversell it in the changeset.
+- **F0.1 — Measure the `isImmutable` hot-path cost.** Microbenchmark in `examples/benchmark/micro.js` isolating object-schema denormalize with/without the check. Sets the regression gate; tells us whether the payoff is perf (0.15 entity-path removal claimed 10–20%) or only bundle/SRP.
+- **F0.2 — Prototype the policy seam** for object/polymorphic denormalize: strategy on the unvisit `delegate` vs. resolved at `getUnvisit` construction from `IMemoPolicy`. Must respect the hidden-class/deopt constraints in `packages/normalizr/AGENTS.md`; hold ≤2% on cached `normalizr` benches. Decides whether `Polymorphic`'s discrimination reads (`value.get('schema')`/`value.get('id')`) share the strategy or need their own hook.
 
-### S0.2 Prototype the policy seam for object/polymorphic denormalize (feeds Stage 1)
+### Work items
 
-- The immutable branch in `Object.ts`/`Polymorphic.ts` must move behind the injected policy. Prototype where the strategy lives: on the unvisit `delegate` (one object per denormalize tree) vs. resolved at `getUnvisit` construction from `IMemoPolicy`.
-- **Constraints to verify** (per `packages/normalizr/AGENTS.md`): adding fields to hot-path objects changes hidden classes and has measured 5–10% costs; conditional call-site shapes deopt. The prototype must run `yarn workspace example-benchmark start normalizr` and hold ≤2% on cached benches.
-- **Question answered**: exact seam shape, and whether `Polymorphic`'s discrimination reads (`value.get('schema')`, `value.get('id')`) can share the same strategy or need their own hook.
+1. Move the immutable branches of `Object.ts`/`Polymorphic.ts` (both packages) behind the policy; POJO policy performs no check, imm policy supplies immutable-aware implementations.
+2. Consolidate the two drifted `ImmutableUtils.ts` copies (or delete if subsumed).
+3. Bundle verification (`yarn ci:build:bundlesize`) + a CI grep asserting main entries contain no immutable code.
+4. Changeset — **breaking** for anyone denormalizing immutable input via main entries (migrate to `/imm`, same shape as the 0.15 `MemoCache` migration).
 
-### S0.3 Enumerate immutable-input surfaces under the supported contract (feeds Stages 1–2)
-
-- Audit which schema `denormalize`/`queryKey` paths can ever receive immutable input when (a) only tables are immutable, (b) entity values are also immutable. Known suspects beyond Object/Polymorphic: `Values` (iterates `Object.keys(input)`), `Collection.createIfValid` (spread), `All` (table iteration — `ImmDelegate.getEntities` already returns the Immutable Map, which is iterable-compatible).
-- Deliverable: a table of schema × operation × input-kind, marking which need policy-routed handling and which are already safe. This becomes the Stage 2 test matrix.
-
-### S0.4 `EntityRecord` design spike (feeds Stage 2)
-
-Prototype an Entity mixin whose instances are Immutable Records. Questions that must be answered before committing to an API:
-
-- **Composition**: extend/wrap `EntityMixin` overriding statics (`fromJS`, `createIfValid`, `merge`, `mergeWithStore`, `denormalize`, `validate`, `defaults`), or a parallel mixin sharing helpers? Prefer the smallest override surface that avoids duplicating normalize logic.
-- **Storage shape**: do Record instances go *into* the entity table, or do we normalize to POJOs and only construct Records at denormalize time? Storage shape is public API (snapshot tests, SSR payloads, devtools) — POJO storage is the conservative default and keeps `mergeWithStore` trivial; Record storage would need Record-aware merge and meta handling. Decide with evidence.
-- **Memoization**: `WeakDependencyMap` chains are keyed by entity object identity. Verify referential-stability contracts hold (`toBe` across repeated `MemoCache.denormalize` calls) with Records, including after unrelated store writes.
-- **Immutable dependency**: `immutable` becomes an optional `peerDependency` (with `peerDependenciesMeta.optional`) imported **only** from the `/imm` entry — verify no accidental graph reachability from the main entry. Check whether we need actual imports at all or can stay duck-typed like `ImmutableUtils` does today (types-only import may suffice).
-- **Types**: confirm the `/imm` subpath types pattern (as done in normalizr's `package.json` `exports`) works across the supported TS matrix, and decide whether legacy `typesVersions` (3.4/4.0/4.1) get the export or it's TS ≥5.x-only.
-
-### S0.5 External immutable-store integration reality check (feeds Stage 4)
-
-- Build a minimal Redux + ImmutableJS example driving `MemoCache(ImmPolicy)` + `/imm` `normalize` in a user reducer. Identify exactly which `Controller` reads break when the *outer* state object is immutable (`state.endpoints[key]`, `state.meta[...]`, `GCPolicy` reads).
-- Search issues/discussions for actual demand signal for an immutable *internal* store vs. external-store interop.
-- **Question answered**: is a thin outer-state adapter (fixed keys: `entities`, `endpoints`, `indexes`, `meta`, `entitiesMeta`, `optimistic`, `lastReset`) sufficient for real integrations, making a `@data-client/core/imm` unnecessary?
+**Exit criteria**: no immutable code in main bundles; POJO benches within noise or improved; `/imm` tests green.
 
 ---
 
-## Stage 1 — Evict immutable code from main bundles; consolidate `ImmutableUtils`
+## Track A — Internal store performance
 
-**Depends on**: S0.1, S0.2, S0.3.
+### Stage A0 — Spikes (A0.1 is the go/no-go gate for the whole track)
 
-**Why**: constraints 1–3 are currently violated on the object/polymorphic path; this also creates the seam Stage 2 builds on.
+- **A0.1 — Three-arm store benchmark (gate).** Compare on `core` suite `^set` filters and memory scenarios, at realistic and adversarial sizes (10k+ entities of one type; thousands of `endpoints`/`meta` keys):
+  1. Current POJO tables (lazy per-key clone in `NormalizeDelegate` — already manual structural sharing),
+  2. Immutable Map tables (existing `ImmNormalizeDelegate`),
+  3. Native `Map` tables with the same lazy-clone strategy (no dependency, no leak risk).
 
-Work items:
+  Measure write throughput, read/denormalize-miss overhead (`getIn` vs. property access), allocation churn, and heap deltas (extend `examples/benchmark` with a memory harness or reuse `benchmark-react` heap-delta methodology). **Decision rule**: ImmutableJS proceeds only if it clearly beats arm 3; otherwise arm 3 (or status quo) becomes the deliverable and A3 pivots accordingly.
+- **A0.2 — GC sweep vs. memoization.** The GC reducer mutates in place (`delete state.entities[key][pk]` in `createReducer.ts`) deliberately, preserving table identity so sweeps don't bust `WeakDependencyMap` chains. Immutable `deleteIn` creates a new per-key table map, invalidating memo chains for every entity of that type per sweep. Investigate mitigations (batched sweeps via `withMutations`, GC epochs, accepting and measuring the re-denormalize cost) — outcome feeds the A0.1 decision.
+- **A0.3 — State-read audit → accessor API design.** Enumerate every raw state read outside core reducers: react hooks (`state.endpoints[key]`, `state.meta[key]` bracket reads in `useCache`/`useSuspense`/`useFetch`/`useDLE`/`useQuery`; table refs used as `useMemo` deps are identity-only and already shape-agnostic), `ExternalDataProvider`'s optimistic replay, managers, `packages/ssr`, devtools serialization. Design the minimal `Controller` accessor surface (or state facade) that makes them shape-agnostic.
 
-1. Move the immutable branch of `Object.ts` and `Polymorphic.ts` denormalize (both packages) behind the policy seam chosen in S0.2. POJO policy performs no check; imm policy supplies the immutable-aware implementations.
-2. Consolidate the two drifted `ImmutableUtils.ts` copies into a single implementation, living with the imm policy code (or delete entirely if the policy move subsumes them).
-3. Bundle verification: `yarn ci:build:bundlesize`; assert main entries of normalizr and endpoint contain no `isImmutable`/immutable branches (add a grep-based check to CI if cheap).
-4. Benchmarks: `normalizr` suite `^denormalize` filters, plus the S0.1 microbenchmark as the before/after evidence.
-5. Changeset (likely **breaking** for anyone denormalizing immutable input through the *main* entry — they must switch to `/imm`, same migration shape as the 0.15 `MemoCache` change).
+### Stage A1 — React/Controller accessor refactor (independent, zero user-facing change)
 
-**Exit criteria**: no immutable code in main bundles; POJO benches within noise or improved; existing `/imm` tests green; drift eliminated (one implementation).
+Route the hooks' bracket reads through `Controller` accessors per A0.3. Ships on its own — it's a correctness-neutral decoupling that also benefits any future store representation. No changeset-visible behavior change (internal, but verify no public API shifts; if accessors become public API, document them).
 
-## Stage 2 — `EntityRecord` and `@data-client/endpoint/imm`
+**Exit criteria**: `packages/react` contains no POJO-shape assumptions on state; all Jest projects green; react benchmarks within noise.
 
-**Depends on**: Stage 1 (seam), S0.3 (test matrix), S0.4 (design decisions).
+### Stage A2 — Core store policy seam
 
-**Why**: this is the actual "full support" feature gap — immutable entity *values* are currently corrupt (the committed snapshot proves it).
+Make state-shape-dependent operations in core pluggable via one injected store policy (mirroring `MemoCache(policy)`):
 
-Work items:
+1. `initialState` construction; `setResponseReducer`'s direct POJO `normalize` import → policy-provided normalize/delegate.
+2. Reducer table ops: `endpoints`/`meta` spreads in `setResponseReducer`, `invalidateReducer`, `expireReducer`; the GC branch (per A0.2 outcome).
+3. Reads in `Controller` (`state.endpoints[key]`, `entityExpiresAt` over `state.entitiesMeta`), `selectMeta`, `GCPolicy`.
+4. Serialization hooks for devtools display and `packages/ssr` hydration (toJS/fromJS boundary).
 
-1. Implement `EntityRecord` per the S0.4 design in `packages/endpoint`, exported from a new `/imm` subpath (`package.json` `exports`, build wiring, `yarn build:types`).
-2. `immutable` as optional peer dependency of `@data-client/endpoint` (or stay duck-typed if S0.4 shows imports are unnecessary).
-3. Fix or explicitly reject the mixed case: plain `Entity` classes with deep-immutable stored values. If rejected, `fromJS` should fail loudly in dev rather than silently producing `id: ""` garbage.
-4. Tests: convert the corrupt-Record snapshot into real assertions; re-enable the commented-out denormalize expectations in `immutable.test.ts`; cover the S0.3 matrix (Collection push/unshift, Union discrimination, Values, All) with Record entities; referential-stability `toBe` tests. All three Jest projects (Node, ReactDOM, ReactNative).
-5. Docs in the same PR (see Stage 5 for the guide; API reference for `EntityRecord` lands here per the docs-in-same-PR policy).
-6. Changeset (minor — new feature).
+POJO policy is the default with **zero added indirection cost** (verify on `core` `^set`/`^get` benches, ≤2%).
 
-**Exit criteria**: Record-based entities normalize, merge, and denormalize correctly with memoization intact; zero main-bundle growth; no new peer warnings for non-users.
+**Exit criteria**: default path benchmark-neutral; policy is the single injection point (no scattered conditionals).
 
-## Stage 3 — Remove the fake-immutable fallback from `normalize.imm.ts`
+### Stage A3 — Ship the winning store
 
-**Depends on**: nothing (can run parallel to Stage 2). No spike needed — the design question is small.
+- If **ImmutableJS won A0.1**: `@data-client/core/imm` exporting the immutable store policy; opt-in wiring through `DataProvider`/`CacheProvider`; `immutable` as optional peer of core. Document the `getState()` caveat for manager authors.
+- If **native-Map or status quo won**: land the winner in the main package (no subpath needed — no dependency), write the ADR closing the ImmutableJS internal-store question with benchmark evidence.
 
-Work items:
+Changeset (minor). Docs per docs-in-same-PR policy.
 
-1. Delete `emptyImmutableLike`, `createNestedImmutable`, and `deepClone`; require explicit immutable state (anyone importing `/imm` has `immutable` available) or accept an injected empty-state factory.
-2. Changeset (**breaking** for `/imm` `normalize` callers relying on the implicit default).
-
-**Exit criteria**: `/imm` bundle shrinks; no POJO shim masquerading as immutable state.
-
-## Stage 4 — Core scope decision (ADR) + external-store adapter if warranted
-
-**Depends on**: S0.5.
-
-**Why**: "full support" needs a written boundary, or scope will creep into an immutable internal store that fights the performance goal.
-
-Work items:
-
-1. Write an ADR (this folder): immutable support targets **external stores**; core's internal store stays POJO. Cite GOALS.md performance priorities and S0.5 findings.
-2. If S0.5 showed real integrations need it: ship the thin outer-state adapter (or document the hand-rolled equivalent) so `Controller.getResponse`/`GCPolicy` work against immutable outer state. This should be a few lines per fixed key, not a core rewrite.
-3. Publish the S0.5 example as `examples/` entry or docs snippet.
-
-**Exit criteria**: the boundary is documented and discoverable; the supported integration path has a working, tested example.
-
-## Stage 5 — Verification infrastructure and docs
-
-**Depends on**: Stages 1–2 (content to document and guard).
-
-Work items:
-
-1. **Benchmarks**: add an imm-policy suite to `examples/benchmark` (normalize + memoized denormalize against Immutable tables, and Record entities once Stage 2 lands) plus a POJO-path guard so "zero cost to non-users" is CI-enforced, not asserted. Keep names stable for history.
-2. **Bundle guard**: CI assertion that main entries contain no immutable code (from Stage 1, item 3).
-3. **Version matrix**: decide the supported `immutable` peer range; if it spans v4 and v5, add a CI cell (devDep is pinned 5.1.8 today; `isImmutable` duck-typing (`__ownerID`, `_map`) must be verified against both).
-4. **Docs**: a guide covering the `/imm` entries, `EntityRecord`, the tables-immutable vs. values-immutable contracts, and the Redux+ImmutableJS integration; link from ROADMAP (and mark the roadmap item done). Follow the packages-documentation skill for placement/format.
-
-**Exit criteria**: a regression in bundle size, POJO perf, or immutable correctness fails CI; a new user can integrate from docs alone.
+**Exit criteria**: measured wins on the targeted `^set`/memory benchmarks landed in CI history; react benchmark suite shows no regression; zero user-visible data-shape change.
 
 ---
 
-## Sequencing summary
+## Track B — External `normalizr` + ImmutableJS support
+
+Target user: owns their store (e.g. Redux + Immutable), calls `normalize`/`denormalize`/`MemoCache(ImmPolicy)` directly. Core's internal store is explicitly **not** this track's concern (that's Track A).
+
+### Stage B0 — Spikes
+
+- **B0.1 — `EntityRecord` design.** Prototype an Entity mixin for Immutable Record instances. Decide: composition (override surface on `EntityMixin` statics — `fromJS`, `createIfValid`, `merge`, `mergeWithStore`, `denormalize`, `validate`, `defaults` — vs. parallel mixin); storage shape (Records in the entity table vs. POJO storage + Record construction at denormalize — storage shape is public API per normalizr AGENTS.md; POJO storage is the conservative default); memoization (`toBe` stability with Records across repeated calls and unrelated writes); dependency wiring (`immutable` as optional peer imported only from `/imm`, or stay duck-typed); `/imm` subpath types across the supported TS matrix.
+- **B0.2 — Integration reality check.** Minimal Redux + ImmutableJS example driving the `/imm` APIs in a user reducer. Identify demand signal (issues/discussions) and whether a thin outer-state adapter (fixed keys) is needed for `Controller`-based reads in that context.
+- **B0.3 — Immutable-input surface matrix.** Audit schema `denormalize`/`queryKey` paths receiving immutable input when entity values are also immutable: `Values` (iterates `Object.keys(input)`), `Collection.createIfValid` (spread), Union/Polymorphic discrimination, `All` table iteration. Deliverable: schema × operation × input-kind table → Stage B1 test matrix.
+
+### Stage B1 — `EntityRecord` + `@data-client/endpoint/imm`
+
+1. Implement per B0.1; new `/imm` subpath in `packages/endpoint` (`exports` wiring, `yarn build:types`).
+2. Fix or explicitly reject the mixed case (plain `Entity` with deep-immutable stored values); if rejected, fail loudly in dev instead of silently producing `id: ""` garbage.
+3. Tests: convert the corrupt-Record snapshot into real assertions; re-enable the commented-out expectations in `immutable.test.ts`; cover the B0.3 matrix; referential-stability `toBe` tests; all three Jest projects.
+4. Changeset (minor) + API reference docs in the same PR.
+
+### Stage B2 — Remove the fake-immutable fallback
+
+Delete `emptyImmutableLike`/`createNestedImmutable`/`deepClone` from `normalize.imm.ts`; require explicit immutable state (anyone importing `/imm` has `immutable`). Changeset (**breaking** for `/imm` `normalize` callers relying on the implicit default). Independent — can land any time after F1.
+
+### Stage B3 — Verification + docs
+
+1. imm-policy benchmark suite in `examples/benchmark` (normalize + memoized denormalize on immutable tables; Record entities after B1).
+2. Supported `immutable` version range decision; CI cell for v4 + v5 if the range spans both (`isImmutable` duck-typing against `__ownerID`/`_map` verified on each; devDep pinned 5.1.8 today).
+3. Docs guide: `/imm` entries, `EntityRecord`, tables-immutable vs. values-immutable contracts, Redux+ImmutableJS integration (from B0.2). Mark the ROADMAP item done.
+
+---
+
+## Sequencing
 
 ```
-S0.1 ─┐
-S0.2 ─┼─► Stage 1 ─► Stage 2 ─► Stage 5
-S0.3 ─┘              ▲
-S0.4 ────────────────┘
-S0.5 ─────► Stage 4          Stage 3 (independent, anytime)
+F0.1, F0.2 ──► F1 (shared foundation)
+                │
+   ┌────────────┴────────────┐
+   ▼ Track A                 ▼ Track B
+A0.3 ─► A1 (react accessors) B0.1 ─► B1 (EntityRecord + endpoint/imm)
+A0.1 ─┬► A2 (core seam)      B0.2 ─► B3 (docs, CI matrix)
+A0.2 ─┘   │                  B0.3 ─► B1
+          ▼                  B2 (independent after F1)
+        A3 (ship winner)
 ```
 
-Every stage that touches `packages/*` needs a changeset; Stages 1 and 3 are breaking for `/imm`-adjacent users and should ideally land in the same minor release to consolidate migration cost.
+- A1 and B2 are independent and can land early.
+- A0.1 is the gate: no core immutable work beyond the (shape-agnostic, independently justified) A1/A2 seams until the benchmark verdict is in.
+- Track B has no performance gate — it's a correctness/completeness commitment; scope is bounded by B0.2's demand findings.
+- Breaking changes (F1, B2) should land in the same minor release to consolidate migration cost.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Motivation

ImmutableJS support is partially built (`@data-client/normalizr/imm` with `MemoPolicy`, `normalize`, `denormalize`), but the remaining work spans two different goals that keep getting conflated:

1. Using immutable data structures **inside** the core store as a performance optimization (targeting the spread-heavy `core` `^set` benchmarks and memory scenarios) — where ImmutableJS must never leak to the react layer or user data.
2. Supporting users who drive `@data-client/normalizr` directly against their **own** ImmutableJS stores (Redux + Immutable), where immutable entity values (`EntityRecord`) are the user-facing contract.

There are also concrete known gaps documented in the plan: `isImmutable` checks shipping in the main bundles of normalizr and endpoint (hot-path cost for everyone, contrary to GOALS.md), two already-drifted copies of `ImmutableUtils.ts`, corrupt output when entities are stored as Immutable Records (committed snapshot proves it), and the empty `EntityRecord.ts` stub.

### Solution

Adds `plans/immutablejs-support.md`, a staged plan with:

- **Shared foundation (F1)**: evict immutable code from main bundles behind the existing policy-injection seam; consolidate `ImmutableUtils`. Prerequisite for both tracks.
- **Track A (internal performance)**: gated by a three-arm benchmark spike (POJO lazy-clone vs. Immutable Map tables vs. native `Map` tables) with an explicit decision rule — ImmutableJS only proceeds if it beats the native-Map arm. Includes the react/Controller accessor refactor that makes hooks state-shape-agnostic (independently shippable), the core store-policy seam, and the GC-sweep memoization wrinkle (in-place deletes currently preserve `WeakDependencyMap` chains; `deleteIn` would bust them).
- **Track B (external normalizr support)**: `EntityRecord` design spike and implementation via a new `@data-client/endpoint/imm` subpath, fixing the corrupt-Record behavior, removing the fake-immutable fallback from `normalize.imm.ts`, immutable version-matrix decision, and docs.

Each stage lists the spikes/knowledge-gathering needed before it, dependencies, exit criteria, and changeset expectations, plus a sequencing diagram.

### Open questions

- Track A decision rule: is "clearly beats the native-Map arm" the right bar, or should ImmutableJS also need to justify its optional-peer footprint with a margin?
- Should the breaking changes (F1 main-entry behavior, B2 fallback removal) be batched into one minor release as proposed?
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b9eebdb-7f52-44d1-b69e-576947ddc17f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b9eebdb-7f52-44d1-b69e-576947ddc17f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

