### PR TITLE
internal: Run GitHub Actions on Node 26

### DIFF
--- a/.github/workflows/benchmark-react.yml
+++ b/.github/workflows/benchmark-react.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '26'
           cache: 'yarn'
       - name: Install packages
         run: ./scripts/ci-install.sh examples/benchmark-react

--- a/.github/workflows/benchmark-spread.yml
+++ b/.github/workflows/benchmark-spread.yml
@@ -47,7 +47,7 @@ jobs:
         fetch-depth: 1
     - uses: actions/setup-node@v6
       with:
-        node-version: '24'
+        node-version: '26'
         cache: 'yarn'
     - name: Install packages
       run: ./scripts/ci-install.sh examples/benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,7 +38,7 @@ jobs:
         fetch-depth: 1
     - uses: actions/setup-node@v6
       with:
-        node-version: '24'
+        node-version: '26'
         cache: 'yarn'
     - name: Install packages
       run: ./scripts/ci-install.sh examples/benchmark

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '26'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
       - name: Install packages

--- a/.github/workflows/bundle_size.yml
+++ b/.github/workflows/bundle_size.yml
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 2
     - uses: actions/setup-node@v6
       with:
-        node-version: '24'
+        node-version: '26'
         cache: 'yarn'
     - name: Install packages
       run: ./scripts/ci-install.sh examples/test-bundlesize

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '26'
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
       - name: Install packages

--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '26'
           cache: 'yarn'
       - name: Install packages
         run: ./scripts/ci-install.sh website


### PR DESCRIPTION
## Summary
- Bump all GitHub Actions `setup-node` pins from Node 24 → 26
- Aligns with CircleCI (`cimg/node:26.5`) and `.nvmrc`

## Test plan
- [ ] Confirm workflows start and install successfully on Node 26 (benchmark / bundle size / site preview as applicable)
- [ ] Spot-check that release/beta-release still resolve Node correctly on next publish path


Made with [Cursor](https://cursor.com)