### PR TITLE
perf(website): Defer Demo playground hydration without SSG code loss

### DIFF
--- a/website/src/components/Demo/CodeEditor.tsx
+++ b/website/src/components/Demo/CodeEditor.tsx
@@ -22,39 +22,40 @@ const DemoPlayground = memo(
     ref: ForwardedRef<HTMLDivElement>,
   ) {
     const { selectedValue, values } = useContext(CodeTabContext);
-    // One sandbox only — hidden siblings still mounted Monaco + DataProvider.
-    const selected =
-      values.find(value => value.value === selectedValue) ?? values[0];
-    const {
-      value,
-      code,
-      fixtures,
-      getInitialInterceptorData,
-      autoFocus = false,
-    } = selected;
 
     return (
       <div ref={ref}>
-        <HooksPlayground
-          groupId="homepage-demo"
-          row
-          key={value}
-          fixtures={fixtures}
-          getInitialInterceptorData={getInitialInterceptorData}
-          headerControls={<PlaygroundHeaderControls />}
-        >
-          {code.map(({ path, code: instanceCode, open }, i) => (
-            <PlaygroundCode
-              key={path}
-              title={capitalizeFirstLetter(path)}
-              path={`${value}/${path}.tsx`}
-              collapsed={!open}
-              autoFocus={autoFocus && code.length === i + 1}
+        {values.map(
+          ({
+            value,
+            code,
+            fixtures,
+            getInitialInterceptorData,
+            autoFocus = false,
+          }) => (
+            <HooksPlayground
+              groupId="homepage-demo"
+              row
+              key={value}
+              hidden={value !== selectedValue}
+              fixtures={fixtures}
+              getInitialInterceptorData={getInitialInterceptorData}
+              headerControls={<PlaygroundHeaderControls />}
             >
-              {instanceCode}
-            </PlaygroundCode>
-          ))}
-        </HooksPlayground>
+              {code.map(({ path, code: instanceCode, open }, i) => (
+                <PlaygroundCode
+                  key={path}
+                  title={capitalizeFirstLetter(path)}
+                  path={`${value}/${path}.tsx`}
+                  collapsed={!open}
+                  autoFocus={autoFocus && code.length === i + 1}
+                >
+                  {instanceCode}
+                </PlaygroundCode>
+              ))}
+            </HooksPlayground>
+          ),
+        )}
       </div>
     );
   }),

--- a/website/src/components/Demo/CodeEditor.tsx
+++ b/website/src/components/Demo/CodeEditor.tsx
@@ -22,40 +22,39 @@ const DemoPlayground = memo(
     ref: ForwardedRef<HTMLDivElement>,
   ) {
     const { selectedValue, values } = useContext(CodeTabContext);
+    // One sandbox only — hidden siblings still mounted Monaco + DataProvider.
+    const selected =
+      values.find(value => value.value === selectedValue) ?? values[0];
+    const {
+      value,
+      code,
+      fixtures,
+      getInitialInterceptorData,
+      autoFocus = false,
+    } = selected;
 
     return (
       <div ref={ref}>
-        {values.map(
-          ({
-            value,
-            code,
-            fixtures,
-            getInitialInterceptorData,
-            autoFocus = false,
-          }) => (
-            <HooksPlayground
-              groupId="homepage-demo"
-              row
-              key={value}
-              hidden={value !== selectedValue}
-              fixtures={fixtures}
-              getInitialInterceptorData={getInitialInterceptorData}
-              headerControls={<PlaygroundHeaderControls />}
+        <HooksPlayground
+          groupId="homepage-demo"
+          row
+          key={value}
+          fixtures={fixtures}
+          getInitialInterceptorData={getInitialInterceptorData}
+          headerControls={<PlaygroundHeaderControls />}
+        >
+          {code.map(({ path, code: instanceCode, open }, i) => (
+            <PlaygroundCode
+              key={path}
+              title={capitalizeFirstLetter(path)}
+              path={`${value}/${path}.tsx`}
+              collapsed={!open}
+              autoFocus={autoFocus && code.length === i + 1}
             >
-              {code.map(({ path, code: instanceCode, open }, i) => (
-                <PlaygroundCode
-                  key={path}
-                  title={capitalizeFirstLetter(path)}
-                  path={`${value}/${path}.tsx`}
-                  collapsed={!open}
-                  autoFocus={autoFocus && Object.values(code).length === i + 1}
-                >
-                  {instanceCode}
-                </PlaygroundCode>
-              ))}
-            </HooksPlayground>
-          ),
-        )}
+              {instanceCode}
+            </PlaygroundCode>
+          ))}
+        </HooksPlayground>
       </div>
     );
   }),

