### PR TITLE
internal(website): Make typecheck and lint feedback actionable

### DIFF
--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -16,6 +16,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'yarn'
+      - name: Install packages
+        run: ./scripts/ci-install.sh website
+      - name: Build package types
+        run: yarn ci:build:types
+      - name: Typecheck website
+        run: yarn workspace rdc-website typecheck
+
   deploy:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Monorepo for `@data-client` high performance npm packages.
 - `yarn build` - Build all packages
 - `yarn test` - Run tests (Jest projects: ReactDOM, Node, ReactNative)
 - `yarn lint` / `yarn format` - Linting and formatting
-- Website dev: `cd website && yarn start:vscode`
+- Website: `yarn workspace rdc-website typecheck` / `yarn lint --quiet 'website/src/**/*.{ts,tsx}'` / `yarn workspace rdc-website build`; dev: `cd website && yarn start:vscode`
 
 **Test naming**: `*.node.test.ts[x]` (Node), `*.native.test.ts[x]` (RN), `*.test.ts[x]` (regular)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,10 @@ export default [
       '**/node_modules*/*',
       'node_modules/*',
       '**/src-*-types/*',
+      // Playground snippet sources loaded via raw-loader; globals come from Monaco scope
+      'website/src/components/Demo/code/**',
+      // Monaco editor ambient stubs (not application source)
+      'website/src/components/Playground/editor-types/**',
     ],
   },
   {

--- a/website/package.json
+++ b/website/package.json
@@ -7,6 +7,7 @@
     "start:vscode": "run start --no-open",
     "start:prod": "serve build",
     "build": "docusaurus build",
+    "typecheck": "yarn node ../node_modules/typescript/lib/tsc.js --noEmit -p tsconfig.json",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus docs:version",

--- a/website/src/components/AutoPlayVideo.tsx
+++ b/website/src/components/AutoPlayVideo.tsx
@@ -24,8 +24,8 @@ const AutoPlayVideo = ({
       threshold: 0.25, // Play when 25% of the video is visible
     };
 
-    const handleIntersect = entries => {
-      entries.forEach(entry => {
+    const handleIntersect = (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry: IntersectionObserverEntry) => {
         if (entry.isIntersecting) {
           videoElement.play();
         } else {

--- a/website/src/components/Demo/CodeEditor.tsx
+++ b/website/src/components/Demo/CodeEditor.tsx
@@ -1,12 +1,13 @@
-import { FixtureEndpoint } from '@data-client/test';
 import React, { useContext, memo, useRef, forwardRef } from 'react';
+import type { ForwardedRef } from 'react';
 
 import CodeProvider from './CodeProvider';
 import CodeTabContext from './CodeTabContext';
+import type { CodeTabValue } from './CodeTabContext';
 import PlaygroundHeaderControls from './PlaygroundHeaderControls';
 import HooksPlayground from '../HooksPlayground';
 
-function capitalizeFirstLetter(string) {
+function capitalizeFirstLetter(string: string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
@@ -16,7 +17,10 @@ function PlaygroundCode({ children }: PlaygroundCodeProps) {
 }
 
 const DemoPlayground = memo(
-  forwardRef((props, ref: React.RefObject<HTMLDivElement>) => {
+  forwardRef(function DemoPlayground(
+    _props: object,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) {
     const { selectedValue, values } = useContext(CodeTabContext);
 
     return (
@@ -66,13 +70,7 @@ interface PlaygroundCodeProps {
 }
 
 interface Props<T extends string> {
-  codes: {
-    label: string;
-    value: string;
-    code: { code: string; path: string; open?: true }[];
-    autoFocus?: boolean;
-    fixtures?: FixtureEndpoint[];
-  }[];
+  codes: CodeTabValue[];
   defaultValue: T;
 }
 
@@ -80,7 +78,7 @@ export default function CodeEditor<T extends string>({
   codes,
   defaultValue,
 }: Props<T>) {
-  const playgroundRef = useRef();
+  const playgroundRef = useRef<HTMLDivElement>(null);
 
   return (
     <CodeProvider

--- a/website/src/components/Demo/CodeProvider.tsx
+++ b/website/src/components/Demo/CodeProvider.tsx
@@ -10,7 +10,14 @@ interface Props<V extends CodeTabValue[]> {
   groupId?: string | null;
   defaultValue: V[number]['value'];
   children: React.ReactNode;
-  playgroundRef: React.RefObject<HTMLElement>;
+  playgroundRef: React.RefObject<HTMLElement | null>;
+}
+
+function isTabValue<V extends CodeTabValue[]>(
+  values: V,
+  choice: string,
+): choice is V[number]['value'] {
+  return values.some(({ value }) => value === choice);
 }
 
 export function CodeProvider<V extends CodeTabValue[]>({
@@ -30,14 +37,17 @@ export function CodeProvider<V extends CodeTabValue[]>({
   if (
     choice != null &&
     choice !== selectedValue &&
-    values.find(({ value }) => value === choice)
+    isTabValue(values, choice)
   ) {
-    setLocalSelectedValue(choice as any);
+    setLocalSelectedValue(choice);
   }
 
   const setSelectedValue = (newTabValue: string) => {
     if (newTabValue !== selectedValue) {
-      blockElementScrollPositionUntilNextRender(playgroundRef.current);
+      const el = playgroundRef.current;
+      if (el) {
+        blockElementScrollPositionUntilNextRender(el);
+      }
       setLocalSelectedValue(newTabValue as V[number]['value']);
 
       if (groupId != null) {

--- a/website/src/components/Demo/CodeTabContext.ts
+++ b/website/src/components/Demo/CodeTabContext.ts
@@ -1,12 +1,12 @@
-import type { FixtureEndpoint } from '@data-client/test';
+import type { Fixture, Interceptor } from '@data-client/test';
 import { createContext } from 'react';
 
 export interface CodeTabValue {
   label: string;
   value: string;
-  code: { code: string; path: string; open?: true }[];
+  code: { code: string; path: string; open?: boolean }[];
   autoFocus?: boolean;
-  fixtures?: FixtureEndpoint[];
+  fixtures?: (Fixture | Interceptor)[];
   getInitialInterceptorData?: () => unknown;
 }
 

--- a/website/src/components/Demo/code/profile-edit/graphql/index.ts
+++ b/website/src/components/Demo/code/profile-edit/graphql/index.ts
@@ -1,13 +1,52 @@
-import PostItem from '!!raw-loader!./PostItem.tsx';
-import PostList from '!!raw-loader!./PostList.tsx';
-import ProfileEdit from '!!raw-loader!./ProfileEdit.tsx';
-import resources from '!!raw-loader!./resources.ts';
+import type { Interceptor } from '@data-client/test';
 
 import { PostResource, UserResource } from './resources';
 import { POSTS, USERS } from '../../../../../mocks/handlers';
 
 import NewPost from '!!raw-loader!./NewPost.tsx';
 import PostContainer from '!!raw-loader!./PostContainer.tsx';
+import PostItem from '!!raw-loader!./PostItem.tsx';
+import PostList from '!!raw-loader!./PostList.tsx';
+import ProfileEdit from '!!raw-loader!./ProfileEdit.tsx';
+import resources from '!!raw-loader!./resources.ts';
+
+type ProfileEditGraphQLState = {
+  posts: Record<number, (typeof POSTS)[number]>;
+  users: Record<number, (typeof USERS)[number]>;
+};
+
+const fixtures: Interceptor<ProfileEditGraphQLState>[] = [
+  {
+    endpoint: PostResource.getList,
+    response() {
+      return {
+        posts: Object.values(this.posts).map(post => ({
+          ...post,
+          author: this.users[post.userId],
+        })),
+      };
+    },
+    delay: 150,
+  },
+  {
+    endpoint: UserResource.get,
+    response({ id }: Parameters<typeof UserResource.get>[0]) {
+      return { user: this.users[id] };
+    },
+    delay: 150,
+  },
+  {
+    endpoint: UserResource.update,
+    response(user: Parameters<typeof UserResource.update>[0]) {
+      const pk = user.id;
+      this.users[pk] = { ...this.users[pk], ...user };
+      console.log(this.users[pk]);
+      return { updateUser: this.users[pk] };
+    },
+    // TODO: make this higher number when optimistic is enabled
+    delay: 0,
+  },
+];
 
 export default {
   label: 'GraphQL',
@@ -31,39 +70,8 @@ export default {
       code: PostList,
     },
   ],
-  fixtures: [
-    {
-      endpoint: PostResource.getList,
-      response() {
-        return {
-          posts: Object.values(this.posts).map((post: any) => ({
-            ...post,
-            author: this.users[post.userId],
-          })),
-        };
-      },
-      delay: 150,
-    },
-    {
-      endpoint: UserResource.get,
-      response({ id }) {
-        return { user: this.users[id] };
-      },
-      delay: 150,
-    },
-    {
-      endpoint: UserResource.update,
-      response(user) {
-        const pk = user.id;
-        this.users[pk] = { ...this.users[pk], ...user };
-        console.log(this.users[pk]);
-        return { updateUser: this.users[pk] };
-      },
-      // TODO: make this higher number when optimistic is enabled
-      delay: 0,
-    },
-  ],
-  getInitialInterceptorData: () => ({
+  fixtures,
+  getInitialInterceptorData: (): ProfileEditGraphQLState => ({
     posts: Object.fromEntries(POSTS.map(post => [post.id, post])),
     users: Object.fromEntries(USERS.map(user => [user.id, user])),
   }),

--- a/website/src/components/Demo/code/profile-edit/rest/index.ts
+++ b/website/src/components/Demo/code/profile-edit/rest/index.ts
@@ -1,9 +1,48 @@
+import type { Interceptor } from '@data-client/test';
+
+import { PostResource } from './resources';
+
 import PostItem from '!!raw-loader!./PostItem.tsx';
 import PostList from '!!raw-loader!./PostList.tsx';
 import ProfileEdit from '!!raw-loader!./ProfileEdit.tsx';
 import resources from '!!raw-loader!./resources.ts';
 
-import { PostResource } from './resources';
+const fixtures: Interceptor[] = [
+  {
+    endpoint: PostResource.getList,
+    async response(...args: Parameters<typeof PostResource.getList>) {
+      return (await PostResource.getList(...args)).slice(0, 4);
+    },
+  },
+  {
+    endpoint: PostResource.partialUpdate,
+    async response(
+      ...args: Parameters<typeof PostResource.partialUpdate>
+    ) {
+      return {
+        ...(await PostResource.partialUpdate(...args)),
+        id: args?.[0]?.id,
+      };
+    },
+  },
+  {
+    endpoint: PostResource.getList.push,
+    async response(
+      ...args: Parameters<typeof PostResource.getList.push>
+    ) {
+      const lastArg = args[args.length - 1];
+      return {
+        ...(await PostResource.getList.push(...args)),
+        id:
+          typeof lastArg === 'object' &&
+          lastArg !== null &&
+          'id' in lastArg
+            ? (lastArg as { id?: number }).id
+            : undefined,
+      };
+    },
+  },
+];
 
 export default {
   label: 'REST',
@@ -27,30 +66,5 @@ export default {
       code: PostList,
     },
   ],
-  fixtures: [
-    {
-      endpoint: PostResource.getList,
-      async response(...args: any) {
-        return (await PostResource.getList(...args)).slice(0, 4);
-      },
-    },
-    {
-      endpoint: PostResource.partialUpdate,
-      async response(...args: any) {
-        return {
-          ...(await PostResource.partialUpdate(...args)),
-          id: args?.[0]?.id,
-        };
-      },
-    },
-    {
-      endpoint: PostResource.getList.push,
-      async response(...args: any) {
-        return {
-          ...(await PostResource.getList.push(...args)),
-          id: args?.[args.length - 1]?.id,
-        };
-      },
-    },
-  ],
+  fixtures,
 };

--- a/website/src/components/Demo/code/todo-app/graphql/index.ts
+++ b/website/src/components/Demo/code/todo-app/graphql/index.ts
@@ -4,37 +4,45 @@ import TodoList from './TodoList.rawts?raw';
 import TodoStats from './TodoStats.rawts?raw';*/
 
 import { GQLEndpoint } from '@data-client/graphql';
+import type { Interceptor } from '@data-client/test';
+
+import { TodoResource } from './api';
+import { TODOS } from '../../../../../mocks/handlers';
 
 import apiCode from '!!raw-loader!./api.ts';
 import TodoItem from '!!raw-loader!./TodoItem.tsx';
 import TodoList from '!!raw-loader!./TodoList.tsx';
 import TodoStats from '!!raw-loader!./TodoStats.tsx';
 
-import { TodoResource } from './api';
-import { TODOS } from '../../../../../mocks/handlers';
+type TodoGraphQLState = Record<
+  number,
+  (typeof TODOS)[number] & { updatedAt: number }
+>;
+
+const fixtures: Interceptor<TodoGraphQLState>[] = [
+  {
+    endpoint: TodoResource.getList,
+    response() {
+      return { todos: Object.values(this) };
+    },
+    delay: 150,
+  },
+  {
+    endpoint: TodoResource.update,
+    response({ todo }: Parameters<typeof TodoResource.update>[0]) {
+      const pk = todo.id;
+      this[pk] = { ...this[pk], ...todo };
+      return { updateTodo: this[pk] };
+    },
+    delay: 150,
+  },
+];
 
 export default {
   label: 'GraphQL',
   value: 'graphql',
-  fixtures: [
-    {
-      endpoint: TodoResource.getList,
-      response() {
-        return { todos: Object.values(this) };
-      },
-      delay: 150,
-    },
-    {
-      endpoint: TodoResource.update,
-      response({ todo }) {
-        const pk = todo.id;
-        this[pk] = { ...this[pk], ...todo };
-        return { updateTodo: this[pk] };
-      },
-      delay: 150,
-    },
-  ],
-  getInitialInterceptorData: () =>
+  fixtures,
+  getInitialInterceptorData: (): TodoGraphQLState =>
     Object.fromEntries(
       TODOS.map(todo => [
         todo.id,

--- a/website/src/components/Demo/code/todo-app/rest/index.ts
+++ b/website/src/components/Demo/code/todo-app/rest/index.ts
@@ -1,4 +1,7 @@
+import type { Interceptor } from '@data-client/test';
 import { v4 as uuid } from 'uuid';
+
+import { TodoResource, UserResource } from './resources';
 
 import NewTodo from '!!raw-loader!./NewTodo.tsx';
 import resources from '!!raw-loader!./resources.ts';
@@ -6,7 +9,61 @@ import TodoItem from '!!raw-loader!./TodoItem.tsx';
 import TodoList from '!!raw-loader!./TodoList.tsx';
 import UserList from '!!raw-loader!./UserList.tsx';
 
-import { TodoResource, UserResource } from './resources';
+type UserData = Awaited<
+  ReturnType<typeof UserResource.getList>
+>[number];
+
+const fixtures: Interceptor[] = [
+  {
+    endpoint: UserResource.getList,
+    async response(...args: Parameters<typeof UserResource.getList>) {
+      const users = (await UserResource.getList(...args)).slice(0, 2);
+      const todos = await Promise.allSettled(
+        users.map((user: UserData) =>
+          TodoResource.getList({ userId: user.id }),
+        ),
+      );
+      users.forEach((user: UserData, i: number) => {
+        delete user.address;
+        delete user.company;
+        const result = todos[i];
+        user.todos =
+          result.status === 'fulfilled'
+            ? result.value.slice(0, 3)
+            : [];
+      });
+      return users;
+    },
+  },
+  {
+    endpoint: TodoResource.getList,
+    async response(...args: Parameters<typeof TodoResource.getList>) {
+      return (await TodoResource.getList(...args)).slice(0, 7);
+    },
+  },
+  {
+    endpoint: TodoResource.partialUpdate,
+    async response(
+      ...args: Parameters<typeof TodoResource.partialUpdate>
+    ) {
+      return {
+        ...(await TodoResource.partialUpdate(...args)),
+        id: args?.[0]?.id,
+      };
+    },
+  },
+  {
+    endpoint: TodoResource.getList.push,
+    async response(
+      ...args: Parameters<typeof TodoResource.getList.push>
+    ) {
+      return {
+        ...(await TodoResource.getList.push(...args)),
+        id: randomId(),
+      };
+    },
+  },
+];
 
 export default {
   label: 'REST',
@@ -34,52 +91,7 @@ export default {
       code: UserList,
     },
   ],
-  fixtures: [
-    {
-      endpoint: UserResource.getList,
-      async response(...args: any) {
-        const users = (await UserResource.getList(...args)).slice(
-          0,
-          2,
-        );
-        const todos = await Promise.allSettled(
-          users.map(user =>
-            TodoResource.getList({ userId: user.id }),
-          ),
-        );
-        users.forEach((user, i) => {
-          delete user.address;
-          delete user.company;
-          user.todos = todos[i].value.slice(0, 3);
-        });
-        return users;
-      },
-    },
-    {
-      endpoint: TodoResource.getList,
-      async response(...args: any) {
-        return (await TodoResource.getList(...args)).slice(0, 7);
-      },
-    },
-    {
-      endpoint: TodoResource.partialUpdate,
-      async response(...args: any) {
-        return {
-          ...(await TodoResource.partialUpdate(...args)),
-          id: args?.[0]?.id,
-        };
-      },
-    },
-    {
-      endpoint: TodoResource.getList.push,
-      async response(...args: any) {
-        return {
-          ...(await TodoResource.getList.push(...args)),
-          id: randomId(),
-        };
-      },
-    },
-  ],
+  fixtures,
 };
 function randomId() {
   return Number.parseInt(uuid().slice(0, 8), 16);

--- a/website/src/components/Demo/index.tsx
+++ b/website/src/components/Demo/index.tsx
@@ -33,7 +33,7 @@ export default function Demo() {
               </Link>{' '}
               including even the most challenging{' '}
               <Link to="/docs/getting-started/mutations#optimistic-updates">
-                <strike>race conditions</strike>
+                <s>race conditions</s>
               </Link>
               .
             </p>

--- a/website/src/components/Grid.tsx
+++ b/website/src/components/Grid.tsx
@@ -1,15 +1,23 @@
 import clsx from 'clsx';
+import type { ReactElement, ReactNode } from 'react';
 
 import styles from './Grid.module.css';
 
-export default function Grid({ children, cols = 2, wrap = false }) {
+export default function Grid({
+  children,
+  wrap = false,
+}: {
+  children: ReactNode;
+  cols?: number;
+  wrap?: boolean;
+}) {
   return (
     <div className={clsx(styles.grid, { [styles.wrap]: wrap })}>
       {typeof children === 'string' ?
         children
       : Array.isArray(children) ?
         children
-      : children.props.children}
+      : (children as ReactElement<{ children?: ReactNode }>).props.children}
     </div>
   );
 }

--- a/website/src/components/HTTP/Request.tsx
+++ b/website/src/components/HTTP/Request.tsx
@@ -5,7 +5,7 @@ import Header from '../Playground/Header';
 
 export default function Request({ input, init }: Props) {
   let text = `${init.method} ${input}`;
-  Object.entries(init.headers).forEach(([key, value]) => {
+  new Headers(init.headers).forEach((value, key) => {
     text += `\n${key}: ${value}`;
   });
   if (init.body) {

--- a/website/src/components/HomepageFeatures.tsx
+++ b/website/src/components/HomepageFeatures.tsx
@@ -82,20 +82,21 @@ const featureList: FeatureItem[] = [
   },
 ];
 
+function isSvgFeature(feature: FeatureItem): feature is SvgFeature {
+  return 'Svg' in feature && feature.Svg != null;
+}
+
 function Feature(feature: FeatureItem) {
   const { title, description } = feature;
   return (
     <div className={clsx('col col--3')}>
       <div className="text--center">
-        {'Svg' in feature ?
-          <feature.Svg className={styles.featureSvg} alt={title} />
-        : <ThemedImage
-            className={styles.featureSvg}
-            alt={title}
-            sources={{
-              light: useBaseUrl(feature.light),
-              dark: useBaseUrl(feature.dark),
-            }}
+        {isSvgFeature(feature) ?
+          <SvgFeatureIcon Svg={feature.Svg} title={title} />
+        : <ThemedFeatureIcon
+            light={feature.light}
+            dark={feature.dark}
+            title={title}
           />
         }
       </div>
@@ -104,6 +105,31 @@ function Feature(feature: FeatureItem) {
         <p>{description}</p>
       </div>
     </div>
+  );
+}
+
+function SvgFeatureIcon({ Svg, title }: { Svg: SvgComponent; title: string }) {
+  return <Svg className={styles.featureSvg} aria-label={title} />;
+}
+
+function ThemedFeatureIcon({
+  light,
+  dark,
+  title,
+}: {
+  light: string;
+  dark: string;
+  title: string;
+}) {
+  return (
+    <ThemedImage
+      className={styles.featureSvg}
+      alt={title}
+      sources={{
+        light: useBaseUrl(light),
+        dark: useBaseUrl(dark),
+      }}
+    />
   );
 }
 

--- a/website/src/components/Playground/FixturePreview.tsx
+++ b/website/src/components/Playground/FixturePreview.tsx
@@ -45,7 +45,7 @@ function FixtureOrInterceptor({
   fixture,
 }: {
   fixture: FixtureOrInterceptor;
-}): JSX.Element {
+}): ReactElement {
   if ('args' in fixture) {
     return (
       <div

--- a/website/src/components/Playground/Tree.tsx
+++ b/website/src/components/Playground/Tree.tsx
@@ -1,6 +1,6 @@
 import { useColorMode } from '@docusaurus/theme-common';
-import React, { useMemo } from 'react';
-import { JSONTree } from 'react-json-tree';
+import React, { useMemo, type CSSProperties } from 'react';
+import { JSONTree, type KeyPath, type ValueRenderer } from 'react-json-tree';
 
 const valueColorMap = {
   String: 'rgb(195, 232, 141)',
@@ -13,7 +13,7 @@ const valueColorMap = {
   Symbol: 'rgb(247, 140, 108)',
 };
 
-export default function Output({ value }: { value: any }) {
+export default function Output({ value }: { value: unknown }) {
   const isDarkTheme = useColorMode().colorMode === 'dark';
   const theme = useMemo(
     () => ({
@@ -27,7 +27,7 @@ export default function Output({ value }: { value: any }) {
         font: 'var(--ifm-code-font-size) / var(--ifm-pre-line-height) var(--ifm-font-family-monospace) !important',
         color: 'rgb(227, 227, 227)',
       },
-      arrowContainer: ({ style }) => ({
+      arrowContainer: ({ style }: { style: CSSProperties }) => ({
         style: {
           ...style,
           fontFamily: 'arial',
@@ -44,7 +44,10 @@ export default function Output({ value }: { value: any }) {
       itemRange: {
         color: 'rgb(105, 112, 152)',
       },
-      valueText: ({ style }, nodeType: keyof typeof valueColorMap) => ({
+      valueText: (
+        { style }: { style: CSSProperties },
+        nodeType: keyof typeof valueColorMap,
+      ) => ({
         style: {
           ...style,
           color: valueColorMap[nodeType],
@@ -70,9 +73,9 @@ const shouldExpandNode = () => {
   let entityCount = 0;
   let schemaCount = 0;
 
-  return (keyName, data, level) => {
+  return (keyName: KeyPath, _data: unknown, level: number) => {
     if (level === 0) return true;
-    if (level === 1 && ['entities', 'results'].includes(keyName[0]))
+    if (level === 1 && ['entities', 'results'].includes(String(keyName[0])))
       return true;
     if (level === 2 && keyName[1] === 'entities') return schemaCount++ < 2;
     if (level === 2 && keyName[1] === 'results') return true;
@@ -94,11 +97,11 @@ const timeFormatter =
     })
   : undefined;
 
-function valueRenderer(
-  valueAsString: string,
+const valueRenderer: ValueRenderer = (
+  valueAsString: unknown,
   value: unknown,
-  ...keyPath: string[]
-) {
+  ...keyPath: KeyPath
+) => {
   const key = keyPath[0];
   if (
     timeFormatter &&
@@ -109,5 +112,5 @@ function valueRenderer(
   ) {
     return timeFormatter.format(value);
   }
-  return valueAsString;
-}
+  return valueAsString as string;
+};

--- a/website/src/components/Playground/monaco-init.ts
+++ b/website/src/components/Playground/monaco-init.ts
@@ -1,4 +1,5 @@
 import { loader } from '@monaco-editor/react';
+import type * as Monaco from 'monaco-editor';
 
 import { MOBILE_OR_BOT_UA_REGEX } from './isMobileOrBot';
 import { MONACO_CDN_VS } from './MonacoPreloads';
@@ -81,13 +82,20 @@ if (
     });
     // go to definition
     monaco.editor.registerEditorOpener({
-      openCodeEditor(sourceEditor, resource, selectionOrPosition) {
+      openCodeEditor(
+        _sourceEditor: Monaco.editor.ICodeEditor,
+        resource: Monaco.Uri,
+        selectionOrPosition?: Monaco.IRange | Monaco.IPosition,
+      ) {
         if (resource.path.startsWith('/')) {
           // alternatively set model directly in the editor if you have your own tab/navigation implementation\
           const model = monaco.editor.getModel(resource);
           const destinationEditor = monaco.editor
             .getEditors()
-            .find(editor => editor.getModel() === model);
+            .find(
+              (editor: Monaco.editor.ICodeEditor) =>
+                editor.getModel() === model,
+            );
           if (!destinationEditor) return false;
           // focus event is handled by editor to show that tab
           destinationEditor.focus();
@@ -118,7 +126,10 @@ if (
       // These characters should trigger our `provideCompletionItems` function
       triggerCharacters: ["'", '"', '.', '/'],
       // Function which returns a list of autocompletion ietems. If we return an empty array, there won't be any autocompletion.
-      provideCompletionItems: (model, position) => {
+      provideCompletionItems: (
+        model: Monaco.editor.ITextModel,
+        position: Monaco.Position,
+      ) => {
         // Get all the text content before the cursor
         const textUntilPosition = model.getValueInRange({
           startLineNumber: 1,
@@ -147,8 +158,10 @@ if (
           ) {
             const completions = monaco.editor
               .getModels()
-              .map(model => model.uri.path)
-              .map(path => {
+              .map(
+                (editorModel: Monaco.editor.ITextModel) => editorModel.uri.path,
+              )
+              .map((path: string) => {
                 const candidateId = /\/\d+\//g.exec(path)?.[0] ?? '';
                 const file = path.substring(candidateId.length - 1);
                 return {
@@ -160,7 +173,7 @@ if (
                   range,
                 };
               });
-            if (!completions.length) return;
+            if (!completions.length) return { suggestions: [] };
             return { suggestions: completions };
           } else {
             // User is trying to import a dependency
@@ -175,6 +188,7 @@ if (
             };
           }
         }
+        return { suggestions: [] };
       },
     });
   });

--- a/website/src/components/Playground/preview/LivePreview.tsx
+++ b/website/src/components/Playground/preview/LivePreview.tsx
@@ -1,6 +1,7 @@
 import { LiveProvider } from 'react-live';
 
 import { previewScope } from './scope';
+import { usePlaygroundConsoleDemotion } from './usePlaygroundConsoleDemotion';
 import Preview from '../Preview';
 import PreviewWrapper from '../PreviewWrapper';
 import transformCode from '../transformCode';
@@ -18,6 +19,8 @@ export default function LivePreview<T>({
   fixtures,
   getInitialInterceptorData,
 }: LivePreviewProps<T>) {
+  usePlaygroundConsoleDemotion();
+
   return (
     <LiveProvider
       key="preview"

--- a/website/src/components/Playground/preview/usePlaygroundConsoleDemotion.ts
+++ b/website/src/components/Playground/preview/usePlaygroundConsoleDemotion.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+const REACT_BOUNDARY_ERROR =
+  /The above error occurred in the <\w+> component:|React will try to recreate this component tree from scratch using the error boundary you provided/i;
+
+let refCount = 0;
+let originalError: typeof console.error | undefined;
+
+function demotedConsoleError(...args: unknown[]) {
+  const first = args[0];
+  const message =
+    typeof first === 'string' ? first
+    : first instanceof Error ? first.message
+    : '';
+  if (message && REACT_BOUNDARY_ERROR.test(message)) {
+    console.warn(...args);
+    return;
+  }
+  originalError?.apply(console, args);
+}
+
+/** Demote React error-boundary console.error noise while live previews are mounted. */
+export function usePlaygroundConsoleDemotion() {
+  useEffect(() => {
+    if (typeof console === 'undefined') return;
+
+    if (refCount === 0) {
+      originalError = console.error;
+      console.error = demotedConsoleError as typeof console.error;
+    }
+    refCount += 1;
+
+    return () => {
+      refCount -= 1;
+      if (refCount === 0 && originalError) {
+        console.error = originalError;
+        originalError = undefined;
+      }
+    };
+  }, []);
+}

--- a/website/src/components/Playground/resources/PlaceholderBaseResource.ts
+++ b/website/src/components/Playground/resources/PlaceholderBaseResource.ts
@@ -16,13 +16,16 @@ export function createPlaceholderResource<U extends string, S extends Schema>({
 }) {
   const base = resource({ path, schema, Endpoint });
   const partialUpdate = base.partialUpdate.extend({
-    fetch: async function (...args: any) {
+    fetch: async function (
+      this: ThisParameterType<typeof base.partialUpdate>,
+      ...args: Parameters<typeof base.partialUpdate>
+    ) {
       // body only contains what we're changing, but we can find the id in params
       return {
         ...(await base.partialUpdate.call(this, ...args)),
-        id: args[0].id,
+        id: (args[0] as unknown as { id: string | number }).id,
       };
-    },
+    } as typeof base.partialUpdate,
   });
   return {
     ...base,
@@ -33,13 +36,16 @@ export function createPlaceholderResource<U extends string, S extends Schema>({
     // More here: https://dataclient.io/docs/guides/network-transform#case-of-the-missing-id
     partialUpdate,
     create: base.create.extend({
-      fetch: async function (...args: any) {
+      fetch: async function (
+        this: ThisParameterType<typeof base.create>,
+        ...args: Parameters<typeof base.create>
+      ) {
         // body only contains what we're changing, but we can find the id in params
         return {
           ...(await base.create.call(this, ...args)),
-          id: args[args.length - 1].id,
+          id: (args[args.length - 1] as unknown as { id: string | number }).id,
         };
-      },
+      } as typeof base.create,
     }),
-  } as typeof base;
+  } as unknown as typeof base;
 }

--- a/website/src/components/Playground/useAutoHeight.tsx
+++ b/website/src/components/Playground/useAutoHeight.tsx
@@ -21,7 +21,7 @@ export default function useAutoHeight({
 }) {
   const [height, setHeight] = useState(initialContentHeight + containerGutter);
 
-  const updateHeightRef = useRef<() => void>();
+  const updateHeightRef = useRef<(() => void) | undefined>(undefined);
   useEffect(() => {
     if (!isFocused || !updateHeightRef.current) return;
     // Wait a frame so display:none → block layout has applied

--- a/website/src/components/ProtocolTabs.tsx
+++ b/website/src/components/ProtocolTabs.tsx
@@ -1,8 +1,12 @@
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
-import React from 'react';
+import React, { type ReactNode } from 'react';
 
-export default function ProtocolTabs({ children }) {
+export default function ProtocolTabs({
+  children,
+}: {
+  children: [ReactNode, ReactNode];
+}) {
   return (
     <Tabs
       defaultValue="rest"

--- a/website/src/components/StackBlitz.tsx
+++ b/website/src/components/StackBlitz.tsx
@@ -1,4 +1,5 @@
 import Link from '@docusaurus/Link';
+import type { ReactElement } from 'react';
 
 import { isGoogleBot } from './Playground/isMobileOrBot';
 import { useHasIntersected } from './useHasIntersected';
@@ -15,6 +16,18 @@ export default function StackBlitz({
   file,
   ctl = '0',
   initialpath = '',
+}: {
+  app?: string;
+  repo?: string;
+  width?: string;
+  height?: string;
+  hidedevtools?: string;
+  view?: string;
+  terminalHeight?: string;
+  hideNavigation?: string;
+  file: string;
+  ctl?: string;
+  initialpath?: string;
 }) {
   const embed = '1';
   const params = new URLSearchParams({
@@ -35,21 +48,7 @@ export default function StackBlitz({
 
   const [frameRef, hasIntersected] = useHasIntersected<HTMLIFrameElement>();
 
-  /* This was causing CORS issues....we probably don't need anymore since we have the
-  intersection code anyway
-  useEffect(() => {
-    if (!hasIntersected) return;
-    const loadListener = () => {
-      frameRef.current?.contentWindow?.addEventListener('focus', event => {
-        // Stop the propagation of the focus event
-        event.stopPropagation();
-      });
-    };
-    frameRef.current?.addEventListener('load', loadListener);
-    return () => frameRef.current?.removeEventListener('load', loadListener);
-  }, [hasIntersected, frameRef]);*/
-
-  let embedElement: React.ReactElement;
+  let embedElement: ReactElement;
   if (!hasIntersected || isGoogleBot) {
     embedElement = (
       <iframe width={width} height={height} ref={frameRef}></iframe>

--- a/website/src/components/useHasIntersected.tsx
+++ b/website/src/components/useHasIntersected.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-export function useHasIntersected<T>(options: Props = {}) {
+export function useHasIntersected<T extends Element>(options: Props = {}) {
   const { threshold = 0.1, root = null, rootMargin = '0%' } = options;
   const ref = useRef<T>(null);
   const [hasIntersected, setHasIntersected] = useState(false);
 
   useEffect(() => {
-    const node = ref?.current;
+    const node = ref.current;
 
     if (!node || typeof IntersectionObserver !== 'function') {
       return;
@@ -36,6 +36,6 @@ export function useHasIntersected<T>(options: Props = {}) {
 }
 export interface Props {
   threshold?: number;
-  root?: React.ReactElement;
+  root?: Element | Document | null;
   rootMargin?: string;
 }

--- a/website/src/components/useIntersectionObserver.tsx
+++ b/website/src/components/useIntersectionObserver.tsx
@@ -1,12 +1,14 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-export function useIntersectionObserver<T>(options: Props = {}) {
+export function useIntersectionObserver<T extends Element>(
+  options: Props = {},
+) {
   const { threshold = 0.1, root = null, rootMargin = '0%' } = options;
   const ref = useRef<T>(null);
   const [entry, setEntry] = useState<null | IntersectionObserverEntry>(null);
 
   useEffect(() => {
-    const node = ref?.current;
+    const node = ref.current;
 
     if (!node || typeof IntersectionObserver !== 'function') {
       return;
@@ -31,6 +33,6 @@ export function useIntersectionObserver<T>(options: Props = {}) {
 }
 export interface Props {
   threshold?: number;
-  root?: React.ReactElement;
+  root?: Element | Document | null;
   rootMargin?: string;
 }

--- a/website/src/fixtures/kanban.ts
+++ b/website/src/fixtures/kanban.ts
@@ -1,4 +1,15 @@
 import { Entity, resource } from '@data-client/rest';
+import type { Interceptor } from '@data-client/test';
+
+type TaskData = {
+  id: string;
+  title: string;
+  status: string;
+};
+
+type KanbanInterceptorState = {
+  tasks: Record<string, TaskData>;
+};
 
 export class Task extends Entity {
   id = '';
@@ -24,14 +35,17 @@ const initialTasks = {
   '4': { id: '4', title: 'Review PR', status: 'in-progress' },
 };
 
-export const getInitialInterceptorData = () => ({
+export const getInitialInterceptorData = (): KanbanInterceptorState => ({
   tasks: JSON.parse(JSON.stringify(initialTasks)),
 });
 
-export const kanbanFixtures = [
+export const kanbanFixtures: Interceptor<KanbanInterceptorState>[] = [
   {
     endpoint: TaskResource.getList.move,
-    response({ id }: { id: string }, body: any) {
+    response(
+      { id }: Parameters<typeof TaskResource.getList.move>[0],
+      body: Parameters<typeof TaskResource.getList.move>[1],
+    ) {
       if (this.tasks[id]) {
         this.tasks[id] = { ...this.tasks[id], ...body };
       }
@@ -41,8 +55,8 @@ export const kanbanFixtures = [
   },
   {
     endpoint: TaskResource.getList,
-    response({ status }: { status: string }) {
-      return Object.values(this.tasks).filter((t: any) => t.status === status);
+    response({ status }: Parameters<typeof TaskResource.getList>[0]) {
+      return Object.values(this.tasks).filter(t => t.status === status);
     },
     delay: 150,
   },

--- a/website/src/fixtures/posts-collection.ts
+++ b/website/src/fixtures/posts-collection.ts
@@ -1,5 +1,18 @@
 import { Entity, RestEndpoint, Collection } from '@data-client/rest';
+import type { Interceptor } from '@data-client/test';
 import { v4 as uuid } from 'uuid';
+
+type EntityPost = {
+  id: string;
+  title: string;
+  body: string;
+  author: string;
+  group: string;
+};
+
+type PostCollectionInterceptorState = {
+  entities: Record<string | number, Record<string, unknown>>;
+};
 
 class Post extends Entity {
   id = '';
@@ -15,7 +28,7 @@ export const getPosts = new RestEndpoint({
   }),
 });
 
-const entities = {
+const entities: Record<string, EntityPost> = {
   '1': {
     id: '1',
     title: 'Why wait on data we already have?',
@@ -39,14 +52,17 @@ const entities = {
   },
 };
 
-export const getInitialInterceptorData = () => ({ entities: {} });
+export const getInitialInterceptorData =
+  (): PostCollectionInterceptorState => ({
+    entities: {},
+  });
 
 const delay = 150;
 
-export const postFixtures = [
+export const postFixtures: Interceptor<PostCollectionInterceptorState>[] = [
   {
     endpoint: getPosts,
-    response(...args) {
+    response(...args: Parameters<typeof getPosts>) {
       if (args[0]?.author) {
         return Object.values(entities).filter(
           post => post.author === args[0].author,
@@ -58,7 +74,10 @@ export const postFixtures = [
   },
   {
     endpoint: getPosts.push,
-    response({ group }, body) {
+    response(
+      { group }: Parameters<typeof getPosts.push>[0],
+      body: Parameters<typeof getPosts.push>[1],
+    ) {
       const id = randomId();
       this.entities[id] = { id, group };
       const entries =

--- a/website/src/fixtures/posts.ts
+++ b/website/src/fixtures/posts.ts
@@ -1,5 +1,26 @@
 import { Entity, resource } from '@data-client/rest';
+import type { Interceptor } from '@data-client/test';
 import { v4 as uuid } from 'uuid';
+
+type EntityPost = {
+  id: string;
+  title: string;
+  body: string;
+  votes: number;
+  author: number;
+};
+
+type PostInterceptorState = {
+  entities: Record<string | number, Record<string, unknown>>;
+  votes?: Record<string | number, number>;
+};
+
+type PostListParams = NonNullable<
+  Parameters<typeof PostResource.getList>[0]
+> & {
+  page?: number;
+  cursor?: number;
+};
 
 export class User extends Entity {
   id = 0;
@@ -58,7 +79,7 @@ export const PostResource = resource({
   },
 });
 
-const entities = {
+const entities: Record<string, EntityPost> = {
   '1': {
     id: '1',
     title: 'Why wait on data we already have?',
@@ -103,30 +124,34 @@ const entities = {
   },
 };
 
-export const getInitialInterceptorData = () => ({ entities: {} });
+export const getInitialInterceptorData = (): PostInterceptorState => ({
+  entities: {},
+});
 
-export const postFixtures = [
+export const postFixtures: Interceptor<PostInterceptorState>[] = [
   {
     endpoint: PostResource.get,
-    async response({ id }) {
-      const author = await UserResource.get({ id: entities[id].author });
+    async response({ id }: Parameters<typeof PostResource.get>[0]) {
+      const entity = entities[String(id)];
+      const author = await UserResource.get({ id: entity.author });
       return {
+        ...entity,
         id,
         votes: 0,
-        ...entities[id],
         author,
       };
     },
   },
   {
     endpoint: PostResource.getList,
-    async response(...args) {
-      const page = args?.[0]?.page ?? 1;
-      const userId = args?.[0]?.userId;
+    async response(...args: Parameters<typeof PostResource.getList>) {
+      const params = args[0] as PostListParams | undefined;
+      const page = params?.page ?? 1;
+      const userId = params?.userId;
       let posts = Object.values(entities);
       if (userId) {
         posts = Object.values(entities).filter(
-          post => post.author === args[0].userId,
+          post => post.author === params?.userId,
         );
       }
       const PAGE_SIZE = 3;
@@ -159,25 +184,34 @@ export const postFixtures = [
   },
   {
     endpoint: PostResource.vote,
-    response({ id }) {
+    response({ id }: Parameters<typeof PostResource.vote>[0]) {
+      const entity = entities[String(id)];
+      if (!this.votes) this.votes = {};
+      const votes = (this.votes[id] = (this.votes[id] ?? entity.votes) + 1);
       return {
         id,
-        votes: (this.votes[id] = (this.votes[id] ?? entities[id].votes) + 1),
+        votes,
       };
     },
     delay: () => 500 + Math.random() * 4500,
   },
   {
     endpoint: PostResource.update,
-    response({ id }, body) {
+    response(
+      { id }: Parameters<typeof PostResource.update>[0],
+      body: Parameters<typeof PostResource.update>[1],
+    ) {
+      const entity = entities[String(id)];
       this.entities[id] = {
+        ...entity,
+        ...(body instanceof FormData ? {} : body),
         id,
         votes: 0,
-        ...entities[id],
-        ...body,
       };
-      for (const [key, value] of body.entries()) {
-        this.entities[id][key] = value;
+      if (body instanceof FormData) {
+        for (const [key, value] of body.entries()) {
+          this.entities[id][key] = value;
+        }
       }
       return this.entities[id];
     },
@@ -185,10 +219,12 @@ export const postFixtures = [
   },
   {
     endpoint: PostResource.getList.push,
-    response(body) {
+    response(body: Parameters<typeof PostResource.getList.push>[0]) {
       const id = randomId();
       this.entities[id] = { id, author: 1 };
-      for (const [key, value] of body.entries()) {
+      const entries =
+        body instanceof FormData ? body.entries() : Object.entries(body);
+      for (const [key, value] of entries) {
         this.entities[id][key] = value;
       }
       return this.entities[id];
@@ -197,16 +233,17 @@ export const postFixtures = [
   },
 ];
 
-export const postPaginatedFixtures = [
+export const postPaginatedFixtures: Interceptor<PostInterceptorState>[] = [
   {
     endpoint: PostResource.getList,
-    async response(...args) {
-      const cursor = args?.[0]?.cursor ?? 1;
-      const userId = args?.[0]?.userId;
+    async response(...args: Parameters<typeof PostResource.getList>) {
+      const params = args[0] as PostListParams | undefined;
+      const cursor = params?.cursor ?? 1;
+      const userId = params?.userId;
       let posts = Object.values(entities);
       if (userId) {
         posts = Object.values(entities).filter(
-          post => post.author === args[0].userId,
+          post => post.author === params?.userId,
         );
       }
       const PAGE_SIZE = 3;
@@ -234,8 +271,9 @@ export const postPaginatedFixtures = [
         cursor: cursor + 1,
       };
     },
-    delay: (...args) => {
-      return args?.[0]?.cursor ? 200 : 0;
+    delay: (...args: Parameters<typeof PostResource.getList>) => {
+      const params = args[0] as PostListParams | undefined;
+      return params?.cursor ? 200 : 0;
     },
   },
 ];

--- a/website/src/fixtures/todos.ts
+++ b/website/src/fixtures/todos.ts
@@ -1,4 +1,5 @@
 import { Entity, Collection, resource } from '@data-client/rest';
+import type { Interceptor } from '@data-client/test';
 import { v4 as uuid } from 'uuid';
 
 export class Todo extends Entity {
@@ -46,22 +47,22 @@ export const UserResource = resource({
   optimistic: true,
 });
 
-export const todoFixtures = [
+export const todoFixtures: Interceptor[] = [
   {
     endpoint: UserResource.getList,
-    async response(...args: any) {
+    async response(...args: Parameters<typeof UserResource.getList>) {
       return (await UserResource.getList(...args)).slice(0, 3);
     },
   },
   {
     endpoint: TodoResource.getList,
-    async response(...args: any) {
+    async response(...args: Parameters<typeof TodoResource.getList>) {
       return (await TodoResource.getList(...args)).slice(0, 7);
     },
   },
   {
     endpoint: TodoResource.partialUpdate,
-    async response(...args: any) {
+    async response(...args: Parameters<typeof TodoResource.partialUpdate>) {
       return {
         ...(await TodoResource.partialUpdate(...args)),
         id: args?.[0]?.id,
@@ -70,7 +71,7 @@ export const todoFixtures = [
   },
   {
     endpoint: TodoResource.getList.push,
-    async response(...args: any) {
+    async response(...args: Parameters<typeof TodoResource.getList.push>) {
       //await new Promise(resolve => setTimeout(resolve, 500));
       return {
         ...(await TodoResource.getList.push(...args)),

--- a/website/src/gtag.js.ts
+++ b/website/src/gtag.js.ts
@@ -1,0 +1,19 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    installedCssChunks?: Record<string, unknown>;
+  }
+}
+
+if (ExecutionEnvironment.canUseDOM) {
+  // compensate for bug in docusaurus 3 devmode
+  if (!window.gtag) {
+    window.gtag = (...args: unknown[]) => {
+      console.info(args);
+    };
+  }
+  // fix devmode webpack bug
+  if (!('installedCssChunks' in window)) window.installedCssChunks = {};
+}

--- a/website/src/theme/BlogPostPage/Metadata/index.tsx
+++ b/website/src/theme/BlogPostPage/Metadata/index.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 type Props = WrapperProps<typeof MetadataType>;
 
-export default function MetadataWrapper(props: Props): JSX.Element {
+export default function MetadataWrapper(props: Props): React.ReactElement {
   const { assets, metadata } = useBlogPost();
   const { frontMatter } = metadata;
 

--- a/website/src/theme/DocItem/Metadata/index.tsx
+++ b/website/src/theme/DocItem/Metadata/index.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 type Props = WrapperProps<typeof MetadataType>;
 
-export default function MetadataWrapper(props: Props): JSX.Element {
+export default function MetadataWrapper(props: Props): React.ReactElement {
   const { metadata, assets, frontMatter } = useDoc();
   const image = assets.image ?? frontMatter.image;
   let { title } = metadata;

--- a/website/src/theme/MDXPage/index.tsx
+++ b/website/src/theme/MDXPage/index.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 type Props = WrapperProps<typeof MDXPageType>;
 
-export default function MDXPageWrapper(props: Props): JSX.Element {
+export default function MDXPageWrapper(props: Props): React.ReactElement {
   const { assets, frontMatter } = useDoc();
   const image = assets.image ?? frontMatter.image;
   return (

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,3 +1,5 @@
-export default function Root({ children }) {
+import type { ReactNode } from 'react';
+
+export default function Root({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }

--- a/website/src/types/raw-loader.d.ts
+++ b/website/src/types/raw-loader.d.ts
@@ -1,0 +1,9 @@
+declare module '!!raw-loader!*' {
+  const content: string;
+  export default content;
+}
+
+declare module '!!raw-loader?*' {
+  const content: string;
+  export default content;
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -2,8 +2,10 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "lib": ["dom", "esnext"],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "ignoreDeprecations": "6.0"
   },
   "extends": "@tsconfig/docusaurus/tsconfig.json",
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/components/Demo/code/**"]
 }


### PR DESCRIPTION
## Summary
- Makes `yarn workspace rdc-website typecheck` a trustworthy green signal by excluding raw-loader playground snippets, adding `raw-loader` typings, and fixing the real website TypeScript baseline (~228 noisy errors → 0).
- Adds a path-scoped GitHub Actions typecheck job on website/docs PRs, documents the canonical validation commands in `AGENTS.md`, and ignores Demo snippet / Monaco stub sources in ESLint.
- Replaces the removed global `console.error = console.warn` monkeypatch with a reference-counted, filtered demotion in LivePreview so only React error-boundary playground noise is demoted.

## Test plan
- [ ] `yarn workspace rdc-website typecheck` exits 0
- [ ] `yarn lint --quiet 'website/src/**/*.{ts,tsx}'` exits 0
- [ ] Confirm site-preview workflow `typecheck` job runs on website path changes
- [ ] Browser-check a failing playground: React boundary diagnostic appears as a warning
- [ ] Browser-check an unrelated `console.error` still shows as an error


Made with [Cursor](https://cursor.com)