### PR TITLE
fix(website): Strip multiline imports in playground transformCode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,8 @@ jobs:
             - project/node_modules
             - project/packages
             - project/scripts
+            # Playground unit tests (transformCode, codeModel); rest of website omitted
+            - project/website/src/components/Playground
             - project/.yarnrc.yml
             - project/babel.config.js
             - project/eslint.config.mjs

--- a/jest.config.js
+++ b/jest.config.js
@@ -60,7 +60,10 @@ const projects = [
   {
     ...baseConfig,
     rootDir: __dirname,
-    roots: packages.map(pkgName => `<rootDir>/packages/${pkgName}/src`),
+    roots: [
+      ...packages.map(pkgName => `<rootDir>/packages/${pkgName}/src`),
+      '<rootDir>/website/src/components/Playground',
+    ],
     displayName: 'ReactDOM',
     setupFiles: ['<rootDir>/scripts/testSetup.js'],
     testEnvironment: 'jsdom',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 process.env.ANANSI_JEST_BABELCONFIG = 'babel.config.js';
 process.env.ANANSI_JEST_TSCONFIG = 'tsconfig.test.json';
 
+const fs = require('fs');
 const path = require('path');
 
 const baseConfig = {
@@ -56,14 +57,24 @@ const packages = [
   'test',
 ];
 
+// CircleCI persist_to_workspace omits most of website/; only include this root
+// when the tree is present (full checkout / when CI persists Playground).
+const playgroundRoot = path.join(
+  __dirname,
+  'website/src/components/Playground',
+);
+const reactDomRoots = [
+  ...packages.map(pkgName => `<rootDir>/packages/${pkgName}/src`),
+  ...(fs.existsSync(playgroundRoot) ?
+    ['<rootDir>/website/src/components/Playground']
+  : []),
+];
+
 const projects = [
   {
     ...baseConfig,
     rootDir: __dirname,
-    roots: [
-      ...packages.map(pkgName => `<rootDir>/packages/${pkgName}/src`),
-      '<rootDir>/website/src/components/Playground',
-    ],
+    roots: reactDomRoots,
     displayName: 'ReactDOM',
     setupFiles: ['<rootDir>/scripts/testSetup.js'],
     testEnvironment: 'jsdom',

--- a/website/src/components/Playground/__tests__/transformCode.test.ts
+++ b/website/src/components/Playground/__tests__/transformCode.test.ts
@@ -1,0 +1,105 @@
+/// <reference types="jest" />
+
+import transformCode from '../transformCode';
+
+describe('transformCode', () => {
+  test('removes Prettier multiline imports', () => {
+    expect(
+      transformCode(
+        `import {
+  GQLEntity,
+  GQLEndpoint,
+} from '@data-client/graphql';
+const x = 1;`,
+      ),
+    ).toBe('const x = 1;');
+  });
+
+  test('removes type-bearing and relative imports', () => {
+    expect(
+      transformCode(
+        `import { type Post, PostResource } from './resources';
+render(PostResource);`,
+      ),
+    ).toBe('render(PostResource);');
+  });
+
+  test('removes side-effect and import-type statements', () => {
+    expect(
+      transformCode(
+        `import './setup'
+import type { User } from './types'
+const user: User = value;`,
+      ),
+    ).toBe('const user: User = value;');
+  });
+
+  test('strips export prefixes from declarations', () => {
+    expect(
+      transformCode(
+        `export type User = { id: string };
+export const user = {} as User;
+export default function App() {}`,
+      ),
+    ).toBe(
+      `type User = { id: string };
+const user = {} as User;
+function App() {}`,
+    );
+  });
+
+  test('removes export lists and re-exports', () => {
+    expect(
+      transformCode(
+        `const X = 1;
+export { X };
+export type { User };
+export { Y } from './y';
+export * from './z';`,
+      ),
+    ).toBe('const X = 1;\n');
+  });
+
+  test('keeps GraphQL resource bodies after multiline import strip', () => {
+    const input = `import {
+  GQLEndpoint,
+  GQLEntity,
+  Collection,
+} from '@data-client/graphql';
+
+const gql = new GQLEndpoint('/');
+
+export class User extends GQLEntity {
+  name = '';
+}
+
+export const UserResource = {
+  get: gql.query(\`query GetUser($id: ID!) { user(id: $id) { id } }\`, { user: User }),
+};`;
+
+    const output = transformCode(input);
+    expect(output).not.toMatch(/\bfrom\b/);
+    expect(output).toContain("const gql = new GQLEndpoint('/');");
+    expect(output).toContain('class User extends GQLEntity');
+    expect(output).toContain('const UserResource =');
+    expect(output.trimStart().startsWith('GQLEndpoint')).toBe(false);
+  });
+
+  test('does not strip import.meta usage', () => {
+    expect(
+      transformCode(
+        `const url = import.meta.url;
+const x = 'value';`,
+      ),
+    ).toBe(
+      `const url = import.meta.url;
+const x = 'value';`,
+    );
+  });
+
+  test('removes namespace re-exports', () => {
+    expect(transformCode(`export * as ns from './x';\nconst y = 1;`)).toBe(
+      'const y = 1;',
+    );
+  });
+});

--- a/website/src/components/Playground/transformCode.ts
+++ b/website/src/components/Playground/transformCode.ts
@@ -7,7 +7,7 @@
  * multiline imports from leaving orphan `} from '…'` syntax.
  */
 const STATIC_IMPORT =
-  /^[ \t]*import(?!\s*\(|\.)(?:[\s\S]*?\bfrom\s*)?["'][^"'\r\n]+["']\s*;?[ \t]*(?:\/\/[^\r\n]*)?(?:\r?\n|$)/gm;
+  /^[ \t]*import(?!\s*\(|\.)(?:(?:[\s\S]*?\bfrom\s*)|\s+)["'][^"'\r\n]+["']\s*;?[ \t]*(?:\/\/[^\r\n]*)?(?:\r?\n|$)/gm;
 
 const EXPORT_LIST =
   /^[ \t]*export\s+(?:type\s+)?(?:\{[\s\S]*?\}|\*(?:\s+as\s+\w+)?)\s*(?:from\s*["'][^"'\r\n]+["'])?\s*;?[ \t]*(?:\/\/[^\r\n]*)?(?:\r?\n|$)/gm;

--- a/website/src/components/Playground/transformCode.ts
+++ b/website/src/components/Playground/transformCode.ts
@@ -1,4 +1,22 @@
-const transformCode = (code: string) => {
-  return code.replaceAll(/^(import.+$|export (default )?)/gm, '');
-};
-export default transformCode;
+/**
+ * Strip ESM import/export wrappers so concatenated playground documents can run
+ * under react-live (scope provides package imports; earlier files provide locals).
+ *
+ * Order matters: remove complete import / export-list declarations first, then
+ * strip `export` prefixes from remaining declarations. That keeps Prettier
+ * multiline imports from leaving orphan `} from '…'` syntax.
+ */
+const STATIC_IMPORT =
+  /^[ \t]*import(?!\s*\(|\.)(?:[\s\S]*?\bfrom\s*)?["'][^"'\r\n]+["']\s*;?[ \t]*(?:\/\/[^\r\n]*)?(?:\r?\n|$)/gm;
+
+const EXPORT_LIST =
+  /^[ \t]*export\s+(?:type\s+)?(?:\{[\s\S]*?\}|\*(?:\s+as\s+\w+)?)\s*(?:from\s*["'][^"'\r\n]+["'])?\s*;?[ \t]*(?:\/\/[^\r\n]*)?(?:\r?\n|$)/gm;
+
+const EXPORT_PREFIX = /^[ \t]*export[ \t]+(?:default[ \t]+)?/gm;
+
+export default function transformCode(code: string): string {
+  return code
+    .replaceAll(STATIC_IMPORT, '')
+    .replaceAll(EXPORT_LIST, '')
+    .replaceAll(EXPORT_PREFIX, '');
+}


### PR DESCRIPTION
## Summary
- Teach `transformCode` to remove complete static imports (including Prettier multiline / `import type`) and export-list/re-export declarations before stripping `export` prefixes
- Fixes GraphQL homepage demos that SyntaxError’d on leftover `} from '@data-client/graphql'`
- Wire `website/src/components/Playground` into the ReactDOM Jest roots so these regressions are covered in CI

## Test plan
- [x] `yarn test --selectProjects ReactDOM --testPathPatterns 'transformCode|codeModel'`
- [ ] Homepage: switch Reactive Mutations to GraphQL — live preview renders (no SyntaxError)
- [ ] REST / polling demos still preview correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to website playground string preprocessing and CI/Jest wiring; no auth, data, or package runtime changes.
> 
> **Overview**
> Fixes GraphQL (and other) homepage playground previews that **SyntaxError**’d when Prettier-style multiline imports were only partially stripped, leaving orphan `} from '…'` fragments.
> 
> **`transformCode`** no longer uses a single-line regex on `import`/`export`. It now removes full static import declarations (including multiline and `import type`), export lists/re-exports, then strips remaining `export` prefixes—while preserving bodies like GraphQL resource classes and **`import.meta`**.
> 
> **CI:** CircleCI persists `website/src/components/Playground` into the workspace; Jest’s ReactDOM project adds that root only when the folder exists, and new **`transformCode`** unit tests lock in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05737e017acce58775b86c091c6a572f00a56f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->