### PR TITLE
fix(website): Clear docs hydration errors and playground console noise

### DIFF
--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -667,7 +667,7 @@ groupId="Demos"
 </TabItem>
 </Tabs>
 
-<p style={{textAlign: 'center'}}>
+<div style={{ textAlign: 'center' }}>
 <Link className="button button--secondary" to="/demos">More Demos</Link>&nbsp;
 <Link className="button button--secondary" to="https://skills.sh/reactive/data-client"><img src="/img/anthropic.svg" alt="Agent Skills" style={{
           height: '1em',
@@ -675,4 +675,4 @@ groupId="Demos"
           display: 'inline',
         }}
 /> Agent Skills</Link>
-</p>
+</div>

--- a/docs/core/api/useSuspense.md
+++ b/docs/core/api/useSuspense.md
@@ -21,8 +21,10 @@ import { detailFixtures, listFixtures } from '@site/src/fixtures/profiles';
 
 # useSuspense()
 
-<p class="tagline">
-High performance async data rendering without overfetching.
+<p className="tagline">
+  {
+    'High performance async data rendering without overfetching.'
+  }
 </p>
 
 `useSuspense()` is like [await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) for React components. This means the remainder of the component only runs after the data has loaded, avoiding the complexity of handling loading and error conditions. Instead, fallback handling is