--- a/website/src/components/Demo/CodeProvider.tsx
+++ b/website/src/components/Demo/CodeProvider.tsx
@@ -1,4 +1,5 @@
 import { useScrollPositionBlocker } from '@docusaurus/theme-common/internal';
+import useIsomorphicLayoutEffect from '@docusaurus/useIsomorphicLayoutEffect';
 import React, { memo, useState } from 'react';
 
 import CodeTabContext from './CodeTabContext';
@@ -27,39 +28,32 @@ export function CodeProvider<V extends CodeTabValue[]>({
   playgroundRef,
   children,
 }: Props<V>) {
-  const [choice, setTabGroupChoice] = useTabStorage(
-    `docusaurus.tab.${groupId}`,
-  );
-  const [selectedValue, setLocalSelectedValue] = useState(defaultValue);
+  const [choice, setTabGroupChoice] = useTabStorage(groupId);
+  const [selectedValue, setSelectedValue] = useState(defaultValue);
   const { blockElementScrollPositionUntilNextRender } =
     useScrollPositionBlocker();
 
-  if (
-    choice != null &&
-    choice !== selectedValue &&
-    isTabValue(values, choice)
-  ) {
-    setLocalSelectedValue(choice);
-  }
-
-  const setSelectedValue = (newTabValue: string) => {
-    if (newTabValue !== selectedValue) {
-      const el = playgroundRef.current;
-      if (el) {
-        blockElementScrollPositionUntilNextRender(el);
-      }
-      setLocalSelectedValue(newTabValue as V[number]['value']);
-
-      if (groupId != null) {
-        setTabGroupChoice(newTabValue);
-      }
+  // Local state stays interactive if storage no-ops; sync like Docusaurus tabs.
+  useIsomorphicLayoutEffect(() => {
+    if (choice != null && isTabValue(values, choice)) {
+      setSelectedValue(choice);
     }
-  };
+  }, [choice, values]);
 
   const value = {
     selectedValue,
     values,
-    setSelectedValue,
+    setSelectedValue: (newTabValue: string) => {
+      if (!isTabValue(values, newTabValue) || newTabValue === selectedValue) {
+        return;
+      }
+      const el = playgroundRef.current;
+      if (el) {
+        blockElementScrollPositionUntilNextRender(el);
+      }
+      setSelectedValue(newTabValue);
+      setTabGroupChoice(newTabValue);
+    },
   };
   return (
     <CodeTabContext.Provider value={value}>{children}</CodeTabContext.Provider>

--- a/website/src/components/HooksPlayground.tsx
+++ b/website/src/components/HooksPlayground.tsx
@@ -6,7 +6,6 @@ import Playground from './Playground';
 const HooksPlayground = ({
   children,
   groupId,
-  hidden = false,
   defaultOpen = 'n',
   row = false,
   fixtures = [],
@@ -18,7 +17,6 @@ const HooksPlayground = ({
     groupId={groupId}
     defaultOpen={defaultOpen}
     row={row}
-    hidden={hidden}
     fixtures={fixtures}
     getInitialInterceptorData={getInitialInterceptorData}
     defaultTab={defaultTab}
@@ -35,17 +33,13 @@ const HooksPlayground = ({
 );
 export default memo(HooksPlayground);
 
-//child.props.children.props.title
-
 interface PlaygroundProps<T = any> {
   groupId: string;
   defaultOpen?: 'y' | 'n';
   row: boolean;
-  hidden: boolean;
   fixtures?: (Fixture | Interceptor<T>)[];
   getInitialInterceptorData?: () => T;
   children: React.ReactNode;
-  reverse?: boolean;
   defaultTab?: string;
   headerControls?: React.ReactNode;
 }

--- a/website/src/components/HooksPlayground.tsx
+++ b/website/src/components/HooksPlayground.tsx
@@ -6,6 +6,7 @@ import Playground from './Playground';
 const HooksPlayground = ({
   children,
   groupId,
+  hidden = false,
   defaultOpen = 'n',
   row = false,
   fixtures = [],
@@ -17,6 +18,7 @@ const HooksPlayground = ({
     groupId={groupId}
     defaultOpen={defaultOpen}
     row={row}
+    hidden={hidden}
     fixtures={fixtures}
     getInitialInterceptorData={getInitialInterceptorData}
     defaultTab={defaultTab}
@@ -37,6 +39,7 @@ interface PlaygroundProps<T = any> {
   groupId: string;
   defaultOpen?: 'y' | 'n';
   row: boolean;
+  hidden?: boolean;
   fixtures?: (Fixture | Interceptor<T>)[];
   getInitialInterceptorData?: () => T;
   children: React.ReactNode;

--- a/website/src/components/Playground/Preview.tsx
+++ b/website/src/components/Playground/Preview.tsx
@@ -23,7 +23,7 @@ function Preview<T>({
   getInitialInterceptorData,
 }: PreviewProps<T>) {
   const [choice, setTabGroupChoice] = useTabStorage(groupId);
-  const selectedValue = (choice ?? defaultOpen) as 'y' | 'n';
+  const selectedValue = choice === 'y' || choice === 'n' ? choice : defaultOpen;
   const { blockElementScrollPositionUntilNextRender } =
     useScrollPositionBlocker();
 

--- a/website/src/components/Playground/Preview.tsx
+++ b/website/src/components/Playground/Preview.tsx
@@ -22,9 +22,7 @@ function Preview<T>({
   fixtures,
   getInitialInterceptorData,
 }: PreviewProps<T>) {
-  const [choice, setTabGroupChoice] = useTabStorage(
-    `docusaurus.tab.${groupId}`,
-  );
+  const [choice, setTabGroupChoice] = useTabStorage(groupId);
   const selectedValue = (choice ?? defaultOpen) as 'y' | 'n';
   const { blockElementScrollPositionUntilNextRender } =
     useScrollPositionBlocker();

--- a/website/src/components/Playground/editor/EditorSurface.tsx
+++ b/website/src/components/Playground/editor/EditorSurface.tsx
@@ -11,7 +11,6 @@ import React, {
 import { LiveEditor } from 'react-live';
 
 import Header from '../Header';
-import { isGoogleBot } from '../isMobileOrBot';
 import Editor from '../PlaygroundEditor';
 import styles from '../styles.module.css';
 import TabList from '../TabList';
@@ -20,6 +19,8 @@ import type { CodeDocument, CodeModel } from './codeModel';
 export interface EditorSurfaceProps extends CodeModel {
   layout: 'row' | 'stacked';
   variant: 'playground' | 'standalone';
+  /** When false, keep static SSR-friendly editors (no Monaco). Defaults true. */
+  interactive?: boolean;
   fixtureContent?: React.ReactNode;
   headerControls?: React.ReactNode;
 }
@@ -29,6 +30,7 @@ export default function EditorSurface({
   update,
   layout,
   variant,
+  interactive = true,
   fixtureContent,
   headerControls,
 }: EditorSurfaceProps) {
@@ -103,6 +105,7 @@ export default function EditorSurface({
           : null}
           <TextEditTab
             hidden={closedList[index]}
+            interactive={interactive}
             tabIndex={index}
             onFocus={
               row && !document.col && documents.length > 1 ?
@@ -125,18 +128,33 @@ export default function EditorSurface({
 
 function TextEditTab({
   hidden,
+  interactive,
   code,
   language,
   tabIndex,
   ...rest
-}: ComponentProps<typeof Editor> & { hidden: boolean }) {
-  const fallback =
-    hidden ? <></>
-    : isGoogleBot ?
-      <pre className="prism-code language-tsx" spellCheck="false">
-        {code}
-      </pre>
-    : <LiveEditor language={language} code={code} disabled />;
+}: ComponentProps<typeof Editor> & {
+  hidden: boolean;
+  interactive: boolean;
+}) {
+  // Stable across SSR/hydration (do not branch on navigator / isGoogleBot here).
+  const staticView = <LiveEditor language={language} code={code} disabled />;
+
+  // Deferred protocols: keep open-file source in the DOM for SSG/crawlers;
+  // skip Monaco until the sandbox has been shown once.
+  if (!interactive) {
+    return (
+      <div
+        className={clsx(styles.playgroundEditor, {
+          [styles.hidden]: hidden,
+        })}
+      >
+        {hidden ? null : staticView}
+      </div>
+    );
+  }
+
+  const fallback = hidden ? <></> : staticView;
 
   return (
     <div

--- a/website/src/components/Playground/index.tsx
+++ b/website/src/components/Playground/index.tsx
@@ -1,6 +1,7 @@
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useIsomorphicLayoutEffect from '@docusaurus/useIsomorphicLayoutEffect';
 import clsx from 'clsx';
-import React, { lazy, useDeferredValue } from 'react';
+import React, { lazy, useDeferredValue, useState } from 'react';
 
 import Boundary from './Boundary';
 import { useCodeDocuments } from './editor/codeModel';
@@ -55,6 +56,7 @@ export default function Playground<T>({
         <PlaygroundContent
           reverse={playgroundPosition === 'top'}
           row={row}
+          hidden={hidden}
           fixtures={fixtures}
           groupId={groupId}
           defaultOpen={defaultOpen}
@@ -73,6 +75,7 @@ function PlaygroundContent<T>({
   reverse,
   children,
   row,
+  hidden,
   fixtures,
   groupId,
   defaultOpen,
@@ -85,10 +88,18 @@ function PlaygroundContent<T>({
   const code = useDeferredValue(
     model.documents.map(document => document.value).join('\n'),
   );
+
+  // Hydrate Monaco on first show and keep it (preserves undo / go-to-def).
+  const [editorInteractive, setEditorInteractive] = useState(!hidden);
+  useIsomorphicLayoutEffect(() => {
+    if (!hidden) setEditorInteractive(true);
+  }, [hidden]);
+
   const editor = (
     <EditorShell key="editor">
       <EditorSurface
         {...model}
+        interactive={editorInteractive}
         layout={row ? 'row' : 'stacked'}
         variant="playground"
         fixtureContent={
@@ -98,18 +109,20 @@ function PlaygroundContent<T>({
       />
     </EditorShell>
   );
-  const preview = (
-    <Boundary key="preview" fallback={previewLoading}>
-      <PreviewWithScopeLazy
-        code={code}
-        groupId={groupId}
-        defaultOpen={defaultOpen}
-        row={row}
-        fixtures={fixtures}
-        getInitialInterceptorData={getInitialInterceptorData}
-      />
-    </Boundary>
-  );
+  // Live preview only while visible — unmounts when hidden (resets store).
+  const preview =
+    hidden ? previewLoading : (
+      <Boundary key="preview" fallback={previewLoading}>
+        <PreviewWithScopeLazy
+          code={code}
+          groupId={groupId}
+          defaultOpen={defaultOpen}
+          row={row}
+          fixtures={fixtures}
+          getInitialInterceptorData={getInitialInterceptorData}
+        />
+      </Boundary>
+    );
 
   return <>{reverse ? [preview, editor] : [editor, preview]}</>;
 }
@@ -117,6 +130,7 @@ function PlaygroundContent<T>({
 interface ContentProps<T> extends PreviewProps<T> {
   children: PlaygroundProps<T>['children'];
   reverse: boolean;
+  hidden: boolean;
   defaultTab?: string;
   headerControls?: React.ReactNode;
 }

--- a/website/src/utils/tabStorage.ts
+++ b/website/src/utils/tabStorage.ts
@@ -1,14 +1,15 @@
 import { useStorageSlot } from '@docusaurus/theme-common';
 import { useCallback } from 'react';
 
-export function useTabStorage(groupId: string) {
-  const key = getStorageKey(groupId);
+/** Persist a tab choice under `docusaurus.tab.${groupId}`. Pass the raw group id. */
+export function useTabStorage(groupId: string | null | undefined) {
+  const key = groupId ? `docusaurus.tab.${groupId}` : null;
   const [value, storageSlot] = useStorageSlot(key);
 
   const setValue = useCallback(
     (newValue: string) => {
       if (!key) {
-        return; // no-op
+        return;
       }
       storageSlot.set(newValue);
     },
@@ -17,5 +18,3 @@ export function useTabStorage(groupId: string) {
 
   return [value, setValue] as const;
 }
-
-const getStorageKey = (groupId: string) => `docusaurus.tab.${groupId}`;


### PR DESCRIPTION
## Summary
- Keep all homepage protocol sandboxes mounted (CSS-hidden) so SSG HTML still includes every protocol’s open-file source for crawlers
- Skip `LivePreview` / DataProvider while a sandbox is hidden; remount when shown
- Latch Monaco hydration on first show (`interactive`) and keep it afterward (undo / go-to-def preserved on switch-back)
- Align `CodeProvider` tab sync with Docusaurus; fix `useTabStorage` double-prefixed localStorage keys

## Test plan
- [ ] Homepage: all protocol open-file sources appear in View Source / SSG HTML (including hidden protocols)
- [ ] Initial load hydrates Monaco + live preview for the selected protocol only
- [ ] Switching protocols initializes Monaco once for the newly shown sandbox and starts its preview
- [ ] Switching back keeps prior editor edits; preview store resets
- [ ] Protocol tabs + store inspector persist via localStorage (`docusaurus.tab.protocol`, etc.)
- [ ] No hydration warnings
- [ ] `yarn workspace rdc-website typecheck`