### PR TITLE
internal(website): Responsive Playground layout via container queries

### DIFF
--- a/website/src/components/DiffEditorMonaco.tsx
+++ b/website/src/components/DiffEditorMonaco.tsx
@@ -17,10 +17,6 @@ export default function DiffEditor({
   codeTabs,
   fallback,
 }: DiffMonacoProps) {
-  const { height, handleMount } = useAutoHeight({
-    lineHeight: options.lineHeight,
-  });
-
   const [original, modified] = useMemo(
     () => [
       codes[0].replaceAll(/^\s*\/\/ highlight-(next-line|start|end)\n/gm, ''),
@@ -28,6 +24,12 @@ export default function DiffEditor({
     ],
     [codes],
   );
+
+  const { height, handleMount } = useAutoHeight({
+    initialContentHeight:
+      Math.max(original.split('\n').length, modified.split('\n').length) *
+      options.lineHeight,
+  });
 
   return (
     <>
@@ -38,28 +40,30 @@ export default function DiffEditor({
             return fallback;
           }
           return (
-            <div
-              className={clsx(
-                styles.playgroundContainer,
-                styles.standaloneEditor,
-              )}
-            >
-              <div className={styles.playgroundTextEdit}>
-                <div className={clsx(styles.playgroundEditor)}>
-                  <BaseDiffEditor
-                    language={extensionToMonacoLanguage(codeTabs[0].language)}
-                    original={original}
-                    modified={modified}
-                    options={DIFF_OPTIONS}
-                    onMount={handleMount}
-                    height={height}
-                    theme="prism"
-                    loading={fallback}
-                    // Prevent "TextModel got disposed before DiffEditorWidget model got reset" error
-                    // by not letting @monaco-editor/react manage model disposal
-                    keepCurrentOriginalModel
-                    keepCurrentModifiedModel
-                  />
+            <div className={styles.playgroundQueryContainer}>
+              <div
+                className={clsx(
+                  styles.playgroundContainer,
+                  styles.standaloneEditor,
+                )}
+              >
+                <div className={styles.playgroundTextEdit}>
+                  <div className={styles.playgroundEditor}>
+                    <BaseDiffEditor
+                      language={extensionToMonacoLanguage(codeTabs[0].language)}
+                      original={original}
+                      modified={modified}
+                      options={DIFF_OPTIONS}
+                      onMount={handleMount}
+                      height={height}
+                      theme="prism"
+                      loading={fallback}
+                      // Prevent "TextModel got disposed before DiffEditorWidget model got reset" error
+                      // by not letting @monaco-editor/react manage model disposal
+                      keepCurrentOriginalModel
+                      keepCurrentModifiedModel
+                    />
+                  </div>
                 </div>
               </div>
             </div>

--- a/website/src/components/HTTP/EndpointPlayground.tsx
+++ b/website/src/components/HTTP/EndpointPlayground.tsx
@@ -21,29 +21,33 @@ export default function EndpointPlayground({
   const { handleCodeChange, codes, codeTabs } = useCode(children);
   const realTheme = useReactLiveTheme();
   return (
-    <div
-      className={clsx(
-        playgroundstyles.endpointPlayground,
-        playgroundstyles.playgroundContainer,
-        playgroundstyles.row,
-      )}
-    >
-      <LiveProvider theme={realTheme} enableTypeScript={true}>
-        <PlaygroundTextEdit
-          fixtures={[]}
-          row
-          codeTabs={codeTabs}
-          handleCodeChange={handleCodeChange}
-          codes={codes}
-          isPlayground={false}
-        />
-      </LiveProvider>
+    <div className={playgroundstyles.playgroundQueryContainer}>
+      <div
+        className={clsx(
+          playgroundstyles.endpointPlayground,
+          playgroundstyles.playgroundContainer,
+          playgroundstyles.row,
+        )}
+      >
+        <LiveProvider theme={realTheme} enableTypeScript={true}>
+          <PlaygroundTextEdit
+            fixtures={[]}
+            row
+            codeTabs={codeTabs}
+            handleCodeChange={handleCodeChange}
+            codes={codes}
+            isPlayground={false}
+          />
+        </LiveProvider>
 
-      <div className={clsx(styles.fixtureCol, playgroundstyles.previewWrapper)}>
-        <Request input={input} init={init} />
-        {status ?
-          <Response status={status} response={response} />
-        : null}
+        <div
+          className={clsx(styles.fixtureCol, playgroundstyles.previewWrapper)}
+        >
+          <Request input={input} init={init} />
+          {status ?
+            <Response status={status} response={response} />
+          : null}
+        </div>
       </div>
       <MonacoPreloads />
     </div>

--- a/website/src/components/Playground/PlaygroundMonacoEditor.tsx
+++ b/website/src/components/Playground/PlaygroundMonacoEditor.tsx
@@ -39,54 +39,51 @@ function PlaygroundMonacoEditor({
 }) {
   const editorOptions = useMemo(() => ({ ...options, readOnly }), [readOnly]);
   const { height, handleMount: handleAutoMount } = useAutoHeight({
+    initialContentHeight: code.split('\n').length * editorOptions.lineHeight,
     isFocused,
-    lineHeight: editorOptions.lineHeight,
   });
 
-  const handleMount = useCallback(
-    (editor: Monaco.editor.ICodeEditor, monaco: typeof Monaco) => {
-      // autofocus
-      if (autoFocus) editor.focus();
-      // autohighlight
-      const myhighlights = highlights ? rangeParser(highlights) : undefined;
+  const handleMount = useCallback((editor: Monaco.editor.ICodeEditor) => {
+    // autofocus
+    if (autoFocus) editor.focus();
+    // autohighlight
+    const myhighlights = highlights ? rangeParser(highlights) : undefined;
 
-      if (myhighlights) {
-        let selectionStartLineNumber = myhighlights[0];
-        let positionLineNumber = selectionStartLineNumber;
-        const selections: ISelection[] = [];
-        myhighlights.forEach(lineNumber => {
-          // more of same selection
-          if (lineNumber === positionLineNumber) {
-            positionLineNumber++;
-          } else {
-            selections.push({
-              selectionStartLineNumber,
-              selectionStartColumn: 0,
-              positionLineNumber,
-              positionColumn: 0,
-            });
-            selectionStartLineNumber = lineNumber;
-            positionLineNumber = lineNumber + 1;
-          }
-        });
-        selections.push({
-          selectionStartLineNumber,
-          selectionStartColumn: 0,
-          positionLineNumber,
-          positionColumn: 0,
-        });
-        editor.setSelections(selections);
-      }
-
-      // go to definition
-      editor.onDidFocusEditorText(() => {
-        onFocus(tabIndex);
+    if (myhighlights) {
+      let selectionStartLineNumber = myhighlights[0];
+      let positionLineNumber = selectionStartLineNumber;
+      const selections: ISelection[] = [];
+      myhighlights.forEach(lineNumber => {
+        // more of same selection
+        if (lineNumber === positionLineNumber) {
+          positionLineNumber++;
+        } else {
+          selections.push({
+            selectionStartLineNumber,
+            selectionStartColumn: 0,
+            positionLineNumber,
+            positionColumn: 0,
+          });
+          selectionStartLineNumber = lineNumber;
+          positionLineNumber = lineNumber + 1;
+        }
       });
+      selections.push({
+        selectionStartLineNumber,
+        selectionStartColumn: 0,
+        positionLineNumber,
+        positionColumn: 0,
+      });
+      editor.setSelections(selections);
+    }
 
-      return handleAutoMount(editor, monaco);
-    },
-    [],
-  );
+    // go to definition
+    editor.onDidFocusEditorText(() => {
+      onFocus(tabIndex);
+    });
+
+    handleAutoMount(editor);
+  }, []);
 
   // loading only shows the initial snapshot, so it need not track code changes
   const loading = useMemo(

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -42,24 +42,29 @@ export default function Playground<T>({
   return (
     <>
       <div
-        className={clsx(styles.playgroundContainer, {
-          [styles.row]: row,
+        className={clsx(styles.playgroundQueryContainer, {
           [styles.hidden]: hidden,
         })}
       >
-        <LiveProvider theme={realTheme} enableTypeScript={true} {...props}>
-          <PlaygroundContent
-            reverse={playgroundPosition === 'top'}
-            row={row}
-            fixtures={fixtures}
-            groupId={groupId}
-            defaultOpen={defaultOpen}
-            getInitialInterceptorData={getInitialInterceptorData}
-            defaultTab={defaultTab}
-          >
-            {children}
-          </PlaygroundContent>
-        </LiveProvider>
+        <div
+          className={clsx(styles.playgroundContainer, {
+            [styles.row]: row,
+          })}
+        >
+          <LiveProvider theme={realTheme} enableTypeScript={true} {...props}>
+            <PlaygroundContent
+              reverse={playgroundPosition === 'top'}
+              row={row}
+              fixtures={fixtures}
+              groupId={groupId}
+              defaultOpen={defaultOpen}
+              getInitialInterceptorData={getInitialInterceptorData}
+              defaultTab={defaultTab}
+            >
+              {children}
+            </PlaygroundContent>
+          </LiveProvider>
+        </div>
       </div>
       <MonacoPreloads />
     </>

--- a/website/src/components/Playground/monacoOptions.tsx
+++ b/website/src/components/Playground/monacoOptions.tsx
@@ -15,4 +15,7 @@ export const options = {
     '"Roboto Mono",SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace',
   fontSize: 13,
   lineHeight: 19,
+  // @monaco-editor/react's default; explicit because useAutoHeight's
+  // resize→rewrap→getContentHeight flow depends on it
+  automaticLayout: true,
 } as const;

--- a/website/src/components/Playground/styles.module.css
+++ b/website/src/components/Playground/styles.module.css
@@ -1,5 +1,11 @@
-.playgroundContainer {
+/* Outer wrapper: container queries measure available width (not viewport).
+   Margin lives here so document spacing is unaffected by the flex container. */
+.playgroundQueryContainer {
+  container-type: inline-size;
+  container-name: playground;
   margin-bottom: var(--ifm-leading);
+}
+.playgroundContainer {
   border-radius: var(--ifm-global-radius);
   box-shadow: var(--ifm-global-shadow-lw);
   overflow: visible;
@@ -11,22 +17,15 @@
 .playgroundContainer.standaloneEditor {
   --ifm-code-font-size: 14.4px;
 }
-.playgroundContainer.row.standaloneEditor > :last-child {
-  overflow: visible;
-}
-.playgroundContainer:not(.row).standaloneEditor > :last-child {
+.playgroundContainer.standaloneEditor > :last-child {
   overflow: visible;
 }
 .playgroundContainer .playgroundHeader.tabControls:first-of-type {
   border-top-left-radius: var(--ifm-global-radius);
   overflow: hidden;
 }
-.playgroundContainer.row > :last-child {
-  overflow: hidden;
-  border-top-right-radius: var(--ifm-global-radius);
-  border-bottom-right-radius: var(--ifm-global-radius);
-}
-.playgroundContainer:not(.row) > :last-child {
+/* Stacked (default) radii; side-by-side radii applied in @container below */
+.playgroundContainer > :last-child {
   overflow: hidden;
   border-bottom-left-radius: var(--ifm-global-radius);
   border-bottom-right-radius: var(--ifm-global-radius);
@@ -39,17 +38,16 @@
 
 .playgroundContainer > div {
   flex: 1 1 auto;
-}
-.playgroundContainer > div:first-child {
-  flex: 0 0 65%;
-}
-.playgroundContainer.endpointPlayground > div:first-child {
-  flex: 0 1 50%;
+  min-width: 0;
 }
 .row.playgroundContainer > div:first-child {
   background-color: var(--monoco-code-background);
-  border-bottom-left-radius: var(--ifm-global-radius);
+  border-bottom-left-radius: 0;
   border-top-left-radius: calc(var(--ifm-global-radius) * 2);
+  border-top-right-radius: var(--ifm-global-radius);
+}
+.playgroundContainer.row .playgroundHeader.tabControls:first-of-type {
+  border-top-right-radius: var(--ifm-global-radius);
 }
 
 .playgroundHeader {
@@ -199,7 +197,6 @@ div > .playgroundHeader.subtabs {
   background-color: var(--ifm-color-emphasis-300);
 }
 
-.playgroundContainer.row.hidden,
 .hidden {
   display: none;
 }
@@ -435,43 +432,32 @@ div.fixtureJson {
 }
 
 
-@media only screen and (min-width: 768px) and (max-width: 996px) {
+/* Side-by-side when the playground itself has enough width (docs sidebar
+   no longer forces an incorrect stack on homepage/blog). */
+@container playground (min-width: 720px) {
   .playgroundContainer.row {
     flex-direction: row;
   }
-}
-@media only screen and (max-width: 768px) {
   .playgroundContainer.row > :last-child {
-    border-top-right-radius: 0;
+    border-top-right-radius: var(--ifm-global-radius);
     border-bottom-right-radius: var(--ifm-global-radius);
-    border-bottom-left-radius: var(--ifm-global-radius);
+    border-bottom-left-radius: 0;
+    /* basis 0 — not auto — so preview content cannot steal editor width */
+    flex: 35 1 0;
+    min-width: 16rem;
   }
   .row.playgroundContainer > div:first-child {
-    border-bottom-left-radius: 0;
-    border-top-right-radius: var(--ifm-global-radius);
-
-  }
-  .playgroundContainer .playgroundHeader.tabControls:first-of-type {
-    border-top-right-radius: var(--ifm-global-radius);
-  }
-}
-@media only screen and (min-width: 997px) and (max-width: 1268px) {
-  .playgroundContainer.row > :last-child {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: var(--ifm-global-radius);
     border-bottom-left-radius: var(--ifm-global-radius);
+    border-top-right-radius: 0;
+    flex: 65 1 0;
+    min-width: 16rem;
   }
-  .row.playgroundContainer > div:first-child {
-    border-bottom-left-radius: 0;
-    border-top-right-radius: var(--ifm-global-radius);
-
+  /* div element kept: must out-specify .row's div:first-child 65% rule */
+  .playgroundContainer.endpointPlayground > div:first-child,
+  .playgroundContainer.endpointPlayground > div:last-child {
+    flex: 50 1 0;
   }
-  .playgroundContainer .playgroundHeader.tabControls:first-of-type {
-    border-top-right-radius: var(--ifm-global-radius);
-  }
-}
-@media only screen and (min-width: 1268px) {
-  .playgroundContainer.row {
-    flex-direction: row;
+  .playgroundContainer.row .playgroundHeader.tabControls:first-of-type {
+    border-top-right-radius: 0;
   }
 }

--- a/website/src/components/Playground/useAutoHeight.tsx
+++ b/website/src/components/Playground/useAutoHeight.tsx
@@ -2,97 +2,66 @@ import { type MonacoDiffEditor } from '@monaco-editor/react';
 import type * as Monaco from 'monaco-editor';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-export default function useAutoHeight({
-  isFocused = false,
-  lineHeight,
-  containerGutter = 10,
-}) {
-  const updateHeightRef = useRef<() => void>();
-  useEffect(() => {
-    if (isFocused && updateHeightRef.current) {
-      setTimeout(updateHeightRef.current, 5);
-    }
-  }, [isFocused]);
-
-  const [height, setHeight] = useState<string | number>('1000');
-  const handleMount = useCallback(
-    (
-      editor: Monaco.editor.ICodeEditor | MonacoDiffEditor,
-      monaco: typeof Monaco,
-    ) => {
-      // autoheight
-      const LINE_HEIGHT = lineHeight;
-      const CONTAINER_GUTTER = containerGutter;
-
-      const el = editor.getContainerDomNode();
-      const codeContainers = el.getElementsByClassName('view-lines');
-
-      const model = editor.getModel();
-      let lineCount = 10;
-      if (model) {
-        // before rendering we have no view information, so we initialize based on unwrapped lines
-        lineCount = getLineCount(model);
-      }
-
-      const contentHeight = lineCount * LINE_HEIGHT + CONTAINER_GUTTER;
-      el.style.height = contentHeight + 'px';
-      setHeight(contentHeight);
-
-      editor.layout();
-
-      let prevHeight = contentHeight;
-      updateHeightRef.current = () => {
-        // For diff editors, take max of both sides' line counts
-        const codeContainerCount = Math.max(
-          ...Array.from(codeContainers).map(c => c.childElementCount),
-        );
-        const viewlinecount =
-          editor._modelData?.viewModel?.getLineCount?.() ?? codeContainerCount;
-        const model = editor.getModel();
-        const modellinecount = model ? getLineCount(model) : codeContainerCount;
-        const lineCount =
-          viewlinecount < modellinecount * 3 ? viewlinecount : modellinecount;
-        const height = lineCount * LINE_HEIGHT + CONTAINER_GUTTER; // fold
-        // decorations change often without affecting height; skip the forced
-        // layout and state update when nothing changed
-        if (height === prevHeight) return;
-        prevHeight = height;
-
-        el.style.height = height + 'px';
-        setHeight(height);
-
-        editor.layout();
-      };
-      if ('onDidChangeModelDecorations' in editor) {
-        editor.onDidChangeModelDecorations(() => {
-          // wait until dom rendered
-          setTimeout(updateHeightRef.current, 0);
-        });
-      } else {
-        editor.getOriginalEditor().onDidChangeModelDecorations(() => {
-          // wait until dom rendered
-          setTimeout(updateHeightRef.current, 0);
-        });
-        editor.getModifiedEditor().onDidChangeModelDecorations(() => {
-          // wait until dom rendered
-          setTimeout(updateHeightRef.current, 0);
-        });
-      }
-      return () => editor?.dispose();
-    },
-    [],
-  );
-  return { height, handleMount };
+function isDiffEditor(
+  editor: Monaco.editor.ICodeEditor | MonacoDiffEditor,
+): editor is MonacoDiffEditor {
+  return 'getOriginalEditor' in editor && 'getModifiedEditor' in editor;
 }
 
-function getLineCount(
-  model: Monaco.editor.ITextModel | Monaco.editor.IDiffEditorModel,
-) {
-  if ('original' in model) {
-    return Math.max(
-      model.original.getLineCount(),
-      model.modified.getLineCount(),
-    );
-  }
-  return model.getLineCount();
+export default function useAutoHeight({
+  initialContentHeight,
+  containerGutter = 10,
+  isFocused = true,
+}: {
+  /** Estimate (line count × line height) shown until Monaco measures itself */
+  initialContentHeight: number;
+  containerGutter?: number;
+  /** Re-measure when a previously hidden tab becomes visible */
+  isFocused?: boolean;
+}) {
+  const [height, setHeight] = useState(initialContentHeight + containerGutter);
+
+  const updateHeightRef = useRef<() => void>();
+  useEffect(() => {
+    if (!isFocused || !updateHeightRef.current) return;
+    // Wait a frame so display:none → block layout has applied
+    const id = requestAnimationFrame(() => updateHeightRef.current?.());
+    return () => cancelAnimationFrame(id);
+  }, [isFocused]);
+
+  const disposablesRef = useRef<{ dispose(): void }[]>([]);
+  useEffect(() => () => disposablesRef.current.forEach(d => d.dispose()), []);
+
+  const handleMount = useCallback(
+    (editor: Monaco.editor.ICodeEditor | MonacoDiffEditor) => {
+      const editors =
+        isDiffEditor(editor) ?
+          [editor.getOriginalEditor(), editor.getModifiedEditor()]
+        : [editor];
+      // modified (or sole) editor is the one users interact with
+      const primary = editors[editors.length - 1];
+
+      const updateHeight = () => {
+        // Hidden tabs (display:none) report width 0; a crushed pane during
+        // flex transitions can be nearly as bad — word-wrap invents thousands
+        // of lines. Skip until the editor has a real layout width.
+        if (primary.getLayoutInfo().width < 40) return;
+
+        setHeight(
+          Math.max(...editors.map(e => e.getContentHeight())) + containerGutter,
+        );
+      };
+
+      updateHeightRef.current = updateHeight;
+      updateHeight();
+
+      disposablesRef.current.forEach(d => d.dispose());
+      disposablesRef.current = editors.map(e =>
+        e.onDidContentSizeChange(updateHeight),
+      );
+    },
+    [containerGutter],
+  );
+
+  return { height, handleMount };
 }

--- a/website/src/components/TypeScriptEditor.tsx
+++ b/website/src/components/TypeScriptEditor.tsx
@@ -12,23 +12,19 @@ export default function TypeScriptEditor({ children, row }) {
   const realTheme = useReactLiveTheme();
   return (
     <LiveProvider theme={realTheme} enableTypeScript={true}>
-      <div
-        className={clsx(styles.playgroundContainer, styles.standaloneEditor)}
-      >
-        <PlaygroundTextEdit
-          fixtures={[]}
-          row={
-            row === undefined ?
-              codeTabs.length > 1 ?
-                true
-              : false
-            : row
-          }
-          codeTabs={codeTabs}
-          handleCodeChange={handleCodeChange}
-          codes={codes}
-          isPlayground={false}
-        />
+      <div className={styles.playgroundQueryContainer}>
+        <div
+          className={clsx(styles.playgroundContainer, styles.standaloneEditor)}
+        >
+          <PlaygroundTextEdit
+            fixtures={[]}
+            row={row ?? codeTabs.length > 1}
+            codeTabs={codeTabs}
+            handleCodeChange={handleCodeChange}
+            codes={codes}
+            isPlayground={false}
+          />
+        </div>
       </div>
       <MonacoPreloads />
     </LiveProvider>


### PR DESCRIPTION
## Motivation

Loading a docs page at a width where the Playground preview stacks below the editor and then widening the window left the row layout broken: the editor kept its stale height (computed from the wrapped line count at the old width) so the preview beside it was far too short until a reload.

## Solution

**Monaco sizing** (`useAutoHeight`)
- Height now derives from Monaco's supported `getContentHeight()` + `onDidContentSizeChange` API, replacing DOM `view-lines` counting, private `_modelData` access, and `onDidChangeModelDecorations`/`setTimeout` plumbing. Combined with `automaticLayout` (explicitly stated; it's `@monaco-editor/react`'s default), resize → relayout → rewrap → height update now works in both directions.
- Initial height estimates from the code's line count instead of a 1000px placeholder (removes the load-time layout jump).
- Content-size listeners are disposed on remount/unmount; height updates are skipped while an editor is hidden/crushed (width < 40px) so word wrap can't explode the line count.
- One code path handles regular and diff editors (max of both sides for diffs).

**Layout** (`styles.module.css`)
- Row-vs-stacked is decided by the playground's *own* available width via a single `@container playground (min-width: 720px)` breakpoint, replacing the 768/996/1268 viewport zigzag. This also fixes homepage/blog demos (no sidebar) incorrectly stacking at 997–1267px viewports.
- Each entry point (`Playground`, `EndpointPlayground`, `TypeScriptEditor`, `DiffEditor`) wraps the flex container in a `container-type: inline-size` wrapper, which also carries the document margin and `hidden` handling.
- Editor/preview split is proportional (`65/35`, endpoint `50/50`) with basis 0 and a 16rem preview min-width, so preview content can't steal editor width and neither pane can be crushed just above the breakpoint.
- Duplicated stacked/row border-radius rules consolidated; stacked is the default, row radii applied only inside the container query.
- Misc simplification: dead `.playgroundQueryContainer.hidden` rule removed, `row={row ?? codeTabs.length > 1}`, dropped a single-argument `clsx`.

Website-only change — no changeset needed.

## Verification

- Browser-tested via dev server: narrow→wide resize (the reported bug), wide→narrow, homepage demos side-by-side at ~1100px, EndpointPlayground 50/50, editor height growth while typing, homepage protocol tab switching/hiding.
- `yarn build` (website production build) passes.

Made with [Cursor](https://cursor.com)