--- a/docs/core/getting-started/resource.md
+++ b/docs/core/getting-started/resource.md
@@ -37,8 +37,7 @@ values={[
 
 <PkgInstall pkgs="@data-client/rest" />
 
-<p>
-<center>
+<div style={{ textAlign: 'center' }}>
 <Link className="button button--secondary button--sm" to="https://chatgpt.com/g/g-682609591fe48191a6850901521b4e4b-typescript-rest-codegen"><img src="/img/gpt.svg" alt="Codegen GPT" style={{
           height: '1em',
           verticalAlign: '-0.125em',
@@ -51,8 +50,7 @@ values={[
           display: 'inline',          // Inline with text
         }}
 /> Skills</Link>
-</center>
-</p>
+</div>
 
 
 

--- a/docs/core/shared/_installation.mdx
+++ b/docs/core/shared/_installation.mdx
@@ -53,9 +53,9 @@ Alternatively [integrate state with redux](../guides/redux.md)
 
 <TabItem value="nextjs">
 
-<p style={{ textAlign: 'center' }}>
+<div style={{ textAlign: 'center' }}>
   <Link className="button button--primary" to="../guides/ssr#nextjs">Full NextJS Guide</Link>
-</p>
+</div>
 
 ```tsx title="app/layout.tsx"
 // highlight-next-line

--- a/docs/graphql/README.md
+++ b/docs/graphql/README.md
@@ -139,7 +139,7 @@ suspends.
 import { GQLEndpoint, GQLEntity } from '@data-client/graphql';
 
 const gql = new GQLEndpoint(
-  'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  'https://swapi-graphql.netlify.app/graphql',
 );
 class Person extends GQLEntity {
   readonly id: string = '';
@@ -198,7 +198,7 @@ import { useController } from '@data-client/react';
 import { GQLEndpoint, GQLEntity } from '@data-client/graphql';
 
 const gql = new GQLEndpoint(
-  'https://swapi-graphql.netlify.app/.netlify/functions/index',
+  'https://swapi-graphql.netlify.app/graphql',
 );
 
 class Review extends GQLEntity {

--- a/docs/rest/README.md
+++ b/docs/rest/README.md
@@ -346,16 +346,14 @@ import SkillTabs from '@site/src/components/SkillTabs';
 
 Then call `/data-client-rest-setup` to migrate
 
-<p>
-<center>
+<div style={{ textAlign: 'center' }}>
 <Link className="button button--secondary button--sm" to="https://skills.sh/reactive/data-client/data-client-rest"><img src="/img/anthropic.svg" alt="REST Codegen Skill" style={{
           height: '1em',
           verticalAlign: '-0.125em',
           display: 'inline',
         }}
 /> REST Codegen Skill</Link>
-</center>
-</p>
+</div>
 
 ### Migrating from Axios
 

--- a/website/blog/2024-06-17-v0.13-nextjs-app-router-expogo-native.md
+++ b/website/blog/2024-06-17-v0.13-nextjs-app-router-expogo-native.md
@@ -112,9 +112,9 @@ export default function RootLayout({ children }) {
 }
 ```
 
-<p style={{ textAlign: 'center' }}>
+<div style={{ textAlign: 'center' }}>
   <Link className="button button--primary" to="/docs/guides/ssr#nextjs">Full NextJS Guide</Link>
-</p>
+</div>
 
 #### Mutations demo
 

--- a/website/blog/2026-01-06-v0.15-vue-support-collection-remove.md
+++ b/website/blog/2026-01-06-v0.15-vue-support-collection-remove.md
@@ -110,9 +110,9 @@ app.use(MockPlugin, {
 });
 ```
 
-<p style={{ textAlign: 'center' }}>
+<div style={{ textAlign: 'center' }}>
   <Link className="button button--primary" to="/docs/getting-started/agent-skills">Getting Started Guide</Link>
-</p>
+</div>
 
 ## Collection.remove
 

--- a/website/src/components/Playground/preview/usePlaygroundConsoleDemotion.ts
+++ b/website/src/components/Playground/preview/usePlaygroundConsoleDemotion.ts
@@ -1,13 +1,30 @@
 import { useEffect } from 'react';
 
-/** React error-boundary console.error noise from live preview failures. */
+/**
+ * Playground console demotion — third-party noise only.
+ *
+ * Live previews pull in packages we do not own (react-live, React's reaction to
+ * react-live's ErrorBoundary, sucrase's classic JSX). Those emit development
+ * console noise that is expected during demos and is safe to demote/suppress.
+ *
+ * Do NOT add matchers for anything we control and should fix instead:
+ * - `@data-client/*` packages
+ * - First-party website / docs / demo code (non-package sources in this repo)
+ *
+ * If a playground surfaces a real library or site bug, fix the source — never
+ * paper over it here.
+ */
+
+/** react-live / React ErrorBoundary follow-ups (not @data-client). → warn */
 const DEMOTE_ERROR = [
+  // React after a preview throw caught by react-live's ErrorBoundary
   /The above error occurred in the <[^>]+> component:/,
   /React will try to recreate this component tree/,
+  // react-live's ErrorBoundary only implements componentDidCatch
   /Error boundaries should implement getDerivedStateFromError\(\)/,
 ];
 
-/** Exact React 19 development warning from classic JSX (react-live/sucrase). */
+/** react-live → sucrase classic JSX (emits __self). Not our transform. → drop */
 const DEMOTE_WARN = [
   /Your app \(or one of its dependencies\) is using an outdated JSX transform/,
 ];
@@ -48,7 +65,7 @@ function demotedConsoleWarn(...args: unknown[]) {
   originalWarn?.apply(console, args);
 }
 
-/** Demote known react-live / React preview console noise while live previews are mounted. */
+/** Demote third-party react-live / React preview console noise while previews are mounted. */
 export function usePlaygroundConsoleDemotion() {
   useEffect(() => {
     if (typeof console === 'undefined') return;

--- a/website/src/components/Playground/preview/usePlaygroundConsoleDemotion.ts
+++ b/website/src/components/Playground/preview/usePlaygroundConsoleDemotion.ts
@@ -1,40 +1,77 @@
 import { useEffect } from 'react';
 
-const REACT_BOUNDARY_ERROR =
-  /The above error occurred in the <\w+> component:|React will try to recreate this component tree from scratch using the error boundary you provided/i;
+/** React error-boundary console.error noise from live preview failures. */
+const DEMOTE_ERROR = [
+  /The above error occurred in the <[^>]+> component:/,
+  /React will try to recreate this component tree/,
+  /Error boundaries should implement getDerivedStateFromError\(\)/,
+];
+
+/** Exact React 19 development warning from classic JSX (react-live/sucrase). */
+const DEMOTE_WARN = [
+  /Your app \(or one of its dependencies\) is using an outdated JSX transform/,
+];
 
 let refCount = 0;
 let originalError: typeof console.error | undefined;
+let originalWarn: typeof console.warn | undefined;
+
+/** Flatten console args the way React 19 may pass them (format string + Error). */
+function consoleMessage(args: unknown[]): string {
+  return args
+    .map(arg => {
+      if (typeof arg === 'string') return arg;
+      if (arg instanceof Error) return arg.message;
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function shouldDemoteConsole(args: unknown[], patterns: RegExp[]): boolean {
+  const message = consoleMessage(args);
+  return Boolean(message) && patterns.some(pattern => pattern.test(message));
+}
 
 function demotedConsoleError(...args: unknown[]) {
-  const first = args[0];
-  const message =
-    typeof first === 'string' ? first
-    : first instanceof Error ? first.message
-    : '';
-  if (message && REACT_BOUNDARY_ERROR.test(message)) {
+  if (shouldDemoteConsole(args, DEMOTE_ERROR)) {
     console.warn(...args);
     return;
   }
   originalError?.apply(console, args);
 }
 
-/** Demote React error-boundary console.error noise while live previews are mounted. */
+function demotedConsoleWarn(...args: unknown[]) {
+  if (shouldDemoteConsole(args, DEMOTE_WARN)) {
+    return;
+  }
+  originalWarn?.apply(console, args);
+}
+
+/** Demote known react-live / React preview console noise while live previews are mounted. */
 export function usePlaygroundConsoleDemotion() {
   useEffect(() => {
     if (typeof console === 'undefined') return;
 
     if (refCount === 0) {
       originalError = console.error;
+      originalWarn = console.warn;
       console.error = demotedConsoleError as typeof console.error;
+      console.warn = demotedConsoleWarn as typeof console.warn;
     }
     refCount += 1;
 
     return () => {
       refCount -= 1;
-      if (refCount === 0 && originalError) {
-        console.error = originalError;
-        originalError = undefined;
+      if (refCount === 0) {
+        if (originalError) {
+          console.error = originalError;
+          originalError = undefined;
+        }
+        if (originalWarn) {
+          console.warn = originalWarn;
+          originalWarn = undefined;
+        }
       }
     };
   }, []);


### PR DESCRIPTION
## Summary
- Fix MDX hydration errors from nested `<p>`, invalid `class`, and `<p><center>` markup on docs/blog pages
- Update GraphQL SWAPI demo endpoint to `https://swapi-graphql.netlify.app/graphql` (old URL 301’d without CORS)
- Harden playground console demotion for React 19 arg shapes, react-live ErrorBoundary noise, and the classic JSX transform warning

## Test plan
- [ ] `/docs`, `/docs/api/useSuspense`, `/rest` — no hydration / invalid DOM property console errors
- [ ] `/graphql` — expand SWAPI Demo; preview shows people; network POST to `/graphql` returns 200 with no CORS errors
- [ ] Homepage playgrounds — no “outdated JSX transform” warn; unrelated console errors still appear
- [ ] Unmount playgrounds (navigate away) — `console.error` / `console.warn` restored


Made with [Cursor](https://cursor.com)