### PR TITLE
fix(website): Resolve monaco-editor root under 0.56 exports map

### DIFF
--- a/website/scripts/generateMonacoPreloads.cjs
+++ b/website/scripts/generateMonacoPreloads.cjs
@@ -14,37 +14,16 @@ const fs = require('fs');
 const path = require('path');
 
 const WEBSITE_ROOT = path.join(__dirname, '..');
-const MONACO_ROOT = resolveMonacoRoot();
-const VS_ROOT = path.join(MONACO_ROOT, 'min', 'vs');
+// monaco-editor >=0.56 exports map `./*` → `esm/vs/*.js`, so
+// require.resolve('monaco-editor/package.json') fails. Entry is min/vs/index.js.
+const VS_ROOT = path.dirname(
+  require.resolve('monaco-editor', { paths: [WEBSITE_ROOT] }),
+);
+const MONACO_ROOT = path.resolve(VS_ROOT, '../..');
 const MANIFEST_PATH = path.join(
   WEBSITE_ROOT,
   'src/components/Playground/monacoPreloadManifest.ts',
 );
-
-/**
- * monaco-editor >=0.56 exports map `./*` → `esm/vs/*.js`, so
- * `require.resolve('monaco-editor/package.json')` fails. Resolve the package
- * entry and walk up to the real package root instead.
- */
-function resolveMonacoRoot() {
-  const entry = require.resolve('monaco-editor', { paths: [WEBSITE_ROOT] });
-  let dir = path.dirname(entry);
-  while (dir !== path.dirname(dir)) {
-    const pkgPath = path.join(dir, 'package.json');
-    if (fs.existsSync(pkgPath)) {
-      try {
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-        if (pkg.name === 'monaco-editor') return dir;
-      } catch {
-        // ignore unreadable/invalid package.json while walking up
-      }
-    }
-    dir = path.dirname(dir);
-  }
-  throw new Error(
-    `Could not locate monaco-editor package root from entry ${entry}`,
-  );
-}
 
 /** @returns {{ monacoVersion: string, preloadPaths: string[], prefetchPaths: string[] }} */
 function computeMonacoPreloadManifest() {

--- a/website/scripts/generateMonacoPreloads.cjs
+++ b/website/scripts/generateMonacoPreloads.cjs
@@ -35,54 +35,16 @@ function computeMonacoPreloadManifest() {
     throw new Error(`monaco-editor min/vs missing at ${VS_ROOT}`);
   }
 
-  const mainPath = path.join(VS_ROOT, 'editor/editor.main.js');
-  const mainSource = fs.readFileSync(mainPath, 'utf8');
-  const defineMatch = mainSource.match(
-    /define\(\s*["']vs\/editor\/editor\.main["']\s*,\s*\[([^\]]+)\]/,
-  );
-  if (!defineMatch) {
-    throw new Error(
-      'Failed to parse AMD dependency array from editor/editor.main.js — Monaco packaging may have changed',
-    );
+  const mainRel = 'editor/editor.main.js';
+  if (!fs.existsSync(path.join(VS_ROOT, mainRel))) {
+    throw new Error(`monaco-editor ${mainRel} missing under ${VS_ROOT}`);
   }
 
-  /** @type {string[]} */
-  const amdDeps = [];
-  const depLiteral = /["']([^"']+)["']/g;
-  let depMatch;
-  while ((depMatch = depLiteral.exec(defineMatch[1]))) {
-    amdDeps.push(depMatch[1]);
-  }
-  if (amdDeps.length < 5) {
-    throw new Error(
-      `Suspiciously few AMD deps parsed from editor.main (${amdDeps.length}): ${amdDeps.join(', ')}`,
-    );
-  }
-
-  /** @type {string[]} */
-  const preloadPaths = ['loader.js', 'editor/editor.main.js'];
-
-  for (const dep of amdDeps) {
-    if (dep === 'exports' || dep === 'require') continue;
-    if (dep.endsWith('.css')) {
-      throw new Error(
-        `Refusing to preload CSS dependency from editor.main: ${dep}`,
-      );
-    }
-    if (
-      dep === 'vs/nls.messages-loader!' ||
-      dep.startsWith('vs/nls.messages-loader')
-    ) {
-      preloadPaths.push('nls.messages-loader.js');
-      continue;
-    }
-    if (dep.startsWith('../')) {
-      const relative = `${dep.slice(3)}.js`.replace(/\.js\.js$/, '.js');
-      preloadPaths.push(relative);
-      continue;
-    }
-    throw new Error(`Unrecognized editor.main AMD dependency: ${dep}`);
-  }
+  // BFS static AMD deps from editor.main so 0.56's nested index bootstrap
+  // (basic-languages, toggleHighContrast, editorWorkerHost, …) is preloaded.
+  // Language grammars are dynamic requires inside basic-languages — not visited.
+  const preloadPaths = collectAmdClosure(mainRel);
+  preloadPaths.unshift('loader.js');
 
   const prefetchPaths = [
     ...exactGlob(VS_ROOT, /^typescript-.+\.js$/),
@@ -107,6 +69,11 @@ function computeMonacoPreloadManifest() {
       'Expected at least one monaco.contribution-* preload path from editor.main deps',
     );
   }
+  if (!normalizedPreload.some(p => p.startsWith('index-'))) {
+    throw new Error(
+      'Expected hashed index-* module in editor.main AMD closure',
+    );
+  }
   if (normalizedPrefetch.length < 2) {
     throw new Error(
       'Expected typescript/tsMode and worker prefetch paths; found none/too few',
@@ -118,6 +85,95 @@ function computeMonacoPreloadManifest() {
     preloadPaths: normalizedPreload,
     prefetchPaths: normalizedPrefetch,
   };
+}
+
+/**
+ * @param {string} entryRel path relative to VS_ROOT
+ * @returns {string[]}
+ */
+function collectAmdClosure(entryRel) {
+  /** @type {string[]} */
+  const ordered = [];
+  const seen = new Set();
+  const queue = [entryRel];
+
+  while (queue.length > 0) {
+    const modRel = queue.shift();
+    if (seen.has(modRel)) continue;
+    seen.add(modRel);
+    ordered.push(modRel);
+
+    for (const dep of parseAmdDependencyArray(modRel)) {
+      const resolved = resolveAmdDependency(modRel, dep);
+      if (!resolved || seen.has(resolved)) continue;
+      if (!fs.existsSync(path.join(VS_ROOT, resolved))) {
+        throw new Error(
+          `AMD dependency missing: ${resolved} (from ${modRel} → ${dep})`,
+        );
+      }
+      queue.push(resolved);
+    }
+  }
+
+  return ordered;
+}
+
+/** @param {string} modRel @returns {string[]} */
+function parseAmdDependencyArray(modRel) {
+  const source = fs.readFileSync(path.join(VS_ROOT, modRel), 'utf8');
+  // Minified modules use define("id",[...],factory). Match the first define.
+  const defineMatch = source.match(
+    /define\(\s*(?:["'][^"']+["']\s*,\s*)?\[([^\]]*)\]/,
+  );
+  if (!defineMatch) {
+    throw new Error(
+      `Failed to parse AMD dependency array from ${modRel} — Monaco packaging may have changed`,
+    );
+  }
+
+  /** @type {string[]} */
+  const deps = [];
+  const depLiteral = /["']([^"']+)["']/g;
+  let depMatch;
+  while ((depMatch = depLiteral.exec(defineMatch[1]))) {
+    deps.push(depMatch[1]);
+  }
+  return deps;
+}
+
+/**
+ * @param {string} fromRel
+ * @param {string} dep
+ * @returns {string | null} path relative to VS_ROOT, or null to skip
+ */
+function resolveAmdDependency(fromRel, dep) {
+  if (dep === 'exports' || dep === 'require') return null;
+  if (dep.endsWith('.css')) {
+    throw new Error(
+      `Refusing to preload CSS dependency from ${fromRel}: ${dep}`,
+    );
+  }
+  if (
+    dep === 'vs/nls.messages-loader!' ||
+    dep.startsWith('vs/nls.messages-loader')
+  ) {
+    return 'nls.messages-loader.js';
+  }
+  if (dep.startsWith('./') || dep.startsWith('../')) {
+    const absolute = path.normalize(
+      path.join(VS_ROOT, path.dirname(fromRel), dep),
+    );
+    const withJs =
+      absolute.endsWith('.js') ? absolute : `${absolute}.js`;
+    return path.relative(VS_ROOT, withJs);
+  }
+  if (dep.startsWith('vs/')) {
+    const rel = dep.slice(3);
+    return rel.endsWith('.js') ? rel : `${rel}.js`;
+  }
+  throw new Error(
+    `Unrecognized AMD dependency from ${fromRel}: ${dep}`,
+  );
 }
 
 /** @param {string} dir @param {RegExp} pattern */

--- a/website/scripts/generateMonacoPreloads.cjs
+++ b/website/scripts/generateMonacoPreloads.cjs
@@ -14,14 +14,37 @@ const fs = require('fs');
 const path = require('path');
 
 const WEBSITE_ROOT = path.join(__dirname, '..');
-const MONACO_ROOT = path.dirname(
-  require.resolve('monaco-editor/package.json', { paths: [WEBSITE_ROOT] }),
-);
+const MONACO_ROOT = resolveMonacoRoot();
 const VS_ROOT = path.join(MONACO_ROOT, 'min', 'vs');
 const MANIFEST_PATH = path.join(
   WEBSITE_ROOT,
   'src/components/Playground/monacoPreloadManifest.ts',
 );
+
+/**
+ * monaco-editor >=0.56 exports map `./*` → `esm/vs/*.js`, so
+ * `require.resolve('monaco-editor/package.json')` fails. Resolve the package
+ * entry and walk up to the real package root instead.
+ */
+function resolveMonacoRoot() {
+  const entry = require.resolve('monaco-editor', { paths: [WEBSITE_ROOT] });
+  let dir = path.dirname(entry);
+  while (dir !== path.dirname(dir)) {
+    const pkgPath = path.join(dir, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+        if (pkg.name === 'monaco-editor') return dir;
+      } catch {
+        // ignore unreadable/invalid package.json while walking up
+      }
+    }
+    dir = path.dirname(dir);
+  }
+  throw new Error(
+    `Could not locate monaco-editor package root from entry ${entry}`,
+  );
+}
 
 /** @returns {{ monacoVersion: string, preloadPaths: string[], prefetchPaths: string[] }} */
 function computeMonacoPreloadManifest() {

--- a/website/src/components/DiffEditorMonaco.tsx
+++ b/website/src/components/DiffEditorMonaco.tsx
@@ -83,4 +83,7 @@ const DIFF_OPTIONS: editor.IDiffEditorConstructionOptions = {
   enableSplitViewResizing: false,
   readOnly: true,
   compactMode: true,
+  // Built-in advanced (default). advanced-wasm / advanced-external need
+  // @vscode/diff via VS Code module resolution — not available on CDN AMD.
+  diffAlgorithm: 'advanced',
 };

--- a/website/src/components/Playground/monaco-init.ts
+++ b/website/src/components/Playground/monaco-init.ts
@@ -73,16 +73,16 @@ if (
 
   monacoPromise.then(async monaco => {
     if (!monaco) return;
-    monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+    monaco.typescript.typescriptDefaults.setCompilerOptions({
       allowNonTsExtensions: true,
-      target: monaco.languages.typescript.ScriptTarget.ES2017,
-      jsx: monaco.languages.typescript.JsxEmit.ReactJSX,
+      target: monaco.typescript.ScriptTarget.ES2017,
+      jsx: monaco.typescript.JsxEmit.ReactJSX,
       strict: true,
       strictNullChecks: true,
       exactOptionalPropertyTypes: true,
       lib: ['dom', 'esnext'],
-      module: monaco.languages.typescript.ModuleKind.ESNext,
-      moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+      module: monaco.typescript.ModuleKind.ESNext,
+      moduleResolution: monaco.typescript.ModuleResolutionKind.NodeJs,
       allowSyntheticDefaultImports: true,
       skipLibCheck: true,
       skipDefaultLibCheck: true,
@@ -240,13 +240,13 @@ if (
       result.status === 'fulfilled' ? result.value.default : '',
     );
 
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare module "react/jsx-runtime" {
         import './';
       }`,
       'file:///node_modules/@types/react/jsx-runtime.d.ts',
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `import * as React from 'react'
 
     declare global {
@@ -258,7 +258,7 @@ if (
     }`,
       'file:///node_modules/@types/react/more.d.ts',
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare function render(component:JSX.Element):void;
         declare function uuid(): string;
         declare function CurrentTime(props: {}):JSX.Element;
@@ -310,53 +310,53 @@ if (
           value: number;
         }`,
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare module "react" { ${react} }`,
       'file:///node_modules/@types/react/index.d.ts',
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare module "bignumber.js" { ${bignumber} }`,
       'file:///node_modules/bignumber.js/index.d.ts',
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare module "@number-flow/react" { ${numberFlow} };`,
       'file:///node_modules/@number-flow/react/index.d.ts',
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare module "temporal-polyfill" { ${temporal} }`,
       'file:///node_modules/temporal-polyfill/index.d.ts',
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare module "uuid" { ${uuid} }`,
       'file:///node_modules/@types/uuid/index.d.ts',
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare module "qs" { ${qs} }`,
       'file:///node_modules/@types/qs/index.d.ts',
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare globals { ${react} }`,
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare globals { export { default as NumberFlow } from '@number-flow/react'; }`,
     );
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare globals { export { Temporal, DateTimeFormat } from 'temporal-polyfill'; }`,
     );
 
     rhLibs.forEach((lib, i) => {
       const dep = rhDeps[i];
-      monaco.languages.typescript.typescriptDefaults.addExtraLib(
+      monaco.typescript.typescriptDefaults.addExtraLib(
         `declare module "@data-client/${dep}" { ${lib} }`,
         `file:///node_modules/@data-client/${dep}/index.d.ts`,
       );
     });
 
-    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+    monaco.typescript.typescriptDefaults.addExtraLib(
       `declare globals { ${globals} }`,
     );
 
-    monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
+    monaco.typescript.typescriptDefaults.setEagerModelSync(true);
     return monaco;
   });
 }

--- a/website/src/components/Playground/monacoPreloadManifest.ts
+++ b/website/src/components/Playground/monacoPreloadManifest.ts
@@ -18,6 +18,9 @@ export const monacoPreloadManifest = {
     'monaco.contribution-BgRy6xDf.js',
     'monaco.contribution-BE88ZNGY.js',
     'monaco.contribution-BPhsneLd.js',
+    'toggleHighContrast-qGX7E9o7.js',
+    'basic-languages/monaco.contribution.js',
+    'editorWorkerHost-fVE1cjcC.js',
   ],
   prefetchPaths: [
     'assets/editor.worker-lj3bdIIn.js',

--- a/website/src/components/Playground/monacoPreloadManifest.ts
+++ b/website/src/components/Playground/monacoPreloadManifest.ts
@@ -7,22 +7,25 @@ export const monacoPreloadManifest = {
   preloadPaths: [
     'loader.js',
     'editor/editor.main.js',
+    'json.worker-BizpAl9O.js',
+    'css.worker-CyhWkhHo.js',
+    'html.worker-CA3iAimZ.js',
+    'ts.worker-2QLmBukE.js',
     'nls.messages-loader.js',
-    'monaco.contribution-DO3azKX8.js',
-    'monaco.contribution-qLAYrEOP.js',
-    'monaco.contribution-EcChJV6a.js',
-    'monaco.contribution-D2OdxNBt.js',
-    'basic-languages/monaco.contribution.js',
-    'editor.api-CalNCsUg.js',
-    'workers-DcJshg-q.js',
+    'index-CBVt3dzv.js',
+    'monaco.contribution-9cKT3C7t.js',
+    'editor-KLE6jdfb.js',
+    'monaco.contribution-BgRy6xDf.js',
+    'monaco.contribution-BE88ZNGY.js',
+    'monaco.contribution-BPhsneLd.js',
   ],
   prefetchPaths: [
-    'assets/editor.worker-Be8ye1pW.js',
-    'assets/ts.worker-CMbG-7ft.js',
-    'tsMode-CZz1Umrk.js',
-    'typescript-DfOrAzoV.js',
+    'assets/editor.worker-lj3bdIIn.js',
+    'assets/ts.worker-BWKtMYOk.js',
+    'tsMode-B0S_kp2q.js',
+    'typescript-_2t_511t.js',
   ],
 } as const;
 
 export const MONACO_CDN_VS =
-  'https://cdn.jsdelivr.net/npm/monaco-editor@0.55.1/min/vs';
+  'https://cdn.jsdelivr.net/npm/monaco-editor@0.56.0/min/vs';


### PR DESCRIPTION
## Summary
- Fix `generateMonacoPreloads.cjs` package-root resolution broken by monaco-editor 0.56's new `exports` map (`./*` → `esm/vs/*.js`)
- Regenerate committed preload/prefetch manifest for `@0.56.0` content hashes

## Why #4054 didn't catch this cleanly
- The manifest is **meant** to regenerate when `docusaurus.config.ts` loads (`ensureMonacoPreloadManifest()`), so a monaco bump should self-heal at website build time
- #4054 never got that far: resolve crashed at module load, so regeneration never ran — committed manifest stayed on 0.55.1
- CircleCI only runs Playground unit tests, not a full Docusaurus build; Vercel preview **did** fail on #4054 but the PR was merged anyway (23/25 checks)

## Drift
- Mild: committed `monacoPreloadManifest.ts` can lag the installed monaco version until someone runs the website build/config
- Not fatal once resolve works — build rewrites the file in the sandbox
- Committing the regenerated file keeps source/CDN hashes honest and makes renovate diffs show the hash churn

## Test plan
- [x] `node website/scripts/generateMonacoPreloads.cjs` succeeds for monaco 0.56.0
- [ ] Vercel / `yarn workspace rdc-website build` loads `docusaurus.config.ts` without MODULE_NOT_FOUND
- [ ] Playground Monaco CDN path points at `@0.56.0`


Made with [Cursor](https://cursor.com)